### PR TITLE
Fix MLX v0.31.2 rebase regressions (autograd SIGTRAP, clip bounds, LLM tokenizer) + idiomatic control-flow refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,12 +78,14 @@ for f in choicemap_test trace_test selection_test handler_test dist_test combina
   bun run --bun nbb "test/genmlx/${f}.cljs"
 done
 
-# Native/autograd shape guard — MUST run after any mlx-node rebuild.
+# Native/membrane contract guard — MUST run after any mlx-node rebuild.
 # These exercise mx/array JS-array shaping (take/squeeze, value_and_grad,
-# multivariate-normal cholesky). A stricter MLX binary turns a malformed-array
-# CLJS bug into a hard SIGTRAP; a more lenient one silently produces NaN/garbage.
-# Either way these suites catch it, so they can never be masked by a stale binary.
-for f in exact_test gradient_fd_test score_gradient_test; do
+# multivariate-normal cholesky) and the mx/clip Either<&MxArray,f64> bounds
+# contract. A stricter MLX binary turns a malformed-array CLJS bug into a hard
+# SIGTRAP; a more lenient one silently produces NaN/garbage; a narrowed NAPI
+# signature rejects valid bounds. Either way these suites catch it, so a stale
+# or drifted binary can never silently mask the regression.
+for f in exact_test gradient_fd_test score_gradient_test clip_contract_test; do
   bun run --bun nbb "test/genmlx/${f}.cljs"
 done
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,15 @@ for f in choicemap_test trace_test selection_test handler_test dist_test combina
   bun run --bun nbb "test/genmlx/${f}.cljs"
 done
 
+# Native/autograd shape guard — MUST run after any mlx-node rebuild.
+# These exercise mx/array JS-array shaping (take/squeeze, value_and_grad,
+# multivariate-normal cholesky). A stricter MLX binary turns a malformed-array
+# CLJS bug into a hard SIGTRAP; a more lenient one silently produces NaN/garbage.
+# Either way these suites catch it, so they can never be masked by a stale binary.
+for f in exact_test gradient_fd_test score_gradient_test; do
+  bun run --bun nbb "test/genmlx/${f}.cljs"
+done
+
 # Level 0 certification (must pass 68/68)
 bun run --bun nbb test/genmlx/level0_certification_test.cljs
 

--- a/examples/memo/empowerment.cljs
+++ b/examples/memo/empowerment.cljs
@@ -113,7 +113,7 @@
 
 (let [states (blahut-arimoto symmetric-channel 5)]
   (doseq [{:keys [q capacity]} (rest states)]
-    (let [qs (.tolist q)]
+    (let [qs (clj->js (mx/->clj q))]
       (println (str "  C = " (.toFixed capacity 4) " bits"
                     "  q = [" (.toFixed (aget qs 0) 4) ", "
                     (.toFixed (aget qs 1) 4) ", "
@@ -136,7 +136,7 @@
 
 (let [states (blahut-arimoto asymmetric-channel 10)]
   (doseq [[i {:keys [q capacity]}] (map-indexed vector (rest states))]
-    (let [qs (.tolist q)]
+    (let [qs (clj->js (mx/->clj q))]
       (println (str "  t=" i
                     "  C = " (.toFixed capacity 4) " bits"
                     "  q = [" (.toFixed (aget qs 0) 4) ", "

--- a/examples/memo/ipomdp.cljs
+++ b/examples/memo/ipomdp.cljs
@@ -271,7 +271,7 @@
                   (mx/item (payout-investor 0 1))) 2)
       q0-hi (/ (+ (mx/item (payout-investor 1 0))
                   (mx/item (payout-investor 1 1))) 2)
-      q1-g0 (.tolist (mx/idx iq1 0))]
+      q1-g0 (clj->js (mx/->clj (mx/idx iq1 0)))]
   (println (str "   Level-0 Q(low)=" (.toFixed q0-lo 2) " Q(high)=" (.toFixed q0-hi 2)
                " -> prefers " (if (> q0-hi q0-lo) "HIGH" "LOW")))
   (println (str "   Level-1 Q(low)=" (.toFixed (aget q1-g0 0) 2) " Q(high)=" (.toFixed (aget q1-g0 1) 2)

--- a/examples/memo/mdp.cljs
+++ b/examples/memo/mdp.cljs
@@ -102,7 +102,7 @@
 
 ;; Helper: extract Q[s, :, g] as JS list
 (defn q-row [s g]
-  (.tolist (mx/idx (mx/idx Q s) g 1)))
+  (clj->js (mx/->clj (mx/idx (mx/idx Q s) g 1))))
 
 ;; ---------------------------------------------------------------------------
 ;; Display Q-values

--- a/src/genmlx/dev.cljs
+++ b/src/genmlx/dev.cljs
@@ -73,12 +73,11 @@
         validating
         (fn [gf op args key opts]
           (let [result (dyn/run-dispatched* gf op args key opts)]
-            (when (:output scope)
-              (when-let [entry (op->validator op)]
-                (when-not ((:validate entry) result)
-                  (report ::invalid-output
-                    {:op op :entry entry :value result
-                     :fn-name (str "DynamicGF/" (name op))}))))
+            (when-let [entry (and (:output scope) (op->validator op))]
+              (when-not ((:validate entry) result)
+                (report ::invalid-output
+                  {:op op :entry entry :value result
+                   :fn-name (str "DynamicGF/" (name op))})))
             result))]
 
     (reset! dyn/dispatch-fn validating)

--- a/src/genmlx/dist.cljs
+++ b/src/genmlx/dist.cljs
@@ -469,7 +469,8 @@
                 (let [log-probs (mx/subtract logits (mx/logsumexp logits))]
                   (mx/take-idx log-probs v)))))
   (support []
-           (let [n (do (mx/materialize! logits) (last (mx/shape logits)))]
+           (mx/materialize! logits)
+           (let [n (last (mx/shape logits))]
              (mapv #(mx/scalar (int %) mx/int32) (range n)))))
 
 (defmethod dc/dist-log-prob-support :categorical [d]
@@ -1247,7 +1248,8 @@
         ;; W = L * A * A^T * L^T
         LA (mx/matmul cholesky-L A)
         W (mx/matmul LA (mx/transpose LA))]
-    (do (mx/materialize! W) W)))
+    (mx/materialize! W)
+    W))
 
 (defmethod dc/dist-log-prob :wishart [d x]
   (let [{:keys [df scale-matrix k]} (:params d)

--- a/src/genmlx/fit.cljs
+++ b/src/genmlx/fit.cljs
@@ -235,30 +235,30 @@
                                          (select-keys opts [:particles :samples :iterations
                                                             :step-size :n-leapfrog])))
                      auto-selection)
-         {:keys [method reason]} selection
-         _ (when (:verbose? opts)
-             (println (str "[fit] Selected method: " (name method) " — " reason)))
-         ;; 2. Tune options (safe — user may override with methods the tuner
-         ;;    doesn't know, e.g. :mcmc. Fall back to user opts in that case.)
-         tuned (try (ms/tune-method-opts selection)
-                    (catch :default _e (:opts selection)))
-         method-opts (merge tuned
-                            (select-keys opts [:lr :iterations :particles :samples
-                                               :key :step-size :n-leapfrog :burn])
-                            ;; Pass residual-addrs through for HMC/VI
-                            {:residual-addrs (:residual-addrs selection)})
-         ;; 3. Run inference
-         result (run-method model args data method method-opts)
-         ;; 4. Optional: parameter learning loop
-         result (if (:learn opts)
-                  (run-learning-loop model args data result
-                                     (:learn opts) method-opts opts)
-                  result)
-         elapsed (- (js/Date.now) start-time)]
-     (assoc result
-            :method method
-            :elapsed-ms elapsed
-            :diagnostics (merge (:diagnostics result)
+         {:keys [method reason]} selection]
+     (when (:verbose? opts)
+       (println (str "[fit] Selected method: " (name method) " — " reason)))
+     (let [;; 2. Tune options (safe — user may override with methods the tuner
+           ;;    doesn't know, e.g. :mcmc. Fall back to user opts in that case.)
+           tuned (try (ms/tune-method-opts selection)
+                      (catch :default _e (:opts selection)))
+           method-opts (merge tuned
+                              (select-keys opts [:lr :iterations :particles :samples
+                                                 :key :step-size :n-leapfrog :burn])
+                              ;; Pass residual-addrs through for HMC/VI
+                              {:residual-addrs (:residual-addrs selection)})
+           ;; 3. Run inference
+           result (run-method model args data method method-opts)
+           ;; 4. Optional: parameter learning loop
+           result (if (:learn opts)
+                    (run-learning-loop model args data result
+                                       (:learn opts) method-opts opts)
+                    result)
+           elapsed (- (js/Date.now) start-time)]
+       (assoc result
+              :method method
+              :elapsed-ms elapsed
+              :diagnostics (merge (:diagnostics result)
                                 {:reason reason
                                  :n-residual (:n-residual selection)
-                                 :n-latent (:n-latent selection)})))))
+                                 :n-latent (:n-latent selection)}))))))

--- a/src/genmlx/gradients.cljs
+++ b/src/genmlx/gradients.cljs
@@ -20,35 +20,36 @@
   [model trace addresses]
   (let [model (dyn/auto-key model)
         args (:args trace)
-        choices (:choices trace)
-        _ (doseq [addr addresses]
+        choices (:choices trace)]
+    (run! (fn [addr]
             (when-not (cm/has-value? (cm/get-submap choices addr))
               (throw (ex-info (str "choice-gradients: address " (pr-str addr)
                                    " not found in trace choices")
                               {:address addr}))))
-        ;; Build a score function parameterized by the target choices
-        indexed-addrs (mapv vector (range) addresses)
-        ;; Extract current values
-        current-vals (mapv #(mx/realize (cm/get-choice choices [%])) addresses)
-        params (mx/array current-vals)
-        ;; Score function: reconstruct choicemap with params, run generate
-        score-fn (fn [params-arr]
-                   (let [cm (reduce
-                              (fn [cm [i addr]]
-                                (cm/set-choice cm [addr] (mx/index params-arr i)))
-                              choices
-                              indexed-addrs)]
-                     (:weight (p/generate model args cm))))
-        ;; Compute gradient (uncompiled — compile-fn severs backward
-        ;; pass when model body uses mx/eval!, returning silent zeros)
-        grad-fn (mx/grad score-fn)
-        grad-arr (grad-fn params)]
-    (mx/materialize! grad-arr)
-    ;; Split gradient array into per-address map
-    (into {}
-      (map (fn [[i addr]]
-             [addr (mx/index grad-arr i)])
-           indexed-addrs))))
+          addresses)
+    (let [;; Build a score function parameterized by the target choices
+          indexed-addrs (mapv vector (range) addresses)
+          ;; Extract current values
+          current-vals (mapv #(mx/realize (cm/get-choice choices [%])) addresses)
+          params (mx/array current-vals)
+          ;; Score function: reconstruct choicemap with params, run generate
+          score-fn (fn [params-arr]
+                     (let [cm (reduce
+                                (fn [cm [i addr]]
+                                  (cm/set-choice cm [addr] (mx/index params-arr i)))
+                                choices
+                                indexed-addrs)]
+                       (:weight (p/generate model args cm))))
+          ;; Compute gradient (uncompiled — compile-fn severs backward
+          ;; pass when model body uses mx/eval!, returning silent zeros)
+          grad-fn (mx/grad score-fn)
+          grad-arr (grad-fn params)]
+      (mx/materialize! grad-arr)
+      ;; Split gradient array into per-address map
+      (into {}
+        (map (fn [[i addr]]
+               [addr (mx/index grad-arr i)])
+             indexed-addrs)))))
 
 (defn score-gradient
   "Compute gradient of the model score w.r.t. a flat parameter array.
@@ -63,22 +64,22 @@
    Returns {:score MLX-scalar :grad MLX-array}."
   [model args observations addresses params]
   (let [model (dyn/auto-key model)
-        _ (let [n-addr (count addresses)
-                n-param (first (mx/shape params))]
-            (when-not (= n-addr n-param)
-              (throw (ex-info (str "score-gradient: addresses count (" n-addr
-                                   ") != params dimension (" n-param ")")
-                              {:addresses-count n-addr
-                               :params-shape (mx/shape params)}))))
-        indexed-addrs (mapv vector (range) addresses)
-        score-fn (fn [p]
-                   (let [cm (reduce
-                              (fn [cm [i addr]]
-                                (cm/set-choice cm [addr] (mx/index p i)))
-                              observations
-                              indexed-addrs)]
-                     (:weight (p/generate model args cm))))
-        vag (mx/value-and-grad score-fn)
-        [score grad] (vag params)]
-    (mx/materialize! score grad)
-    {:score score :grad grad}))
+        n-addr (count addresses)
+        n-param (first (mx/shape params))]
+    (when-not (= n-addr n-param)
+      (throw (ex-info (str "score-gradient: addresses count (" n-addr
+                           ") != params dimension (" n-param ")")
+                      {:addresses-count n-addr
+                       :params-shape (mx/shape params)})))
+    (let [indexed-addrs (mapv vector (range) addresses)
+          score-fn (fn [p]
+                     (let [cm (reduce
+                                (fn [cm [i addr]]
+                                  (cm/set-choice cm [addr] (mx/index p i)))
+                                observations
+                                indexed-addrs)]
+                       (:weight (p/generate model args cm))))
+          vag (mx/value-and-grad score-fn)
+          [score grad] (vag params)]
+      (mx/materialize! score grad)
+      {:score score :grad grad})))

--- a/src/genmlx/handler.cljs
+++ b/src/genmlx/handler.cljs
@@ -59,7 +59,7 @@
     [value (-> state
                (assoc :key k1)
                (update :choices cm/set-value addr value)
-               (update :score #(mx/add % lp)))]))
+               (update :score mx/add lp))]))
 
 (defn generate-transition
   "Pure: if constrained at addr, use constraint; otherwise simulate."
@@ -70,8 +70,8 @@
             lp (dc/dist-log-prob dist value)]
         [value (-> state
                    (update :choices cm/set-value addr value)
-                   (update :score #(mx/add % lp))
-                   (update :weight #(mx/add % lp)))])
+                   (update :score mx/add lp)
+                   (update :weight mx/add lp))])
       (simulate-transition state addr dist))))
 
 (defn assess-transition
@@ -83,8 +83,8 @@
             lp (dc/dist-log-prob dist value)]
         [value (-> state
                    (update :choices cm/set-value addr value)
-                   (update :score #(mx/add % lp))
-                   (update :weight #(mx/add % lp)))])
+                   (update :score mx/add lp)
+                   (update :weight mx/add lp))])
       (throw (ex-info (str "assess: address " addr " not found in provided choices. "
                            "All addresses must be constrained for assess.")
                       {:addr addr})))))
@@ -103,8 +103,8 @@
             old-lp (if old-val (dc/dist-log-prob dist old-val) ZERO)]
         [new-val (-> state
                      (update :choices cm/set-value addr new-val)
-                     (update :score #(mx/add % new-lp))
-                     (update :weight #(mx/add % (mx/subtract new-lp old-lp)))
+                     (update :score mx/add new-lp)
+                     (update :weight mx/add (mx/subtract new-lp old-lp))
                      (cond->
                       old-val (update :discard cm/set-value addr old-val)))])
 
@@ -114,7 +114,7 @@
             lp (dc/dist-log-prob dist val)]
         [val (-> state
                  (update :choices cm/set-value addr val)
-                 (update :score #(mx/add % lp)))])
+                 (update :score mx/add lp))])
 
       ;; New address: sample fresh
       :else (simulate-transition state addr dist))))
@@ -134,8 +134,8 @@
         [new-val (-> state
                      (assoc :key k1)
                      (update :choices cm/set-value addr new-val)
-                     (update :score #(mx/add % new-lp))
-                     (update :weight #(mx/add % (mx/subtract new-lp old-lp))))])
+                     (update :score mx/add new-lp)
+                     (update :weight mx/add (mx/subtract new-lp old-lp)))])
       ;; Not selected: keep old
       (let [val (when (cm/has-value? old-choice)
                   (cm/get-value old-choice))]
@@ -146,25 +146,25 @@
         (let [lp (dc/dist-log-prob dist val)]
           [val (-> state
                    (update :choices cm/set-value addr val)
-                   (update :score #(mx/add % lp)))])))))
+                   (update :score mx/add lp))])))))
 
 (defn project-transition
   "Pure: replay old value, accumulate log-prob for selected addresses."
   [state addr dist]
   (let [old-choice (cm/get-submap (:old-choices state) addr)
         val (when (cm/has-value? old-choice)
-              (cm/get-value old-choice))
-        _ (when (nil? val)
-            (throw (ex-info (str "project: address not found in previous trace choices. "
-                                 "Cannot replay a value for an address that was never sampled.")
-                            {})))
-        lp (dc/dist-log-prob dist val)
-        sel (:selection state)]
-    [val (-> state
-             (update :choices cm/set-value addr val)
-             (update :score #(mx/add % lp))
-             (cond-> (and sel (sel/selected? sel addr))
-               (update :weight #(mx/add % lp))))]))
+              (cm/get-value old-choice))]
+    (when (nil? val)
+      (throw (ex-info (str "project: address not found in previous trace choices. "
+                           "Cannot replay a value for an address that was never sampled.")
+                      {})))
+    (let [lp (dc/dist-log-prob dist val)
+          sel (:selection state)]
+      [val (-> state
+               (update :choices cm/set-value addr val)
+               (update :score mx/add lp)
+               (cond-> (and sel (sel/selected? sel addr))
+                 (update :weight mx/add lp)))])))
 
 ;; ---------------------------------------------------------------------------
 ;; Batched state transitions (vectorized: [N]-shaped values)
@@ -180,7 +180,7 @@
     [value (-> state
                (assoc :key k1)
                (update :choices cm/set-value addr value)
-               (update :score #(mx/add % lp)))]))
+               (update :score mx/add lp))]))
 
 (defn batched-generate-transition
   "Pure: constrained sites use scalar observation (broadcasts into [N] score),
@@ -193,8 +193,8 @@
             lp (dc/dist-log-prob dist value)]
         [value (-> state
                    (update :choices cm/set-value addr value)
-                   (update :score #(mx/add % lp))
-                   (update :weight #(mx/add % lp)))])
+                   (update :score mx/add lp)
+                   (update :weight mx/add lp))])
       (batched-simulate-transition state addr dist))))
 
 (defn batched-update-transition
@@ -212,8 +212,8 @@
             old-lp (if old-val (dc/dist-log-prob dist old-val) ZERO)]
         [new-val (-> state
                      (update :choices cm/set-value addr new-val)
-                     (update :score #(mx/add % new-lp))
-                     (update :weight #(mx/add % (mx/subtract new-lp old-lp)))
+                     (update :score mx/add new-lp)
+                     (update :weight mx/add (mx/subtract new-lp old-lp))
                      (cond->
                       old-val (update :discard cm/set-value addr old-val)))])
 
@@ -223,7 +223,7 @@
             lp (dc/dist-log-prob dist val)]
         [val (-> state
                  (update :choices cm/set-value addr val)
-                 (update :score #(mx/add % lp)))])
+                 (update :score mx/add lp))])
 
       ;; New address: sample [N] fresh values
       :else (batched-simulate-transition state addr dist))))
@@ -244,14 +244,14 @@
         [new-val (-> state
                      (assoc :key k1)
                      (update :choices cm/set-value addr new-val)
-                     (update :score #(mx/add % new-lp))
-                     (update :weight #(mx/add % (mx/subtract new-lp old-lp))))])
+                     (update :score mx/add new-lp)
+                     (update :weight mx/add (mx/subtract new-lp old-lp)))])
       ;; Not selected: keep old [N]-shaped values
       (let [val (cm/get-value old-choice)
             lp (dc/dist-log-prob dist val)]
         [val (-> state
                  (update :choices cm/set-value addr val)
-                 (update :score #(mx/add % lp)))]))))
+                 (update :score mx/add lp))]))))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure helpers used by runtime.cljs
@@ -262,11 +262,11 @@
   [state addr sub-result]
   (-> state
       (update :choices cm/set-submap addr (:choices sub-result))
-      (update :score (fn [sc] (mx/add sc (:score sub-result))))
+      (update :score mx/add (:score sub-result))
       (update :splice-scores (fn [ss] (assoc (or ss {}) addr (:score sub-result))))
       (cond->
        (and (contains? state :weight) (:weight sub-result))
-        (update :weight (fn [w] (mx/add w (:weight sub-result))))
+        (update :weight mx/add (:weight sub-result))
 
         (:discard sub-result)
         (update :discard cm/set-submap addr (:discard sub-result))

--- a/src/genmlx/inference/adev.cljs
+++ b/src/genmlx/inference/adev.cljs
@@ -273,7 +273,12 @@
       (if (>= i iterations)
         {:params params :loss-history (persistent! losses)}
         (let [key (rng/fresh-key)
-              bl (when baseline (mx/scalar baseline))
+              ;; Always pass a concrete scalar (never nil): bl is forwarded as a
+              ;; value-and-grad input arg, and a nil/null there fails NAPI MxArray
+              ;; recovery. baseline=0.0 is identity in vadev-surrogate
+              ;; (stop_gradient(costs - 0) = stop_gradient(costs)), so this is
+              ;; equivalent to "no baseline" on the first iteration.
+              bl (mx/scalar (or baseline 0.0))
               [loss grad] (mx/tidy-run
                             #(grad-fn params key bl)
                             (fn [[l g]] [l g]))

--- a/src/genmlx/inference/analytical.cljs
+++ b/src/genmlx/inference/analytical.cljs
@@ -26,11 +26,10 @@
    the dispatch map before falling through to base-transition."
   [base-transition dispatch-map]
   (fn [state addr dist]
-    (if-let [handler-fn (get dispatch-map (:type dist))]
-      ;; Handler can return nil to signal "not my address" — fall through
-      (or (handler-fn state addr dist)
-          (base-transition state addr dist))
-      (base-transition state addr dist))))
+    ;; Handler can return nil to signal "not my address" — fall through
+    (or (when-let [handler-fn (get dispatch-map (:type dist))]
+          (handler-fn state addr dist))
+        (base-transition state addr dist))))
 
 (defn compose-middleware
   "Compose multiple dispatch maps into a single transition.

--- a/src/genmlx/inference/compiled_gradient.cljs
+++ b/src/genmlx/inference/compiled_gradient.cljs
@@ -149,30 +149,28 @@
         objective
         (fn [params]
           ;; params affects init-state (simple case: params IS init-state)
-          (let [init-n (mx/broadcast-to params [particles])
-                result
-                (loop [t 0
-                       current-state init-n
-                       log-ml (mx/scalar 0.0)]
-                  (if (>= t T)
-                    log-ml
-                    (let [obs-t (nth obs-vec t)
-                          noise-t (mx/index extend-noise t)
-                          kernel-args [(mx/ensure-array t) current-state]
-                          {:keys [obs-log-prob values-map retval]}
-                          (extend-fn noise-t kernel-args obs-t)
-                          new-state (or retval (get values-map (first all-addrs)))
-                          ;; Log-ML increment
-                          ml-inc (mx/subtract (mx/logsumexp obs-log-prob)
-                                              (mx/scalar (js/Math.log particles)))
-                          ;; Soft-resample state (differentiable)
-                          gumbel-t (mx/index gumbel-noise t)
-                          resampled-state (dr/gumbel-softmax-1d
-                                            new-state obs-log-prob
-                                            gumbel-t tau-arr)]
-                      (recur (inc t) resampled-state
-                             (mx/add log-ml ml-inc)))))]
-            result))
+          (let [init-n (mx/broadcast-to params [particles])]
+            (loop [t 0
+                   current-state init-n
+                   log-ml (mx/scalar 0.0)]
+              (if (>= t T)
+                log-ml
+                (let [obs-t (nth obs-vec t)
+                      noise-t (mx/index extend-noise t)
+                      kernel-args [(mx/ensure-array t) current-state]
+                      {:keys [obs-log-prob values-map retval]}
+                      (extend-fn noise-t kernel-args obs-t)
+                      new-state (or retval (get values-map (first all-addrs)))
+                      ;; Log-ML increment
+                      ml-inc (mx/subtract (mx/logsumexp obs-log-prob)
+                                          (mx/scalar (js/Math.log particles)))
+                      ;; Soft-resample state (differentiable)
+                      gumbel-t (mx/index gumbel-noise t)
+                      resampled-state (dr/gumbel-softmax-1d
+                                        new-state obs-log-prob
+                                        gumbel-t tau-arr)]
+                  (recur (inc t) resampled-state
+                         (mx/add log-ml ml-inc)))))))
         vag (mx/value-and-grad objective)
         [value grad] (vag model-params)]
     (mx/materialize! value grad)

--- a/src/genmlx/inference/conjugate.cljs
+++ b/src/genmlx/inference/conjugate.cljs
@@ -246,7 +246,7 @@
   [target-addr]
   {:nn-prior
    (fn [state addr dist]
-     (if (= addr target-addr)
+     (when (= addr target-addr)
        (let [{:keys [prior-mean prior-std]} (:params dist)
              posterior (or (get-in state [:conjugate-posteriors addr])
                           {:mean prior-mean
@@ -254,13 +254,12 @@
          [(:mean posterior)
           (-> state
               (assoc-in [:conjugate-posteriors addr] posterior)
-              (update :choices cm/set-value addr (:mean posterior)))])
-       nil))
+              (update :choices cm/set-value addr (:mean posterior)))])))
 
    :nn-obs
    (fn [state addr dist]
      (let [{:keys [prior-addr obs-std mask]} (:params dist)]
-       (if (= prior-addr target-addr)
+       (when (= prior-addr target-addr)
          (let [posterior (get-in state [:conjugate-posteriors target-addr])
                constraint (cm/get-submap (:constraints state) addr)
                obs (cm/get-value constraint)
@@ -270,8 +269,7 @@
                     (assoc-in [:conjugate-posteriors target-addr] posterior)
                     (update :choices cm/set-value addr obs)
                     (update :conjugate-ll
-                      #(mx/add (or % (mx/zeros (ll-shape (:mean posterior)))) ll)))])
-         nil)))})
+                      #(mx/add (or % (mx/zeros (ll-shape (:mean posterior)))) ll)))]))))})
 
 (defn make-bb-dispatch
   "Create Beta-Binomial conjugate dispatch map.
@@ -282,7 +280,7 @@
   [target-addr]
   {:bb-prior
    (fn [state addr dist]
-     (if (= addr target-addr)
+     (when (= addr target-addr)
        (let [{:keys [alpha beta-param]} (:params dist)
              posterior (or (get-in state [:conjugate-posteriors addr])
                           {:alpha alpha :beta beta-param})
@@ -292,13 +290,12 @@
          [post-mean
           (-> state
               (assoc-in [:conjugate-posteriors addr] posterior)
-              (update :choices cm/set-value addr post-mean))])
-       nil))
+              (update :choices cm/set-value addr post-mean))])))
 
    :bb-obs
    (fn [state addr dist]
      (let [{:keys [prior-addr mask]} (:params dist)]
-       (if (= prior-addr target-addr)
+       (when (= prior-addr target-addr)
          (let [posterior (get-in state [:conjugate-posteriors target-addr])
                constraint (cm/get-submap (:constraints state) addr)
                obs (cm/get-value constraint)
@@ -307,8 +304,7 @@
                     (assoc-in [:conjugate-posteriors target-addr] posterior)
                     (update :choices cm/set-value addr obs)
                     (update :conjugate-ll
-                      #(mx/add (or % (mx/zeros (ll-shape (:alpha posterior)))) ll)))])
-         nil)))})
+                      #(mx/add (or % (mx/zeros (ll-shape (:alpha posterior)))) ll)))]))))})
 
 (defn make-gp-dispatch
   "Create Gamma-Poisson conjugate dispatch map.
@@ -319,7 +315,7 @@
   [target-addr]
   {:gp-prior
    (fn [state addr dist]
-     (if (= addr target-addr)
+     (when (= addr target-addr)
        (let [{:keys [shape-param rate-param]} (:params dist)
              posterior (or (get-in state [:conjugate-posteriors addr])
                           {:shape shape-param :rate rate-param})
@@ -328,13 +324,12 @@
          [post-mean
           (-> state
               (assoc-in [:conjugate-posteriors addr] posterior)
-              (update :choices cm/set-value addr post-mean))])
-       nil))
+              (update :choices cm/set-value addr post-mean))])))
 
    :gp-obs
    (fn [state addr dist]
      (let [{:keys [prior-addr mask]} (:params dist)]
-       (if (= prior-addr target-addr)
+       (when (= prior-addr target-addr)
          (let [posterior (get-in state [:conjugate-posteriors target-addr])
                constraint (cm/get-submap (:constraints state) addr)
                obs (cm/get-value constraint)
@@ -343,8 +338,7 @@
                     (assoc-in [:conjugate-posteriors target-addr] posterior)
                     (update :choices cm/set-value addr obs)
                     (update :conjugate-ll
-                      #(mx/add (or % (mx/zeros (ll-shape (:shape posterior)))) ll)))])
-         nil)))})
+                      #(mx/add (or % (mx/zeros (ll-shape (:shape posterior)))) ll)))]))))})
 
 ;; ---------------------------------------------------------------------------
 ;; High-level API

--- a/src/genmlx/inference/differentiable_resample.cljs
+++ b/src/genmlx/inference/differentiable_resample.cljs
@@ -32,7 +32,8 @@
         ;; Clamp to (eps, 1-eps) for numerical stability
         eps (mx/scalar 1e-7)
         clamped (mx/clip uniforms eps (mx/scalar (- 1.0 1e-7)))]
-    (mx/negative (mx/log (mx/negative (mx/log clamped))))))
+    ;; Gumbel(0,1) = -log(-log(clamped))
+    (-> clamped mx/log mx/negative mx/log mx/negative)))
 
 ;; =========================================================================
 ;; Mode 1: Gumbel-top-k (hard, exact, non-differentiable)

--- a/src/genmlx/inference/ekf_nd.cljs
+++ b/src/genmlx/inference/ekf_nd.cljs
@@ -142,10 +142,11 @@
                    (fn [cs other]
                      (let [k (cov-key addrs addr other)
                            p (get cs k)]
-                       (if (= addr other)
-                         (assoc cs k (mx/add (mx/multiply A (mx/multiply A p))
-                                             (mx/multiply q q)))
-                         (assoc cs k (mx/multiply A p)))))
+                       (assoc cs k
+                              (if (= addr other)
+                                (mx/add (mx/multiply A (mx/multiply A p))
+                                        (mx/multiply q q))
+                                (mx/multiply A p)))))
                    covs addrs)]
     [f-z0 new-means new-covs]))
 

--- a/src/genmlx/inference/enumerate.cljs
+++ b/src/genmlx/inference/enumerate.cljs
@@ -107,14 +107,12 @@
     (into {}
       (map (fn [addr]
              [addr
-              (let [marginal-map
-                    (reduce (fn [acc {:keys [choices prob]}]
-                              (let [v (cm/get-choice choices [addr])
-                                    v-key (mx/item v)]
-                                (update acc v-key (fnil + 0.0) prob)))
-                            {}
-                            joint)]
-                marginal-map)])
+              (reduce (fn [acc {:keys [choices prob]}]
+                        (let [v (cm/get-choice choices [addr])
+                              v-key (mx/item v)]
+                          (update acc v-key (fnil + 0.0) prob)))
+                      {}
+                      joint)])
            addrs)))))
 
 (defn enumerate-marginal-likelihood

--- a/src/genmlx/inference/exact.cljs
+++ b/src/genmlx/inference/exact.cljs
@@ -438,6 +438,11 @@
 ;; Conditioning and joint marginals (Phase 2)
 ;; ---------------------------------------------------------------------------
 
+(defn- ->num
+  "Coerce an MLX scalar to a JS number, leaving plain numbers untouched."
+  [v]
+  (if (mx/array? v) (mx/item v) v))
+
 (defn condition-on
   "Condition the joint on addr = value. Removes that axis and renormalizes.
 
@@ -459,7 +464,7 @@
         ndim (count axes)
         tensor-pos (dim->pos ndim (:dim target))
         ;; Find support index matching value
-        value-num (if (mx/array? value) (mx/item value) value)
+        value-num (->num value)
         idx (first (keep-indexed
                     (fn [i sv] (when (= (mx/item sv) value-num) i))
                     (:support target)))

--- a/src/genmlx/inference/fisher.cljs
+++ b/src/genmlx/inference/fisher.cljs
@@ -65,12 +65,11 @@
   "Cholesky decomposition with increasing damping fallback.
    Returns {:L cholesky-factor, :added-damping scalar} or nil."
   [a D schedule]
-  (reduce (fn [_ tau]
-            (let [a-damped (if (zero? tau) a (mx/add a (mx/multiply (mx/scalar tau) (mx/eye D))))
-                  L (try-cholesky a-damped)]
-              (when L (reduced {:L L :added-damping tau}))))
-          nil
-          schedule))
+  (some (fn [tau]
+          (let [a-damped (if (zero? tau) a (mx/add a (mx/multiply (mx/scalar tau) (mx/eye D))))]
+            (when-let [L (try-cholesky a-damped)]
+              {:L L :added-damping tau})))
+        schedule))
 
 (defn- try-solve
   "Attempt solve, return solution or nil on failure."
@@ -85,12 +84,10 @@
   "Solve F·d = b with increasing damping fallback.
    Falls back to b (steepest descent) if all attempts fail, with a warning."
   [F b D schedule]
-  (or (reduce (fn [_ tau]
-                (let [F-damped (if (zero? tau) F (mx/add F (mx/multiply (mx/scalar tau) (mx/eye D))))
-                      d (try-solve F-damped b)]
-                  (when d (reduced d))))
-              nil
-              schedule)
+  (or (some (fn [tau]
+              (let [F-damped (if (zero? tau) F (mx/add F (mx/multiply (mx/scalar tau) (mx/eye D))))]
+                (try-solve F-damped b)))
+            schedule)
       (do (js/console.warn "Fisher: robust-solve failed, falling back to steepest descent")
           b)))
 

--- a/src/genmlx/inference/hmm_forward.cljs
+++ b/src/genmlx/inference/hmm_forward.cljs
@@ -83,12 +83,8 @@
   ;; log-alpha: [P,K] -> expand to [P,K,1]
   ;; log-trans: [K,K] -> broadcast [1,K,K]
   ;; sum:       [P,K,K] -> logsumexp over axis -2 -> [P,K]
-  (let [ndim (count (mx/shape log-alpha))
-        expanded (if (= ndim 1)
-                   ;; [K] -> [K,1]
-                   (mx/expand-dims log-alpha -1)
-                   ;; [P,K] -> [P,K,1]
-                   (mx/expand-dims log-alpha -1))
+  (let [;; [K] -> [K,1], [P,K] -> [P,K,1]
+        expanded (mx/expand-dims log-alpha -1)
         ;; expanded: [...,K,1] + log-trans: [K,K] -> [...,K,K]
         joint (mx/add expanded log-trans)]
     ;; logsumexp over the "from" axis (second-to-last)
@@ -109,9 +105,8 @@
         norm-alpha (mx/subtract unnorm (mx/expand-dims ll-raw -1))
         ;; Masked: if mask=0, keep old belief, ll=0
         ndim-mask (count (mx/shape mask))
-        mask-expanded (if (zero? ndim-mask)
-                        mask
-                        (mx/expand-dims mask -1))
+        mask-expanded (cond-> mask
+                        (pos? ndim-mask) (mx/expand-dims -1))
         new-alpha (mx/add (mx/multiply mask-expanded norm-alpha)
                           (mx/multiply (mx/subtract (mx/scalar 1.0) mask-expanded)
                                        log-alpha))
@@ -173,16 +168,16 @@
      (let [{:keys [log-emission-probs mask]} (:params dist)
            log-alpha (:hmm-belief state)
            n (:hmm-n state)
-           {:keys [log-alpha ll]} (hmm-update log-alpha log-emission-probs mask)]
-       ;; Store constrained observation in choices
-       (let [constraint (cm/get-submap (:constraints state) addr)
-             obs (when (cm/has-value? constraint) (cm/get-value constraint))]
-         [(or obs (mx/scalar 0.0))
-          (-> state
-              (assoc :hmm-belief log-alpha)
-              (cond-> obs (update :choices cm/set-value addr obs))
-              (update :hmm-ll
-                #(mx/add (or % (mx/zeros (if n [n] []))) ll)))])))})
+           {:keys [log-alpha ll]} (hmm-update log-alpha log-emission-probs mask)
+           ;; Store constrained observation in choices
+           constraint (cm/get-submap (:constraints state) addr)
+           obs (when (cm/has-value? constraint) (cm/get-value constraint))]
+       [(or obs (mx/scalar 0.0))
+        (-> state
+            (assoc :hmm-belief log-alpha)
+            (cond-> obs (update :choices cm/set-value addr obs))
+            (update :hmm-ll
+              #(mx/add (or % (mx/zeros (if n [n] []))) ll)))]))})
 
 (defn make-hmm-transition
   "Handler middleware: wraps generate-transition for HMM forward algorithm.

--- a/src/genmlx/inference/importance.cljs
+++ b/src/genmlx/inference/importance.cljs
@@ -129,17 +129,17 @@
         (importance-sampling {:samples particles :key key} model args observations)
         ;; Normalize weights via log-softmax
         {:keys [probs]} (u/normalize-log-weights log-weights)
-        key (or key (rng/fresh-key))]
+        key (or key (rng/fresh-key))
+        keys (rng/split-n key samples)]
     ;; Resample
-    (let [keys (rng/split-n key samples)]
-      (mapv (fn [ki]
-              (let [u (mx/realize (rng/uniform ki []))
-                    result (reduce (fn [cumsum [i p]]
-                                     (let [cumsum' (+ cumsum p)]
-                                       (if (>= cumsum' u)
-                                         (reduced (nth traces i))
-                                         cumsum')))
-                                   0.0
-                                   (map-indexed vector probs))]
-                (if (number? result) (last traces) result)))
-            keys))))
+    (mapv (fn [ki]
+            (let [u (mx/realize (rng/uniform ki []))
+                  result (reduce (fn [cumsum [i p]]
+                                   (let [cumsum' (+ cumsum p)]
+                                     (if (>= cumsum' u)
+                                       (reduced (nth traces i))
+                                       cumsum')))
+                                 0.0
+                                 (map-indexed vector probs))]
+              (if (number? result) (last traces) result)))
+          keys)))

--- a/src/genmlx/inference/kalman.cljs
+++ b/src/genmlx/inference/kalman.cljs
@@ -139,8 +139,8 @@
    observations: [{:obs :base-mean :loading :noise-std :mask} ...]
    Returns {:belief updated, :ll per-element total LL for this step}."
   [belief {:keys [transition-coeff process-noise]} observations]
-  (let [pred (kalman-predict belief transition-coeff process-noise)]
-    (kalman-sequential-update pred observations)))
+  (-> (kalman-predict belief transition-coeff process-noise)
+      (kalman-sequential-update observations)))
 
 ;; ---------------------------------------------------------------------------
 ;; Handler middleware (Level 2)

--- a/src/genmlx/inference/mcmc.cljs
+++ b/src/genmlx/inference/mcmc.cljs
@@ -918,12 +918,9 @@
                       block-k (min k (js/Math.ceil (/ remaining n-chains)))
                       ;; Pool: for each step k, take all N chains
                       block-samples
-                      (loop [ki 0, s []]
-                        (if (>= ki block-k) s
-                            (let [step-k (nth traj-js ki)]
-                              (recur (inc ki)
-                                     (into s (map (fn [n] (nth step-k n))
-                                                  (range n-chains)))))))
+                      (vec (mapcat (fn [step-k]
+                                     (map (fn [n] (nth step-k n)) (range n-chains)))
+                                   (take block-k traj-js)))
                       ;; Last params for next block
                       p' (mx/array (nth traj-js (dec k)))]
                   (when (zero? (mod b 10)) (mx/clear-cache!))
@@ -1057,9 +1054,7 @@
   (let [gf (:gen-fn current-trace)
         ;; For each candidate value, compute model score
         log-scores (mapv (fn [val]
-                           (let [constraint (cm/choicemap addr val)
-                                 {:keys [trace]} (p/update gf current-trace constraint)]
-                             (:score trace)))
+                           (:score (:trace (p/update gf current-trace (cm/choicemap addr val)))))
                          support-values)
         ;; Normalize via log-softmax
         log-scores-arr (mx/array (mapv mx/realize log-scores))
@@ -1395,8 +1390,7 @@
     (loop [eps 1.0, i 0]
       (if (>= i 100) eps
           (let [a (test-accept eps)]
-            (if (or (and (pos? dir) (< a 0.5))
-                    (and (neg? dir) (> a 0.5)))
+            (if (neg? (* dir (- a 0.5)))
               eps
               (recur (* eps (js/Math.pow 2.0 dir)) (inc i))))))))
 
@@ -2010,8 +2004,7 @@
     (loop [eps 1.0, i 0]
       (if (>= i 100) eps
           (let [a (test-accept eps)]
-            (if (or (and (pos? dir) (< a 0.5))
-                    (and (neg? dir) (> a 0.5)))
+            (if (neg? (* dir (- a 0.5)))
               eps
               (recur (* eps (js/Math.pow 2.0 dir)) (inc i))))))))
 

--- a/src/genmlx/inference/smcp3.cljs
+++ b/src/genmlx/inference/smcp3.cljs
@@ -33,9 +33,8 @@
   [model args observations proposal-gf particles key]
   (let [model (dyn/auto-key model)
         proposal-gf (when proposal-gf (dyn/auto-key proposal-gf))
-        keys (rng/split-n (rng/ensure-key key) particles)
         results (mapv
-                  (fn [ki]
+                  (fn [_]
                     (if proposal-gf
                       ;; Use proposal to generate initial choices
                       (let [proposal-result (p/propose proposal-gf [])
@@ -53,7 +52,7 @@
                       (let [r (p/generate model args observations)]
                         (mx/materialize! (:weight r) (:score (:trace r)))
                         r)))
-                  keys)
+                  (range particles))
         traces (mapv :trace results)
         log-weights (mapv :weight results)
         w-arr (u/materialize-weights log-weights)
@@ -99,9 +98,8 @@
                                 (vec (repeat particles (mx/scalar 0.0)))])
                              [traces log-weights])
         ;; Apply forward kernel to each particle via edit
-        step-keys (rng/split-n-or-nils step-key particles)
         results (mapv
-                  (fn [trace ki]
+                  (fn [trace]
                     (if forward-kernel
                       ;; Use proposal edit
                       (let [edit-req (if backward-kernel
@@ -117,7 +115,7 @@
                       (let [result (p/update (:gen-fn trace) trace observations)]
                         (mx/materialize! (:weight result))
                         {:trace (:trace result) :weight (:weight result)})))
-                  traces' step-keys)
+                  traces')
         new-traces (mapv :trace results)
         update-weights (mapv :weight results)
         new-weights (mapv mx/add weights' update-weights)
@@ -176,21 +174,17 @@
          :log-ml-estimate log-ml}
         (let [obs-t (nth obs-vec t)
               [step-key next-key] (rng/split-or-nils rk)
-              _ (when (and (pos? t) (zero? (mod t 10))) (mx/sweep-dead-arrays!) (mx/clear-cache!))]
-          (if (zero? t)
-            ;; Init step
-            (let [{:keys [traces log-weights log-ml-increment]}
-                  (smcp3-init model args obs-t init-proposal particles step-key)]
-              (when callback
-                (callback {:step t :ess (u/compute-ess log-weights)}))
-              (recur (inc t) traces log-weights
-                     (mx/add log-ml log-ml-increment) next-key))
-            ;; Subsequent steps
-            (let [{:keys [traces log-weights log-ml-increment ess resampled?]}
-                  (smcp3-step traces log-weights model obs-t
-                              forward-kernel backward-kernel
-                              particles ess-threshold rejuvenation-fn step-key)]
-              (when callback
-                (callback {:step t :ess ess :resampled? resampled?}))
-              (recur (inc t) traces log-weights
-                     (mx/add log-ml log-ml-increment) next-key))))))))
+              _ (when (and (pos? t) (zero? (mod t 10))) (mx/sweep-dead-arrays!) (mx/clear-cache!))
+              {new-traces :traces new-weights :log-weights :keys [log-ml-increment]
+               :as result}
+              (if (zero? t)
+                (smcp3-init model args obs-t init-proposal particles step-key)
+                (smcp3-step traces log-weights model obs-t
+                            forward-kernel backward-kernel
+                            particles ess-threshold rejuvenation-fn step-key))]
+          (when callback
+            (callback (if (zero? t)
+                        {:step t :ess (u/compute-ess new-weights)}
+                        {:step t :ess (:ess result) :resampled? (:resampled? result)})))
+          (recur (inc t) new-traces new-weights
+                 (mx/add log-ml log-ml-increment) next-key))))))

--- a/src/genmlx/inference/util.cljs
+++ b/src/genmlx/inference/util.cljs
@@ -238,8 +238,7 @@
   (cond
     (mx/array? v) (vswap! arrays conj! v)
     (map? v) (doseq [[_ val] v] (walk-value-arrays val arrays))
-    (sequential? v) (doseq [item v] (walk-value-arrays item arrays))
-    :else nil))
+    (sequential? v) (doseq [item v] (walk-value-arrays item arrays))))
 
 (defn collect-trace-arrays
   "Collect all MLX arrays from a trace for bulk evaluation.
@@ -254,8 +253,7 @@
                   (when (mx/array? v) (vswap! arrays conj! v)))
                 (instance? cm/Node cm)
                 (doseq [[_ sub] (cm/-submaps cm)]
-                  (walk sub))
-                :else nil))]
+                  (walk sub))))]
       (when-let [choices (:choices trace)]
         (walk choices)))
     (when-let [s (:score trace)]

--- a/src/genmlx/inference/vi.cljs
+++ b/src/genmlx/inference/vi.cljs
@@ -35,10 +35,9 @@
                                            (mx/square diff-norm)))
         log-q (mx/sum log-q-per-dim [1])
         ;; log p for each sample via vmap
-        log-p-vals (vmapped-log-density samples)
-        ;; ELBO = mean(log_p - log_q)
-        elbo (mx/mean (mx/subtract log-p-vals log-q))]
-    elbo))
+        log-p-vals (vmapped-log-density samples)]
+    ;; ELBO = mean(log_p - log_q)
+    (mx/mean (mx/subtract log-p-vals log-q))))
 
 ;; ---------------------------------------------------------------------------
 ;; VI main

--- a/src/genmlx/learning.cljs
+++ b/src/genmlx/learning.cljs
@@ -129,7 +129,8 @@
               [new-params new-opt-st]
               (case optimizer
                 :sgd [(sgd-step params grad lr) nil]
-                :adam (adam-step params grad opt-st {:lr lr}))]
+                :adam (adam-step params grad opt-st {:lr lr})
+                (throw (ex-info "Unknown optimizer" {:optimizer optimizer})))]
           (when callback
             (callback {:iter i :loss loss-val :params new-params}))
           ;; Periodic resource cleanup — critical for models with large

--- a/src/genmlx/llm/backend.cljs
+++ b/src/genmlx/llm/backend.cljs
@@ -5,6 +5,11 @@
    This is Layer 0 of the LLM integration — everything above (token-transition
    handler, beam search, grammar constraints) builds on these functions."
   (:require ["@mlx-node/lm" :as mlx-lm :refer [ChatSession]]
+            ;; Qwen3Tokenizer is sourced from @mlx-node/core directly (it is a
+            ;; first-class core export). @mlx-node/lm's re-export of it was
+            ;; removed upstream (mlx-node #57); relying on it broke on a clean
+            ;; `tsc -b`. See bean genmlx-mwm4.
+            ["@mlx-node/core" :as mlx-core]
             [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
             [promesa.core :as p]))
@@ -23,7 +28,7 @@
   [model-path]
   (p/let [model (.loadModel mlx-lm model-path)
           model-type (.detectModelType mlx-lm model-path)
-          tokenizer (.fromPretrained (.-Qwen3Tokenizer mlx-lm)
+          tokenizer (.fromPretrained (.-Qwen3Tokenizer mlx-core)
                                      (str model-path "/tokenizer.json"))]
     {:model model
      :tokenizer tokenizer

--- a/src/genmlx/llm/bytes.cljs
+++ b/src/genmlx/llm/bytes.cljs
@@ -332,8 +332,7 @@
                                            (filter (fn [[ch _]]
                                                      (let [s (grammar/dfa-advance
                                                               dfa dfa-state ch)]
-                                                       (and (not= s :dead)
-                                                            (contains? alive s)))))
+                                                       (contains? alive s))))
                                            raw-lps)]
                        (if (empty? valid-lps)
                          bytes-acc

--- a/src/genmlx/llm/codegen.cljs
+++ b/src/genmlx/llm/codegen.cljs
@@ -137,22 +137,24 @@ Syntax: (fn [args] body), (let [bindings] body), (case val clauses default),
 (defn extract-code
   "Extract ClojureScript code from LLM output text."
   [text]
-  (if-not (seq text)
+  (cond
+    ;; Empty text
+    (not (seq text))
     ""
-    (cond
-      ;; Fenced code block
-      (re-find #"```(?:clojure|cljs|clojurescript|clj)?\s*\n" text)
-      (let [m (re-find #"```(?:clojure|cljs|clojurescript|clj)?\s*\n([\s\S]*?)```" text)]
-        (if m (str/trim (nth m 1)) ""))
 
-      ;; Starts with paren -- raw code
-      (str/starts-with? (str/trim text) "(")
-      (str/trim text)
+    ;; Fenced code block
+    (re-find #"```(?:clojure|cljs|clojurescript|clj)?\s*\n" text)
+    (let [m (re-find #"```(?:clojure|cljs|clojurescript|clj)?\s*\n([\s\S]*?)```" text)]
+      (if m (str/trim (nth m 1)) ""))
 
-      ;; Strip prefix to first paren
-      :else
-      (let [idx (str/index-of text "(")]
-        (if idx (subs text idx) "")))))
+    ;; Starts with paren -- raw code
+    (str/starts-with? (str/trim text) "(")
+    (str/trim text)
+
+    ;; Strip prefix to first paren
+    :else
+    (let [idx (str/index-of text "(")]
+      (if idx (subs text idx) ""))))
 
 ;; ============================================================
 ;; 7.5 Reader-constrained byte GF
@@ -211,16 +213,20 @@ Syntax: (fn [args] body), (let [bindings] body), (case val clauses default),
                                new-prefix (str prefix chosen-byte)
                                next-node (get-in trie-pos [:children chosen-byte])
                                new-acc (conj bytes-acc chosen-byte)]
-                           (if (= :complete status)
+                           (cond
+                             (= :complete status)
                              new-acc
-                             (if (bytes/trie-leaf? next-node)
-                               (recur (inc i) trie new-prefix
-                                      (bytes/logits->logprobs
-                                       (llm/forward-step model
-                                                         (bytes/commit-token-id next-node)))
-                                      new-acc)
-                               (recur (inc i) next-node new-prefix logprobs
-                                      new-acc))))))))
+
+                             (bytes/trie-leaf? next-node)
+                             (recur (inc i) trie new-prefix
+                                    (bytes/logits->logprobs
+                                     (llm/forward-step model
+                                                       (bytes/commit-token-id next-node)))
+                                    new-acc)
+
+                             :else
+                             (recur (inc i) next-node new-prefix logprobs
+                                    new-acc)))))))
                  (finally
                    (llm/reset-cache! model))))))))))
 

--- a/src/genmlx/llm/grammar.cljs
+++ b/src/genmlx/llm/grammar.cljs
@@ -267,12 +267,11 @@
                       (let [known? (contains? (:state-map dfa) target)
                             id (or (get-in dfa [:state-map target])
                                    (:next-id dfa))
-                            dfa (cond-> dfa
-                                  (not known?)
-                                  (-> (assoc-in [:state-map target] id)
-                                      (update :next-id inc))
-                                  true
-                                  (assoc-in [:transitions [current ch]] target))]
+                            dfa (-> (cond-> dfa
+                                       (not known?)
+                                       (-> (assoc-in [:state-map target] id)
+                                           (update :next-id inc)))
+                                     (assoc-in [:transitions [current ch]] target))]
                         [dfa (if known? wl (conj wl target))]))))
                 [dfa worklist]
                 chars)]

--- a/src/genmlx/llm/msa.cljs
+++ b/src/genmlx/llm/msa.cljs
@@ -126,16 +126,15 @@
   (let [lines (str/split-lines (str/trim text))]
     (reduce
      (fn [acc var-kw]
-       (let [var-name (name var-kw)
-             line (some #(when (str/starts-with? (str/trim %) var-name) %)
-                        lines)]
-         (if-not line
-           acc
+       (let [var-name (name var-kw)]
+         (if-let [line (some #(when (str/starts-with? (str/trim %) var-name) %)
+                             lines)]
            (let [expr (-> line
                           (str/replace (re-pattern (str "^\\s*" var-name "\\s*[=:]\\s*")) "")
                           str/trim
                           (str/replace #"[,;]\s*$" ""))]
-             (assoc acc var-kw expr)))))
+             (assoc acc var-kw expr))
+           acc)))
      {}
      variables)))
 

--- a/src/genmlx/llm/vision.cljs
+++ b/src/genmlx/llm/vision.cljs
@@ -85,7 +85,6 @@
         str/trim
         (str/split #"\s+")
         first
-        (or "")
         str/lower-case
         (str/replace #"[^a-z]" ""))))
 

--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -79,11 +79,14 @@
     [coll]))
 
 (defn- infer-shape
-  "Infer shape from nested collection. Returns [flat-data shape-vec]."
+  "Infer shape from nested collection. Returns [flat-data shape-vec].
+   Handles JS arrays (#js [...]) as well as Clojure collections — mirrors
+   flatten-nested's predicates so the dtype/shape arities of `array` shape
+   JS-array inputs correctly (not as 0-dim scalars)."
   [coll]
-  (if (or (vector? coll) (seq? coll) (sequential? coll))
+  (if (or (vector? coll) (seq? coll) (sequential? coll) (js/Array.isArray coll))
     (let [first-el (first coll)]
-      (if (or (vector? first-el) (seq? first-el) (sequential? first-el))
+      (if (or (vector? first-el) (seq? first-el) (sequential? first-el) (js/Array.isArray first-el))
         (let [[_ inner-shape] (infer-shape first-el)]
           [(flatten-nested coll) (into [(count coll)] inner-shape)])
         [(vec coll) [(count coll)]]))
@@ -358,13 +361,13 @@
   ([v]
    (cond
      (array? v) v
-     (or (vector? v) (seq? v) (sequential? v))
+     ;; JS arrays (#js [...]) included so NESTED JS arrays shape correctly via
+     ;; infer-shape, not just flat ones. The old flat-only (js/Array.isArray v)
+     ;; branch coerced #js [#js [..] #js [..]] to NaN — see infer-shape.
+     (or (vector? v) (seq? v) (sequential? v) (js/Array.isArray v))
      (let [[flat-data sh] (infer-shape v)
            f32 (js/Float32Array.from (clj->js flat-data))]
        (.fromFloat32 c f32 (clj->js sh)))
-     (js/Array.isArray v)
-     (let [f32 (js/Float32Array.from v)]
-       (.fromFloat32 c f32 #js [(.-length f32)]))
      :else (scalar v)))
   ([v shape-or-dtype]
    (if (or (vector? shape-or-dtype) (seq? shape-or-dtype))

--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -305,12 +305,11 @@
   "Ensure indices are integer dtype (int32). MLX take/gather crashes with
    float32 indices — Metal kernels expect integer index types."
   [indices]
-  (if (number? indices)
-    (scalar indices int32)
+  (cond
+    (number? indices)            (scalar indices int32)
     ;; int32 is dtype code 1; float32 is code 0. Cast non-int to int32.
-    (if (= (.dtypeOf c indices) 1)
-      indices
-      (.astype indices int32))))
+    (= (.dtypeOf c indices) 1)   indices
+    :else                        (.astype indices int32)))
 
 (defn take-idx
   ([a indices]
@@ -615,8 +614,7 @@
 (defn tidy [f]
   (swap! tidy-depth inc)
   (try
-    (let [result (f)]
-      result)
+    (f)
     (finally
       (swap! tidy-depth dec)
       (when (zero? @tidy-depth)

--- a/src/genmlx/nn.cljs
+++ b/src/genmlx/nn.cljs
@@ -24,6 +24,11 @@
 (declare make-linear-rebuild make-layer-norm-rebuild make-embedding-rebuild
          make-sequential-rebuild rebuild-with-params)
 
+(defn- apply-layers
+  "Run x through each layer's :forward in order."
+  [x layers]
+  (reduce (fn [acc layer] ((:forward layer) acc)) x layers))
+
 ;; ---------------------------------------------------------------------------
 ;; Layer constructors
 ;; ---------------------------------------------------------------------------
@@ -59,7 +64,7 @@
                                     (:params layer)))
                              (map-indexed vector layers)))]
     {:params all-params
-     :forward (fn [x] (reduce (fn [acc layer] ((:forward layer) acc)) x layers))
+     :forward (fn [x] (apply-layers x layers))
      :type :sequential
      :layers (vec layers)
      :rebuild (make-sequential-rebuild (vec layers))}))
@@ -184,26 +189,26 @@
 
 (defn- make-sequential-rebuild [child-layers]
   (fn rebuild [new-params]
-    (let [rebuilt (vec (map-indexed
-                         (fn [i child]
-                           (let [prefix (str i "/")
-                                 ;; Look up each child's param keys via the parent's
-                                 ;; prefixed keys. Uses direct `get` on new-params
-                                 ;; to preserve traced array identity for autograd.
-                                 child-param-keys (keys (:params child))
-                                 child-params (reduce
-                                                (fn [acc ck]
-                                                  (let [pk (keyword (str prefix (name ck)))]
-                                                    (if-let [v (get new-params pk)]
-                                                      (assoc acc ck v)
-                                                      acc)))
-                                                {} child-param-keys)]
-                             (if (empty? child-params)
-                               child
-                               (rebuild-with-params child child-params))))
-                         child-layers))]
+    (let [rebuilt (mapv
+                    (fn [i child]
+                      (let [prefix (str i "/")
+                            ;; Look up each child's param keys via the parent's
+                            ;; prefixed keys. Uses direct `get` on new-params
+                            ;; to preserve traced array identity for autograd.
+                            child-param-keys (keys (:params child))
+                            child-params (reduce
+                                           (fn [acc ck]
+                                             (let [pk (keyword (str prefix (name ck)))]
+                                               (if-let [v (get new-params pk)]
+                                                 (assoc acc ck v)
+                                                 acc)))
+                                           {} child-param-keys)]
+                        (if (empty? child-params)
+                          child
+                          (rebuild-with-params child child-params))))
+                    (range) child-layers)]
       {:params new-params
-       :forward (fn [x] (reduce (fn [acc l] ((:forward l) acc)) x rebuilt))
+       :forward (fn [x] (apply-layers x rebuilt))
        :type :sequential
        :layers rebuilt
        :rebuild (make-sequential-rebuild rebuilt)})))
@@ -318,20 +323,24 @@
             b2cs (mx/scalar (- 1.0 beta2))
             lrs  (mx/scalar lr)
             epss (mx/scalar eps)]
-        (reduce (fn [acc [k p]]
-                  (let [g  (get grads k)
-                        mk (mx/add (mx/multiply b1s (get m k (mx/zeros (mx/shape p))))
-                                   (mx/multiply b1cs g))
-                        vk (mx/add (mx/multiply b2s (get v k (mx/zeros (mx/shape p))))
-                                   (mx/multiply b2cs (mx/square g)))
-                        mh (mx/divide mk (mx/scalar (- 1.0 (js/Math.pow beta1 t))))
-                        vh (mx/divide vk (mx/scalar (- 1.0 (js/Math.pow beta2 t))))
-                        np (mx/subtract p (mx/divide (mx/multiply lrs mh)
-                                                     (mx/add (mx/sqrt vh) epss)))]
-                    (swap! state assoc-in [:m k] mk)
-                    (swap! state assoc-in [:v k] vk)
-                    (assoc acc k np)))
-                {} params)))))
+        (let [{:keys [params m' v']}
+              (reduce (fn [acc [k p]]
+                        (let [g  (get grads k)
+                              mk (mx/add (mx/multiply b1s (get m k (mx/zeros (mx/shape p))))
+                                         (mx/multiply b1cs g))
+                              vk (mx/add (mx/multiply b2s (get v k (mx/zeros (mx/shape p))))
+                                         (mx/multiply b2cs (mx/square g)))
+                              mh (mx/divide mk (mx/scalar (- 1.0 (js/Math.pow beta1 t))))
+                              vh (mx/divide vk (mx/scalar (- 1.0 (js/Math.pow beta2 t))))
+                              np (mx/subtract p (mx/divide (mx/multiply lrs mh)
+                                                           (mx/add (mx/sqrt vh) epss)))]
+                          (-> acc
+                              (assoc-in [:params k] np)
+                              (assoc-in [:m' k] mk)
+                              (assoc-in [:v' k] vk))))
+                      {:params {} :m' m :v' v} params)]
+          (swap! state assoc :m m' :v v')
+          params)))))
 
 (defn optimizer
   "Create an optimizer function: (fn [params grads] -> new-params).

--- a/src/genmlx/program.cljs
+++ b/src/genmlx/program.cljs
@@ -242,9 +242,7 @@
                    (if (>= i n-particles)
                      ws
                      (let [w (try
-                               (let [{:keys [weight]} (p/generate gf [transitions] constraints)
-                                     v (mx/item weight)]
-                                 v)
+                               (mx/item (:weight (p/generate gf [transitions] constraints)))
                                (catch :default _ ##-Inf))]
                        (when (zero? (mod (inc i) 10))
                          (mx/force-gc!))

--- a/src/genmlx/schema.cljs
+++ b/src/genmlx/schema.cljs
@@ -282,25 +282,24 @@
   "Infer which gen-fn parameter determines the loop count.
    Returns index into params vector, or -1."
   [count-form params]
-  (cond
-    (integer? count-form)
-    -1
+  (let [pv (vec params)]
+    (cond
+      (integer? count-form)
+      -1
 
-    ;; (count sym) where sym is a param
-    (and (seq? count-form)
-         (= 2 (count count-form))
-         (symbol? (first count-form))
-         (= "count" (name (first count-form)))
-         (symbol? (second count-form)))
-    (let [idx (.indexOf (vec params) (second count-form))]
-      (if (>= idx 0) idx -1))
+      ;; (count sym) where sym is a param
+      (and (seq? count-form)
+           (= 2 (count count-form))
+           (symbol? (first count-form))
+           (= "count" (name (first count-form)))
+           (symbol? (second count-form)))
+      (.indexOf pv (second count-form))
 
-    ;; Plain symbol that is a param
-    (symbol? count-form)
-    (let [idx (.indexOf (vec params) count-form)]
-      (if (>= idx 0) idx -1))
+      ;; Plain symbol that is a param
+      (symbol? count-form)
+      (.indexOf pv count-form)
 
-    :else -1))
+      :else -1)))
 
 (defn- find-all-calls
   "Recursively find all calls matching pred in forms."
@@ -449,14 +448,9 @@
                         :for (analyze-for-bindings bindings-form)
                         nil)
             ;; Collect loop binding symbols for dep classification
-            loop-syms (cond-> #{}
-                        (:element-sym bind-info)
-                        (conj (if (symbol? (:element-sym bind-info))
-                                (:element-sym bind-info)
-                                nil))
-                        (:index-sym bind-info)
-                        (conj (:index-sym bind-info)))
-            loop-syms (disj loop-syms nil)
+            loop-syms (into #{}
+                            (filter symbol?)
+                            [(:element-sym bind-info) (:index-sym bind-info)])
             ;; Extract loop-specific trace/splice/param sites
             loop-body-info (extract-loop-trace-sites body loop-syms env)
             loop-traces (:trace-sites loop-body-info)

--- a/src/genmlx/serialize.cljs
+++ b/src/genmlx/serialize.cljs
@@ -117,7 +117,6 @@
   [v]
   (cond
     (mx/array? v)   (mlx-value->data v)
-    (vector? v)     (mapv serialize-value v)
     (sequential? v) (mapv serialize-value v)
     (map? v)        (into {} (map (fn [[k val]] [(name k) (serialize-value val)]) v))
     (keyword? v)    {:type "keyword" :value (name v)}
@@ -134,7 +133,6 @@
     (and (map? v) (= "keyword" (:type v)))
     (keyword (:value v))
 
-    (vector? v)     (mapv deserialize-value v)
     (sequential? v) (mapv deserialize-value v)
     (map? v)        (into {} (map (fn [[k val]] [(keyword k) (deserialize-value val)]) v))
     :else           v))
@@ -148,10 +146,10 @@
    Options:
      :gen-fn-id - optional string identifier for the gen-fn"
   [trace & {:keys [gen-fn-id]}]
-  (let [data {:version 1
-              :format "genmlx-choices-v1"
-              :choices (choicemap->data (:choices trace))}
-        data (if gen-fn-id (assoc data :gen-fn-id gen-fn-id) data)]
+  (let [data (cond-> {:version 1
+                      :format "genmlx-choices-v1"
+                      :choices (choicemap->data (:choices trace))}
+               gen-fn-id (assoc :gen-fn-id gen-fn-id))]
     (js/JSON.stringify (clj->js data) nil 2)))
 
 (defn load-choices
@@ -191,7 +189,8 @@
                (assoc data :retval (serialize-value (:retval trace)))
                (catch :default _
                  data))
-        data (if gen-fn-id (assoc data :gen-fn-id gen-fn-id) data)]
+        data (cond-> data
+               gen-fn-id (assoc :gen-fn-id gen-fn-id))]
     (js/JSON.stringify (clj->js data) nil 2)))
 
 (defn load-trace

--- a/src/genmlx/vectorized.cljs
+++ b/src/genmlx/vectorized.cljs
@@ -96,15 +96,15 @@
    Returns a new VectorizedTrace with reindexed choices, uniform weights."
   [vtrace key]
   (let [{:keys [weight n-particles choices score]} vtrace
-        indices (systematic-resample-indices weight n-particles key)]
-    (let [new-choices (reindex-choicemap choices indices)
-          new-score (mx/take-idx score indices)
-          new-weight (mx/zeros [n-particles])]
-      (mx/materialize! new-score new-weight)
-      (assoc vtrace
-             :choices new-choices
-             :score   new-score
-             :weight  new-weight))))
+        indices (systematic-resample-indices weight n-particles key)
+        new-choices (reindex-choicemap choices indices)
+        new-score (mx/take-idx score indices)
+        new-weight (mx/zeros [n-particles])]
+    (mx/materialize! new-score new-weight)
+    (assoc vtrace
+           :choices new-choices
+           :score   new-score
+           :weight  new-weight)))
 
 ;; ---------------------------------------------------------------------------
 ;; Diagnostics

--- a/src/genmlx/verify.cljs
+++ b/src/genmlx/verify.cljs
@@ -132,9 +132,9 @@
     [value (-> state
                (assoc :key k1)
                (update :choices cm/set-value addr value)
-               (update :score #(mx/add % lp))
-               (assoc :seen-addrs (conj seen addr))
-               (assoc :violations violations'))]))
+               (update :score mx/add lp)
+               (assoc :seen-addrs (conj seen addr)
+                      :violations violations'))]))
 
 ;; ---------------------------------------------------------------------------
 ;; Single-trial validation

--- a/src/genmlx/vmap.cljs
+++ b/src/genmlx/vmap.cljs
@@ -48,7 +48,7 @@
 
     ;; in-axes provided: find first non-nil axis
     :else
-    (let [idx (some (fn [i] (when (nth in-axes i) i)) (range (count in-axes)))]
+    (let [idx (first (keep-indexed (fn [i ax] (when ax i)) in-axes))]
       (if idx
         (let [a (nth args idx)
               n (axis-size-of a)]
@@ -70,23 +70,31 @@
    axis=nil: pass through unchanged.
    Empty args are returned as-is."
   [args in-axes i]
-  (if (empty? args)
+  (cond
+    (empty? args)
     args
-    (if (nil? in-axes)
-      (mapv #(index-arg % i) args)
-      (mapv (fn [a ax] (if (nil? ax) a (index-arg a i)))
-            args in-axes))))
+
+    (nil? in-axes)
+    (mapv #(index-arg % i) args)
+
+    :else
+    (mapv (fn [a ax] (if (nil? ax) a (index-arg a i)))
+          args in-axes)))
 
 (defn- batched-args?
   "Check if args are suitable for batched fast path.
    All axis=0 args must be MLX arrays (not sequences)."
   [args in-axes]
-  (if (empty? args)
+  (cond
+    (empty? args)
     true
-    (if (nil? in-axes)
-      (every? mlx-arr? args)
-      (every? (fn [[a ax]] (or (nil? ax) (mlx-arr? a)))
-              (map vector args in-axes)))))
+
+    (nil? in-axes)
+    (every? mlx-arr? args)
+
+    :else
+    (every? (fn [[a ax]] (or (nil? ax) (mlx-arr? a)))
+            (map vector args in-axes))))
 
 (defn- scalar-leaf?
   "Check if all leaves in a choicemap are scalar (not [N]-shaped)."

--- a/test/genmlx/clip_contract_test.cljs
+++ b/test/genmlx/clip_contract_test.cljs
@@ -1,0 +1,50 @@
+(ns genmlx.clip-contract-test
+  "Regression guard for the mx/clip bounds contract (bean genmlx-aonv).
+
+   mx/clip accepts lo/hi as Option<Either<&MxArray,f64>> at the NAPI boundary:
+   MLX float-scalar / float-array / int32-array bounds, plain JS numbers, mixed
+   (MxArray + number), and nil (one-sided / unbounded). The mlx-node MLX v0.31.2
+   bump briefly narrowed this to f64-only, which broke examples/memo/mdp.cljs
+   (int32 array bounds) and differentiable_resample (scalar MxArray bounds).
+   Restored in mlx-node d2aee0c. These tests lock the full contract so it can
+   never silently regress again."
+  (:require [cljs.test :refer [deftest is]]
+            [genmlx.test-helpers :as h]
+            [genmlx.mlx :as mx]))
+
+(def xf (mx/array #js [-2.0 0.5 3.0]))
+(def xi (mx/array #js [-5 5 9] mx/int32))
+
+(deftest clip-float-scalar-bounds
+  (is (h/all-close? [0.0 0.5 1.0]
+                    (h/realize-vec (mx/clip xf (mx/scalar 0.0) (mx/scalar 1.0))))))
+
+(deftest clip-float-array-bounds
+  (is (h/all-close? [-1.0 0.5 2.0]
+                    (h/realize-vec (mx/clip xf
+                                            (mx/array #js [-1.0 0.0 0.0])
+                                            (mx/array #js [0.0 1.0 2.0]))))))
+
+(deftest clip-int32-array-bounds  ;; the original memo/mdp.cljs regression case
+  (is (h/all-close? [0.0 3.0 3.0]
+                    (h/realize-vec (mx/clip xi
+                                            (mx/array #js [0 0 0] mx/int32)
+                                            (mx/array #js [3 3 3] mx/int32))))))
+
+(deftest clip-js-number-bounds
+  (is (h/all-close? [0.0 0.5 1.0]
+                    (h/realize-vec (mx/clip xf 0.0 1.0)))))
+
+(deftest clip-mixed-bounds  ;; MxArray lo + JS-number hi
+  (is (h/all-close? [0.0 0.5 1.0]
+                    (h/realize-vec (mx/clip xf (mx/scalar 0.0) 1.0)))))
+
+(deftest clip-one-sided-bounds  ;; nil = unbounded on that side
+  (is (h/all-close? [0.0 0.5 3.0]
+                    (h/realize-vec (mx/clip xf (mx/scalar 0.0) nil)))
+      "lo only (hi unbounded)")
+  (is (h/all-close? [-2.0 0.5 1.0]
+                    (h/realize-vec (mx/clip xf nil (mx/scalar 1.0))))
+      "hi only (lo unbounded)"))
+
+(cljs.test/run-tests)


### PR DESCRIPTION
## Summary

Restores GenMLX to fully working after the mlx-node resync/rebase onto MLX **v0.31.2**, and folds in the `idiomatic-controlflow-9x7s` refactor. Three regressions from the bump are fixed — autograd/exact `SIGTRAP`s, the `mx/clip` bounds contract, and LLM tokenizer loading — each root-caused with a regression guard.

## What broke and why

The v0.31.2 binary is **stricter**: it throws C++ exceptions where the previous binary silently produced NaN/garbage. That turned two **longstanding latent CLJS bugs** in `mx/array`'s JS-array handling into hard `SIGTRAP`s:

1. **`infer-shape` didn't treat `#js [...]` as sequential** → the dtype/shape arities produced 0-dim scalars. `condition-on`'s `(mx/array #js [idx] mx/int32)` → scalar → `take` dropped the axis → `squeeze` threw → **`exact_test` SIGTRAP**.
2. **The 1-arg arity's flat-only branch bypassed `infer-shape`** → nested JS arrays (`#js [#js [..]]`) coerced to NaN → `multivariate-normal` cholesky threw → **`gradient_fd_test` / `score_gradient_test` SIGTRAP**.

The native binding was innocent — trivial autograd, direct `.fromInt32`, and clojure-vector inputs all worked. The fix mirrors the already-correct `flatten-nested` predicates.

## Changes

**Regression fixes (MLX v0.31.2 rebase):**
- `mlx.cljs` — shape JS arrays correctly in `mx/array` (both arities); fixes the autograd/exact SIGTRAPs
- `mlx-node` → `d2aee0c` — `mx/clip` accepts `Either<&MxArray,f64>` bounds again (had narrowed to f64-only, breaking int32/scalar array bounds)
- `clip_contract_test.cljs` — new regression guard for the full clip bounds contract (float-scalar/array, int32-array, JS-number, mixed, one-sided)
- `llm/backend.cljs` — source `Qwen3Tokenizer` from `@mlx-node/core` directly (the `@mlx-node/lm` re-export was dropped upstream; load-model only worked via a stale `dist` artifact)
- `examples/memo/{mdp,empowerment,ipomdp}.cljs` — `.tolist` → `(clj->js (mx/->clj …))` (non-existent binding)
- `adev` — pass a concrete scalar baseline to value-and-grad (was nil on iter 0)
- `CLAUDE.md` — added a native/membrane contract guard loop (exact / gradient_fd / score_gradient / clip suites) to run after any mlx-node rebuild

**Idiomatic control-flow refactor (`idiomatic-controlflow-9x7s`, behavior-preserving):**
- 7 commits tidying branching/threading across inference, LLM, schema, vmap, and mlx modules

## Verification

Full gate green on the rebuilt v0.31.2 binary:
- 15-suite regression sweep (L0 68, schema 227, compiled_simulate 82, partial 92, combinator 92, L4 41, gen_clj 356, genjax 73, + core) — **0 failures**
- Native/membrane guard: `exact_test` 120/0, `gradient_fd_test` + `score_gradient_test` 0-fail, `clip_contract_test` 0-fail
- All 7 `llm/*` namespaces load; the 3 memo examples run clean

## Notes
- The mlx-node submodule advances to `d2aee0c` (clip fix), reachable via the `fix-clip-napi-bounds` fork branch. Rebuild with `yarn build:native` (incremental Rust-only; inner MLX C++ unchanged) to get the fix into the binary.
- `main` currently lacks the `infer-shape` fix, so a clean checkout crashes on the rebuilt binary — this PR is what makes the default branch healthy again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
