### PR TITLE
fix(diff): thread real PRNG key into optimize-params (fixes hierarchical SIGTRAP)

### DIFF
--- a/src/genmlx/inference/differentiable.cljs
+++ b/src/genmlx/inference/differentiable.cljs
@@ -45,7 +45,11 @@
                    (mx/negative (vec/vtrace-log-ml-estimate vtrace))))
         vg (mx/value-and-grad raw-fn [0])]
     (fn [params key]
-      (let [[loss grad] (vg params key)]
+      ;; ensure-key guarantees a real uint32 PRNG key fills value-and-grad's
+      ;; arg slot. A nil key would be coerced to a float 0-scalar at the autograd
+      ;; NAPI boundary and then consumed as a PRNG key by vgenerate's sampling —
+      ;; splitting a float scalar crashes Metal (SIGTRAP). See A4 / genmlx-yo6y.
+      (let [[loss grad] (vg params (rng/ensure-key key))]
         {:loss loss :grad grad}))))
 
 ;; ---------------------------------------------------------------------------
@@ -87,7 +91,11 @@
    model args observations param-names init-params]
   (let [loss-grad-fn (make-is-loss-grad-fn model args observations param-names n-particles)
         result (learn/train
-                 {:iterations iterations :lr lr :key key
+                 ;; ensure-key (never nil): learn/train threads sub-keys via
+                 ;; split-or-nils, and a nil key would propagate as [nil nil]
+                 ;; every iteration, becoming a float 0-scalar through the
+                 ;; autograd boundary and crashing on the first latent sample.
+                 {:iterations iterations :lr lr :key (rng/ensure-key key)
                   :callback (when callback
                               (fn [{:keys [iter loss params]}]
                                 (callback {:iter iter :log-ml (- loss) :params params})))}

--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -476,13 +476,28 @@
    (fn [& args] (let [r (.vmap M f (to-array args) (clj->js in-axes) (clj->js out-axes))] (aget r 0)))))
 
 (defn- grad-args
-  "Marshal an arg vector for the autograd NAPI boundary. A nil placeholder arg
-   (e.g. the ignored key of an auto-keyed model passed through value-and-grad)
-   becomes a 0-scalar: the v0.31.2 binary rejects nil args (\"Failed to recover
-   MxArray type from napi value\"), and a nil arg is never differentiated, so
-   the substitution is inert. Restores the old binary's nil tolerance."
+  "Marshal an arg vector for the autograd NAPI boundary. Every arg must be a
+   concrete MLX value. The v0.31.2 binary rejects a nil arg (\"Failed to recover
+   MxArray type from napi value\"), but silently substituting a 0-scalar is NOT
+   safe: an arg that is not differentiated can still be consumed as DATA inside
+   the function (e.g. a PRNG key threaded into value-and-grad), and a float
+   0-scalar passed where a uint32 key is expected crashes Metal with a C++
+   exception (SIGTRAP). So a nil arg is a caller bug — surface it loudly here,
+   naming the offending index, rather than corrupting the computation downstream.
+   (This intentionally retracts an earlier nil->0-scalar coercion whose \"inert\"
+   premise was false: the nil was being consumed as a PRNG key. See genmlx-yo6y.)"
   [args]
-  (to-array (mapv (fn [a] (if (nil? a) (scalar 0.0) a)) args)))
+  (to-array
+   (vec (map-indexed
+         (fn [i a]
+           (when (nil? a)
+             (throw (ex-info (str "value-and-grad/grad: argument " i " is nil. "
+                                  "Pass a concrete MLX value — a nil PRNG key or "
+                                  "placeholder is not supported (thread a real key "
+                                  "via rng/ensure-key before the autograd boundary).")
+                             {:arg-index i :args-count (count args)})))
+           a)
+         args))))
 
 (defn grad
   "Returns a function that computes gradients of f w.r.t. its arguments.

--- a/src/genmlx/mlx/random.cljs
+++ b/src/genmlx/mlx/random.cljs
@@ -31,22 +31,56 @@
     (bit-and (bit-xor (int (nth arr 0)) (int (nth arr 1)))
              0x7FFFFFFF)))
 
+(defn valid-key?
+  "True if k is a well-formed MLX PRNG key: an MLX array of shape [2] whose
+   dtype is not float32. A fresh key is uint32[2]; the float 0-scalar that an
+   autograd boundary can produce (shape [], float32) is rejected. Shape/dtype
+   are lazy-graph metadata, so this is a cheap check (no GPU eval)."
+  [k]
+  (and (mx/array? k)
+       (= [2] (mx/shape k))
+       (not= mx/float32 (mx/dtype k))))
+
+(defn- check-key
+  "Raise a clear error if k is non-nil but not a valid PRNG key. Catches a
+   mis-typed key (e.g. a float scalar from a coerced-nil autograd arg) at the
+   rng boundary with an actionable message, instead of letting it reach NAPI
+   and crash Metal with a C++ exception (SIGTRAP)."
+  [k where]
+  (when (and (some? k) (not (valid-key? k)))
+    (throw (ex-info (str "rng/" where ": malformed PRNG key — expected a uint32 "
+                         "array of shape [2], got "
+                         (if (mx/array? k)
+                           (str "shape " (mx/shape k) " dtype " (mx/dtype k))
+                           (pr-str k))
+                         ". A float scalar here usually means a nil key was "
+                         "coerced at an autograd boundary; thread a real key.")
+                    {:key-shape (when (mx/array? k) (mx/shape k))
+                     :key-dtype (when (mx/array? k) (mx/dtype k))}))))
+
 (defn split
   "Split a key into two independent sub-keys. Returns [k1 k2]."
   [key]
+  (check-key key "split")
   (let [ks (.randomSplit c key)]
     [(aget ks 0) (aget ks 1)]))
 
 (defn split-n
   "Split a key into n independent sub-keys. Returns vector of n keys."
   [key n]
+  (check-key key "split-n")
   (let [ks (.randomSplitN c key n)]
     (mapv #(mx/index ks %) (range n))))
 
 (defn ensure-key
-  "Return key if non-nil, otherwise a fresh random key."
+  "Return key if it is a valid PRNG key, or a fresh key if nil. A non-nil but
+   malformed key (e.g. a float scalar from a coerced-nil autograd arg) is a
+   caller bug and raises here rather than silently producing garbage samples
+   (the (or key (fresh-key)) shorthand let a truthy float scalar slip through)."
   [key]
-  (or key (fresh-key)))
+  (if (nil? key)
+    (fresh-key)
+    (do (check-key key "ensure-key") key)))
 
 (defn split-or-nils [key]
   (if key (split key) [nil nil]))


### PR DESCRIPTION
## Summary

Closes the last open item (**A4**) of the v0.31.2 blast-radius sweep: the hierarchical empirical-Bayes `optimize-params` path crashed with a hard C++ exception (SIGTRAP, exit 133) — not a catchable error — once the A1–A3 MxArray-recovery fixes landed.

## Root cause

`optimize-params` threaded **no PRNG key**, so `learn/train` passed `nil` every iteration. `value-and-grad`'s `grad-args` (the A3 fix) coerced that `nil` into a float `scalar(0.0)`, which then flowed into `vgenerate` as the "PRNG key" and crashed when `rng/split` was invoked on it to sample an unconstrained latent (`theta_j`).

Fully-constrained models (e.g. `differentiable_test`'s) never sample, so `rng/split` is never reached — which is exactly why they survived the same no-key path while the hierarchical models (which sample 8 latents) crashed.

Proof: `(rng/split (mx/scalar 0.0))` alone SIGTRAPs; `optimize-params` *with* an explicit key runs the full 8-latent / 2000-particle / 200-iter loop cleanly (log-ML improves). Confirmed by 3 independent adversarial refuters plus a full `grad`/`value-and-grad` call-site audit (the differentiable key path is the only live site that can feed `nil`).

## Fix (3 parts)

1. **`inference/differentiable.cljs`** — `optimize-params` and `make-is-loss-grad-fn` now `rng/ensure-key` the key, so a real `uint32[2]` key reaches `value-and-grad` (matching `log-ml-gradient` and the canonical `adev` pattern).
2. **`mlx.cljs`** — `grad-args` no longer silently coerces `nil → 0-scalar` (its "inert" premise was false; the arg is consumed as a PRNG key). It now throws a clear error naming the offending arg index.
3. **`mlx/random.cljs`** — `split` / `split-n` / `ensure-key` validate the key (`uint32[2]`) and raise an actionable error on a malformed key, converting the whole mistyped-key class from a process-killing SIGTRAP into a catchable CLJS error.

## Verification

- **`differentiable_hard_test` + `differentiable_hard2_test`** now pass (were SIGTRAP).
- No regression: safety gates (`exact`/`gradient_fd`/`score_gradient`/`clip_contract`), **L0 cert 68/68**, core (`choicemap`/`trace`/`selection`/`handler`/`dist`/`combinators`/`inference`/`vectorized`), grad/learning (`gradient_learning_property`/`compiled_optimizer`/`compiled_gen`/`fisher`/`adev`/`inference_adev`/`vi_property`), and rng-heavy (`mcmc_property`/`smc_property`/`smcp3_kernel`/`pmcmc`/`kernel_dsl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)