### PR TITLE
fix(dist): clamp beta batch samples into open support (finite log-prob)

### DIFF
--- a/src/genmlx/dist.cljs
+++ b/src/genmlx/dist.cljs
@@ -399,7 +399,9 @@
         one ONE
         g1 (gamma-sample-n (mx/realize alpha) one k1 n)
         g2 (gamma-sample-n (mx/realize beta-param) one k2 n)]
-    (mx/divide g1 (mx/add g1 g2))))
+    ;; Clamp into the open support (0,1): for alpha/beta < 1 a float32 sample can
+    ;; round to exactly 0.0/1.0, where the beta density (and log-prob) is +inf.
+    (mx/clip (mx/divide g1 (mx/add g1 g2)) 1e-7 (- 1.0 1e-7))))
 
 ;; Dirichlet batch sampling via k independent gamma samples, then normalize
 (defmethod dc/dist-sample-n* :dirichlet [d key n]


### PR DESCRIPTION
## Summary
Last confirmed item from the full-suite sweep (bean genmlx-yo6y, item F). beta(alpha,beta) with alpha or beta < 1 has unbounded density at 0/1; the g1/(g1+g2) gamma-ratio sampler can round to exactly 0.0/1.0 in float32 -> log-prob = +inf. The `sample-n-elements-have-finite-log-prob` defspec shrank to beta(0.5,0.5) and failed.

**Fix:** clamp beta batch samples to [1e-7, 1-1e-7] (the open support) — negligible bias, same pattern as the differentiable-resample uniform clamp.

**Verified:** no 0/1 samples, all log-probs finite; support_property + dist_property tests 6/6 clean across random seeds; beta-using suites (conjugate_bb, conjugate, dist_logprob, dist_statistics, l3_5_combinator_conjugacy) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)