### PR TITLE
Fix v0.31.2 blast-radius regressions found by full-suite sweep (genmlx-yo6y)

### DIFF
--- a/src/genmlx/handler.cljs
+++ b/src/genmlx/handler.cljs
@@ -188,8 +188,10 @@
   [state addr dist]
   (let [constraint (cm/get-submap (:constraints state) addr)]
     (if (cm/has-value? constraint)
-      ;; Constrained: scalar observation, scalar log-prob → broadcasts into [N] score/weight
-      (let [value (cm/get-value constraint)
+      ;; Constrained: scalar observation, scalar log-prob → broadcasts into [N] score/weight.
+      ;; ensure-array so the stored choice is an MxArray (a raw JS number is rejected by
+      ;; the v0.31.2 binary on downstream array ops like mx/shape / value_and_grad).
+      (let [value (mx/ensure-array (cm/get-value constraint))
             lp (dc/dist-log-prob dist value)]
         [value (-> state
                    (update :choices cm/set-value addr value)

--- a/src/genmlx/inference/kernel.cljs
+++ b/src/genmlx/inference/kernel.cljs
@@ -277,14 +277,14 @@
   [fwd-gf backward]
   (fn [trace key]
     (let [gf (dyn/auto-key (:gen-fn trace))
-          [_k1 _k2 k3] (rng/split-n (rng/ensure-key key) 3)
-          fwd-result    (p/propose fwd-gf [(:choices trace)])
+          [k1 k2 k3]   (rng/split-n (rng/ensure-key key) 3)
+          fwd-result    (p/propose (dyn/with-key fwd-gf k1) [(:choices trace)])
           fwd-choices   (:choices fwd-result)
           fwd-score     (:weight fwd-result)
           update-result (p/update gf trace fwd-choices)
           trace'        (:trace update-result)
           update-weight (:weight update-result)
-          bwd-result    (p/assess backward [(:choices trace')] (:discard update-result))
+          bwd-result    (p/assess (dyn/with-key backward k2) [(:choices trace')] (:discard update-result))
           bwd-score     (:weight bwd-result)
           _             (mx/materialize! update-weight fwd-score bwd-score)
           log-alpha     (mx/item (mx/subtract (mx/add update-weight bwd-score)
@@ -307,8 +307,8 @@
     (symmetric-kernel
       (fn [trace key]
         (let [gf (dyn/auto-key (:gen-fn trace))
-              [_k1 k2]     (rng/split (rng/ensure-key key))
-              fwd-result    (p/propose fwd-gf [(:choices trace)])
+              [k1 k2]      (rng/split (rng/ensure-key key))
+              fwd-result    (p/propose (dyn/with-key fwd-gf k1) [(:choices trace)])
               fwd-choices   (:choices fwd-result)
               update-result (p/update gf trace fwd-choices)
               w             (mx/realize (:weight update-result))]

--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -289,7 +289,14 @@
 (defn transpose
   ([a]      (.transpose c a))
   ([a axes] (.transpose c a (->js axes))))
-(defn broadcast-to [a sh] (.broadcastTo c a (clj->js sh)))
+(defn broadcast-to
+  "Broadcast a to shape sh, preserving a's dtype.
+   Reconstructed via the (correct) add-broadcasting onto a zeros of the target
+   shape: the v0.31.2 native broadcast_to mis-fills a size-1 source dim,
+   producing [v 0 0 …] instead of [v v v …]."
+  [a sh]
+  (let [a (if (instance? M a) a (.scalar c a))]
+    (add (.zeros c (clj->js sh) (.dtypeOf c a)) a)))
 (defn tile       [a reps] (.tile c a (clj->js reps)))
 (defn repeat-arr [a repeats axis] (.repeat c a repeats axis))
 (defn stack

--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -468,6 +468,15 @@
   ([f in-axes out-axes]
    (fn [& args] (let [r (.vmap M f (to-array args) (clj->js in-axes) (clj->js out-axes))] (aget r 0)))))
 
+(defn- grad-args
+  "Marshal an arg vector for the autograd NAPI boundary. A nil placeholder arg
+   (e.g. the ignored key of an auto-keyed model passed through value-and-grad)
+   becomes a 0-scalar: the v0.31.2 binary rejects nil args (\"Failed to recover
+   MxArray type from napi value\"), and a nil arg is never differentiated, so
+   the substitution is inert. Restores the old binary's nil tolerance."
+  [args]
+  (to-array (mapv (fn [a] (if (nil? a) (scalar 0.0) a)) args)))
+
 (defn grad
   "Returns a function that computes gradients of f w.r.t. its arguments.
    The returned function builds a backward-pass graph lazily — gradient
@@ -476,7 +485,7 @@
    (fn [& args]
      (swap! grad-depth inc)
      (try
-       (let [grads (.computeGradients M f (to-array args))]
+       (let [grads (.computeGradients M f (grad-args args))]
          (aget grads 0))
        (finally (swap! grad-depth dec)))))
   ([f argnums]
@@ -484,7 +493,7 @@
      (swap! grad-depth inc)
      (try
        (let [argnum-vec (if (vector? argnums) argnums [argnums])
-             grads (.computeGradients M f (to-array args))]
+             grads (.computeGradients M f (grad-args args))]
          (if (= 1 (count argnum-vec))
            (aget grads (first argnum-vec))
            (mapv #(aget grads %) argnum-vec)))
@@ -497,14 +506,14 @@
    (fn [& args]
      (swap! grad-depth inc)
      (try
-       (let [result (.valueAndGrad M f (to-array args))]
+       (let [result (.valueAndGrad M f (grad-args args))]
          [(aget result 0) (aget result 1)])
        (finally (swap! grad-depth dec)))))
   ([f argnums]
    (fn [& args]
      (swap! grad-depth inc)
      (try
-       (let [result (.valueAndGrad M f (to-array args))
+       (let [result (.valueAndGrad M f (grad-args args))
              v (aget result 0)
              argnum-vec (if (vector? argnums) argnums [argnums])
              g (if (= 1 (count argnum-vec))
@@ -566,7 +575,11 @@
    EFFECTFUL: this is the primary GPU dispatch point. Traverses the lazy
    computation DAG and executes all pending operations on Metal."
   [& arrs]
-  (let [valid (filterv some? arrs)]
+  ;; Keep only MxArrays (not just non-nil): a non-array value (a JS number,
+  ;; a collection) reaching .evalArrays is rejected by the v0.31.2 binary
+  ;; ("Failed to recover MxArray type from napi value"). The old binary
+  ;; silently ignored them; this restores that, matching materialize!.
+  (let [valid (filterv array? arrs)]
     (when (seq valid)
       (.evalArrays c (to-array valid)))))
 

--- a/test/genmlx/gamma_batch_test.cljs
+++ b/test/genmlx/gamma_batch_test.cljs
@@ -57,7 +57,10 @@
 (deftest gamma-alpha-0-5-rate-1
   (testing "gamma alpha=0.5, rate=1.0 (Ahrens-Dieter path)"
     (let [d (dist/gamma-dist (mx/scalar 0.5) (mx/scalar 1.0))
-          n 2000
+          ;; gamma(0.5) is heavily right-skewed (high kurtosis), so the sample
+          ;; variance is noisy — needs more draws than lighter-tailed cases for a
+          ;; reliable estimate (the sampler converges to var=0.5 exactly at large n).
+          n 20000
           samples (dc/dist-sample-n d (rng/fresh-key 99) n)
           _ (mx/eval! samples)
           vals (mx/->clj samples)

--- a/test/genmlx/kernel_dsl_test.cljs
+++ b/test/genmlx/kernel_dsl_test.cljs
@@ -148,7 +148,9 @@
                       cm/EMPTY (map-indexed vector xs))
           {:keys [trace]} (p/generate model2 [xs] obs)
           k (kern/gibbs {:slope 0.3 :intercept 0.3})
-          traces (kern/run-kernel {:samples 200 :burn 100} k trace)
+          ;; more samples/burn: 200/100 gave a posterior-slope estimate that
+          ;; occasionally fell outside tol 1.0 (MCMC estimate noise).
+          traces (kern/run-kernel {:samples 600 :burn 300} k trace)
           slope-vals (mapv (fn [t] (mx/realize (cm/get-value (cm/get-submap (:choices t) :slope)))) traces)
           slope-mean (/ (reduce + slope-vals) (count slope-vals))]
       (is (h/close? 2.0 slope-mean 1.0) "gibbs(map): slope near 2"))))

--- a/test/genmlx/memory_test.cljs
+++ b/test/genmlx/memory_test.cljs
@@ -16,7 +16,9 @@
       (is (number? peak) "get-peak-memory returns number")
       (is (>= peak 0) "get-peak-memory >= 0")
       (is (number? wraps) "get-wrappers-count returns number")
-      (is (> wraps 0) "get-wrappers-count > 0"))))
+      ;; get-wrappers-count is now a backward-compat alias for active memory
+      ;; (v0.31.2 dropped the wrapper-count API): >= 0, can be 0 at a fresh start.
+      (is (>= wraps 0) "get-wrappers-count (active-memory alias) >= 0"))))
 
 (deftest metal-availability
   (testing "metal device"
@@ -26,8 +28,7 @@
   (testing "metal-device-info returns expected fields"
     (let [info (mx/metal-device-info)]
       (is (map? info) "device-info is a map")
-      (is (contains? info :resource-limit) "has :resource-limit")
-      (is (= 499000 (:resource-limit info)) "resource-limit is 499000")
+      ;; :resource-limit removed — v0.31.2's metalDeviceInfo no longer reports it.
       (is (contains? info :device-name) "has :device-name")
       (is (string? (:device-name info)) "device-name is string")
       (is (contains? info :memory-size) "has :memory-size")
@@ -64,10 +65,9 @@
       (is (map? report) "memory-report is a map")
       (is (contains? report :active-bytes) "has :active-bytes")
       (is (contains? report :cache-bytes) "has :cache-bytes")
-      (is (contains? report :peak-bytes) "has :peak-bytes")
-      (is (contains? report :wrappers) "has :wrappers")
-      (is (contains? report :resource-limit) "has :resource-limit")
-      (is (= 499000 (:resource-limit report)) "resource-limit matches"))))
+      ;; :wrappers and :resource-limit removed — memory-report tracks active/cache/
+      ;; peak bytes only after the v0.31.2 memory_napi.rs adaptation.
+      (is (contains? report :peak-bytes) "has :peak-bytes"))))
 
 (deftest allocation-tracking
   (testing "allocating arrays increases active memory"


### PR DESCRIPTION
Fixes the v0.31.2 regressions surfaced by the full 237-file sweep (bean genmlx-yo6y). 201/237 passed; of 36 non-OK, most were GPU-contention/heavy/LLM-model/flaky artifacts. This PR fixes the confirmed real ones — ~10 tests across the items below.

## A — "Failed to recover MxArray type from napi value" (3 sub-causes, 4 tests)
- **A1** `eval!` filtered only nil, not non-arrays -> filter `array?` (match `materialize!`). l2_mcmc, map.
- **A2** batched-generate stored the raw constraint number -> `ensure-array` it. loop_obs.
- **A3** `value-and-grad`/`grad` passed a nil placeholder arg (auto-keyed model key) to NAPI -> `grad-args` coerces nil -> 0-scalar. differentiable.

## B — broadcast-to mis-fills size-1 source dims (delta batch garbage)
Native broadcast_to returns `[v 0 0 …]`. Re-implemented via `(add (zeros sh (dtype a)) a)`, dtype-preserving. Fixes dist_batch + dist_moments.

## C — gamma(0.5) variance test under-powered
Heavy-tailed; var is correct (0.4994 @ n=50000) but noisy @ n=2000. Bumped n. (test)

## D — memory_test referenced removed APIs
v0.31.2 memory_napi.rs adaptation dropped wrapper-count / :resource-limit / :wrappers; membrane is correct, tests were stale. (test)

## E — proposal MH kernels did not key the proposal gen-fns
Thread split keys via dyn/with-key into propose (fwd) + assess (bwd). (not v0.31.2 — a pure key-management bug.)

## Verification
22-suite safety gate green for the membrane fixes (eval!/grad/broadcast-to are hot); each fixed suite re-verified.

## Not included (tracked in genmlx-yo6y)
- A4: differentiable_hard/hard2 hit a separate deeper C++ exception in the hierarchical model (masked until A1-A3).
- F: beta(0.5,0.5) finite-log-prob property failure (boundary; possibly flaky).

🤖 Generated with [Claude Code](https://claude.com/claude-code)