### PR TITLE
refactor(compiler): flatten branching and drop dead guards (84qk)

### DIFF
--- a/src/genmlx/affine.cljs
+++ b/src/genmlx/affine.cljs
@@ -48,13 +48,10 @@
     (if (every? :affine? results)
       (let [target-results (filter :has-target? results)
             const-results (filter (complement :has-target?) results)]
-        (cond
+        (if (empty? target-results)
           ;; No target dependency — pure constant addition
-          (empty? target-results)
           (affine-constant (cons 'mx/add (map :offset results)))
-
           ;; One or more target-dependent terms: sum coefficients and offsets
-          :else
           (let [coeff (if (= 1 (count target-results))
                         (:coefficient (first target-results))
                         (cons 'mx/add (map :coefficient target-results)))
@@ -193,8 +190,7 @@
 (defn- analyze-affine-call
   "Analyze a function call for affine structure."
   [expr target-sym env]
-  (let [op (first expr)
-        op-name (name op)
+  (let [op-name (name (first expr))
         args (rest expr)]
     (case op-name
       ("add" "+")       (analyze-affine-add (vec args) target-sym env)
@@ -292,14 +288,10 @@
         result (when natural-arg
                  (analyze-affine natural-arg target-sym env))]
     (cond
-      (nil? result)
+      (or (nil? result)
+          (not (:affine? result))
+          (not (:has-target? result)))  ;; nonlinear, unknown, or no prior dependency
       {:type :nonlinear}
-
-      (not (:affine? result))
-      {:type :nonlinear}
-
-      (not (:has-target? result))
-      {:type :nonlinear}  ;; doesn't actually depend on prior
 
       ;; Direct: coefficient=1, offset=0
       (and (= 1 (:coefficient result)) (= 0 (:offset result)))

--- a/src/genmlx/compiled.cljs
+++ b/src/genmlx/compiled.cljs
@@ -52,9 +52,9 @@
         compiled (mx/compile-fn unfold-fn)]
     ;; Warm up: trace with dummy data to cache Metal program
     (let [dummy-state (mx/zeros [state-dim])
-          dummy-noise (mx/zeros [n-steps noise-dim])]
-      (let [[s states sc] (compiled dummy-state dummy-noise)]
-        (mx/materialize! s states sc)))
+          dummy-noise (mx/zeros [n-steps noise-dim])
+          [s states sc] (compiled dummy-state dummy-noise)]
+      (mx/materialize! s states sc))
     compiled))
 
 (defn make-compiled-unfold-generate
@@ -96,9 +96,9 @@
     ;; Warm up
     (let [dummy-state (mx/zeros [state-dim])
           dummy-noise (mx/zeros [n-steps noise-dim])
-          dummy-obs (mx/zeros [n-steps obs-dim])]
-      (let [[s states sc w] (compiled dummy-state dummy-noise dummy-obs)]
-        (mx/materialize! s states sc w)))
+          dummy-obs (mx/zeros [n-steps obs-dim])
+          [s states sc w] (compiled dummy-state dummy-noise dummy-obs)]
+      (mx/materialize! s states sc w))
     compiled))
 
 ;; ---------------------------------------------------------------------------
@@ -281,9 +281,9 @@
     (let [dummy-states (mx/zeros [n-particles state-dim])
           dummy-noise (mx/zeros [n-steps n-particles noise-dim])
           dummy-obs (mx/zeros [n-steps obs-dim])
-          dummy-u (mx/ones [n-steps 1])]
-      (let [[s ml] (compiled dummy-states dummy-noise dummy-obs dummy-u)]
-        (mx/materialize! s ml)))
+          dummy-u (mx/ones [n-steps 1])
+          [s ml] (compiled dummy-states dummy-noise dummy-obs dummy-u)]
+      (mx/materialize! s ml))
     compiled))
 
 (defn compiled-particle-filter
@@ -1140,10 +1140,14 @@
     (if (contains? compiled-values addr)
       ;; Replay prefix site: set value, advance key per constraint status
       (let [value (get compiled-values addr)
-            constrained? (cm/has-value? (cm/get-submap (:constraints state) addr))]
+            constrained? (cm/has-value? (cm/get-submap (:constraints state) addr))
+            advance-key (fn [s]
+                          (let [[k1 _k2] (rng/split (:key s))]
+                            (assoc s :key k1)))]
+        ;; Unconstrained prefix sites split the key (matches simulate-transition);
+        ;; constrained sites leave it (matches generate-transition).
         [value (cond-> (update state :choices cm/set-value addr value)
-                 (not constrained?) (#(let [[k1 _k2] (rng/split (:key %))]
-                                        (assoc % :key k1))))])
+                 (not constrained?) advance-key)])
       ;; Dynamic site: standard generate
       (h/generate-transition state addr dist))))
 

--- a/src/genmlx/compiled_ops.cljs
+++ b/src/genmlx/compiled_ops.cljs
@@ -131,8 +131,8 @@
             {:values (:values result)
              :score (:score result)
              :weight (:weight result)
-             :retval (when retval-fn
-                       (retval-fn (:values result) mlx-args))}))))))
+             ;; retval-fn proven truthy by the outer guard (every? some? + retval-fn)
+             :retval (retval-fn (:values result) mlx-args)}))))))
 
 (defn make-branch-rewritten-generate
   "Build a compiled generate for models with rewritable branches (L1-M4).
@@ -241,8 +241,8 @@
             {:values (:values result)
              :score (:score result)
              :discard (:discard result)
-             :retval (when retval-fn
-                       (retval-fn (:values result) mlx-args))}))))))
+             ;; retval-fn proven truthy by the outer guard (every? some? + retval-fn)
+             :retval (retval-fn (:values result) mlx-args)}))))))
 
 (defn get-compiled-update
   "Returns the compiled-update function for a gen-fn, or nil."
@@ -729,10 +729,14 @@
   (fn [state addr dist]
     (if (contains? compiled-values addr)
       (let [value (get compiled-values addr)
-            selected? (sel/selected? (:selection state) addr)]
-        [value (cond-> (update state :choices cm/set-value addr value)
-                 selected? (#(let [[k1 _] (rng/split (:key %))]
-                               (assoc % :key k1))))])
+            selected? (sel/selected? (:selection state) addr)
+            state' (update state :choices cm/set-value addr value)]
+        ;; Selected sites split the key (matching handler's regenerate-transition);
+        ;; unselected sites replay the value with the key untouched.
+        [value (if selected?
+                 (let [[k1 _] (rng/split (:key state'))]
+                   (assoc state' :key k1))
+                 state')])
       (h/regenerate-transition state addr dist))))
 
 (defn get-compiled-regenerate

--- a/src/genmlx/conjugacy.cljs
+++ b/src/genmlx/conjugacy.cljs
@@ -107,8 +107,7 @@
   [prior-addr obs-site family-info]
   (let [natural-idx (:natural-param-idx family-info)
         dist-args (:dist-args obs-site)
-        natural-arg (when (and dist-args (< natural-idx (count dist-args)))
-                      (nth dist-args natural-idx))]
+        natural-arg (nth dist-args natural-idx nil)]
     (cond
       ;; Direct: the natural parameter arg IS the prior symbol
       (symbol-resolves-to-addr? natural-arg prior-addr)

--- a/src/genmlx/dep_graph.cljs
+++ b/src/genmlx/dep_graph.cljs
@@ -139,27 +139,27 @@
                                   in-z? (contains? z-set node)
                                   ;; Determine next visits based on direction and evidence
                                   next-visits
-                                  (cond
+                                  (case [dir in-z?]
                                     ;; Arrived from child (:up), node NOT in Z:
                                     ;; Can pass to parents (up) and children (down)
-                                    (and (= dir :up) (not in-z?))
+                                    [:up false]
                                     (concat
                                       (map (fn [p] [:up p]) (get (:parents graph) node #{}))
                                       (map (fn [c] [:down c]) (get (:children graph) node #{})))
 
                                     ;; Arrived from child (:up), node IN Z:
                                     ;; Blocked — explaining away only works from parent direction
-                                    (and (= dir :up) in-z?)
+                                    [:up true]
                                     []
 
                                     ;; Arrived from parent (:down), node NOT in Z:
                                     ;; Can pass to children (down)
-                                    (and (= dir :down) (not in-z?))
+                                    [:down false]
                                     (map (fn [c] [:down c]) (get (:children graph) node #{}))
 
                                     ;; Arrived from parent (:down), node IN Z:
                                     ;; Collider is activated! Can go to parents (up) — explaining away
-                                    (and (= dir :down) in-z?)
+                                    [:down true]
                                     (map (fn [p] [:up p]) (get (:parents graph) node #{})))]
                               (recur (reduce conj queue' next-visits)
                                      visited'

--- a/src/genmlx/method_selection.cljs
+++ b/src/genmlx/method_selection.cljs
@@ -24,7 +24,7 @@
 (defn- has-splice?
   "Does the model have any splice sites (sub-model calls)?"
   [schema]
-  (pos? (count-splice-sites schema)))
+  (boolean (seq (:splice-sites schema))))
 
 (defn- all-trace-addrs
   "Set of all trace-site addresses."

--- a/src/genmlx/rewrite.cljs
+++ b/src/genmlx/rewrite.cljs
@@ -144,10 +144,8 @@
               (let [family (:family (first pairs))
                     obs-addrs (mapv :obs-addr pairs)
                     non-conj (find-non-conjugate-children schema prior-addr obs-addrs)]
-                (if (seq non-conj)
-                  ;; Shared prior — use RaoBlackwell instead
-                  nil
-                  ;; Pure conjugate — can eliminate
+                (when-not (seq non-conj)
+                  ;; Pure conjugate — can eliminate (shared priors become RaoBlackwell below)
                   (->ConjugacyRule family prior-addr obs-addrs))))
             grouped))
 


### PR DESCRIPTION
## Summary
Behavior-preserving idiomatic control-flow cleanup across the compiler layer (bean genmlx-84qk). 11 edits across 7 files:

- **affine** — merge 3 `{:type :nonlinear}` predicates into one `or`; `cond`→two-armed `if` in analyze-affine-add; drop the intermediate `op` binding
- **conjugacy** — `(nth dist-args idx nil)` instead of a count-guard
- **rewrite** — `when-not` instead of `(if (seq ..) nil ..)`
- **dep_graph** — `(case [dir in-z?] ..)` surfaces the exhaustive 2×2 in `d-separated?`
- **method_selection** — `has-splice?` as `(boolean (seq ..))`
- **compiled_ops** — explicit `if`/`let` for the replay-regenerate key-split; drop the dead `(when retval-fn ..)` in the static generate/update builders (outer guard already proves it truthy; branch-rewritten variants untouched)
- **compiled** — hoist the replay-generate key-advance to a named local; collapse the warm-up double-lets in unfold / unfold-generate / particle-filter

## Verification
Full 19-suite gate green. Pre-existing failures on main (`rewrite_test`, `branch_rewrite_test`, flaky `compiled_gen_test`) confirmed **unchanged** by these edits via a clean-baseline stash comparison — so they are not introduced here (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)