### PR TITLE
Idiomatic ClojureScript excellence (genmlx-b3nx): 49 behavior-preserving refactors

### DIFF
--- a/src/genmlx/affine.cljs
+++ b/src/genmlx/affine.cljs
@@ -57,8 +57,8 @@
                         (cons 'mx/add (map :coefficient target-results)))
                 ;; Collect all offsets
                 all-offsets (keep (fn [r]
-                                   (when (and (:offset r) (not= 0 (:offset r)))
-                                     (:offset r)))
+                                    (let [o (:offset r)]
+                                      (when (and o (not= 0 o)) o)))
                                   results)
                 offset (cond
                          (empty? all-offsets) 0

--- a/src/genmlx/affine.cljs
+++ b/src/genmlx/affine.cljs
@@ -191,13 +191,13 @@
   "Analyze a function call for affine structure."
   [expr target-sym env]
   (let [op-name (name (first expr))
-        args (rest expr)]
+        args (vec (rest expr))]
     (case op-name
-      ("add" "+")       (analyze-affine-add (vec args) target-sym env)
-      ("subtract" "-")  (analyze-affine-subtract (vec args) target-sym env)
-      ("multiply" "*")  (analyze-affine-multiply (vec args) target-sym env)
-      ("divide" "/")    (analyze-affine-divide (vec args) target-sym env)
-      ("negate")        (analyze-affine-negate (vec args) target-sym env)
+      ("add" "+")       (analyze-affine-add args target-sym env)
+      ("subtract" "-")  (analyze-affine-subtract args target-sym env)
+      ("multiply" "*")  (analyze-affine-multiply args target-sym env)
+      ("divide" "/")    (analyze-affine-divide args target-sym env)
+      ("negate")        (analyze-affine-negate args target-sym env)
       ("scalar")        (analyze-affine (first args) target-sym env)
       ;; Everything else is nonlinear (conservative)
       (not-affine))))

--- a/src/genmlx/affine.cljs
+++ b/src/genmlx/affine.cljs
@@ -73,38 +73,40 @@
   [args target-sym env]
   (if (= 2 (count args))
     (let [a (analyze-affine (first args) target-sym env)
-          b (analyze-affine (second args) target-sym env)]
+          b (analyze-affine (second args) target-sym env)
+          {a-tgt? :has-target? a-coeff :coefficient a-off :offset} a
+          {b-tgt? :has-target? b-coeff :coefficient b-off :offset} b]
       (if (and (:affine? a) (:affine? b))
         (cond
           ;; Neither depends on target
-          (and (not (:has-target? a)) (not (:has-target? b)))
-          (affine-constant (list 'mx/subtract (:offset a) (:offset b)))
+          (and (not a-tgt?) (not b-tgt?))
+          (affine-constant (list 'mx/subtract a-off b-off))
 
           ;; Only a depends on target: a*x + a_off - b_off
-          (and (:has-target? a) (not (:has-target? b)))
-          (let [offset (if (and (= 0 (:offset a)) (= 0 (:offset b)))
+          (and a-tgt? (not b-tgt?))
+          (let [offset (if (and (= 0 a-off) (= 0 b-off))
                          0
                          (list 'mx/subtract
-                               (if (= 0 (:offset a)) 0 (:offset a))
-                               (if (= 0 (:offset b)) 0 (:offset b))))]
-            (affine-linear (:coefficient a) offset))
+                               (if (= 0 a-off) 0 a-off)
+                               (if (= 0 b-off) 0 b-off)))]
+            (affine-linear a-coeff offset))
 
           ;; Only b depends on target: -b*x + a_off - b_off
-          (and (not (:has-target? a)) (:has-target? b))
-          (let [neg-coeff (if (= 1 (:coefficient b))
+          (and (not a-tgt?) b-tgt?)
+          (let [neg-coeff (if (= 1 b-coeff)
                             -1
-                            (list 'mx/negate (:coefficient b)))
-                offset (if (= 0 (:offset b))
-                         (:offset a)
-                         (list 'mx/subtract (:offset a) (:offset b)))]
+                            (list 'mx/negate b-coeff))
+                offset (if (= 0 b-off)
+                         a-off
+                         (list 'mx/subtract a-off b-off))]
             (affine-linear neg-coeff offset))
 
           ;; Both depend on target: (a-b)*x + (a_off - b_off)
           :else
-          (let [coeff (list 'mx/subtract (:coefficient a) (:coefficient b))
-                offset (if (and (= 0 (:offset a)) (= 0 (:offset b)))
+          (let [coeff (list 'mx/subtract a-coeff b-coeff)
+                offset (if (and (= 0 a-off) (= 0 b-off))
                          0
-                         (list 'mx/subtract (:offset a) (:offset b)))]
+                         (list 'mx/subtract a-off b-off))]
             (affine-linear coeff offset)))
         (not-affine)))
     (not-affine)))
@@ -116,20 +118,22 @@
   [args target-sym env]
   (if (= 2 (count args))
     (let [a (analyze-affine (first args) target-sym env)
-          b (analyze-affine (second args) target-sym env)]
+          b (analyze-affine (second args) target-sym env)
+          {a-tgt? :has-target?} a
+          {b-tgt? :has-target?} b]
       (if (and (:affine? a) (:affine? b))
         (cond
           ;; Neither depends on target — constant * constant
-          (and (not (:has-target? a)) (not (:has-target? b)))
+          (and (not a-tgt?) (not b-tgt?))
           (affine-constant (list 'mx/multiply (:offset a) (:offset b)))
 
           ;; Both depend on target — quadratic, not affine
-          (and (:has-target? a) (:has-target? b))
+          (and a-tgt? b-tgt?)
           (not-affine)
 
           ;; One constant, one target-dependent
           :else
-          (let [[const-r target-r] (if (:has-target? a) [b a] [a b])
+          (let [[const-r target-r] (if a-tgt? [b a] [a b])
                 c (:offset const-r)
                 coeff (if (= 1 (:coefficient target-r))
                         c
@@ -148,26 +152,28 @@
   [args target-sym env]
   (if (= 2 (count args))
     (let [a (analyze-affine (first args) target-sym env)
-          b (analyze-affine (second args) target-sym env)]
+          b (analyze-affine (second args) target-sym env)
+          {a-tgt? :has-target? a-coeff :coefficient a-off :offset} a
+          {b-tgt? :has-target? b-off :offset} b]
       (if (and (:affine? a) (:affine? b))
         (cond
           ;; Dividing by target-dependent expression — nonlinear
-          (:has-target? b)
+          b-tgt?
           (not-affine)
 
           ;; Neither depends on target
-          (not (:has-target? a))
-          (affine-constant (list 'mx/divide (:offset a) (:offset b)))
+          (not a-tgt?)
+          (affine-constant (list 'mx/divide a-off b-off))
 
           ;; Numerator depends on target, denominator constant
           :else
-          (let [c (:offset b)
-                coeff (if (= 1 (:coefficient a))
+          (let [c b-off
+                coeff (if (= 1 a-coeff)
                         (list 'mx/divide 1 c)
-                        (list 'mx/divide (:coefficient a) c))
-                offset (if (= 0 (:offset a))
+                        (list 'mx/divide a-coeff c))
+                offset (if (= 0 a-off)
                          0
-                         (list 'mx/divide (:offset a) c))]
+                         (list 'mx/divide a-off c))]
             (affine-linear coeff offset)))
         (not-affine)))
     (not-affine)))

--- a/src/genmlx/choicemap.cljs
+++ b/src/genmlx/choicemap.cljs
@@ -31,6 +31,8 @@
 
 (def EMPTY (->Node {}))
 
+(declare from-map)
+
 ;; ---------------------------------------------------------------------------
 ;; Smart constructor from flat key-value pairs
 ;; ---------------------------------------------------------------------------
@@ -46,7 +48,7 @@
       (map (fn [[k v]]
              [k (cond
                   (satisfies? IChoiceMap v) v
-                  (map? v) (apply choicemap (mapcat identity v))
+                  (map? v) (from-map v)
                   :else (->Value v))])
            (partition 2 kvs)))))
 
@@ -148,12 +150,11 @@
     (nil? cm) []
     (not (choicemap? cm)) []
     (has-value? cm) [[]]
-    (instance? Node cm)
+    :else
     (into []
       (mapcat (fn [[addr sub]]
                 (mapv #(into [addr] %) (addresses sub)))
-              (-submaps cm)))
-    :else []))
+              (-submaps cm)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Conversion to/from plain maps

--- a/src/genmlx/choicemap.cljs
+++ b/src/genmlx/choicemap.cljs
@@ -107,15 +107,15 @@
 (defn set-choice
   "Set a value at the given path, returning a new choice map."
   [cm path value]
-  (let [node-m (if (instance? Node cm) (:m cm) {})]
-    (if (= 1 (count path))
+  (let [node-m (if (instance? Node cm) (:m cm) {})
+        [addr & more] path]
+    (if (seq more)
+      (let [child (get-submap cm addr)
+            updated (set-choice child more value)]
+        (->Node (assoc node-m addr updated)))
       (->Node (assoc node-m
-                     (first path)
-                     (if (satisfies? IChoiceMap value) value (->Value value))))
-      (let [addr (first path)
-            child (get-submap cm addr)
-            updated (set-choice child (rest path) value)]
-        (->Node (assoc node-m addr updated))))))
+                     addr
+                     (if (satisfies? IChoiceMap value) value (->Value value)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Merge: values in b override values in a

--- a/src/genmlx/choicemap.cljs
+++ b/src/genmlx/choicemap.cljs
@@ -54,21 +54,26 @@
 ;; Access
 ;; ---------------------------------------------------------------------------
 
+(defn choicemap?
+  "Is x a non-nil value satisfying the IChoiceMap protocol?"
+  [x]
+  (and (some? x) (satisfies? IChoiceMap x)))
+
 (defn has-value?
   "Does this choice map node hold a leaf value?"
   [cm]
-  (and (some? cm) (satisfies? IChoiceMap cm) (-has-value? cm)))
+  (and (choicemap? cm) (-has-value? cm)))
 
 (defn get-value
   "Get the leaf value from a choice map node."
   [cm]
-  (when (and cm (satisfies? IChoiceMap cm) (-has-value? cm))
+  (when (and (choicemap? cm) (-has-value? cm))
     (-get-value cm)))
 
 (defn get-submap
   "Get the sub-choice-map at the given address."
   [cm addr]
-  (or (when (and cm (satisfies? IChoiceMap cm))
+  (or (when (choicemap? cm)
         (-get-submap cm addr))
       EMPTY))
 
@@ -102,15 +107,15 @@
 (defn set-choice
   "Set a value at the given path, returning a new choice map."
   [cm path value]
-  (if (= 1 (count path))
-    (->Node (assoc (if (instance? Node cm) (:m cm) {})
-                   (first path)
-                   (if (satisfies? IChoiceMap value) value (->Value value))))
-    (let [addr (first path)
-          child (get-submap cm addr)
-          updated (set-choice child (rest path) value)]
-      (->Node (assoc (if (instance? Node cm) (:m cm) {})
-                     addr updated)))))
+  (let [node-m (if (instance? Node cm) (:m cm) {})]
+    (if (= 1 (count path))
+      (->Node (assoc node-m
+                     (first path)
+                     (if (satisfies? IChoiceMap value) value (->Value value))))
+      (let [addr (first path)
+            child (get-submap cm addr)
+            updated (set-choice child (rest path) value)]
+        (->Node (assoc node-m addr updated))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Merge: values in b override values in a
@@ -122,8 +127,8 @@
   (cond
     (nil? b) a
     (nil? a) b
-    (not (satisfies? IChoiceMap b)) b
-    (not (satisfies? IChoiceMap a)) a
+    (not (choicemap? b)) b
+    (not (choicemap? a)) a
     (has-value? b) b
     (has-value? a) a
     :else
@@ -141,7 +146,7 @@
   [cm]
   (cond
     (nil? cm) []
-    (not (satisfies? IChoiceMap cm)) []
+    (not (choicemap? cm)) []
     (has-value? cm) [[]]
     (instance? Node cm)
     (into []
@@ -159,7 +164,7 @@
   [cm]
   (cond
     (nil? cm) {}
-    (not (satisfies? IChoiceMap cm)) {}
+    (not (choicemap? cm)) {}
     (has-value? cm) (-get-value cm)
     :else (into {} (map (fn [[k v]] [k (to-map v)])) (-submaps cm))))
 

--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -31,7 +31,7 @@
   "Sum a field across results, starting from scalar 0.0."
   [results field-fn]
   (reduce (fn [acc r] (mx/add acc (field-fn r)))
-          (mx/scalar 0.0)
+          ZERO
           results))
 
 (defn- values->choices
@@ -130,7 +130,7 @@
                         cm/EMPTY (map-indexed vector results))
         retvals (mapv :retval results)
         score (reduce (fn [acc r] (mx/add acc (:score r)))
-                      (mx/scalar 0.0) results)
+                      ZERO results)
         element-scores (mapv :score results)]
     (with-meta
       (tr/make-trace {:gen-fn this :args args
@@ -170,7 +170,7 @@
       (let [n (count (first args))
             init-key (rng/fresh-key)]
         (loop [i 0 key init-key
-               choices cm/EMPTY score (mx/scalar 0.0) weight (mx/scalar 0.0)
+               choices cm/EMPTY score ZERO weight ZERO
                retvals [] element-scores []]
           (if (>= i n)
             {:trace (with-meta
@@ -214,7 +214,7 @@
             n (count (first args))
             init-key (rng/fresh-key)]
         (loop [i 0 key init-key
-               choices cm/EMPTY score (mx/scalar 0.0) discard cm/EMPTY
+               choices cm/EMPTY score ZERO discard cm/EMPTY
                retvals [] element-scores []]
           (if (>= i n)
             {:trace (with-meta
@@ -247,7 +247,7 @@
                                   old-trace (tr/make-trace
                                              {:gen-fn kernel :args kernel-args
                                               :choices (cm/get-submap old-choices i)
-                                              :retval nil :score (if old-element-scores (nth old-element-scores i) (mx/scalar 0.0))})]
+                                              :retval nil :score (if old-element-scores (nth old-element-scores i) ZERO)})]
                               (p/update kernel old-trace (cm/get-submap constraints i))))
                           (range n))
             choices (assemble-choices results (comp :choices :trace))
@@ -273,7 +273,7 @@
             n (count (first args))
             init-key (rng/fresh-key)]
         (loop [i 0 key init-key
-               choices cm/EMPTY score (mx/scalar 0.0) weight (mx/scalar 0.0)
+               choices cm/EMPTY score ZERO weight ZERO
                retvals [] element-scores []]
           (if (>= i n)
             {:trace (with-meta
@@ -289,7 +289,7 @@
                   elem-choices (values->choices (:values result))
                   old-elem-score (or (some-> (::element-scores (meta trace))
                                              (nth i nil))
-                                     (mx/scalar 0.0))
+                                     ZERO)
                   ;; compiled-regenerate returns proposal_ratio in :weight
                   ;; per-step weight = new_score - old_score - proposal_ratio
                   step-weight (mx/subtract (mx/subtract (:score result) old-elem-score)
@@ -310,7 +310,7 @@
                                   old-trace (tr/make-trace
                                              {:gen-fn kernel :args kernel-args
                                               :choices (cm/get-submap old-choices i)
-                                              :retval nil :score (if old-element-scores (nth old-element-scores i) (mx/scalar 0.0))})]
+                                              :retval nil :score (if old-element-scores (nth old-element-scores i) ZERO)})]
                               (p/regenerate kernel old-trace
                                             (sel/get-subselection selection i))))
                           (range n))
@@ -373,12 +373,10 @@
   [cached-extras current-extras]
   (or (identical? cached-extras current-extras)
       (and (= (count cached-extras) (count current-extras))
-           (every? true?
-                   (map (fn [a b]
-                          (let [av (mx/item (mx/ensure-array a))
-                                bv (mx/item (mx/ensure-array b))]
-                            (== av bv)))
-                        cached-extras current-extras)))))
+           (every? (fn [[a b]]
+                     (== (mx/item (mx/ensure-array a))
+                         (mx/item (mx/ensure-array b))))
+                   (map vector cached-extras current-extras)))))
 
 (defn- get-or-build-fused-unfold
   "Get cached or build new fused unfold simulate.
@@ -421,7 +419,7 @@
   [this args kernel n init-state extra csim]
   (let [init-key (rng/fresh-key)]
     (loop [t 0 state init-state key init-key
-           choices cm/EMPTY score (mx/scalar 0.0)
+           choices cm/EMPTY score ZERO
            states [] step-scores []]
       (if (>= t n)
         (with-meta
@@ -443,7 +441,7 @@
   "Handler Unfold simulate: delegate to kernel per step."
   [this args kernel n init-state extra]
   (loop [t 0 state init-state
-         choices cm/EMPTY score (mx/scalar 0.0)
+         choices cm/EMPTY score ZERO
          states [] step-scores []]
     (if (>= t n)
       (with-meta
@@ -476,7 +474,7 @@
         ;; Compiled path
         (let [init-key (rng/fresh-key)]
           (loop [t 0 state init-state key init-key
-                 choices cm/EMPTY score (mx/scalar 0.0) weight (mx/scalar 0.0)
+                 choices cm/EMPTY score ZERO weight ZERO
                  states [] step-scores []]
             (if (>= t n)
               {:trace (with-meta
@@ -497,7 +495,7 @@
                        (conj step-scores (:score result)))))))
         ;; Fallback: handler path
         (loop [t 0 state init-state
-               choices cm/EMPTY score (mx/scalar 0.0) weight (mx/scalar 0.0)
+               choices cm/EMPTY score ZERO weight ZERO
                states [] step-scores []]
           (if (>= t n)
             {:trace (with-meta
@@ -535,7 +533,7 @@
                           0)]
       ;; If no steps have constraints and we have metadata, return trace unchanged
       (if (and old-step-scores (= first-changed n))
-        {:trace trace :weight (mx/scalar 0.0) :discard cm/EMPTY}
+        {:trace trace :weight ZERO :discard cm/EMPTY}
         ;; Build prefix from old trace (steps 0..first-changed-1)
         (let [prefix-choices (if (pos? first-changed)
                                (reduce (fn [cm t]
@@ -544,8 +542,8 @@
                                cm/EMPTY)
               prefix-score (if (pos? first-changed)
                              (reduce (fn [acc t] (mx/add acc (nth old-step-scores t)))
-                                     (mx/scalar 0.0) (range first-changed))
-                             (mx/scalar 0.0))
+                                     ZERO (range first-changed))
+                             ZERO)
               prefix-states (if (pos? first-changed)
                               (subvec (:retval trace) 0 first-changed)
                               [])
@@ -592,7 +590,7 @@
                       old-trace (tr/make-trace
                                  {:gen-fn kern :args kernel-args
                                   :choices old-sub-choices
-                                  :retval nil :score (if old-step-scores (nth old-step-scores t) (mx/scalar 0.0))})
+                                  :retval nil :score (if old-step-scores (nth old-step-scores t) ZERO)})
                       result (p/update kern old-trace (cm/get-submap constraints t))
                       new-trace (:trace result)
                       new-state (:retval new-trace)]
@@ -615,7 +613,7 @@
           old-step-scores (::step-scores (meta trace))
           init-key (when cregen (rng/fresh-key))]
       (loop [t 0 state init-state key init-key
-             new-choices cm/EMPTY score (mx/scalar 0.0) weight (mx/scalar 0.0)
+             new-choices cm/EMPTY score ZERO weight ZERO
              states [] step-scores []]
         (if (>= t n)
           {:trace (with-meta
@@ -626,7 +624,7 @@
            :weight weight}
           (let [old-sub-choices (cm/get-submap choices t)
                 kernel-args (into [t state] extra)
-                old-score (if old-step-scores (nth old-step-scores t) (mx/scalar 0.0))]
+                old-score (if old-step-scores (nth old-step-scores t) ZERO)]
             (if cregen
               ;; WP-9A: compiled regenerate path
               (let [[k1 k2] (rng/split key)
@@ -722,7 +720,7 @@
   (let [args (into [0 init-state] extra-args)]
     (with-meta
       (tr/make-trace {:gen-fn unfold-gf :args args
-                      :choices cm/EMPTY :retval [] :score (mx/scalar 0.0)})
+                      :choices cm/EMPTY :retval [] :score ZERO})
       {::step-scores []})))
 
 (defn unfold-extend
@@ -1024,7 +1022,7 @@
         (tr/make-trace {:gen-fn this :args args
                         :choices cm/EMPTY
                         :retval nil
-                        :score (mx/scalar 0.0)}))))
+                        :score ZERO}))))
 
   p/IGenerate
   (generate [this args constraints]
@@ -1039,8 +1037,8 @@
         {:trace (tr/make-trace {:gen-fn this :args args
                                 :choices cm/EMPTY
                                 :retval nil
-                                :score (mx/scalar 0.0)})
-         :weight (mx/scalar 0.0)}))))
+                                :score ZERO})
+         :weight ZERO}))))
 
 (defn mask-combinator
   "Create a Mask combinator that gates execution of an inner GF.
@@ -1065,7 +1063,7 @@
                                   :retval (:retval new-trace)
                                   :score (:score new-trace)})
            :weight (:weight result) :discard (:discard result)})
-        {:trace trace :weight (mx/scalar 0.0) :discard cm/EMPTY})))
+        {:trace trace :weight ZERO :discard cm/EMPTY})))
 
   p/IRegenerate
   (regenerate [this trace selection]
@@ -1083,7 +1081,7 @@
                                   :retval (:retval new-trace)
                                   :score (:score new-trace)})
            :weight (:weight result)})
-        {:trace trace :weight (mx/scalar 0.0)}))))
+        {:trace trace :weight ZERO}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Recurse Combinator
@@ -1155,7 +1153,7 @@
   p/IUpdateWithDiffs
   (update-with-diffs [this trace constraints argdiffs]
     (if (and (diff/no-change? argdiffs) (= constraints cm/EMPTY))
-      {:trace trace :weight (mx/scalar 0.0) :discard cm/EMPTY}
+      {:trace trace :weight ZERO :discard cm/EMPTY}
       (p/update this trace constraints)))
 
   edit/IEdit
@@ -1244,7 +1242,7 @@
                           (if (zero? i)
                             (:score bd)
                             (mx/where (idx-mask index i) (:score bd) acc)))
-                        (mx/scalar 0.0)
+                        ZERO
                         (vec branch-data))
         ;; Combine retvals
         combined-retval (let [rvs (mapv :retval branch-data)]
@@ -1335,7 +1333,7 @@
   [this args kernel init-carry inputs n csim]
   (let [init-key (rng/fresh-key)]
     (loop [t 0 carry init-carry key init-key
-           choices cm/EMPTY score (mx/scalar 0.0)
+           choices cm/EMPTY score ZERO
            outputs [] step-scores [] step-carries []]
       (if (>= t n)
         (with-meta
@@ -1361,7 +1359,7 @@
   "Handler Scan simulate: delegate to kernel per step."
   [this args kernel init-carry inputs n]
   (loop [t 0 carry init-carry
-         choices cm/EMPTY score (mx/scalar 0.0)
+         choices cm/EMPTY score ZERO
          outputs [] step-scores [] step-carries []]
     (if (>= t n)
       (with-meta
@@ -1399,7 +1397,7 @@
         ;; Compiled path
         (let [init-key (rng/fresh-key)]
           (loop [t 0 carry init-carry key init-key
-                 choices cm/EMPTY score (mx/scalar 0.0) weight (mx/scalar 0.0)
+                 choices cm/EMPTY score ZERO weight ZERO
                  outputs [] step-scores [] step-carries []]
             (if (>= t n)
               {:trace (with-meta
@@ -1424,7 +1422,7 @@
                        (conj step-carries new-carry))))))
         ;; Fallback: handler path
         (loop [t 0 carry init-carry
-               choices cm/EMPTY score (mx/scalar 0.0) weight (mx/scalar 0.0)
+               choices cm/EMPTY score ZERO weight ZERO
                outputs [] step-scores [] step-carries []]
           (if (>= t n)
             {:trace (with-meta
@@ -1467,7 +1465,7 @@
                           0)]
       ;; If no steps have constraints and we have metadata, return trace unchanged
       (if (and old-step-scores old-step-carries (= first-changed n))
-        {:trace trace :weight (mx/scalar 0.0) :discard cm/EMPTY}
+        {:trace trace :weight ZERO :discard cm/EMPTY}
         ;; Build prefix from old trace (steps 0..first-changed-1)
         (let [prefix-choices (if (pos? first-changed)
                                (reduce (fn [cm t]
@@ -1476,8 +1474,8 @@
                                cm/EMPTY)
               prefix-score (if (pos? first-changed)
                              (reduce (fn [acc t] (mx/add acc (nth old-step-scores t)))
-                                     (mx/scalar 0.0) (range first-changed))
-                             (mx/scalar 0.0))
+                                     ZERO (range first-changed))
+                             ZERO)
               prefix-outputs (if (pos? first-changed)
                                (subvec (:outputs (:retval trace)) 0 first-changed)
                                [])
@@ -1529,7 +1527,7 @@
                       old-trace (tr/make-trace
                                  {:gen-fn kern :args [carry (nth inputs t)]
                                   :choices old-sub-choices
-                                  :retval nil :score (if old-step-scores (nth old-step-scores t) (mx/scalar 0.0))})
+                                  :retval nil :score (if old-step-scores (nth old-step-scores t) ZERO)})
                       result (p/update kern old-trace (cm/get-submap constraints t))
                       new-trace (:trace result)
                       [new-carry output] (:retval new-trace)]
@@ -1554,7 +1552,7 @@
           old-step-scores (::step-scores (meta trace))
           init-key (when cregen (rng/fresh-key))]
       (loop [t 0 carry init-carry key init-key
-             new-choices cm/EMPTY score (mx/scalar 0.0) weight (mx/scalar 0.0)
+             new-choices cm/EMPTY score ZERO weight ZERO
              outputs [] step-scores [] step-carries []]
         (if (>= t n)
           {:trace (with-meta
@@ -1567,7 +1565,7 @@
            :weight weight}
           (let [old-sub-choices (cm/get-submap choices t)
                 kernel-args [carry (nth inputs t)]
-                old-score (if old-step-scores (nth old-step-scores t) (mx/scalar 0.0))]
+                old-score (if old-step-scores (nth old-step-scores t) ZERO)]
             (if cregen
               ;; WP-9A: compiled regenerate path
               (let [[k1 k2] (rng/split key)
@@ -1815,7 +1813,7 @@
                        (let [d (dc/->Distribution :categorical {:logits log-w})]
                          (dc/dist-generate d idx-constraint))
                        (let [d (dc/->Distribution :categorical {:logits log-w})]
-                         {:trace (dc/dist-simulate d) :weight (mx/scalar 0.0)}))
+                         {:trace (dc/dist-simulate d) :weight ZERO}))
           idx (mx/item (cm/get-value (:choices (:trace idx-result))))
           component (nth components (int idx))
           comp-constraints (without-component-idx constraints)]
@@ -2140,7 +2138,7 @@
       (cond
         ;; No changes to args and no new constraints: return trace unchanged
         (and (diff/no-change? argdiffs) (not has-constraints))
-        {:trace trace :weight (mx/scalar 0.0) :discard cm/EMPTY}
+        {:trace trace :weight ZERO :discard cm/EMPTY}
 
         ;; vector-diff with stored element scores: optimize
         (and (or (diff/no-change? argdiffs)
@@ -2162,7 +2160,7 @@
                                  old-trace (tr/make-trace
                                             {:gen-fn kernel :args kernel-args
                                              :choices (cm/get-submap old-choices i)
-                                             :retval nil :score (if old-element-scores (nth old-element-scores i) (mx/scalar 0.0))})]
+                                             :retval nil :score (if old-element-scores (nth old-element-scores i) ZERO)})]
                              (p/update kernel old-trace (cm/get-submap constraints i)))
                             ;; Element unchanged: reuse old choices and score
                            {:trace (tr/make-trace
@@ -2171,7 +2169,7 @@
                                      :choices (cm/get-submap old-choices i)
                                      :retval (nth (:retval trace) i nil)
                                      :score (nth old-element-scores i)})
-                            :weight (mx/scalar 0.0)
+                            :weight ZERO
                             :discard cm/EMPTY}))
                        (range n))
               choices (assemble-choices results (comp :choices :trace))
@@ -2195,7 +2193,7 @@
     (cond
       ;; No changes at all: fast path
       (and (diff/no-change? argdiffs) (= constraints cm/EMPTY))
-      {:trace trace :weight (mx/scalar 0.0) :discard cm/EMPTY}
+      {:trace trace :weight ZERO :discard cm/EMPTY}
 
       ;; Args changed: full update (strip step-scores to prevent invalid prefix-skip)
       (not (diff/no-change? argdiffs))
@@ -2209,7 +2207,7 @@
   p/IUpdateWithDiffs
   (update-with-diffs [this trace constraints argdiffs]
     (if (and (diff/no-change? argdiffs) (= constraints cm/EMPTY))
-      {:trace trace :weight (mx/scalar 0.0) :discard cm/EMPTY}
+      {:trace trace :weight ZERO :discard cm/EMPTY}
       (p/update this trace constraints))))
 
 (extend-type ScanCombinator
@@ -2218,7 +2216,7 @@
     (cond
       ;; No changes at all: fast path
       (and (diff/no-change? argdiffs) (= constraints cm/EMPTY))
-      {:trace trace :weight (mx/scalar 0.0) :discard cm/EMPTY}
+      {:trace trace :weight ZERO :discard cm/EMPTY}
 
       ;; Args changed: full update (strip metadata to prevent invalid prefix-skip)
       (not (diff/no-change? argdiffs))
@@ -2232,28 +2230,28 @@
   p/IUpdateWithDiffs
   (update-with-diffs [this trace constraints argdiffs]
     (if (and (diff/no-change? argdiffs) (= constraints cm/EMPTY))
-      {:trace trace :weight (mx/scalar 0.0) :discard cm/EMPTY}
+      {:trace trace :weight ZERO :discard cm/EMPTY}
       (p/update this trace constraints))))
 
 (extend-type ContramapGF
   p/IUpdateWithDiffs
   (update-with-diffs [this trace constraints argdiffs]
     (if (and (diff/no-change? argdiffs) (= constraints cm/EMPTY))
-      {:trace trace :weight (mx/scalar 0.0) :discard cm/EMPTY}
+      {:trace trace :weight ZERO :discard cm/EMPTY}
       (p/update this trace constraints))))
 
 (extend-type MapRetvalGF
   p/IUpdateWithDiffs
   (update-with-diffs [this trace constraints argdiffs]
     (if (and (diff/no-change? argdiffs) (= constraints cm/EMPTY))
-      {:trace trace :weight (mx/scalar 0.0) :discard cm/EMPTY}
+      {:trace trace :weight ZERO :discard cm/EMPTY}
       (p/update this trace constraints))))
 
 (extend-type MixCombinator
   p/IUpdateWithDiffs
   (update-with-diffs [this trace constraints argdiffs]
     (if (and (diff/no-change? argdiffs) (= constraints cm/EMPTY))
-      {:trace trace :weight (mx/scalar 0.0) :discard cm/EMPTY}
+      {:trace trace :weight ZERO :discard cm/EMPTY}
       (p/update this trace constraints))))
 
 ;; ---------------------------------------------------------------------------
@@ -2274,11 +2272,11 @@
                                  {:gen-fn kernel :args kernel-args
                                   :choices (cm/get-submap old-choices i)
                                   :retval (nth (:retval trace) i nil)
-                                  :score (if old-element-scores (nth old-element-scores i) (mx/scalar 0.0))})
+                                  :score (if old-element-scores (nth old-element-scores i) ZERO)})
                       w (p/project kernel sub-trace
                                    (sel/get-subselection selection i))]
                   (mx/add acc w)))
-              (mx/scalar 0.0)
+              ZERO
               (range n)))))
 
 (extend-type UnfoldCombinator
@@ -2288,7 +2286,7 @@
           {:keys [args choices]} trace
           [n init-state & extra] args]
       (loop [t 0 state init-state
-             weight (mx/scalar 0.0)]
+             weight ZERO]
         (if (>= t n)
           weight
           (let [kernel-args (into [t state] extra)
@@ -2319,7 +2317,7 @@
           [init-carry inputs] args
           n (count inputs)]
       (loop [t 0 carry init-carry
-             weight (mx/scalar 0.0)]
+             weight ZERO]
         (if (>= t n)
           weight
           (let [sub-choices (cm/get-submap choices t)
@@ -2339,7 +2337,7 @@
                             :choices (:choices trace)
                             :retval (:retval trace) :score (:score trace)})]
           (p/project (:inner this) inner-trace selection))
-        (mx/scalar 0.0)))))
+        ZERO))))
 
 (extend-type MixCombinator
   p/IProject
@@ -2355,7 +2353,7 @@
           ;; Project the component-idx if selected
           idx-weight (if (sel/selected? selection :component-idx)
                        (dc/dist-log-prob idx-dist (mx/scalar old-idx mx/int32))
-                       (mx/scalar 0.0))
+                       ZERO)
           ;; Project the inner component
           component (nth (:components this) old-idx)
           old-idx-score (dc/dist-log-prob idx-dist (mx/scalar old-idx mx/int32))
@@ -2415,7 +2413,7 @@
   p/IAssess
   (assess [this args choices]
     (let [[n init-state & extra] args]
-      (loop [t 0 state init-state weight (mx/scalar 0.0) states []]
+      (loop [t 0 state init-state weight ZERO states []]
         (if (>= t n)
           {:retval states :weight weight}
           (let [result (p/assess (:kernel this)
@@ -2430,7 +2428,7 @@
   (propose [this args]
     (let [[n init-state & extra] args]
       (loop [t 0 state init-state
-             choices cm/EMPTY weight (mx/scalar 0.0) states []]
+             choices cm/EMPTY weight ZERO states []]
         (if (>= t n)
           {:choices choices :weight weight :retval states}
           (let [result (p/propose (:kernel this)
@@ -2457,7 +2455,7 @@
   (assess [this args choices]
     (let [[init-carry inputs] args
           n (count inputs)]
-      (loop [t 0 carry init-carry weight (mx/scalar 0.0) outputs []]
+      (loop [t 0 carry init-carry weight ZERO outputs []]
         (if (>= t n)
           {:retval {:carry carry :outputs outputs} :weight weight}
           (let [result (p/assess (:kernel this)
@@ -2473,7 +2471,7 @@
     (let [[init-carry inputs] args
           n (count inputs)]
       (loop [t 0 carry init-carry
-             choices cm/EMPTY weight (mx/scalar 0.0) outputs []]
+             choices cm/EMPTY weight ZERO outputs []]
         (if (>= t n)
           {:choices choices :weight weight
            :retval {:carry carry :outputs outputs}}
@@ -2491,14 +2489,14 @@
     (let [[active? & inner-args] args]
       (if active?
         (p/assess (:inner this) (vec inner-args) choices)
-        {:retval nil :weight (mx/scalar 0.0)})))
+        {:retval nil :weight ZERO})))
 
   p/IPropose
   (propose [this args]
     (let [[active? & inner-args] args]
       (if active?
         (p/propose (:inner this) (vec inner-args))
-        {:choices cm/EMPTY :weight (mx/scalar 0.0) :retval nil}))))
+        {:choices cm/EMPTY :weight ZERO :retval nil}))))
 
 (extend-type RecurseCombinator
   p/IAssess

--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -1182,8 +1182,8 @@
   "Given N traces from the same GF, stack their values into [N]-shaped arrays."
   [traces]
   (let [first-choices (:choices (first traces))
-        is-leaf (cm/has-value? first-choices)]
-    {:choices (if is-leaf
+        leaf? (cm/has-value? first-choices)]
+    {:choices (if leaf?
                 (cm/->Value (mx/stack (mapv #(cm/get-value (:choices %)) traces)))
                 (let [addrs (cm/addresses first-choices)]
                   (reduce (fn [cm addr-path]
@@ -1212,11 +1212,11 @@
                           branches)
         ;; Combine branches using mx/where based on index
         first-choices (:choices (first branch-data))
-        is-leaf (cm/has-value? first-choices)
+        leaf? (cm/has-value? first-choices)
         ;; Build combined choices
         ;; Note: reduce-kv over full vector (not rest) so indices match branch indices
         combined-choices
-        (if is-leaf
+        (if leaf?
           ;; Distribution branches: combine leaf values
           (let [vals (mapv #(cm/get-value (:choices %)) branch-data)
                 combined (reduce-kv

--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -39,6 +39,33 @@
   [values]
   (cm/from-flat-map values))
 
+(defn- without-component-idx
+  "Drop the Mix combinator's :component-idx entry from a choicemap, leaving the
+   inner component's choices. Non-Node inputs (e.g. EMPTY) pass through unchanged."
+  [cm-choices]
+  (if (instance? cm/Node cm-choices)
+    (cm/->Node (dissoc (:m cm-choices) :component-idx))
+    cm-choices))
+
+(defn- batched-sub
+  "Build [transition init-sub] for one batched sub-execution.
+   Selects the generate transition (carrying weight) when constraints are
+   present, else the simulate transition, and merges the parent param-store.
+   zero is the [N]-shaped (or scalar) accumulator seed for score/weight."
+  [state constraints key batch-size zero]
+  (let [has-constraints? (and constraints (not= constraints cm/EMPTY))
+        init-sub (if has-constraints?
+                   {:choices cm/EMPTY :score zero :weight zero
+                    :key key :constraints constraints
+                    :batch-size batch-size :batched? true}
+                   {:choices cm/EMPTY :score zero
+                    :key key :batch-size batch-size :batched? true})
+        init-sub (if-let [ps (:param-store state)]
+                   (assoc init-sub :param-store ps)
+                   init-sub)]
+    [(if has-constraints? h/batched-generate-transition h/batched-simulate-transition)
+     init-sub]))
+
 ;; ---------------------------------------------------------------------------
 ;; Map Combinator
 ;; ---------------------------------------------------------------------------
@@ -675,20 +702,8 @@
               ;; Run one kernel step with batched handler
               (let [[sk nk] (rng/split key)
                     step-constraints (cm/get-submap sub-constraints t)
-                    has-constraints? (and step-constraints
-                                          (not= step-constraints cm/EMPTY))
                     [transition init-sub]
-                    (if has-constraints?
-                      [h/batched-generate-transition
-                       {:choices cm/EMPTY :score ZERO :weight ZERO
-                        :key sk :constraints step-constraints
-                        :batch-size batch-size :batched? true}]
-                      [h/batched-simulate-transition
-                       {:choices cm/EMPTY :score ZERO
-                        :key sk :batch-size batch-size :batched? true}])
-                    init-sub (if-let [ps (:param-store state)]
-                               (assoc init-sub :param-store ps)
-                               init-sub)
+                    (batched-sub state step-constraints sk batch-size ZERO)
                     step-result (rt/run-handler transition init-sub
                                                 (fn [rt] (apply (:body-fn kern) rt
                                                                 (into [t carry] extra))))
@@ -920,6 +935,21 @@
          (cm/set-choice acc addr-path (mx/where mask v-t v-f))))
      cm/EMPTY addrs)))
 
+(defn- idx-mask
+  "Boolean mask selecting particles whose [N]-shaped index equals branch i."
+  [index i]
+  (mx/equal index (mx/scalar i mx/int32)))
+
+(defn- where-combine
+  "Mask-select per-branch values into one [N]-shaped result.
+   value-fn extracts the value contributed by branch i's result; where the
+   [N]-shaped index equals i, that value wins over the running accumulator."
+  [index init results value-fn]
+  (reduce-kv
+   (fn [acc i r]
+     (mx/where (idx-mask index i) (value-fn r) acc))
+   init results))
+
 (extend-type SwitchCombinator
   p/IBatchedSplice
   (batched-splice [this state addr args]
@@ -940,54 +970,30 @@
                 (if (>= i (count brs))
                   results
                   (let [[bk nk] (rng/split key)
-                        has-constraints? (and sub-constraints
-                                              (not= sub-constraints cm/EMPTY))
                         [transition init-sub]
-                        (if has-constraints?
-                          [h/batched-generate-transition
-                           {:choices cm/EMPTY :score batch-zero :weight batch-zero
-                            :key bk :constraints sub-constraints
-                            :batch-size batch-size :batched? true}]
-                          [h/batched-simulate-transition
-                           {:choices cm/EMPTY :score batch-zero
-                            :key bk :batch-size batch-size :batched? true}])
-                        init-sub (if-let [ps (:param-store state)]
-                                   (assoc init-sub :param-store ps)
-                                   init-sub)
+                        (batched-sub state sub-constraints bk batch-size batch-zero)
                         result (rt/run-handler transition init-sub
                                                (fn [rt] (apply (:body-fn (nth brs i)) rt
                                                                (vec branch-args))))]
                     (recur (inc i) (conj results result) nk))))
               ;; Combine results using mx/where based on [N]-shaped index
               combined-score
-              (reduce-kv
-               (fn [acc i br]
-                 (let [mask (mx/equal index (mx/scalar i mx/int32))]
-                   (mx/where mask (:score br) acc)))
-               batch-zero branch-results)
+              (where-combine index batch-zero branch-results :score)
               combined-weight
               (when (contains? state :weight)
-                (reduce-kv
-                 (fn [acc i br]
-                   (let [mask (mx/equal index (mx/scalar i mx/int32))]
-                     (mx/where mask (or (:weight br) batch-zero) acc)))
-                 batch-zero branch-results))
+                (where-combine index batch-zero branch-results
+                               #(or (:weight %) batch-zero)))
               combined-choices
               (reduce-kv
                (fn [acc i br]
-                 (let [mask (mx/equal index (mx/scalar i mx/int32))]
-                   (if (zero? i)
-                     (:choices br)
-                     (where-select-choicemap mask (:choices br) acc))))
+                 (if (zero? i)
+                   (:choices br)
+                   (where-select-choicemap (idx-mask index i) (:choices br) acc)))
                cm/EMPTY branch-results)
               combined-retval
               (let [rvs (mapv :retval branch-results)]
                 (when (mx/array? (first rvs))
-                  (reduce-kv
-                   (fn [acc i rv]
-                     (let [mask (mx/equal index (mx/scalar i mx/int32))]
-                       (mx/where mask rv acc)))
-                   (first rvs) rvs)))
+                  (where-combine index (first rvs) rvs identity)))
               ;; Merge into parent state
               sub-result {:choices combined-choices
                           :score combined-score
@@ -1216,7 +1222,7 @@
                 combined (reduce-kv
                           (fn [acc i v]
                             (if (zero? i) acc
-                                (mx/where (mx/equal index (mx/scalar i mx/int32)) v acc)))
+                                (mx/where (idx-mask index i) v acc)))
                           (first vals) vals)]
             (cm/->Value combined))
           ;; GF branches: combine per-address
@@ -1230,7 +1236,7 @@
                      combined (reduce-kv
                                (fn [acc i v]
                                  (if (or (zero? i) (nil? v)) acc
-                                     (mx/where (mx/equal index (mx/scalar i mx/int32)) v acc)))
+                                     (mx/where (idx-mask index i) v acc)))
                                (or (first vals) (mx/zeros [n-val]))
                                vals)]
                  (cm/set-choice cm addr-path combined)))
@@ -1240,8 +1246,7 @@
                         (fn [acc i bd]
                           (if (zero? i)
                             (:score bd)
-                            (mx/where (mx/equal index (mx/scalar i mx/int32))
-                                      (:score bd) acc)))
+                            (mx/where (idx-mask index i) (:score bd) acc)))
                         (mx/scalar 0.0)
                         (vec branch-data))
         ;; Combine retvals
@@ -1250,7 +1255,7 @@
                             (reduce-kv
                              (fn [acc i rv]
                                (if (or (zero? i) (nil? rv)) acc
-                                   (mx/where (mx/equal index (mx/scalar i mx/int32)) rv acc)))
+                                   (mx/where (idx-mask index i) rv acc)))
                              (first rvs) rvs)
                             (first rvs)))]
     {:choices combined-choices
@@ -1639,20 +1644,8 @@
                 [state' carry])
               (let [[sk nk] (rng/split key)
                     step-constraints (cm/get-submap sub-constraints t)
-                    has-constraints? (and step-constraints
-                                          (not= step-constraints cm/EMPTY))
                     [transition init-sub]
-                    (if has-constraints?
-                      [h/batched-generate-transition
-                       {:choices cm/EMPTY :score batch-zero :weight batch-zero
-                        :key sk :constraints step-constraints
-                        :batch-size batch-size :batched? true}]
-                      [h/batched-simulate-transition
-                       {:choices cm/EMPTY :score batch-zero
-                        :key sk :batch-size batch-size :batched? true}])
-                    init-sub (if-let [ps (:param-store state)]
-                               (assoc init-sub :param-store ps)
-                               init-sub)
+                    (batched-sub state step-constraints sk batch-size batch-zero)
                     step-result (rt/run-handler transition init-sub
                                                 (fn [rt] ((:body-fn kern) rt carry (nth inputs t))))
                     [new-carry _output] (:retval step-result)]
@@ -1828,9 +1821,7 @@
                          {:trace (dc/dist-simulate d) :weight (mx/scalar 0.0)}))
           idx (mx/item (cm/get-value (:choices (:trace idx-result))))
           component (nth components (int idx))
-          comp-constraints (if (instance? cm/Node constraints)
-                             (cm/->Node (dissoc (:m constraints) :component-idx))
-                             constraints)]
+          comp-constraints (without-component-idx constraints)]
       (if-let [cgen (cops/get-compiled-generate component)]
         ;; Compiled path — only the component generate is compiled
         (let [key (rng/fresh-key)
@@ -1917,54 +1908,30 @@
                 (if (>= i (count comps))
                   results
                   (let [[ck nk] (rng/split key)
-                        has-inner? (and inner-constraints
-                                        (not= inner-constraints cm/EMPTY))
                         [transition init-sub]
-                        (if has-inner?
-                          [h/batched-generate-transition
-                           {:choices cm/EMPTY :score batch-zero :weight batch-zero
-                            :key ck :constraints inner-constraints
-                            :batch-size batch-size :batched? true}]
-                          [h/batched-simulate-transition
-                           {:choices cm/EMPTY :score batch-zero
-                            :key ck :batch-size batch-size :batched? true}])
-                        init-sub (if-let [ps (:param-store state)]
-                                   (assoc init-sub :param-store ps)
-                                   init-sub)
+                        (batched-sub state inner-constraints ck batch-size batch-zero)
                         result (rt/run-handler transition init-sub
                                                (fn [rt] (apply (:body-fn (nth comps i)) rt
                                                                (vec args))))]
                     (recur (inc i) (conj results result) nk))))
               ;; Combine per-particle results using mx/where on idx-vals
               combined-score
-              (reduce-kv
-               (fn [acc i cr]
-                 (let [mask (mx/equal idx-vals (mx/scalar i mx/int32))]
-                   (mx/where mask (:score cr) acc)))
-               batch-zero comp-results)
+              (where-combine idx-vals batch-zero comp-results :score)
               combined-weight
               (when (contains? state :weight)
-                (reduce-kv
-                 (fn [acc i cr]
-                   (let [mask (mx/equal idx-vals (mx/scalar i mx/int32))]
-                     (mx/where mask (or (:weight cr) batch-zero) acc)))
-                 batch-zero comp-results))
+                (where-combine idx-vals batch-zero comp-results
+                               #(or (:weight %) batch-zero)))
               combined-choices
               (reduce-kv
                (fn [acc i cr]
-                 (let [mask (mx/equal idx-vals (mx/scalar i mx/int32))]
-                   (if (zero? i)
-                     (:choices cr)
-                     (where-select-choicemap mask (:choices cr) acc))))
+                 (if (zero? i)
+                   (:choices cr)
+                   (where-select-choicemap (idx-mask idx-vals i) (:choices cr) acc)))
                cm/EMPTY comp-results)
               combined-retval
               (let [rvs (mapv :retval comp-results)]
                 (when (mx/array? (first rvs))
-                  (reduce-kv
-                   (fn [acc i rv]
-                     (let [mask (mx/equal idx-vals (mx/scalar i mx/int32))]
-                       (mx/where mask rv acc)))
-                   (first rvs) rvs)))
+                  (where-combine idx-vals (first rvs) rvs identity)))
               ;; Add component-idx to choices + add idx-score to combined score
               final-choices (cm/set-value combined-choices :component-idx idx-vals)
               final-score (mx/add combined-score idx-score)
@@ -1997,10 +1964,8 @@
                     (int (mx/item (cm/get-value idx-constraint)))
                     old-idx)
           ;; Inner choices = everything except component-idx
-          inner-old-choices (cm/->Node (dissoc (:m old-choices) :component-idx))
-          inner-constraints (if (= constraints cm/EMPTY)
-                              cm/EMPTY
-                              (cm/->Node (dissoc (:m constraints) :component-idx)))]
+          inner-old-choices (without-component-idx old-choices)
+          inner-constraints (without-component-idx constraints)]
       (if (= new-idx old-idx)
         ;; Same component: update inner only
         (let [component (nth (:components this) old-idx)
@@ -2084,7 +2049,7 @@
         ;; Same component: regenerate within the component
         (let [component (nth (:components this) old-idx)
               inner-old-score (mx/subtract (:score trace) old-idx-score)
-              inner-old-choices (cm/->Node (dissoc (:m old-choices) :component-idx))]
+              inner-old-choices (without-component-idx old-choices)]
           (if-let [cregen (cops/get-compiled-regenerate component)]
             ;; WP-9A: compiled regenerate path
             (let [key (rng/fresh-key)
@@ -2397,7 +2362,7 @@
           ;; Project the inner component
           component (nth (:components this) old-idx)
           old-idx-score (dc/dist-log-prob idx-dist (mx/scalar old-idx mx/int32))
-          inner-old-choices (cm/->Node (dissoc (:m old-choices) :component-idx))
+          inner-old-choices (without-component-idx old-choices)
           inner-old-score (mx/subtract (:score trace) old-idx-score)
           inner-trace (tr/make-trace {:gen-fn component :args args
                                       :choices inner-old-choices
@@ -2582,9 +2547,7 @@
           idx-dist (dc/->Distribution :categorical {:logits log-w})
           idx-weight (dc/dist-log-prob idx-dist (mx/scalar idx mx/int32))
           component (nth (:components this) idx)
-          inner-choices (if (instance? cm/Node choices)
-                          (cm/->Node (dissoc (:m choices) :component-idx))
-                          choices)
+          inner-choices (without-component-idx choices)
           inner-result (p/assess component args inner-choices)]
       {:retval (:retval inner-result)
        :weight (mx/add idx-weight (:weight inner-result))}))

--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -6,6 +6,7 @@
             [genmlx.choicemap :as cm]
             [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
+            [genmlx.mlx.constants :refer [ZERO]]
             [genmlx.selection :as sel]
             [genmlx.handler :as h]
             [genmlx.runtime :as rt]
@@ -642,8 +643,6 @@
 ;; When spliced inside a batched handler (vsimulate/vgenerate), loops T times
 ;; running the kernel body-fn ONCE per step with all N particles via the
 ;; batched handler. O(T) kernel executions instead of O(N*T).
-
-(def ^:private ZERO (mx/scalar 0.0))
 
 (extend-type UnfoldCombinator
   p/IBatchedSplice

--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -1141,9 +1141,8 @@
                               :choices (:choices new-trace)
                               :retval (:retval new-trace)
                               :score (:score new-trace)})
-       :weight (:weight result)})))
+       :weight (:weight result)}))
 
-(extend-type RecurseCombinator
   p/IProject
   (project [this trace selection]
     (let [gf ((:maker this) this)
@@ -1151,16 +1150,14 @@
                        {:gen-fn gf :args (:args trace)
                         :choices (:choices trace)
                         :retval (:retval trace) :score (:score trace)})]
-      (p/project gf inner-trace selection))))
+      (p/project gf inner-trace selection)))
 
-(extend-type RecurseCombinator
   p/IUpdateWithDiffs
   (update-with-diffs [this trace constraints argdiffs]
     (if (and (diff/no-change? argdiffs) (= constraints cm/EMPTY))
       {:trace trace :weight (mx/scalar 0.0) :discard cm/EMPTY}
-      (p/update this trace constraints))))
+      (p/update this trace constraints)))
 
-(extend-type RecurseCombinator
   edit/IEdit
   (edit [gf trace edit-request]
     (edit/edit-dispatch gf trace edit-request)))

--- a/src/genmlx/compiled.cljs
+++ b/src/genmlx/compiled.cljs
@@ -20,6 +20,30 @@
             [genmlx.handler :as h]))
 
 ;; ---------------------------------------------------------------------------
+;; Shared compiled-loop helpers
+;; ---------------------------------------------------------------------------
+
+(defn- slice-row
+  "Extract row `idx` from the leading axis of `tensor` and reshape to `shape`.
+   The take-idx + reshape idiom used throughout the compiled unfold/PF loops."
+  [tensor idx shape]
+  (mx/reshape (mx/take-idx tensor (mx/array [idx] mx/int32) 0) shape))
+
+(defn- diag-gaussian-logprob
+  "Log-density of a diagonal Gaussian. `diff` = value - mean, `std` = per-dim
+   std, `dim` = dimensionality. With `sum-axis` the quadratic term is reduced
+   along that axis (per-row [N] log-probs); without it the result is a scalar
+   full reduction."
+  ([diff std dim] (diag-gaussian-logprob diff std dim nil))
+  ([diff std dim sum-axis]
+   (let [quad (mx/divide (mx/multiply diff diff) (mx/multiply std std))
+         quad-sum (if sum-axis (mx/sum quad sum-axis) (mx/sum quad))]
+     (mx/subtract
+      (mx/subtract (mx/multiply (mx/scalar -0.5) quad-sum)
+                   (mx/sum (mx/log std)))
+      (mx/scalar (* 0.5 dim (js/Math.log (* 2 js/Math.PI))))))))
+
+;; ---------------------------------------------------------------------------
 ;; Core: compiled unfold step loop
 ;; ---------------------------------------------------------------------------
 
@@ -43,9 +67,7 @@
           (loop [t 0, state init-state, score (mx/scalar 0.0), states []]
             (if (>= t n-steps)
               [state (mx/stack states) score]
-              (let [noise-row (mx/reshape
-                               (mx/take-idx noise-2d (mx/array [t] mx/int32) 0)
-                               [noise-dim])
+              (let [noise-row (slice-row noise-2d t [noise-dim])
                     [new-state step-score] (step-fn state noise-row)]
                 (recur (inc t)
                        new-state
@@ -82,12 +104,8 @@
                  states []]
             (if (>= t n-steps)
               [state (mx/stack states) score weight]
-              (let [noise-row (mx/reshape
-                               (mx/take-idx noise-2d (mx/array [t] mx/int32) 0)
-                               [noise-dim])
-                    obs-row (mx/reshape
-                             (mx/take-idx obs-2d (mx/array [t] mx/int32) 0)
-                             [obs-dim])
+              (let [noise-row (slice-row noise-2d t [noise-dim])
+                    obs-row (slice-row obs-2d t [obs-dim])
                     [new-state step-score step-weight] (step-fn state noise-row obs-row)]
                 (recur (inc t)
                        new-state
@@ -129,10 +147,7 @@
         ;; Build choicemap from states tensor
         choices (reduce
                  (fn [cm t]
-                   (let [state-t (mx/reshape
-                                  (mx/take-idx states (mx/array [t] mx/int32) 0)
-                                  [state-dim])]
-                     (cm/set-value cm (addr-fn t) state-t)))
+                   (cm/set-value cm (addr-fn t) (slice-row states t [state-dim])))
                  cm/EMPTY
                  (range n-steps))]
     (tr/make-trace {:gen-fn nil :args [n-steps init-state]
@@ -164,10 +179,7 @@
         ;; Build choicemap from states tensor
         choices (reduce
                  (fn [cm t]
-                   (let [state-t (mx/reshape
-                                  (mx/take-idx states (mx/array [t] mx/int32) 0)
-                                  [state-dim])]
-                     (cm/set-value cm (addr-fn t) state-t)))
+                   (cm/set-value cm (addr-fn t) (slice-row states t [state-dim])))
                  cm/EMPTY
                  (range n-steps))]
     {:trace (tr/make-trace {:gen-fn nil :args [n-steps init-state]
@@ -192,23 +204,11 @@
           new-state (mx/add t-mean (mx/multiply t-std noise-row))
           ;; Transition log-prob
           t-diff (mx/subtract new-state t-mean)
-          t-lp (mx/subtract
-                (mx/subtract
-                 (mx/multiply (mx/scalar -0.5)
-                              (mx/sum (mx/divide (mx/multiply t-diff t-diff)
-                                                 (mx/multiply t-std t-std))))
-                 (mx/sum (mx/log t-std)))
-                (mx/scalar (* 0.5 state-dim (js/Math.log (* 2 js/Math.PI)))))
+          t-lp (diag-gaussian-logprob t-diff t-std state-dim)
           ;; Observation log-prob
           [o-mean o-std] (observation-fn new-state)
           o-diff (mx/subtract obs-row o-mean)
-          o-lp (mx/subtract
-                (mx/subtract
-                 (mx/multiply (mx/scalar -0.5)
-                              (mx/sum (mx/divide (mx/multiply o-diff o-diff)
-                                                 (mx/multiply o-std o-std))))
-                 (mx/sum (mx/log o-std)))
-                (mx/scalar (* 0.5 obs-dim (js/Math.log (* 2 js/Math.PI)))))
+          o-lp (diag-gaussian-logprob o-diff o-std obs-dim)
           ;; score = transition + observation, weight = observation
           score (mx/add t-lp o-lp)]
       [new-state score o-lp])))
@@ -255,17 +255,11 @@
             (if (>= t n-steps)
               [states log-ml]
               (let [;; Extract noise for this step: [N, noise-dim]
-                    noise-t (mx/reshape
-                             (mx/take-idx noise-3d (mx/array [t] mx/int32) 0)
-                             [n-particles noise-dim])
+                    noise-t (slice-row noise-3d t [n-particles noise-dim])
                     ;; Extract observation: [obs-dim]
-                    obs-t (mx/reshape
-                           (mx/take-idx obs-2d (mx/array [t] mx/int32) 0)
-                           [obs-dim])
+                    obs-t (slice-row obs-2d t [obs-dim])
                     ;; Extract uniform for resampling: [1]
-                    u0 (mx/reshape
-                        (mx/take-idx uniforms-2d (mx/array [t] mx/int32) 0)
-                        [1])
+                    u0 (slice-row uniforms-2d t [1])
                     ;; 1. Extend particles
                     [new-states log-weights] (particle-step-fn states noise-t obs-t)
                     ;; 2. Log-ML increment: logsumexp(w) - log(N)
@@ -334,15 +328,8 @@
           [o-mean o-std] (observation-fn new-states)
           ;; obs-row is [M], o-mean is [N,M] — broadcast subtraction
           o-diff (mx/subtract obs-row o-mean)
-          ;; Per-particle log-prob: sum over obs dimensions
-          log-weights (mx/subtract
-                       (mx/subtract
-                        (mx/multiply (mx/scalar -0.5)
-                                     (mx/sum (mx/divide (mx/multiply o-diff o-diff)
-                                                        (mx/multiply o-std o-std))
-                                             1)) ;; sum along obs dim (axis=1)
-                        (mx/sum (mx/log o-std))) ;; this is scalar, broadcasts
-                       (mx/scalar (* 0.5 obs-dim (js/Math.log (* 2 js/Math.PI)))))]
+          ;; Per-particle log-prob: sum over obs dimensions (axis=1)
+          log-weights (diag-gaussian-logprob o-diff o-std obs-dim 1)]
       [new-states log-weights])))
 
 ;; ===========================================================================
@@ -731,20 +718,10 @@
         nt (get noise-transforms-full dist-type)]
     (when nt
       (cond
-        (:noise-fn nt)
-        ;; Standard distribution: noise pre-generated, transform + score inside compiled fn
-        (let [transform-fn (:transform nt)
-              log-prob-fn (:log-prob nt)]
-          (fn [{:keys [values score]} site-idx noise-array args-vec]
-            (let [eval-args (mapv #(% values args-vec) compiled-args)
-                  noise (mx/index noise-array site-idx)
-                  value (apply transform-fn noise eval-args)
-                  lp (apply log-prob-fn value eval-args)]
-              {:values (assoc values addr value)
-               :score (mx/add score lp)})))
-
-        (:args-noise-fn nt)
-        ;; Dynamic-shape noise: noise pre-generated outside, passed in
+        ;; Noise-driven sites: :noise-fn pre-generates standard noise,
+        ;; :args-noise-fn pre-generates dynamic-shape noise. Both transform the
+        ;; pre-generated noise and score it identically inside the compiled fn.
+        (or (:noise-fn nt) (:args-noise-fn nt))
         (let [transform-fn (:transform nt)
               log-prob-fn (:log-prob nt)]
           (fn [{:keys [values score]} site-idx noise-array args-vec]
@@ -803,6 +780,30 @@
               v (if nfn (nfn k2) (mx/scalar 0.0))]
           (recur (inc i) k1 (conj! noise-vals v)))))))
 
+(defn- run-site-steps
+  "Run the noise-transform step-fns and return a flat JS array
+   [v0 v1 ... vN score], values ordered by `addrs`. Shared inner-fn body for
+   the M2/M3/M4 compiled simulate paths."
+  [step-fns addrs noise-array args-vec]
+  (let [result (reduce-kv
+                (fn [state idx step-fn]
+                  (step-fn state idx noise-array args-vec))
+                {:values {} :score (mx/scalar 0.0)}
+                step-fns)
+        vals (mapv #(get (:values result) %) addrs)]
+    (to-array (conj vals (:score result)))))
+
+(defn- unpack-result
+  "Unpack a flat [v0 ... vN score] JS array (from run-site-steps) into
+   {:values {addr->val} :score}."
+  [result addrs n-sites]
+  (let [values (loop [i 0 m {}]
+                 (if (= i n-sites)
+                   m
+                   (recur (inc i)
+                          (assoc m (nth addrs i) (aget result i)))))]
+    {:values values :score (aget result n-sites)}))
+
 (defn make-compiled-simulate
   "Build a compiled simulate function from a gen schema and source.
 
@@ -827,15 +828,7 @@
         ;; Build the inner pure function: takes pre-generated noise array
         (let [inner-fn
               (fn [noise-array args-vec]
-                (let [result
-                      (reduce-kv
-                       (fn [state idx step-fn]
-                         (step-fn state idx noise-array args-vec))
-                       {:values {} :score (mx/scalar 0.0)}
-                       step-fns)
-                      vals (mapv #(get (:values result) %) addrs)]
-                  ;; Return flat JS array: [v0 v1 ... vN score]
-                  (to-array (conj vals (:score result)))))
+                (run-site-steps step-fns addrs noise-array args-vec))
               ;; Build arity-specific wrapper for mx/compile-fn.
               ;; Skip mx/compile-fn when any site uses :args-noise-fn
               ;; (dynamic noise shape breaks Metal graph caching).
@@ -873,13 +866,7 @@
                   result (if (not= (count mlx-args) n-params)
                            (inner-fn noise mlx-args)
                            (compiled-inner noise mlx-args))
-                  ;; Unpack flat JS array → values map
-                  values (loop [i 0 m {}]
-                           (if (= i n-sites)
-                             m
-                             (recur (inc i)
-                                    (assoc m (nth addrs i) (aget result i)))))
-                  score (aget result n-sites)]
+                  {:keys [values score]} (unpack-result result addrs n-sites)]
               {:values values
                :score score
                :retval (when retval-fn
@@ -1071,14 +1058,7 @@
       (when (every? some? step-fns)
         (let [inner-fn
               (fn [noise-array args-vec]
-                (let [result
-                      (reduce-kv
-                       (fn [state idx step-fn]
-                         (step-fn state idx noise-array args-vec))
-                       {:values {} :score (mx/scalar 0.0)}
-                       step-fns)
-                      vals (mapv #(get (:values result) %) addrs)]
-                  (to-array (conj vals (:score result)))))
+                (run-site-steps step-fns addrs noise-array args-vec))
               n-params (count (first source))
               ;; mx/compile-fn for 0-param models (no risk of complex args).
               ;; Noise generated outside to avoid compile-fn caching.
@@ -1091,14 +1071,8 @@
           {:fn (fn compiled-prefix [key args-vec]
                  (let [mlx-args (ensure-numeric-mlx-args args-vec)
                        noise (generate-site-noise compiled-sites key)
-                       result (compiled-inner noise mlx-args)
-                       values (loop [i 0 m {}]
-                                (if (= i n-sites)
-                                  m
-                                  (recur (inc i)
-                                         (assoc m (nth addrs i) (aget result i)))))
-                       score (aget result n-sites)]
-                   {:values values :score score}))
+                       result (compiled-inner noise mlx-args)]
+                   (unpack-result result addrs n-sites)))
            :addrs addrs})))))
 
 ;; ---------------------------------------------------------------------------
@@ -1386,14 +1360,7 @@
         (let [n-sites (count site-specs)
               inner-fn
               (fn [noise-array args-vec]
-                (let [result
-                      (reduce-kv
-                       (fn [state idx step-fn]
-                         (step-fn state idx noise-array args-vec))
-                       {:values {} :score (mx/scalar 0.0)}
-                       step-fns)
-                      vals (mapv #(get (:values result) %) addrs)]
-                  (to-array (conj vals (:score result)))))
+                (run-site-steps step-fns addrs noise-array args-vec))
               ;; Skip mx/compile-fn for M4 — mx/where args vary per call.
               ;; Noise generated outside for consistency with M2/M3.
               compiled-inner
@@ -1402,12 +1369,7 @@
             (let [mlx-args (ensure-mlx-args args-vec)
                   noise (generate-site-noise site-specs key)
                   result (compiled-inner noise mlx-args)
-                  values (loop [i 0 m {}]
-                           (if (= i n-sites)
-                             m
-                             (recur (inc i)
-                                    (assoc m (nth addrs i) (aget result i)))))
-                  score (aget result n-sites)]
+                  {:keys [values score]} (unpack-result result addrs n-sites)]
               {:values values
                :score score
                :retval (when retval-fn

--- a/src/genmlx/compiled.cljs
+++ b/src/genmlx/compiled.cljs
@@ -797,12 +797,8 @@
   "Unpack a flat [v0 ... vN score] JS array (from run-site-steps) into
    {:values {addr->val} :score}."
   [result addrs n-sites]
-  (let [values (loop [i 0 m {}]
-                 (if (= i n-sites)
-                   m
-                   (recur (inc i)
-                          (assoc m (nth addrs i) (aget result i)))))]
-    {:values values :score (aget result n-sites)}))
+  ;; zipmap stops at the shorter seq (addrs), so the trailing score slot is excluded
+  {:values (zipmap addrs result) :score (aget result n-sites)})
 
 (defn make-compiled-simulate
   "Build a compiled simulate function from a gen schema and source.

--- a/src/genmlx/compiled.cljs
+++ b/src/genmlx/compiled.cljs
@@ -12,6 +12,8 @@
    enabling fusion into a single Metal kernel. No mutable state, no handler."
   (:require [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
+            [genmlx.mlx.constants :refer [ZERO ONE TWO HALF NEG-INF
+                                          LOG-2PI-HALF LOG-2 LOG-PI MLX-PI]]
             [genmlx.choicemap :as cm]
             [genmlx.trace :as tr]
             [genmlx.vectorized :as vec]
@@ -552,15 +554,7 @@
 ;;
 ;; Distributions NOT in this map fall back to dc/dist-sample (no compilation).
 
-(def ^:private LOG-2PI-HALF (mx/scalar (* 0.5 (js/Math.log (* 2.0 js/Math.PI)))))
-(def ^:private HALF (mx/scalar 0.5))
-(def ^:private ONE (mx/scalar 1.0))
-(def ^:private ZERO (mx/scalar 0.0))
-(def ^:private NEG-INF (mx/scalar ##-Inf))
-(def ^:private TWO (mx/scalar 2.0))
-(def ^:private LOG-2 (mx/scalar (js/Math.log 2.0)))
-(def ^:private LOG-PI (mx/scalar (js/Math.log js/Math.PI)))
-(def ^:private MLX-PI (mx/scalar js/Math.PI))
+;; Scalar/log constants live in genmlx.mlx.constants (centralized, cached).
 
 ;; ---------------------------------------------------------------------------
 ;; Arg coercion helpers

--- a/src/genmlx/compiled_gen.cljs
+++ b/src/genmlx/compiled_gen.cljs
@@ -13,9 +13,6 @@
    on top of the standard vgenerate pipeline."
   (:require [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
-            [genmlx.dynamic :as dyn]
-            [genmlx.vectorized :as vec]
-            [genmlx.learning :as learn]
             [genmlx.inference.differentiable :as diff]))
 
 ;; ---------------------------------------------------------------------------
@@ -26,10 +23,9 @@
   "Trigger Metal kernel compilation with dummy inputs."
   [compiled-fn d & extra-args]
   (let [dummy (mx/zeros [d])
-        r1 (apply compiled-fn dummy extra-args)]
-    (mx/materialize! (if (sequential? r1) (first r1) r1))
-    (let [r2 (apply compiled-fn dummy extra-args)]
-      (mx/materialize! (if (sequential? r2) (first r2) r2)))))
+        materialize-result (fn [r] (mx/materialize! (if (sequential? r) (first r) r)))]
+    (dotimes [_ 2]
+      (materialize-result (apply compiled-fn dummy extra-args)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Compiled log-ML (fixed key — deterministic IS)
@@ -82,12 +78,10 @@
      :n-particles  - IS particles (default 1000)"
   [{:keys [n-particles] :or {n-particles 1000}}
    model args observations param-names]
-  (let [model (dyn/auto-key model)
-        loss-fn (fn [p key]
-                  (let [store {:params (learn/array->params p param-names)}
-                        gf (vary-meta model assoc :genmlx.dynamic/param-store store)
-                        vtrace (dyn/vgenerate gf args observations n-particles key)]
-                    (mx/negative (vec/vtrace-log-ml-estimate vtrace))))
-        compiled (mx/compile-fn (mx/value-and-grad loss-fn [0]))]
+  (let [loss-grad-fn (diff/make-is-loss-grad-fn model args observations param-names n-particles)
+        compiled (mx/compile-fn
+                   (fn [p key]
+                     (let [{:keys [loss grad]} (loss-grad-fn p key)]
+                       [loss grad])))]
     (warm-up compiled (count param-names) (rng/fresh-key 0))
     compiled))

--- a/src/genmlx/compiled_ops.cljs
+++ b/src/genmlx/compiled_ops.cljs
@@ -808,8 +808,7 @@
           state-keys (when map-state? (vec (sort (keys return-expr))))
           n-state (if map-state? (count state-keys) 1)
           retval-fn (compiled/compile-expr return-expr binding-env #{})
-          addr-order (mapv :addr static-sites)
-          n-sites (count static-sites)]
+          addr-order (mapv :addr static-sites)]
       (when (and (every? some? site-specs)
                  (every? some? fused-steps)
                  retval-fn
@@ -897,8 +896,7 @@
                      (compiled/compile-expr (first return-expr) binding-env #{}))
           output-fn (when (vector? return-expr)
                       (compiled/compile-expr (second return-expr) binding-env #{}))
-          addr-order (mapv :addr static-sites)
-          n-sites (count static-sites)]
+          addr-order (mapv :addr static-sites)]
       (when (and (every? some? site-specs)
                  (every? some? fused-steps)
                  carry-fn output-fn

--- a/src/genmlx/compiled_ops.cljs
+++ b/src/genmlx/compiled_ops.cljs
@@ -438,15 +438,7 @@
              (empty? (:param-sites schema)))
     (let [binding-env (compiled/build-binding-env source)
           static-sites (filterv :static? (:trace-sites schema))
-          site-specs
-          (mapv (fn [ts]
-                  (let [cargs (mapv #(compiled/compile-expr % binding-env #{})
-                                    (:dist-args ts))]
-                    (when (every? some? cargs)
-                      {:addr (:addr ts)
-                       :compiled-args cargs
-                       :dist-type (:dist-type ts)})))
-                static-sites)
+          site-specs (compiled/build-fused-site-specs static-sites binding-env)
           step-fns (when (every? some? site-specs)
                      (mapv build-project-site-step site-specs))]
       (when (and step-fns (every? some? step-fns))
@@ -490,39 +482,20 @@
    Returns {:fn (fn [args-vec old-choices selection] -> {:values :weight})
             :addrs [keyword...]} or nil."
   [schema source]
-  (when (and (not (:static? schema))
-             (seq (:trace-sites schema))
-             (empty? (:splice-sites schema))
-             (empty? (:param-sites schema)))
-    (let [raw-prefix (compiled/extract-prefix-sites source)]
-      (when (seq raw-prefix)
-        (let [binding-env (compiled/build-binding-env source)
-              compiled-sites
-              (reduce
-               (fn [acc site]
-                 (let [cargs (mapv #(compiled/compile-expr % binding-env #{})
-                                   (:dist-args site))
-                       nt (get compiled/noise-transforms-full (:dist-type site))]
-                   (if (and nt (every? some? cargs))
-                     (conj acc (assoc site :compiled-args cargs))
-                     (reduced acc))))
-               []
-               raw-prefix)]
-          (when (seq compiled-sites)
-            (let [step-fns (mapv build-project-site-step compiled-sites)
-                  addrs (mapv :addr compiled-sites)]
-              (when (every? some? step-fns)
-                {:fn (fn compiled-prefix-project [args-vec old-choices selection]
-                       (let [mlx-args (compiled/ensure-numeric-mlx-args args-vec)
-                             result
-                             (reduce
-                              (fn [state step-fn]
-                                (step-fn state mlx-args old-choices selection))
-                              {:values {} :score (mx/scalar 0.0) :weight (mx/scalar 0.0)}
-                              step-fns)]
-                         {:values (:values result)
-                          :weight (:weight result)}))
-                 :addrs addrs}))))))))
+  (when-let [{:keys [compiled-sites addrs]} (compiled/prepare-prefix-sites schema source)]
+    (let [step-fns (mapv build-project-site-step compiled-sites)]
+      (when (every? some? step-fns)
+        {:fn (fn compiled-prefix-project [args-vec old-choices selection]
+               (let [mlx-args (compiled/ensure-numeric-mlx-args args-vec)
+                     result
+                     (reduce
+                      (fn [state step-fn]
+                        (step-fn state mlx-args old-choices selection))
+                      {:values {} :score (mx/scalar 0.0) :weight (mx/scalar 0.0)}
+                      step-fns)]
+                 {:values (:values result)
+                  :weight (:weight result)}))
+         :addrs addrs}))))
 
 (defn make-replay-project-transition
   "Build a replay transition for partial project compilation.
@@ -619,15 +592,7 @@
              (empty? (:param-sites schema)))
     (let [binding-env (compiled/build-binding-env source)
           static-sites (filterv :static? (:trace-sites schema))
-          site-specs
-          (mapv (fn [ts]
-                  (let [cargs (mapv #(compiled/compile-expr % binding-env #{})
-                                    (:dist-args ts))]
-                    (when (every? some? cargs)
-                      {:addr (:addr ts)
-                       :compiled-args cargs
-                       :dist-type (:dist-type ts)})))
-                static-sites)
+          site-specs (compiled/build-fused-site-specs static-sites binding-env)
           step-fns (when (every? some? site-specs)
                      (mapv build-regenerate-site-step site-specs))
           return-expr (compiled/extract-return-expr (:return-form schema))
@@ -684,40 +649,21 @@
             :addrs [keyword...]}
    or nil if partial compilation isn't applicable."
   [schema source]
-  (when (and (not (:static? schema))
-             (seq (:trace-sites schema))
-             (empty? (:splice-sites schema))
-             (empty? (:param-sites schema)))
-    (let [raw-prefix (compiled/extract-prefix-sites source)]
-      (when (seq raw-prefix)
-        (let [binding-env (compiled/build-binding-env source)
-              compiled-sites
-              (reduce
-               (fn [acc site]
-                 (let [cargs (mapv #(compiled/compile-expr % binding-env #{})
-                                   (:dist-args site))
-                       nt (get compiled/noise-transforms-full (:dist-type site))]
-                   (if (and nt (every? some? cargs))
-                     (conj acc (assoc site :compiled-args cargs))
-                     (reduced acc))))
-               []
-               raw-prefix)]
-          (when (seq compiled-sites)
-            (let [step-fns (mapv build-regenerate-site-step compiled-sites)
-                  addrs (mapv :addr compiled-sites)]
-              (when (every? some? step-fns)
-                {:fn (fn compiled-prefix-regenerate [key args-vec old-choices selection]
-                       (let [mlx-args (compiled/ensure-numeric-mlx-args args-vec)
-                             result
-                             (reduce
-                              (fn [state step-fn]
-                                (step-fn state mlx-args old-choices selection))
-                              {:values {} :score (mx/scalar 0.0) :weight (mx/scalar 0.0) :key key}
-                              step-fns)]
-                         {:values (:values result)
-                          :score (:score result)
-                          :weight (:weight result)}))
-                 :addrs addrs}))))))))
+  (when-let [{:keys [compiled-sites addrs]} (compiled/prepare-prefix-sites schema source)]
+    (let [step-fns (mapv build-regenerate-site-step compiled-sites)]
+      (when (every? some? step-fns)
+        {:fn (fn compiled-prefix-regenerate [key args-vec old-choices selection]
+               (let [mlx-args (compiled/ensure-numeric-mlx-args args-vec)
+                     result
+                     (reduce
+                      (fn [state step-fn]
+                        (step-fn state mlx-args old-choices selection))
+                      {:values {} :score (mx/scalar 0.0) :weight (mx/scalar 0.0) :key key}
+                      step-fns)]
+                 {:values (:values result)
+                  :score (:score result)
+                  :weight (:weight result)}))
+         :addrs addrs}))))
 
 (defn make-replay-regenerate-transition
   "Build a replay transition for partial regenerate compilation.

--- a/src/genmlx/custom_gradient.cljs
+++ b/src/genmlx/custom_gradient.cljs
@@ -10,6 +10,9 @@
             [genmlx.choicemap :as cm]
             [genmlx.mlx :as mx]))
 
+;; Deterministic GF: score and all weights/projections are zero.
+(def ^:private ZERO (mx/scalar 0.0))
+
 (defn- wrap-with-custom-grad
   "Wrap forward-fn so MLX autograd uses gradient-fn for backward pass.
    Uses stop-gradient trick: output = sg(f(x)) + surrogate - sg(surrogate)
@@ -18,7 +21,7 @@
   (fn [& args]
     (let [fwd (apply forward-fn args)
           grads (gradient-fn (vec args) fwd (mx/scalar 1.0))
-          surrogate (reduce mx/add (mx/scalar 0.0)
+          surrogate (reduce mx/add ZERO
                       (map (fn [g a] (mx/multiply (mx/stop-gradient g) a))
                            grads args))]
       (mx/add (mx/stop-gradient fwd)
@@ -31,39 +34,39 @@
       (tr/make-trace {:gen-fn this :args args
                       :choices cm/EMPTY
                       :retval retval
-                      :score (mx/scalar 0.0)})))
+                      :score ZERO})))
 
   p/IGenerate
   (generate [this args constraints]
     ;; Deterministic: no stochastic choices to constrain
     {:trace (p/simulate this args)
-     :weight (mx/scalar 0.0)})
+     :weight ZERO})
 
   p/IAssess
   (assess [this args choices]
     {:retval (apply forward-fn args)
-     :weight (mx/scalar 0.0)})
+     :weight ZERO})
 
   p/IPropose
   (propose [this args]
     {:choices cm/EMPTY
-     :weight (mx/scalar 0.0)
+     :weight ZERO
      :retval (apply forward-fn args)})
 
   p/IUpdate
   (update [this trace constraints]
     {:trace (p/simulate this (:args trace))
-     :weight (mx/scalar 0.0)
+     :weight ZERO
      :discard cm/EMPTY})
 
   p/IRegenerate
   (regenerate [this trace selection]
     {:trace (p/simulate this (:args trace))
-     :weight (mx/scalar 0.0)})
+     :weight ZERO})
 
   p/IProject
   (project [this trace selection]
-    (mx/scalar 0.0))
+    ZERO)
 
   p/IHasArgumentGrads
   (has-argument-grads [_] arg-grads))

--- a/src/genmlx/custom_gradient.cljs
+++ b/src/genmlx/custom_gradient.cljs
@@ -20,7 +20,8 @@
   [forward-fn gradient-fn]
   (fn [& args]
     (let [fwd (apply forward-fn args)
-          grads (gradient-fn (vec args) fwd (mx/scalar 1.0))
+          cotangent (mx/scalar 1.0)            ; seed cotangent for the backward pass
+          grads (gradient-fn (vec args) fwd cotangent)
           surrogate (reduce mx/add ZERO
                       (map (fn [g a] (mx/multiply (mx/stop-gradient g) a))
                            grads args))]

--- a/src/genmlx/dep_graph.cljs
+++ b/src/genmlx/dep_graph.cljs
@@ -130,10 +130,10 @@
                           (if (contains? visited [dir node])
                             (recur queue' visited reached)
                             (let [visited' (conj visited [dir node])
-                                  reached' (if (not (contains? z-set node))
-                                             (conj reached node)
-                                             reached)
                                   in-z? (contains? z-set node)
+                                  reached' (if in-z?
+                                             reached
+                                             (conj reached node))
                                   ;; Determine next visits based on direction and evidence
                                   next-visits
                                   (case [dir in-z?]

--- a/src/genmlx/dep_graph.cljs
+++ b/src/genmlx/dep_graph.cljs
@@ -70,10 +70,11 @@
   [graph]
   (set (filter #(empty? (get (:children graph) %)) (:nodes graph))))
 
-(defn find-ancestors
-  "Find all ancestors of a node (transitive parents)."
-  [graph node]
-  (loop [frontier (get (:parents graph) node #{})
+(defn- transitive-closure
+  "Transitively follow adjacency (a {node -> #{neighbors}} map) from a node,
+   returning the set of all reachable nodes (excluding node itself)."
+  [adjacency node]
+  (loop [frontier (get adjacency node #{})
          visited #{}]
     (if (empty? frontier)
       visited
@@ -81,22 +82,18 @@
             frontier' (disj frontier next-node)]
         (if (contains? visited next-node)
           (recur frontier' visited)
-          (recur (into frontier' (get (:parents graph) next-node #{}))
+          (recur (into frontier' (get adjacency next-node #{}))
                  (conj visited next-node)))))))
+
+(defn find-ancestors
+  "Find all ancestors of a node (transitive parents)."
+  [graph node]
+  (transitive-closure (:parents graph) node))
 
 (defn find-descendants
   "Find all descendants of a node (transitive children)."
   [graph node]
-  (loop [frontier (get (:children graph) node #{})
-         visited #{}]
-    (if (empty? frontier)
-      visited
-      (let [next-node (first frontier)
-            frontier' (disj frontier next-node)]
-        (if (contains? visited next-node)
-          (recur frontier' visited)
-          (recur (into frontier' (get (:children graph) next-node #{}))
-                 (conj visited next-node)))))))
+  (transitive-closure (:children graph) node))
 
 ;; =========================================================================
 ;; D-separation (Bayes-Ball algorithm)

--- a/src/genmlx/dev.cljs
+++ b/src/genmlx/dev.cljs
@@ -24,24 +24,28 @@
 ;; Precompiled validators — compiled once at load time, not per call.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private op->validator
-  (into {} (map (fn [[op schema]] [op {:validate (m/validator schema)
-                                       :explain  (m/explainer schema)
-                                       :schema   schema}]))
-        {:simulate   schemas/SimulateReturn
-         :generate   schemas/GenerateReturn
-         :update     schemas/UpdateReturn
-         :regenerate schemas/RegenerateReturn
-         :assess     schemas/AssessReturn
-         :propose    schemas/ProposeReturn
-         :project    schemas/ProjectReturn}))
-
-(def ^:private key->validator
+(defn- compile-validators
+  "Precompile a {key -> schema} map into {key -> {:validate :explain :schema}}."
+  [schema-map]
   (into {} (map (fn [[k schema]] [k {:validate (m/validator schema)
                                      :explain  (m/explainer schema)
                                      :schema   schema}]))
-        {:base-state schemas/BaseState
-         :sub-result schemas/SubResult}))
+        schema-map))
+
+(def ^:private op->validator
+  (compile-validators
+   {:simulate   schemas/SimulateReturn
+    :generate   schemas/GenerateReturn
+    :update     schemas/UpdateReturn
+    :regenerate schemas/RegenerateReturn
+    :assess     schemas/AssessReturn
+    :propose    schemas/ProposeReturn
+    :project    schemas/ProjectReturn}))
+
+(def ^:private key->validator
+  (compile-validators
+   {:base-state schemas/BaseState
+    :sub-result schemas/SubResult}))
 
 ;; ---------------------------------------------------------------------------
 ;; Default reporter

--- a/src/genmlx/dev.cljs
+++ b/src/genmlx/dev.cljs
@@ -70,34 +70,33 @@
    Options:
      :report — (fn [type data]) error reporter (default: throws with humanized errors)
      :scope  — #{:output :input} validation scope (default: both)"
-  [& [opts]]
-  (let [report (or (:report opts) default-thrower)
-        scope  (or (:scope opts) #{:output :input})
+  ([] (start! {}))
+  ([{:keys [report scope]
+     :or   {report default-thrower scope #{:output :input}}}]
+   (let [validating
+         (fn [gf op args key opts]
+           (let [result (dyn/run-dispatched* gf op args key opts)]
+             (when-let [entry (and (:output scope) (op->validator op))]
+               (when-not ((:validate entry) result)
+                 (report ::invalid-output
+                   {:op op :entry entry :value result
+                    :fn-name (str "DynamicGF/" (name op))})))
+             result))]
 
-        validating
-        (fn [gf op args key opts]
-          (let [result (dyn/run-dispatched* gf op args key opts)]
-            (when-let [entry (and (:output scope) (op->validator op))]
-              (when-not ((:validate entry) result)
-                (report ::invalid-output
-                  {:op op :entry entry :value result
-                   :fn-name (str "DynamicGF/" (name op))})))
-            result))]
+     (reset! dyn/dispatch-fn validating)
 
-    (reset! dyn/dispatch-fn validating)
+     (when (:input scope)
+       (reset! rt/validate-fn
+         (fn [schema-key value context]
+           (when-let [entry (key->validator schema-key)]
+             (when-not ((:validate entry) value)
+               (report ::invalid-input
+                 {:schema-key schema-key :entry entry
+                  :value value :context context}))))))
 
-    (when (:input scope)
-      (reset! rt/validate-fn
-        (fn [schema-key value context]
-          (when-let [entry (key->validator schema-key)]
-            (when-not ((:validate entry) value)
-              (report ::invalid-input
-                {:schema-key schema-key :entry entry
-                 :value value :context context}))))))
-
-    (println "genmlx.dev: schema validation enabled"
-             (str "(" (str/join ", " (map name scope)) ")"))
-    :started))
+     (println "genmlx.dev: schema validation enabled"
+              (str "(" (str/join ", " (map name scope)) ")"))
+     :started)))
 
 (defn stop!
   "Disable all schema validation. Returns to zero-cost dispatch."

--- a/src/genmlx/diff.cljs
+++ b/src/genmlx/diff.cljs
@@ -20,8 +20,3 @@
   "Returns true if the diff indicates no change."
   [d]
   (= (:diff-type d) :no-change))
-
-(defn- changed?
-  "Returns true if the diff indicates any change."
-  [d]
-  (not (no-change? d)))

--- a/src/genmlx/dispatch.cljs
+++ b/src/genmlx/dispatch.cljs
@@ -42,10 +42,7 @@
    The stack must have a fallback dispatcher at the bottom that always
    returns non-nil (HandlerDispatcher)."
   [stack op schema opts]
-  (loop [dispatchers stack]
-    (when (seq dispatchers)
-      (or (resolve-transition (first dispatchers) op schema opts)
-          (recur (rest dispatchers))))))
+  (some #(resolve-transition % op schema opts) stack))
 
 ;; ---------------------------------------------------------------------------
 ;; Handler substitution

--- a/src/genmlx/dist.cljs
+++ b/src/genmlx/dist.cljs
@@ -7,28 +7,17 @@
    Reparameterized sampling enables gradient flow."
   (:require [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
-            [genmlx.dist.core :as dc])
+            [genmlx.dist.core :as dc]
+            [genmlx.mlx.constants :refer [LOG-2PI ZERO ONE TWO THREE HALF
+                                          NEG-INF LOG-2PI-HALF LOG-PI MLX-PI
+                                          SQRT-TWO TINY]])
   (:require-macros [genmlx.dist.macros :refer [defdist]]))
 
 ;; ---------------------------------------------------------------------------
 ;; Constants
 ;; ---------------------------------------------------------------------------
 
-(def ^:private LOG-2PI (js/Math.log (* 2.0 js/Math.PI)))
-
-;; Cached MLX scalar constants — avoid per-call allocation.
-;; MLX arrays are immutable; mx/add etc. always create new arrays.
-(def ^:private ZERO (mx/scalar 0.0))
-(def ^:private ONE (mx/scalar 1.0))
-(def ^:private TWO (mx/scalar 2.0))
-(def ^:private THREE (mx/scalar 3.0))
-(def ^:private HALF (mx/scalar 0.5))
-(def ^:private NEG-INF (mx/scalar ##-Inf))
-(def ^:private LOG-2PI-HALF (mx/scalar (* 0.5 LOG-2PI)))
-(def ^:private LOG-PI (mx/scalar (js/Math.log js/Math.PI)))
-(def ^:private MLX-PI (mx/scalar js/Math.PI))
-(def ^:private SQRT-TWO (mx/scalar (js/Math.sqrt 2.0)))
-(def ^:private TINY (mx/scalar 1e-30))
+;; Scalar/log constants live in genmlx.mlx.constants (centralized, cached).
 (def ^:private BERNOULLI-SUPPORT [ZERO ONE])
 
 ;; ---------------------------------------------------------------------------
@@ -454,22 +443,27 @@
 ;; Categorical
 ;; ---------------------------------------------------------------------------
 
+(defn- logits->logprobs
+  "Log-softmax: normalize logits along the last axis. Shape-preserving."
+  [logits]
+  (if (> (count (mx/shape logits)) 1)
+    (mx/subtract logits (mx/expand-dims (mx/logsumexp logits [-1]) -1))
+    (mx/subtract logits (mx/logsumexp logits))))
+
 (defdist categorical
   "Categorical distribution from log-probabilities (logits)."
   [logits]
   (sample [key]
           (rng/categorical key logits))
   (log-prob [v]
-            (let [v (mx/ensure-array v mx/int32)]
+            (let [v (mx/ensure-array v mx/int32)
+                  log-probs (logits->logprobs logits)]
+        ;; Multi-dim logits [... K]: index along last axis (handles scalar v
+        ;; when constrained and multi-dim v when batched/enumerate).
+        ;; 1D logits [K]: v is scalar or [N].
               (if (> (count (mx/shape logits)) 1)
-        ;; Multi-dim logits [... K]: normalize along last axis, index along last axis.
-        ;; Handles both scalar v (constrained) and multi-dim v (batched/enumerate).
-                (let [lse (mx/expand-dims (mx/logsumexp logits [-1]) -1)
-                      log-probs (mx/subtract logits lse)]
-                  (mx/take-idx log-probs v -1))
-        ;; 1D logits [K]: v is scalar or [N]
-                (let [log-probs (mx/subtract logits (mx/logsumexp logits))]
-                  (mx/take-idx log-probs v)))))
+                (mx/take-idx log-probs v -1)
+                (mx/take-idx log-probs v))))
   (support []
            (mx/materialize! logits)
            (let [n (last (mx/shape logits))]
@@ -478,14 +472,13 @@
 (defmethod dc/dist-log-prob-support :categorical [d]
   ;; log_softmax(logits) — all K log-probs in one op.
   ;; For multi-dim logits [..., K]: transpose to put K first → [K, ...]
-  (let [{:keys [logits]} (:params d)]
+  (let [{:keys [logits]} (:params d)
+        log-probs (logits->logprobs logits)]
     (if (> (count (mx/shape logits)) 1)
-      (let [lse (mx/expand-dims (mx/logsumexp logits [-1]) -1)
-            log-probs (mx/subtract logits lse)
-            nd (count (mx/shape log-probs))
+      (let [nd (count (mx/shape log-probs))
             perm (into [(dec nd)] (range (dec nd)))]
         (mx/transpose log-probs perm))
-      (mx/subtract logits (mx/logsumexp logits)))))
+      log-probs)))
 
 (defmethod dc/dist-sample-n* :categorical [d key n]
   (let [{:keys [logits]} (:params d)

--- a/src/genmlx/dist.cljs
+++ b/src/genmlx/dist.cljs
@@ -57,6 +57,18 @@
        (mx/subtract loc)))
 
 ;; ---------------------------------------------------------------------------
+;; Log binomial-coefficient helper
+;; ---------------------------------------------------------------------------
+
+(defn- log-choose
+  "Log binomial coefficient log C(n, k) = lgamma(n+1) - lgamma(k+1) - lgamma(n-k+1).
+   n and k are MLX arrays (stays on GPU for autograd)."
+  [n k]
+  (mx/subtract (mx/lgamma (mx/add n ONE))
+               (mx/add (mx/lgamma (mx/add k ONE))
+                       (mx/lgamma (mx/add (mx/subtract n k) ONE)))))
+
+;; ---------------------------------------------------------------------------
 ;; Public API wrappers (backward compatible)
 ;; ---------------------------------------------------------------------------
 
@@ -143,12 +155,12 @@
   (reparam [key]
            (mx/add mu (mx/multiply sigma (rng/normal key [])))))
 
-(let [gaussian-raw gaussian]
+(let [raw gaussian]
   (defn gaussian
     "Gaussian (normal) distribution with mean mu and std sigma."
     [mu sigma]
     (check-positive "gaussian" "sigma" sigma)
-    (gaussian-raw mu sigma)))
+    (raw mu sigma)))
 
 (defmethod dc/dist-sample-n* :gaussian [d key n]
   (let [{:keys [mu sigma]} (:params d)
@@ -176,12 +188,12 @@
   (reparam [key]
            (mx/add lo (mx/multiply (mx/subtract hi lo) (rng/uniform key [])))))
 
-(let [uniform-raw uniform]
+(let [raw uniform]
   (defn uniform
     "Continuous uniform distribution on [lo, hi]."
     [lo hi]
     (check-less-than "uniform" "lo" lo "hi" hi)
-    (uniform-raw lo hi)))
+    (raw lo hi)))
 
 (defmethod dc/dist-sample-n* :uniform [d key n]
   (let [{:keys [lo hi]} (:params d)
@@ -265,13 +277,13 @@
                                        (mx/log (mx/subtract ONE v))))
                   (mx/subtract log-beta-val)))))
 
-(let [beta-dist-raw beta-dist]
+(let [raw beta-dist]
   (defn beta-dist
     "Beta distribution with parameters alpha and beta."
     [alpha beta-param]
     (check-positive "beta-dist" "alpha" alpha)
     (check-positive "beta-dist" "beta" beta-param)
-    (beta-dist-raw alpha beta-param)))
+    (raw alpha beta-param)))
 
 ;; ---------------------------------------------------------------------------
 ;; Gamma
@@ -312,13 +324,13 @@
                   (mx/subtract (mx/multiply rate v))
                   (mx/subtract (mx/lgamma k))))))
 
-(let [gamma-dist-raw gamma-dist]
+(let [raw gamma-dist]
   (defn gamma-dist
     "Gamma distribution with shape and rate parameters."
     [shape-param rate]
     (check-positive "gamma-dist" "shape" shape-param)
     (check-positive "gamma-dist" "rate" rate)
-    (gamma-dist-raw shape-param rate)))
+    (raw shape-param rate)))
 
 (defn- gamma-sample-n
   "Vectorized Marsaglia-Tsang: sample [n] gamma values with given shape and rate.
@@ -424,12 +436,12 @@
            (let [u (rng/uniform key [])]
              (mx/divide (mx/negative (mx/log (mx/subtract ONE u))) rate))))
 
-(let [exponential-raw exponential]
+(let [raw exponential]
   (defn exponential
     "Exponential distribution with the given rate."
     [rate]
     (check-positive "exponential" "rate" rate)
-    (exponential-raw rate)))
+    (raw rate)))
 
 (defmethod dc/dist-sample-n* :exponential [d key n]
   (let [{:keys [rate]} (:params d)
@@ -852,9 +864,7 @@
                   (mx/scalar k))))))
   (log-prob [v]
     ;; log C(v + r - 1, v) + r*log(p) + v*log(1-p)
-            (let [log-coeff (mx/subtract (mx/lgamma (mx/add v r))
-                                         (mx/add (mx/lgamma (mx/add v ONE))
-                                                 (mx/lgamma r)))]
+            (let [log-coeff (log-choose (mx/subtract (mx/add v r) ONE) v)]
               (-> log-coeff
                   (mx/add (mx/multiply r (mx/log p)))
                   (mx/add (mx/multiply v (mx/log (mx/subtract ONE p))))))))
@@ -885,10 +895,7 @@
             (mx/scalar successes)))
   (log-prob [v]
     ;; log C(n, k) + k*log(p) + (n-k)*log(1-p)
-            (let [log-coeff (mx/subtract (mx/lgamma (mx/add n-trials ONE))
-                                         (mx/add (mx/lgamma (mx/add v ONE))
-                                                 (mx/lgamma (mx/add (mx/subtract n-trials v)
-                                                                    ONE))))]
+            (let [log-coeff (log-choose n-trials v)]
               (-> log-coeff
                   (mx/add (mx/multiply v (mx/log p)))
                   (mx/add (mx/multiply (mx/subtract n-trials v)
@@ -1367,12 +1374,12 @@
               (mx/subtract (mx/multiply kappa (mx/cos (mx/subtract v mu)))
                            log-norm))))
 
-(let [von-mises-raw von-mises]
+(let [raw von-mises]
   (defn von-mises
     "Von Mises distribution on [-π, π) with mean direction mu and concentration kappa."
     [mu kappa]
     (check-positive "von-mises" "kappa" kappa)
-    (von-mises-raw mu kappa)))
+    (raw mu kappa)))
 
 (defmethod dc/dist-sample-n* :von-mises [d key n]
   (let [{:keys [mu kappa]} (:params d)
@@ -1447,12 +1454,12 @@
                                                          (mx/cos (mx/subtract v mu))))
                                rho-sq))))))
 
-(let [wrapped-cauchy-raw wrapped-cauchy]
+(let [raw wrapped-cauchy]
   (defn wrapped-cauchy
     "Wrapped Cauchy distribution on [-π, π) with mean mu and concentration rho (0 < ρ < 1)."
     [mu rho]
     (check-open-probability "wrapped-cauchy" "rho" rho)
-    (wrapped-cauchy-raw mu rho)))
+    (raw mu rho)))
 
 (defmethod dc/dist-sample-n* :wrapped-cauchy [d key n]
   (let [key (rng/ensure-key key)
@@ -1485,12 +1492,12 @@
       ;; logsumexp over the 7 terms
               (reduce mx/logaddexp terms))))
 
-(let [wrapped-normal-raw wrapped-normal]
+(let [raw wrapped-normal]
   (defn wrapped-normal
     "Wrapped normal distribution on [-π, π) with mean mu and std sigma."
     [mu sigma]
     (check-positive "wrapped-normal" "sigma" sigma)
-    (wrapped-normal-raw mu sigma)))
+    (raw mu sigma)))
 
 (defmethod dc/dist-sample-n* :wrapped-normal [d key n]
   (let [{:keys [mu sigma]} (:params d)

--- a/src/genmlx/dist.cljs
+++ b/src/genmlx/dist.cljs
@@ -385,9 +385,8 @@
   (let [{:keys [alpha beta-param]} (:params d)
         key (rng/ensure-key key)
         [k1 k2] (rng/split key)
-        one ONE
-        g1 (gamma-sample-n (mx/realize alpha) one k1 n)
-        g2 (gamma-sample-n (mx/realize beta-param) one k2 n)]
+        g1 (gamma-sample-n (mx/realize alpha) ONE k1 n)
+        g2 (gamma-sample-n (mx/realize beta-param) ONE k2 n)]
     ;; Clamp into the open support (0,1): for alpha/beta < 1 a float32 sample can
     ;; round to exactly 0.0/1.0, where the beta density (and log-prob) is +inf.
     (mx/clip (mx/divide g1 (mx/add g1 g2)) 1e-7 (- 1.0 1e-7))))
@@ -399,9 +398,8 @@
         alpha-vals (mx/->clj alpha)
         k (count alpha-vals)
         keys (rng/split-n key k)
-        one ONE
         ;; Sample k gamma arrays, each [n], then stack to [k n]
-        gammas (mx/stack (mapv (fn [a ki] (gamma-sample-n a one ki n))
+        gammas (mx/stack (mapv (fn [a ki] (gamma-sample-n a ONE ki n))
                                alpha-vals keys))
         ;; gammas is [k n], sum along axis 0 -> [n], then transpose and divide
         totals (mx/sum gammas [0])]
@@ -692,7 +690,7 @@
                 normalized (mapv #(/ % total) gammas)]
             (mx/array normalized)))
   (log-prob [v]
-            (let [v (if (mx/array? v) v (mx/array v))
+            (let [v (mx/ensure-array v)
                   log-beta (mx/subtract (mx/sum (mx/lgamma alpha))
                                         (mx/lgamma (mx/sum alpha)))
                   log-terms (mx/sum
@@ -1013,6 +1011,18 @@
     (raw mu sigma lo hi)))
 
 ;; ---------------------------------------------------------------------------
+;; Matrix-distribution helper
+;; ---------------------------------------------------------------------------
+
+(defn- as-square
+  "Reshape a flat [k*k] array into [k k]; pass 2-d arrays through unchanged."
+  [a]
+  (if (= 1 (mx/ndim a))
+    (let [k (int (js/Math.sqrt (mx/size a)))]
+      (mx/reshape a [k k]))
+    a))
+
+;; ---------------------------------------------------------------------------
 ;; Multivariate Normal (via Cholesky) — manual definition
 ;; ---------------------------------------------------------------------------
 
@@ -1021,12 +1031,8 @@
    mean-vec: [k] array, cov-matrix: [k k] positive definite array.
    Cholesky decomposition and L-inverse are computed once at construction."
   [mean-vec cov-matrix]
-  (let [mu (if (mx/array? mean-vec) mean-vec (mx/array mean-vec))
-        cov (if (mx/array? cov-matrix) cov-matrix (mx/array cov-matrix))
-        cov-2d (if (= 1 (mx/ndim cov))
-                 (let [k (first (mx/shape mu))]
-                   (mx/reshape cov [k k]))
-                 cov)
+  (let [mu (mx/ensure-array mean-vec)
+        cov-2d (as-square (mx/ensure-array cov-matrix))
         L (mx/cholesky cov-2d)
         _ (mx/materialize! L)
         Li (mx/tri-inv L false)
@@ -1050,7 +1056,7 @@
 
 (defmethod dc/dist-log-prob :multivariate-normal [d v]
   (let [{:keys [mean-vec L-inv k norm-const neg-half]} (:params d)
-        v (if (mx/array? v) v (mx/array v))
+        v (mx/ensure-array v)
         diff (mx/subtract v mean-vec)
         y (mx/flatten (mx/matmul L-inv (mx/reshape diff [k 1])))
         mahal (mx/sum (mx/square y))]
@@ -1194,12 +1200,8 @@
   "Wishart distribution with df degrees of freedom and [k x k] scale matrix V.
    Uses Bartlett decomposition for sampling."
   [df scale-matrix]
-  (let [V (if (mx/array? scale-matrix) scale-matrix (mx/array scale-matrix))
+  (let [V-2d (as-square (mx/ensure-array scale-matrix))
         df-val (if (mx/array? df) (mx/realize df) df)
-        V-2d (if (= 1 (mx/ndim V))
-               (let [k (int (js/Math.sqrt (first (mx/shape V))))]
-                 (mx/reshape V [k k]))
-               V)
         L (mx/cholesky V-2d)
         _ (mx/materialize! L)
         k (first (mx/shape V-2d))]
@@ -1248,7 +1250,7 @@
 
 (defmethod dc/dist-log-prob :wishart [d x]
   (let [{:keys [df scale-matrix k]} (:params d)
-        x (if (mx/array? x) x (mx/array x))
+        x (mx/ensure-array x)
         x-2d (if (= 1 (mx/ndim x)) (mx/reshape x [k k]) x)
         ;; Recompute V-inv and log-det-V from scale-matrix (not precomputed)
         ;; so gradient tape is preserved for differentiating w.r.t. V.
@@ -1274,12 +1276,8 @@
   "Inverse Wishart distribution with df degrees of freedom and [k x k] scale matrix Psi.
    Sample: W ~ Wishart(df, Psi^{-1}), return W^{-1}."
   [df scale-matrix]
-  (let [Psi (if (mx/array? scale-matrix) scale-matrix (mx/array scale-matrix))
+  (let [Psi-2d (as-square (mx/ensure-array scale-matrix))
         df-val (if (mx/array? df) (mx/realize df) df)
-        Psi-2d (if (= 1 (mx/ndim Psi))
-                 (let [k (int (js/Math.sqrt (first (mx/shape Psi))))]
-                   (mx/reshape Psi [k k]))
-                 Psi)
         k (first (mx/shape Psi-2d))
         Psi-inv (mx/inv Psi-2d)
         _ (mx/materialize! Psi-inv)
@@ -1296,7 +1294,7 @@
 
 (defmethod dc/dist-log-prob :inv-wishart [d x]
   (let [{:keys [df scale-matrix k]} (:params d)
-        x (if (mx/array? x) x (mx/array x))
+        x (mx/ensure-array x)
         x-2d (if (= 1 (mx/ndim x)) (mx/reshape x [k k]) x)
         X-inv (mx/inv x-2d)
         ;; Recompute log-det from raw matrices (not precomputed) so gradient

--- a/src/genmlx/dist/core.cljs
+++ b/src/genmlx/dist/core.cljs
@@ -63,11 +63,17 @@
 ;; GFI bridge: distribution -> trace
 ;; ---------------------------------------------------------------------------
 
-(defn dist-simulate [dist]
+(defn- sample-and-score
+  "Draw a value from dist (using its threaded PRNG key, if any) and its log-prob.
+   Returns [value log-prob]."
+  [dist]
   (let [key (or (:genmlx.dynamic/key (meta dist)) (rng/fresh-key))
-
         v  (dist-sample dist key)
         lp (dist-log-prob dist v)]
+    [v lp]))
+
+(defn dist-simulate [dist]
+  (let [[v lp] (sample-and-score dist)]
     (tr/make-trace {:gen-fn dist :args [] :choices (cm/->Value v)
                     :retval v :score lp})))
 
@@ -85,10 +91,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn dist-propose [dist]
-  (let [key (or (:genmlx.dynamic/key (meta dist)) (rng/fresh-key))
-
-        v  (dist-sample dist key)
-        lp (dist-log-prob dist v)]
+  (let [[v lp] (sample-and-score dist)]
     {:choices (cm/->Value v) :weight lp :retval v}))
 
 (defn- dist-assess [dist choices]
@@ -213,20 +216,25 @@
     (throw (ex-info "product requires a vector or map of distributions"
                     {:got (type components)}))))
 
-(defmethod dist-sample* :product [d key]
+(defn- product-map
+  "Split key across a product distribution's components and apply f to each.
+   f is (fn [component sub-key] -> value). Returns a vector for :vector form,
+   a key->value map (preserving component keys) for :map form."
+  [d key f]
   (let [{:keys [form components]} (:params d)
         key (rng/ensure-key key)]
     (if (= form :vector)
       (let [keys (rng/split-n key (count components))]
-        (mapv (fn [comp k] (dist-sample comp k))
-              components keys))
-      ;; map form
+        (mapv f components keys))
       (let [entries (vec components)
             keys (rng/split-n key (count entries))]
         (into {}
           (map-indexed (fn [i [k comp]]
-                         [k (dist-sample comp (nth keys i))])
+                         [k (f comp (nth keys i))])
                        entries))))))
+
+(defmethod dist-sample* :product [d key]
+  (product-map d key dist-sample))
 
 (defmethod dist-log-prob :product [d value]
   (let [{:keys [form components]} (:params d)]
@@ -242,18 +250,7 @@
                    components)))))
 
 (defmethod dist-reparam :product [d key]
-  (let [{:keys [form components]} (:params d)
-        key (rng/ensure-key key)]
-    (if (= form :vector)
-      (let [keys (rng/split-n key (count components))]
-        (mapv (fn [comp k] (dist-reparam comp k))
-              components keys))
-      (let [entries (vec components)
-            keys (rng/split-n key (count entries))]
-        (into {}
-          (map-indexed (fn [i [k comp]]
-                         [k (dist-reparam comp (nth keys i))])
-                       entries))))))
+  (product-map d key dist-reparam))
 
 (defmethod dist-support :product [d]
   (let [{:keys [form components]} (:params d)]
@@ -277,15 +274,4 @@
         (mapv (fn [vals] (zipmap ks vals)) value-seqs)))))
 
 (defmethod dist-sample-n* :product [d key n]
-  (let [{:keys [form components]} (:params d)
-        key (rng/ensure-key key)]
-    (if (= form :vector)
-      (let [keys (rng/split-n key (count components))]
-        (mapv (fn [comp k] (dist-sample-n comp k n))
-              components keys))
-      (let [entries (vec components)
-            keys (rng/split-n key (count entries))]
-        (into {}
-          (map-indexed (fn [i [k comp]]
-                         [k (dist-sample-n comp (nth keys i) n)])
-                       entries))))))
+  (product-map d key (fn [comp k] (dist-sample-n comp k n))))

--- a/src/genmlx/dist/core.cljs
+++ b/src/genmlx/dist/core.cljs
@@ -183,18 +183,14 @@
   (let [{:keys [components log-weights]} (:params d)
         v (mx/ensure-array v)
         ;; Normalize log-weights
-        log-norm-w (mx/subtract log-weights (mx/logsumexp log-weights))
-        n (count components)]
+        log-norm-w (mx/subtract log-weights (mx/logsumexp log-weights))]
     ;; Compute log p(v) = logsumexp_k(log w_k + log p_k(v))
-    ;; Stay in MLX graph: compute each log(w_k * p_k(v)) and reduce
-    (let [component-lps (mapv #(dist-log-prob % v) components)]
-      ;; Build sum via logaddexp chain to stay differentiable
-      (reduce (fn [acc i]
-                (mx/logaddexp acc
-                  (mx/add (mx/index log-norm-w i)
-                          (nth component-lps i))))
-              (mx/add (mx/index log-norm-w 0) (first component-lps))
-              (range 1 n)))))
+    ;; Stay in MLX graph: compute each log(w_k * p_k(v)) and reduce via a
+    ;; logaddexp chain to stay differentiable.
+    (->> components
+         (map #(dist-log-prob % v))
+         (map-indexed (fn [i lp] (mx/add (mx/index log-norm-w i) lp)))
+         (reduce mx/logaddexp))))
 
 ;; ---------------------------------------------------------------------------
 ;; Product distribution
@@ -229,9 +225,8 @@
       (let [entries (vec components)
             keys (rng/split-n key (count entries))]
         (into {}
-          (map-indexed (fn [i [k comp]]
-                         [k (f comp (nth keys i))])
-                       entries))))))
+          (map (fn [[k comp] sub-key] [k (f comp sub-key)])
+               entries keys))))))
 
 (defmethod dist-sample* :product [d key]
   (product-map d key dist-sample))
@@ -254,24 +249,20 @@
 
 (defmethod dist-support :product [d]
   (let [{:keys [form components]} (:params d)]
-    (if (= form :vector)
-      ;; Cartesian product of component supports
-      (let [supports (mapv dist-support components)]
-        (reduce (fn [acc s]
-                  (for [prefix acc, v s]
-                    (conj prefix v)))
-                (mapv vector (first supports))
-                (rest supports)))
-      ;; Map form: Cartesian product with keys
-      (let [entries (vec components)
-            ks (mapv first entries)
-            supports (mapv (fn [[_ comp]] (dist-support comp)) entries)
-            value-seqs (reduce (fn [acc s]
-                                 (for [prefix acc, v s]
-                                   (conj prefix v)))
-                               (mapv vector (first supports))
-                               (rest supports))]
-        (mapv (fn [vals] (zipmap ks vals)) value-seqs)))))
+    (letfn [(cartesian [supports]
+              (reduce (fn [acc s]
+                        (for [prefix acc, v s]
+                          (conj prefix v)))
+                      (mapv vector (first supports))
+                      (rest supports)))]
+      (if (= form :vector)
+        ;; Cartesian product of component supports
+        (cartesian (mapv dist-support components))
+        ;; Map form: Cartesian product with keys
+        (let [entries (vec components)
+              ks (mapv first entries)
+              supports (mapv (fn [[_ comp]] (dist-support comp)) entries)]
+          (mapv (fn [vals] (zipmap ks vals)) (cartesian supports)))))))
 
 (defmethod dist-sample-n* :product [d key n]
   (product-map d key (fn [comp k] (dist-sample-n comp k n))))

--- a/src/genmlx/dist/core.cljs
+++ b/src/genmlx/dist/core.cljs
@@ -86,10 +86,6 @@
        :weight lp})
     {:trace (dist-simulate dist) :weight ZERO}))
 
-;; ---------------------------------------------------------------------------
-;; THE single record for all distributions
-;; ---------------------------------------------------------------------------
-
 (defn dist-propose [dist]
   (let [[v lp] (sample-and-score dist)]
     {:choices (cm/->Value v) :weight lp :retval v}))
@@ -100,6 +96,10 @@
           lp (dist-log-prob dist v)]
       {:retval v :weight lp})
     (throw (ex-info "assess requires fully-specified choices" {:dist (:type dist)}))))
+
+;; ---------------------------------------------------------------------------
+;; THE single record for all distributions
+;; ---------------------------------------------------------------------------
 
 (defrecord Distribution [type params]
   p/IGenerativeFunction

--- a/src/genmlx/dist/core.cljs
+++ b/src/genmlx/dist/core.cljs
@@ -6,13 +6,8 @@
             [genmlx.trace :as tr]
             [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
+            [genmlx.mlx.constants :refer [ZERO]]
             [genmlx.selection :as sel]))
-
-;; ---------------------------------------------------------------------------
-;; Cached zero constant
-;; ---------------------------------------------------------------------------
-
-(def ^:private ZERO (mx/scalar 0.0))
 
 ;; ---------------------------------------------------------------------------
 ;; Open multimethods — dispatch on (:type dist)

--- a/src/genmlx/dist/macros.cljc
+++ b/src/genmlx/dist/macros.cljc
@@ -38,6 +38,16 @@
                                      [p (list (keyword (name p))
                                               (list :params 'd))])
                                    params))]
+       (letfn [;; Emit a single-arg defmethod (sample/log-prob/reparam): bind the
+               ;; params from (:params d), coerce the raw arg, then run the body.
+               (emit-arg-method [clause-key method-sym coerce-sym raw-sym]
+                 (when-let [clause (get clause-map clause-key)]
+                   (let [[clause-args & clause-body] clause
+                         arg-sym (first clause-args)]
+                     `(defmethod ~method-sym ~type-kw [~'d ~raw-sym]
+                        (let [~@params-let
+                              ~arg-sym (~coerce-sym ~raw-sym)]
+                          ~@clause-body)))))]
        `(do
           ;; Constructor function
           ~(let [ctor-body `(genmlx.dist.core/->Distribution
@@ -45,48 +55,28 @@
                               ~(into {} (map (fn [p]
                                                [(keyword (name p)) p])
                                              params)))]
-             (if docstr
-               `(defn ~dist-name ~docstr ~params
-                  (let [~@(mapcat (fn [p] [p (list 'genmlx.mlx/ensure-array p)])
-                                  params)]
-                    ~ctor-body))
-               `(defn ~dist-name ~params
-                  (let [~@(mapcat (fn [p] [p (list 'genmlx.mlx/ensure-array p)])
-                                  params)]
-                    ~ctor-body))))
+             `(defn ~dist-name ~@(when docstr [docstr]) ~params
+                (let [~@(mapcat (fn [p] [p (list 'genmlx.mlx/ensure-array p)])
+                                params)]
+                  ~ctor-body)))
 
           ;; dist-sample method
-          ~(when-let [sample-clause (get clause-map 'sample)]
-             (let [[sample-args & sample-body] sample-clause
-                   key-sym (first sample-args)]
-               `(defmethod genmlx.dist.core/dist-sample* ~type-kw [~'d ~'raw-key#]
-                  (let [~@params-let
-                        ~key-sym (genmlx.mlx.random/ensure-key ~'raw-key#)]
-                    ~@sample-body))))
+          ~(emit-arg-method 'sample 'genmlx.dist.core/dist-sample*
+                            'genmlx.mlx.random/ensure-key 'raw-key#)
 
           ;; dist-log-prob method
-          ~(when-let [lp-clause (get clause-map 'log-prob)]
-             (let [[lp-args & lp-body] lp-clause
-                   val-sym (first lp-args)]
-               `(defmethod genmlx.dist.core/dist-log-prob ~type-kw [~'d ~'raw-val#]
-                  (let [~@params-let
-                        ~val-sym (genmlx.mlx/ensure-array ~'raw-val#)]
-                    ~@lp-body))))
+          ~(emit-arg-method 'log-prob 'genmlx.dist.core/dist-log-prob
+                            'genmlx.mlx/ensure-array 'raw-val#)
 
           ;; dist-reparam method (optional)
-          ~(when-let [reparam-clause (get clause-map 'reparam)]
-             (let [[reparam-args & reparam-body] reparam-clause
-                   key-sym (first reparam-args)]
-               `(defmethod genmlx.dist.core/dist-reparam ~type-kw [~'d ~'raw-key#]
-                  (let [~@params-let
-                        ~key-sym (genmlx.mlx.random/ensure-key ~'raw-key#)]
-                    ~@reparam-body))))
+          ~(emit-arg-method 'reparam 'genmlx.dist.core/dist-reparam
+                            'genmlx.mlx.random/ensure-key 'raw-key#)
 
           ;; dist-support method (optional)
           ~(when-let [support-clause (get clause-map 'support)]
              (let [[_support-args & support-body] support-clause]
                `(defmethod genmlx.dist.core/dist-support ~type-kw [~'d]
                   (let [~@params-let]
-                    ~@support-body)))))))
+                    ~@support-body))))))))
 
 )

--- a/src/genmlx/dist/macros.cljc
+++ b/src/genmlx/dist/macros.cljc
@@ -30,9 +30,7 @@
            params (first args)
            clauses (rest args)
            type-kw (keyword (name dist-name))
-           clause-map (into {} (map (fn [clause]
-                                      [(first clause) (rest clause)])
-                                    clauses))
+           clause-map (into {} (map (juxt first rest)) clauses)
            ;; Build the destructuring let for params from (:params d)
            params-let (vec (mapcat (fn [p]
                                      [p (list (keyword (name p))
@@ -52,9 +50,7 @@
           ;; Constructor function
           ~(let [ctor-body `(genmlx.dist.core/->Distribution
                               ~type-kw
-                              ~(into {} (map (fn [p]
-                                               [(keyword (name p)) p])
-                                             params)))]
+                              ~(into {} (map (juxt (comp keyword name) identity)) params))]
              `(defn ~dist-name ~@(when docstr [docstr]) ~params
                 (let [~@(mapcat (fn [p] [p (list 'genmlx.mlx/ensure-array p)])
                                 params)]

--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -890,26 +890,27 @@
   (reduce cm/merge-cm cm/EMPTY cms))
 
 ;; ---------------------------------------------------------------------------
-;; IEdit implementation on DynamicGF
+;; Protocol extensions on DynamicGF
+;;   IEdit             — edit requests dispatch through edit/edit-dispatch
+;;   IUpdateWithDiffs  — short-circuit when args and constraints are unchanged
+;;   IHasArgumentGrads — DynamicGF does not declare argument differentiability
 ;; ---------------------------------------------------------------------------
 
 (extend-type DynamicGF
   edit/IEdit
   (edit [gf trace edit-request]
-    (edit/edit-dispatch gf trace edit-request)))
+    (edit/edit-dispatch gf trace edit-request))
 
-;; ---------------------------------------------------------------------------
-;; IUpdateWithDiffs implementation on DynamicGF
-;; ---------------------------------------------------------------------------
-
-(extend-type DynamicGF
   p/IUpdateWithDiffs
   (update-with-diffs [gf trace constraints argdiffs]
     (if (and (diff/no-change? argdiffs) (= constraints cm/EMPTY))
       ;; No arg changes and no constraints: trace is unchanged
       {:trace trace :weight SCORE-ZERO :discard cm/EMPTY}
       ;; Otherwise delegate to regular update (body must be re-executed)
-      (p/update gf trace constraints))))
+      (p/update gf trace constraints)))
+
+  p/IHasArgumentGrads
+  (has-argument-grads [_] nil))
 
 (defn param
   "Read a trainable parameter outside a gen body.
@@ -918,11 +919,3 @@
    binding from the gen macro instead."
   [name default-value]
   (if (mx/array? default-value) default-value (mx/scalar default-value)))
-
-;; ---------------------------------------------------------------------------
-;; IHasArgumentGrads — DynamicGF does not declare argument differentiability
-;; ---------------------------------------------------------------------------
-
-(extend-type DynamicGF
-  p/IHasArgumentGrads
-  (has-argument-grads [_] nil))

--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -17,9 +17,9 @@
             [genmlx.schema :as schema]
             [genmlx.compiled :as compiled]
             [genmlx.compiled-ops :as cops]
-            [genmlx.conjugacy :as conjugacy]
+            [genmlx.conjugacy :as conj]
             [genmlx.rewrite :as rewrite]
-            [genmlx.inference.auto-analytical :as auto-analytical]
+            [genmlx.inference.auto-analytical :as auto]
             [genmlx.dispatch :as dispatch]
             [clojure.set :as set]))
 
@@ -125,9 +125,8 @@
 
 ;; -- Common: param-store and body-fn extraction --
 
-(defn- ps  [gf] (::param-store (meta gf)))
-(defn- bfn [gf] (:body-fn gf))
-(defn- run-body [gf rt args] (apply (bfn gf) rt args))
+(defn- param-store [gf] (::param-store (meta gf)))
+(defn- run-body [gf rt args] (apply (:body-fn gf) rt args))
 
 ;; -- Transition-parameterized handler execution --
 ;;
@@ -138,7 +137,7 @@
 (defn- run-simulate [transition gf args key _opts]
   (let [result (rt/run-handler transition
                  {:choices cm/EMPTY :score SCORE-ZERO :key key
-                  :executor execute-sub :param-store (ps gf)}
+                  :executor execute-sub :param-store (param-store gf)}
                  (fn [rt] (run-body gf rt args)))]
     (attach-splice-scores (make-result-trace gf args result) result)))
 
@@ -146,7 +145,7 @@
   (let [result (rt/run-handler transition
                  {:choices cm/EMPTY :score SCORE-ZERO :weight SCORE-ZERO
                   :key key :constraints constraints
-                  :executor execute-sub :param-store (ps gf)}
+                  :executor execute-sub :param-store (param-store gf)}
                  (fn [rt] (run-body gf rt args)))
         trace (make-result-trace gf args result)]
     (make-generate-result trace (:weight result) constraints (:choices result) result)))
@@ -159,7 +158,7 @@
                   :old-splice-scores (::splice-scores (meta trace))
                   :old-nested-splice-scores (::nested-splice-scores (meta trace))
                   :discard cm/EMPTY
-                  :executor execute-sub :param-store (ps gf)}
+                  :executor execute-sub :param-store (param-store gf)}
                  (fn [rt] (run-body gf rt (:args trace))))
         new-trace (make-result-trace gf (:args trace) result)]
     (make-update-result new-trace
@@ -174,7 +173,7 @@
                   :old-choices (:choices trace)
                   :old-splice-scores (::splice-scores (meta trace))
                   :old-nested-splice-scores (::nested-splice-scores (meta trace))
-                  :executor execute-sub :param-store (ps gf)}
+                  :executor execute-sub :param-store (param-store gf)}
                  (fn [rt] (run-body gf rt (:args trace))))]
     (make-regen-result gf trace result old-score)))
 
@@ -182,7 +181,7 @@
   (let [result (rt/run-handler transition
                  {:choices cm/EMPTY :score SCORE-ZERO :weight SCORE-ZERO
                   :key key :constraints constraints
-                  :executor execute-sub-assess :param-store (ps gf)}
+                  :executor execute-sub-assess :param-store (param-store gf)}
                  (fn [rt] (run-body gf rt args)))]
     {:retval (:retval result) :weight (:score result)}))
 
@@ -192,14 +191,14 @@
                   :key key :selection selection
                   :old-choices (:choices trace)
                   :constraints cm/EMPTY
-                  :executor execute-sub-project :param-store (ps gf)}
+                  :executor execute-sub-project :param-store (param-store gf)}
                  (fn [rt] (run-body gf rt (:args trace))))]
     (:weight result)))
 
 (defn- run-propose [transition gf args key _opts]
   (let [result (rt/run-handler transition
                  {:choices cm/EMPTY :score SCORE-ZERO :key key
-                  :executor execute-sub :param-store (ps gf)}
+                  :executor execute-sub :param-store (param-store gf)}
                  (fn [rt] (run-body gf rt args)))]
     {:choices (:choices result)
      :weight (:score result)
@@ -258,7 +257,7 @@
         replay (compiled/make-replay-simulate-transition (:values result))
         handler-result (rt/run-handler replay
                          {:choices cm/EMPTY :score (:score result) :key key
-                          :executor execute-sub :param-store (ps gf)}
+                          :executor execute-sub :param-store (param-store gf)}
                          (fn [rt] (run-body gf rt args)))]
     (attach-splice-scores (make-result-trace gf args handler-result) handler-result)))
 
@@ -269,7 +268,7 @@
         handler-result (rt/run-handler replay
                          {:choices cm/EMPTY :score (:score result)
                           :weight (:weight result) :key key :constraints constraints
-                          :executor execute-sub :param-store (ps gf)}
+                          :executor execute-sub :param-store (param-store gf)}
                          (fn [rt] (run-body gf rt args)))
         trace (make-result-trace gf args handler-result)]
     (make-generate-result trace (:weight handler-result) constraints
@@ -284,7 +283,7 @@
                           :weight SCORE-ZERO :key key :constraints constraints
                           :old-choices (:choices trace) :discard (cm/from-flat-map (:discard result))
                           :old-nested-splice-scores (::nested-splice-scores (meta trace))
-                          :executor execute-sub :param-store (ps gf)}
+                          :executor execute-sub :param-store (param-store gf)}
                          (fn [rt] (run-body gf rt (:args trace))))
         new-trace (make-result-trace gf (:args trace) handler-result)]
     (make-update-result new-trace
@@ -301,7 +300,7 @@
                           :weight (:weight result) :key key :selection selection
                           :old-choices (:choices trace)
                           :old-nested-splice-scores (::nested-splice-scores (meta trace))
-                          :executor execute-sub :param-store (ps gf)}
+                          :executor execute-sub :param-store (param-store gf)}
                          (fn [rt] (run-body gf rt (:args trace))))]
     (make-regen-result gf trace handler-result old-score)))
 
@@ -312,7 +311,7 @@
         handler-result (rt/run-handler replay
                          {:choices cm/EMPTY :score (:score result)
                           :weight (:score result) :key key :constraints constraints
-                          :executor execute-sub-assess :param-store (ps gf)}
+                          :executor execute-sub-assess :param-store (param-store gf)}
                          (fn [rt] (run-body gf rt args)))]
     {:retval (:retval handler-result) :weight (:score handler-result)}))
 
@@ -324,7 +323,7 @@
                          {:choices cm/EMPTY :score SCORE-ZERO
                           :weight (:weight result) :key key :selection selection
                           :old-choices (:choices trace) :constraints cm/EMPTY
-                          :executor execute-sub-project :param-store (ps gf)}
+                          :executor execute-sub-project :param-store (param-store gf)}
                          (fn [rt] (run-body gf rt (:args trace))))]
     (:weight handler-result)))
 
@@ -332,26 +331,26 @@
 
 (defn- run-generate-analytical [gf args key {:keys [constraints]}]
   (let [schema (:schema gf)
-        transition (auto-analytical/make-address-dispatch
+        transition (auto/make-address-dispatch
                      h/generate-transition (:auto-handlers schema))
         result (rt/run-handler transition
                  {:choices cm/EMPTY :score SCORE-ZERO :weight SCORE-ZERO
                   :key key :constraints constraints
                   :auto-posteriors {} :auto-kalman-beliefs {} :auto-kalman-noise-vars {}
-                  :executor execute-sub :param-store (ps gf)}
+                  :executor execute-sub :param-store (param-store gf)}
                  (fn [rt] (run-body gf rt args)))
         trace (vary-meta (make-result-trace gf args result) assoc ::score-type :marginal)]
     (make-generate-result trace (:weight result) constraints (:choices result) result)))
 
 (defn- run-assess-analytical [gf args key {:keys [constraints]}]
   (let [schema (:schema gf)
-        transition (auto-analytical/make-address-dispatch
+        transition (auto/make-address-dispatch
                      h/assess-transition (:auto-handlers schema))
         result (rt/run-handler transition
                  {:choices cm/EMPTY :score SCORE-ZERO :weight SCORE-ZERO
                   :key key :constraints constraints
                   :auto-posteriors {} :auto-kalman-beliefs {} :auto-kalman-noise-vars {}
-                  :executor execute-sub-assess :param-store (ps gf)}
+                  :executor execute-sub-assess :param-store (param-store gf)}
                  (fn [rt] (run-body gf rt args)))]
     {:retval (:retval result) :weight (:score result)}))
 
@@ -365,7 +364,7 @@
                   :auto-posteriors {} :auto-kalman-beliefs {} :auto-kalman-noise-vars {}
                   :old-splice-scores (::splice-scores (meta trace))
                   :old-nested-splice-scores (::nested-splice-scores (meta trace))
-                  :executor execute-sub :param-store (ps gf)}
+                  :executor execute-sub :param-store (param-store gf)}
                  (fn [rt] (run-body gf rt (:args trace))))
         regen-result (make-regen-result gf trace result old-score)]
     (clojure.core/update regen-result :trace vary-meta assoc ::score-type :marginal)))
@@ -471,7 +470,7 @@
           (:generate :assess)
           (when (and (not (mx/in-grad?))
                      (:auto-handlers schema)
-                     (auto-analytical/some-conjugate-obs-constrained?
+                     (auto/some-conjugate-obs-constrained?
                        (:conjugate-pairs schema) (:constraints opts)))
             {:run run-fn :score-type :marginal :label :analytical})
 
@@ -746,15 +745,15 @@
                  :else schema)
         ;; L3: full rewrite engine (Kalman > Conjugacy > RaoBlackwell)
         schema (if schema
-                 (let [augmented (conjugacy/augment-schema-with-conjugacy schema)]
+                 (let [augmented (conj/augment-schema-with-conjugacy schema)]
                    (if (:has-conjugate? augmented)
                      (let [plan (rewrite/build-analytical-plan augmented)
-                           regen-handlers (auto-analytical/build-all-regenerate-handlers
+                           regen-handlers (auto/build-all-regenerate-handlers
                                            (:conjugate-pairs augmented)
                                            :chains (:kalman-chains plan))
                            ;; Opt 1: precompute dispatch transition once at construction
                            regen-transition (when (seq regen-handlers)
-                                              (auto-analytical/make-address-dispatch
+                                              (auto/make-address-dispatch
                                                h/regenerate-transition regen-handlers))]
                        (-> augmented
                            (assoc :auto-handlers (get-in plan [:rewrite-result :handlers]))
@@ -803,7 +802,7 @@
                                {:choices cm/EMPTY :score SCORE-ZERO
                                 :key key :batch-size n :batched? true
                                 :executor execute-sub
-                                :param-store (ps gf)}
+                                :param-store (param-store gf)}
                                (fn [rt] (run-body gf rt args)))]
     (vec/->VectorizedTrace gf args (:choices result) (:score result)
                            (mx/zeros [n]) n (:retval result))))
@@ -822,7 +821,7 @@
                                 :weight SCORE-ZERO :key key
                                 :constraints constraints :batch-size n :batched? true
                                 :executor execute-sub
-                                :param-store (ps gf)}
+                                :param-store (param-store gf)}
                                (fn [rt] (run-body gf rt args)))]
     (vec/->VectorizedTrace gf args (:choices result) (:score result)
                            (:weight result) n (:retval result))))
@@ -843,8 +842,8 @@
                                 :discard cm/EMPTY
                                 :batch-size n :batched? true
                                 :executor execute-sub
-                                :param-store (ps gf)}
-                               (fn [rt] (apply (bfn gf) rt (:args vtrace))))]
+                                :param-store (param-store gf)}
+                               (fn [rt] (run-body gf rt (:args vtrace))))]
     {:vtrace (vec/->VectorizedTrace gf (:args vtrace) (:choices result)
                                     (:score result) (:weight result)
                                     n (:retval result))
@@ -867,8 +866,8 @@
                                 :old-choices (:choices vtrace)
                                 :batch-size n :batched? true
                                 :executor execute-sub
-                                :param-store (ps gf)}
-                               (fn [rt] (apply (bfn gf) rt (:args vtrace))))
+                                :param-store (param-store gf)}
+                               (fn [rt] (run-body gf rt (:args vtrace))))
         new-score (:score result)
         proposal-ratio (:weight result)
         weight (mx/subtract (mx/subtract new-score old-score) proposal-ratio)]

--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -80,26 +80,30 @@
                   :retval (:retval result)
                   :score (:score result)}))
 
+(defn- attach-unused
+  "Assoc :unused-constraints onto a result map when the trace left some
+   top-level constraint keys unconsumed."
+  [result-map constraints result-choices]
+  (if-let [unused (find-unused-constraints constraints result-choices)]
+    (assoc result-map :unused-constraints unused)
+    result-map))
+
 (defn- make-generate-result
   "Build the generate return map: {:trace :weight}, with unused-constraint
    detection and splice-score attachment."
   [trace weight constraints result-choices result]
-  (let [result-map {:trace (attach-splice-scores trace result)
-                    :weight weight}]
-    (if-let [unused (find-unused-constraints constraints result-choices)]
-      (assoc result-map :unused-constraints unused)
-      result-map)))
+  (-> {:trace (attach-splice-scores trace result)
+       :weight weight}
+      (attach-unused constraints result-choices)))
 
 (defn- make-update-result
   "Build the update return map: {:trace :weight :discard}, with unused-constraint
    detection and splice-score attachment."
   [trace weight discard constraints result-choices result]
-  (let [result-map {:trace (attach-splice-scores trace result)
-                    :weight weight
-                    :discard discard}]
-    (if-let [unused (find-unused-constraints constraints result-choices)]
-      (assoc result-map :unused-constraints unused)
-      result-map)))
+  (-> {:trace (attach-splice-scores trace result)
+       :weight weight
+       :discard discard}
+      (attach-unused constraints result-choices)))
 
 (defn- make-regen-result
   "Build the regenerate return map from handler result, computing the MH weight."
@@ -583,6 +587,13 @@
       (mx/gfi-cleanup!)
       result)))
 
+(defn- propagate-meta
+  "Propagate the PRNG key and param-store to a sub-gf via metadata, when present."
+  [gf key param-store]
+  (cond-> gf
+    key (vary-meta assoc ::key key)
+    param-store (vary-meta assoc ::param-store param-store)))
+
 (defn- extract-splice-meta
   "Extract splice metadata from a trace result into a flat result map."
   [result trace]
@@ -606,60 +617,49 @@
    Propagates param-store and key to sub-gfs via metadata."
   [gf args {:keys [constraints old-choices selection key old-splice-score
                     old-sub-splice-scores old-sub-nested-splice-scores param-store]}]
-  (let [gf (cond-> gf
-             key (vary-meta assoc ::key key)
-             param-store (vary-meta assoc ::param-store param-store))]
-    (cond
-      ;; Regenerate mode
-      selection
-      (let [old-trace (-> (tr/make-trace {:gen-fn gf :args args
-                                          :choices (or old-choices cm/EMPTY)
-                                          :retval nil :score (or old-splice-score SCORE-ZERO)})
-                          (attach-old-splice-meta old-sub-splice-scores
-                                                  old-sub-nested-splice-scores))
-            {:keys [trace weight]} (p/regenerate gf old-trace selection)]
-        (extract-splice-meta
-         {:choices (:choices trace) :retval (:retval trace)
-          :score (:score trace) :weight weight}
-         trace))
+  (let [gf (propagate-meta gf key param-store)
+        [trace result] (cond
+                         ;; Regenerate mode
+                         selection
+                         (let [old-trace (-> (tr/make-trace {:gen-fn gf :args args
+                                                             :choices (or old-choices cm/EMPTY)
+                                                             :retval nil :score (or old-splice-score SCORE-ZERO)})
+                                             (attach-old-splice-meta old-sub-splice-scores
+                                                                     old-sub-nested-splice-scores))
+                               {:keys [trace weight]} (p/regenerate gf old-trace selection)]
+                           [trace {:choices (:choices trace) :retval (:retval trace)
+                                   :score (:score trace) :weight weight}])
 
-      ;; Update mode: has old-choices (possibly with new constraints)
-      (and old-choices (not= old-choices cm/EMPTY))
-      (let [old-trace (-> (tr/make-trace {:gen-fn gf :args args
-                                          :choices old-choices
-                                          :retval nil :score (or old-splice-score SCORE-ZERO)})
-                          (attach-old-splice-meta old-sub-splice-scores
-                                                  old-sub-nested-splice-scores))
-            {:keys [trace weight discard]} (p/update gf old-trace
-                                                     (or constraints cm/EMPTY))]
-        (extract-splice-meta
-         {:choices (:choices trace) :retval (:retval trace)
-          :score (:score trace) :weight weight :discard discard}
-         trace))
+                         ;; Update mode: has old-choices (possibly with new constraints)
+                         (and old-choices (not= old-choices cm/EMPTY))
+                         (let [old-trace (-> (tr/make-trace {:gen-fn gf :args args
+                                                             :choices old-choices
+                                                             :retval nil :score (or old-splice-score SCORE-ZERO)})
+                                             (attach-old-splice-meta old-sub-splice-scores
+                                                                     old-sub-nested-splice-scores))
+                               {:keys [trace weight discard]} (p/update gf old-trace
+                                                                        (or constraints cm/EMPTY))]
+                           [trace {:choices (:choices trace) :retval (:retval trace)
+                                   :score (:score trace) :weight weight :discard discard}])
 
-      ;; Generate with constraints
-      (and constraints (not= constraints cm/EMPTY))
-      (let [{:keys [trace weight]} (p/generate gf args constraints)]
-        (extract-splice-meta
-         {:choices (:choices trace) :retval (:retval trace)
-          :score (:score trace) :weight weight}
-         trace))
+                         ;; Generate with constraints
+                         (and constraints (not= constraints cm/EMPTY))
+                         (let [{:keys [trace weight]} (p/generate gf args constraints)]
+                           [trace {:choices (:choices trace) :retval (:retval trace)
+                                   :score (:score trace) :weight weight}])
 
-      ;; Plain simulate
-      :else
-      (let [trace (p/simulate gf args)]
-        (extract-splice-meta
-         {:choices (:choices trace) :retval (:retval trace)
-          :score (:score trace)}
-         trace)))))
+                         ;; Plain simulate
+                         :else
+                         (let [trace (p/simulate gf args)]
+                           [trace {:choices (:choices trace) :retval (:retval trace)
+                                   :score (:score trace)}]))]
+    (extract-splice-meta result trace)))
 
 (defn- execute-sub-project
   "Execute sub-GF in project mode: replay via generate, then project.
    Propagates param-store and key via metadata."
   [gf args {:keys [old-choices selection key param-store]}]
-  (let [gf (cond-> gf
-             key (vary-meta assoc ::key key)
-             param-store (vary-meta assoc ::param-store param-store))
+  (let [gf (propagate-meta gf key param-store)
         {:keys [trace]} (p/generate gf args (or old-choices cm/EMPTY))
         weight (p/project gf trace (or selection sel/none))]
     {:choices (:choices trace)
@@ -671,9 +671,7 @@
   "Execute a sub-GF in assess mode: all choices must be provided.
    Propagates param-store and key via metadata."
   [gf args {:keys [constraints key param-store]}]
-  (let [gf (cond-> gf
-             key (vary-meta assoc ::key key)
-             param-store (vary-meta assoc ::param-store param-store))
+  (let [gf (propagate-meta gf key param-store)
         {:keys [retval weight]} (p/assess gf args (or constraints cm/EMPTY))]
     {:choices (or constraints cm/EMPTY) :retval retval
      :score weight :weight weight}))

--- a/src/genmlx/edit.cljs
+++ b/src/genmlx/edit.cljs
@@ -14,18 +14,15 @@
 ;; EditRequest types
 ;; ---------------------------------------------------------------------------
 
-(defrecord ConstraintEdit [constraints]
-  ;; Equivalent to current update: change observed values
-  )
+;; Equivalent to current update: change observed values
+(defrecord ConstraintEdit [constraints])
 
-(defrecord SelectionEdit [selection]
-  ;; Equivalent to current regenerate: resample selected addresses
-  )
+;; Equivalent to current regenerate: resample selected addresses
+(defrecord SelectionEdit [selection])
 
-(defrecord ProposalEdit [forward-gf forward-args backward-gf backward-args]
-  ;; Forward proposal GF + backward proposal GF (for SMCP3)
-  ;; forward-gf proposes new choices, backward-gf scores the reverse move
-  )
+;; Forward proposal GF + backward proposal GF (for SMCP3):
+;; forward-gf proposes new choices, backward-gf scores the reverse move
+(defrecord ProposalEdit [forward-gf forward-args backward-gf backward-args])
 
 ;; Constructors
 (defn constraint-edit

--- a/src/genmlx/edit.cljs
+++ b/src/genmlx/edit.cljs
@@ -65,48 +65,52 @@
   [result]
   (or (:discard result) cm/EMPTY))
 
-(defn edit-dispatch
+(defmulti edit-dispatch
   "Generic edit implementation that dispatches based on EditRequest type."
+  (fn [_gf _trace edit-request] (type edit-request)))
+
+(defmethod edit-dispatch ConstraintEdit
   [gf trace edit-request]
-  (cond
-    (instance? ConstraintEdit edit-request)
-    (let [result (p/update gf trace (:constraints edit-request))
-          discard (discard-of result)]
-      (assoc result
-             :backward-request (->ConstraintEdit discard)))
+  (let [result (p/update gf trace (:constraints edit-request))
+        discard (discard-of result)]
+    (assoc result
+           :backward-request (->ConstraintEdit discard))))
 
-    (instance? SelectionEdit edit-request)
-    (let [result (p/regenerate gf trace (:selection edit-request))
-          ;; Backward request: regenerate the same selection
-          ;; (since regenerate is its own inverse in terms of the proposal)
-          ]
-      (assoc result
-             :discard cm/EMPTY
-             :backward-request (->SelectionEdit (:selection edit-request))))
+(defmethod edit-dispatch SelectionEdit
+  [gf trace edit-request]
+  (let [result (p/regenerate gf trace (:selection edit-request))
+        ;; Backward request: regenerate the same selection
+        ;; (since regenerate is its own inverse in terms of the proposal)
+        ]
+    (assoc result
+           :discard cm/EMPTY
+           :backward-request (->SelectionEdit (:selection edit-request)))))
 
-    (instance? ProposalEdit edit-request)
-    (let [{:keys [forward-gf forward-args backward-gf backward-args]} edit-request
-          ;; 1. Run propose on forward GF
-          fwd-args (or forward-args [(:choices trace)])
-          fwd-result (p/propose forward-gf fwd-args)
-          fwd-choices (:choices fwd-result)
-          fwd-score (:weight fwd-result)
-          ;; 2. Apply proposed choices to model via update
-          update-result (p/update gf trace fwd-choices)
-          new-trace (:trace update-result)
-          update-weight (:weight update-result)
-          ;; 3. Score backward proposal
-          bwd-args (or backward-args [(:choices new-trace)])
-          bwd-result (p/assess backward-gf bwd-args
-                               (discard-of update-result))
-          bwd-score (:weight bwd-result)
-          ;; 4. Combined weight
-          weight (mx/add update-weight (mx/subtract bwd-score fwd-score))]
-      {:trace new-trace
-       :weight weight
-       :discard (discard-of update-result)
-       :backward-request (->ProposalEdit backward-gf backward-args
-                                          forward-gf forward-args)})
+(defmethod edit-dispatch ProposalEdit
+  [gf trace edit-request]
+  (let [{:keys [forward-gf forward-args backward-gf backward-args]} edit-request
+        ;; 1. Run propose on forward GF
+        fwd-args (or forward-args [(:choices trace)])
+        fwd-result (p/propose forward-gf fwd-args)
+        fwd-choices (:choices fwd-result)
+        fwd-score (:weight fwd-result)
+        ;; 2. Apply proposed choices to model via update
+        update-result (p/update gf trace fwd-choices)
+        new-trace (:trace update-result)
+        update-weight (:weight update-result)
+        ;; 3. Score backward proposal
+        bwd-args (or backward-args [(:choices new-trace)])
+        bwd-result (p/assess backward-gf bwd-args
+                             (discard-of update-result))
+        bwd-score (:weight bwd-result)
+        ;; 4. Combined weight
+        weight (mx/add update-weight (mx/subtract bwd-score fwd-score))]
+    {:trace new-trace
+     :weight weight
+     :discard (discard-of update-result)
+     :backward-request (->ProposalEdit backward-gf backward-args
+                                        forward-gf forward-args)}))
 
-    :else
-    (throw (ex-info "Unknown EditRequest type" {:request edit-request}))))
+(defmethod edit-dispatch :default
+  [_gf _trace edit-request]
+  (throw (ex-info "Unknown EditRequest type" {:request edit-request})))

--- a/src/genmlx/edit.cljs
+++ b/src/genmlx/edit.cljs
@@ -60,13 +60,18 @@
 ;; Default implementation that delegates to existing GFI operations
 ;; ---------------------------------------------------------------------------
 
+(defn- discard-of
+  "The :discard choicemap from a GFI result, defaulting to the empty map."
+  [result]
+  (or (:discard result) cm/EMPTY))
+
 (defn edit-dispatch
   "Generic edit implementation that dispatches based on EditRequest type."
   [gf trace edit-request]
   (cond
     (instance? ConstraintEdit edit-request)
     (let [result (p/update gf trace (:constraints edit-request))
-          discard (or (:discard result) cm/EMPTY)]
+          discard (discard-of result)]
       (assoc result
              :backward-request (->ConstraintEdit discard)))
 
@@ -93,13 +98,13 @@
           ;; 3. Score backward proposal
           bwd-args (or backward-args [(:choices new-trace)])
           bwd-result (p/assess backward-gf bwd-args
-                               (or (:discard update-result) cm/EMPTY))
+                               (discard-of update-result))
           bwd-score (:weight bwd-result)
           ;; 4. Combined weight
           weight (mx/add update-weight (mx/subtract bwd-score fwd-score))]
       {:trace new-trace
        :weight weight
-       :discard (or (:discard update-result) cm/EMPTY)
+       :discard (discard-of update-result)
        :backward-request (->ProposalEdit backward-gf backward-args
                                           forward-gf forward-args)})
 

--- a/src/genmlx/edit.cljs
+++ b/src/genmlx/edit.cljs
@@ -68,20 +68,21 @@
 
 (defmethod edit-dispatch ConstraintEdit
   [gf trace edit-request]
-  (let [result (p/update gf trace (:constraints edit-request))
+  (let [{:keys [constraints]} edit-request
+        result (p/update gf trace constraints)
         discard (discard-of result)]
     (assoc result
            :backward-request (->ConstraintEdit discard))))
 
 (defmethod edit-dispatch SelectionEdit
   [gf trace edit-request]
-  (let [result (p/regenerate gf trace (:selection edit-request))
-        ;; Backward request: regenerate the same selection
-        ;; (since regenerate is its own inverse in terms of the proposal)
-        ]
+  (let [{:keys [selection]} edit-request
+        result (p/regenerate gf trace selection)]
     (assoc result
            :discard cm/EMPTY
-           :backward-request (->SelectionEdit (:selection edit-request)))))
+           ;; Backward request: regenerate the same selection
+           ;; (since regenerate is its own inverse in terms of the proposal)
+           :backward-request (->SelectionEdit selection))))
 
 (defmethod edit-dispatch ProposalEdit
   [gf trace edit-request]

--- a/src/genmlx/fit.cljs
+++ b/src/genmlx/fit.cljs
@@ -53,10 +53,10 @@
       (into {}
             (map-indexed
              (fn [i addr]
-               (let [vals (mapv (fn [s] (nth s i)) samples)
+               (let [vals (mapv #(nth % i) samples)
                      mean (/ (reduce + vals) n)
                      variance (if (> n 1)
-                                (/ (reduce + (map #(* (- % mean) (- % mean)) vals))
+                                (/ (transduce (map #(let [d (- % mean)] (* d d))) + vals)
                                    (dec n))
                                 0.0)
                      std (js/Math.sqrt variance)]

--- a/src/genmlx/fit.cljs
+++ b/src/genmlx/fit.cljs
@@ -79,18 +79,9 @@
    (without :method and :elapsed-ms — those are added by `fit`)."
   [model args data method opts]
   (case method
-    ;; --- Exact (all-conjugate or trivial) ---
-    :exact
-    (let [result (p/generate model args data)
-          trace (:trace result)
-          weight (:weight result)]
-      (mx/materialize! weight)
-      {:trace trace
-       :log-ml (mx/item weight)
-       :posterior (extract-posterior trace data)})
-
-    ;; --- Kalman (auto-handlers in p/generate) ---
-    :kalman
+    ;; --- Exact (all-conjugate / trivial) and Kalman (auto-handlers): both
+    ;;     get the answer directly from p/generate's weight ---
+    (:exact :kalman)
     (let [result (p/generate model args data)
           trace (:trace result)
           weight (:weight result)]
@@ -141,20 +132,9 @@
                  (- (last (:loss-history result))))
        :loss-history (:loss-history result)})
 
-    ;; --- SMC ---
-    :smc
-    ;; SMC requires temporal structure; fall back to IS for non-temporal
-    (let [is-opts {:samples (or (:particles opts) (:n-particles opts) 200)
-                   :key (:key opts)}
-          result (importance/importance-sampling is-opts model args data)
-          best-trace (first (:traces result))]
-      (mx/materialize! (:log-ml-estimate result))
-      {:trace best-trace
-       :posterior (when best-trace (extract-posterior best-trace data))
-       :log-ml (mx/item (:log-ml-estimate result))})
-
-    ;; --- Handler-based importance sampling (safest fallback) ---
-    :handler-is
+    ;; --- SMC (no temporal structure → fall back to IS) and handler-based
+    ;;     importance sampling (safest fallback): identical IS path ---
+    (:smc :handler-is)
     (let [is-opts {:samples (or (:particles opts) (:n-particles opts) 200)
                    :key (:key opts)}
           result (importance/importance-sampling is-opts model args data)

--- a/src/genmlx/fit.cljs
+++ b/src/genmlx/fit.cljs
@@ -74,6 +74,12 @@
 ;; Method dispatcher
 ;; ---------------------------------------------------------------------------
 
+(defn- opt
+  "Coalesce an option across alias keys, falling back to default.
+   (opt opts 100 :samples :n-samples) => first truthy of those keys, else 100."
+  [opts default & ks]
+  (or (some opts ks) default))
+
 (defn- run-method
   "Execute the selected inference method. Returns a partial result map
    (without :method and :elapsed-ms — those are added by `fit`)."
@@ -92,10 +98,10 @@
     :hmc
     (let [residual (or (:residual-addrs opts) [])
           addrs (vec residual)
-          hmc-opts {:samples (or (:samples opts) (:n-samples opts) 100)
-                    :step-size (or (:step-size opts) 0.01)
-                    :leapfrog-steps (or (:n-leapfrog opts) 10)
-                    :burn (or (:burn opts) (:n-warmup opts) 50)
+          hmc-opts {:samples (opt opts 100 :samples :n-samples)
+                    :step-size (opt opts 0.01 :step-size)
+                    :leapfrog-steps (opt opts 10 :n-leapfrog)
+                    :burn (opt opts 50 :burn :n-warmup)
                     :addresses addrs
                     :key (:key opts)}
           samples (mcmc/hmc hmc-opts model args data)]
@@ -106,8 +112,8 @@
 
     ;; --- MH (generic MCMC) ---
     :mcmc
-    (let [mh-opts {:samples (or (:samples opts) 200)
-                   :burn (or (:burn opts) 100)
+    (let [mh-opts {:samples (opt opts 200 :samples)
+                   :burn (opt opts 100 :burn)
                    :key (:key opts)}
           traces (mcmc/mh mh-opts model args data)]
       {:trace (last traces)
@@ -119,8 +125,8 @@
     :vi
     (let [residual (or (:residual-addrs opts) [])
           addrs (vec residual)
-          vi-opts (merge {:iterations (or (:iterations opts) (:n-iters opts) 500)
-                          :lr (or (:lr opts) (:learning-rate opts) 0.01)}
+          vi-opts (merge {:iterations (opt opts 500 :iterations :n-iters)
+                          :lr (opt opts 0.01 :lr :learning-rate)}
                          (select-keys opts [:key]))
           result (co/learn model args data addrs vi-opts)]
       {:trace nil
@@ -133,7 +139,7 @@
     ;; --- SMC (no temporal structure → fall back to IS) and handler-based
     ;;     importance sampling (safest fallback): identical IS path ---
     (:smc :handler-is)
-    (let [is-opts {:samples (or (:particles opts) (:n-particles opts) 200)
+    (let [is-opts {:samples (opt opts 200 :particles :n-particles)
                    :key (:key opts)}
           {:keys [traces log-ml-estimate]} (importance/importance-sampling
                                              is-opts model args data)
@@ -156,9 +162,9 @@
    param-names: vector of param keywords to optimize.
    inference-result: initial inference result from run-method."
   [model args data inference-result param-names method-opts user-opts]
-  (let [learn-opts {:iterations (or (:iterations user-opts) 200)
-                    :lr (or (:lr user-opts) 0.01)
-                    :log-every (or (:log-every user-opts) 50)
+  (let [learn-opts {:iterations (opt user-opts 200 :iterations)
+                    :lr (opt user-opts 0.01 :lr)
+                    :log-every (opt user-opts 50 :log-every)
                     :callback (:callback user-opts)}
         result (co/learn model args data param-names learn-opts)]
     (merge inference-result

--- a/src/genmlx/fit.cljs
+++ b/src/genmlx/fit.cljs
@@ -82,9 +82,7 @@
     ;; --- Exact (all-conjugate / trivial) and Kalman (auto-handlers): both
     ;;     get the answer directly from p/generate's weight ---
     (:exact :kalman)
-    (let [result (p/generate model args data)
-          trace (:trace result)
-          weight (:weight result)]
+    (let [{:keys [trace weight]} (p/generate model args data)]
       (mx/materialize! weight)
       {:trace trace
        :log-ml (mx/item weight)
@@ -137,12 +135,13 @@
     (:smc :handler-is)
     (let [is-opts {:samples (or (:particles opts) (:n-particles opts) 200)
                    :key (:key opts)}
-          result (importance/importance-sampling is-opts model args data)
-          best-trace (first (:traces result))]
-      (mx/materialize! (:log-ml-estimate result))
+          {:keys [traces log-ml-estimate]} (importance/importance-sampling
+                                             is-opts model args data)
+          best-trace (first traces)]
+      (mx/materialize! log-ml-estimate)
       {:trace best-trace
        :posterior (when best-trace (extract-posterior best-trace data))
-       :log-ml (mx/item (:log-ml-estimate result))})
+       :log-ml (mx/item log-ml-estimate)})
 
     ;; --- Unknown method ---
     (throw (ex-info (str "Unknown inference method: " method)

--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -46,10 +46,8 @@
 ;; Helpers
 ;; ---------------------------------------------------------------------------
 
-(defn- ev
-  "Evaluate an MLX array and extract its scalar value."
-  [x]
-  (mx/realize x))
+;; Evaluate an MLX array and extract its scalar value.
+(def ^:private ev mx/realize)
 
 (defn- approx=
   "True if |a - b| <= tol. Both must be finite."
@@ -59,15 +57,15 @@
         (js/Number.isFinite b)
         (<= (js/Math.abs (- a b)) tol))))
 
-(defn- pos-infinite?
-  "True if x is +Infinity."
-  [x]
-  (and (number? x) (not (js/Number.isFinite x)) (pos? x)))
+(defn- choice-val
+  "The raw leaf value at a single-keyword address in a choicemap."
+  [cm addr]
+  (cm/get-value (cm/get-submap cm addr)))
 
-(defn- first-leaf-path
-  "Return the first leaf address path from a choicemap, or nil."
-  [choices]
-  (first (cm/addresses choices)))
+(defn- choice-num
+  "The realized numeric leaf value at a single-keyword address."
+  [cm addr]
+  (ev (choice-val cm addr)))
 
 (defn path->selection
   "Convert an address path like [:x] or [:inner :z] to a selection."
@@ -79,10 +77,8 @@
             (sel/select (last path))
             (reverse (butlast path)))))
 
-(defn- all-leaf-addrs
-  "Return all leaf address paths from a choicemap."
-  [choices]
-  (cm/addresses choices))
+;; Return all leaf address paths from a choicemap.
+(def ^:private all-leaf-addrs cm/addresses)
 
 (defn strip-compiled
   "Return a copy of model with all compiled execution paths removed from
@@ -291,15 +287,12 @@
                  (let [selected (first (first addrs))
                        unselected (map first (rest addrs))
                        orig-vals (into {} (map (fn [a]
-                                                 [a (ev (cm/get-value
-                                                         (cm/get-submap
-                                                          (:choices t) a)))])
+                                                 [a (choice-num (:choices t) a)])
                                                unselected))
                        {:keys [trace]} (p/regenerate model t
                                                      (sel/select selected))]
                    (every? (fn [a]
-                             (let [v (ev (cm/get-value
-                                          (cm/get-submap (:choices trace) a)))]
+                             (let [v (choice-num (:choices trace) a)]
                                (approx= (get orig-vals a) v 1e-6)))
                            unselected)))))}
 
@@ -367,8 +360,7 @@
                                    w (ev weight)
                                    accept? (u/accept-mh? w k1)
                                    next-t (if accept? trace t)
-                                   x-val (ev (cm/get-value
-                                              (cm/get-submap (:choices next-t) :x)))]
+                                   x-val (choice-num (:choices next-t) :x)]
                                (recur next-t (inc i)
                                       (if (>= i 500) (conj acc x-val) acc)
                                       k2))))
@@ -489,7 +481,7 @@
                (if (< (count addrs) 2)
                  true
                  (let [first-addr (first (first addrs))
-                       val (cm/get-value (cm/get-submap (:choices t) first-addr))
+                       val (choice-val (:choices t) first-addr)
                        partial (cm/choicemap first-addr val)
                        {:keys [trace weight]} (p/generate model args partial)]
                    (and (js/Number.isFinite (ev (:score trace)))
@@ -627,7 +619,7 @@
                    h 1e-3]
                (every?
                 (fn [addr]
-                  (let [v (ev (cm/get-value (cm/get-submap (:choices t) addr)))
+                  (let [v (choice-num (:choices t) addr)
                         choices-plus (cm/set-choice (:choices t) [addr]
                                                     (mx/scalar (+ v h)))
                         choices-minus (cm/set-choice (:choices t) [addr]
@@ -690,7 +682,7 @@
                (if (< (count addrs) 2)
                  true
                  (let [obs-addr (first (first addrs))
-                       obs-val (cm/get-value (cm/get-submap (:choices t) obs-addr))
+                       obs-val (choice-val (:choices t) obs-addr)
                        obs (cm/choicemap obs-addr obs-val)
                        {:keys [trace weight]} (p/generate model args obs)
                        w (ev weight)
@@ -709,7 +701,7 @@
                (if (< (count addrs) 2)
                  true
                  (let [obs-addr (first (first addrs))
-                       obs-val (cm/get-value (cm/get-submap (:choices t) obs-addr))
+                       obs-val (choice-val (:choices t) obs-addr)
                        obs (cm/choicemap obs-addr obs-val)
                        weights (repeatedly 20
                                            #(ev (:weight (p/generate model args obs))))]
@@ -728,7 +720,7 @@
                (if (< (count addrs) 2)
                  true
                  (let [obs-addr (first (first addrs))
-                       obs-val (cm/get-value (cm/get-submap (:choices t) obs-addr))
+                       obs-val (choice-val (:choices t) obs-addr)
                        obs (cm/choicemap obs-addr obs-val)
                        weights (repeatedly 100
                                            #(ev (:weight (p/generate model args obs))))
@@ -890,8 +882,8 @@
                                                                         (cm/choicemap :c (mx/scalar 3.0)))
                                      w (ev weight)
                                      s (ev (:score trace))
-                                     a (ev (cm/get-value (cm/get-submap (:choices trace) :a)))
-                                     b (ev (cm/get-value (cm/get-submap (:choices trace) :b)))
+                                     a (choice-num (:choices trace) :a)
+                                     b (choice-num (:choices trace) :b)
                                ;; log q(a,b) = lp(a) + lp(b|a)
                                      lp-a (ev (dist/log-prob (dist/uniform 0 1) (mx/scalar a)))
                                      lp-b (ev (dist/log-prob (dist/laplace (mx/scalar a) 1)
@@ -909,7 +901,7 @@
                                      {:keys [trace weight]} (p/generate m [] constraints)
                                      w (ev weight)
                                      s (ev (:score trace))
-                                     b (ev (cm/get-value (cm/get-submap (:choices trace) :b)))
+                                     b (choice-num (:choices trace) :b)
                                ;; log q(b) = lp(b|a=0.7)
                                      log-q (ev (dist/log-prob (dist/laplace (mx/scalar 0.7) 1)
                                                               (mx/scalar b)))]
@@ -946,7 +938,7 @@
                (if (empty? addrs)
                  true
                  (let [obs-addr (first (first addrs))
-                       obs-val (cm/get-value (cm/get-submap (:choices t) obs-addr))
+                       obs-val (choice-val (:choices t) obs-addr)
                        obs (cm/choicemap obs-addr obs-val)
                        vt (dyn/vgenerate model args obs n (rng/fresh-key 99))]
                    (and (= [n] (vec (mx/shape (:score vt))))
@@ -964,7 +956,7 @@
                (if (empty? addrs)
                  true
                  (let [obs-addr (first (first addrs))
-                       obs-val (cm/get-value (cm/get-submap (:choices t-scalar) obs-addr))
+                       obs-val (choice-val (:choices t-scalar) obs-addr)
                        obs (cm/choicemap obs-addr obs-val)
                        {:keys [weight]} (dyn/vupdate model vt obs (rng/fresh-key 77))]
                    (and (= [n] (vec (mx/shape weight)))
@@ -983,17 +975,13 @@
                  (let [selected (first (first addrs))
                        unselected-addrs (map first (rest addrs))
                        orig-vals (into {} (map (fn [a]
-                                                 [a (mx/->clj (cm/get-value
-                                                                (cm/get-submap
-                                                                 (:choices vt) a)))])
+                                                 [a (mx/->clj (choice-val (:choices vt) a))])
                                                unselected-addrs))
                        {:keys [vtrace]} (dyn/vregenerate model vt
                                                           (sel/select selected)
                                                           (rng/fresh-key 55))]
                    (every? (fn [a]
-                             (let [new-vals (mx/->clj (cm/get-value
-                                                       (cm/get-submap
-                                                        (:choices vtrace) a)))]
+                             (let [new-vals (mx/->clj (choice-val (:choices vtrace) a))]
                                (= (get orig-vals a) new-vals)))
                            unselected-addrs)))))}
 
@@ -1045,8 +1033,8 @@
                                       (trace :y (dist/gaussian x 0.5))))))
                    n 2000
                    samples (repeatedly n #(let [t (p/simulate ref-model [])]
-                                            [(ev (cm/get-value (cm/get-submap (:choices t) :x)))
-                                             (ev (cm/get-value (cm/get-submap (:choices t) :y)))]))
+                                            [(choice-num (:choices t) :x)
+                                             (choice-num (:choices t) :y)]))
                    xs (map first samples)
                    ys (map second samples)
                    mean-y (/ (reduce + ys) n)
@@ -1188,10 +1176,8 @@
                                w (ev weight)
                                accept? (u/accept-mh? w k1)
                                next-t (if accept? trace t)
-                               x-val (ev (cm/get-value
-                                          (cm/get-submap (:choices next-t) :x)))
-                               y-val (ev (cm/get-value
-                                          (cm/get-submap (:choices next-t) :y)))]
+                               x-val (choice-num (:choices next-t) :x)
+                               y-val (choice-num (:choices next-t) :y)]
                            (recur next-t (inc i)
                                   (if (>= i burn)
                                     (conj acc (+ x-val y-val))
@@ -1371,10 +1357,8 @@
                        preserved? (every?
                                    (fn [a]
                                      (approx=
-                                      (ev (cm/get-value
-                                           (cm/get-submap (:choices t) a)))
-                                      (ev (cm/get-value
-                                           (cm/get-submap (:choices trace) a)))
+                                      (choice-num (:choices t) a)
+                                      (choice-num (:choices trace) a)
                                       1e-6))
                                    unselected)]
                    (and (approx= compiled-score handler-score 1e-4)
@@ -1502,7 +1486,7 @@
                          {:keys [trace weight]} (comb/unfold-extend tr (nth obs-seq t) k1)
                          _ (mx/materialize! weight)
                          step-cm (cm/get-submap (:choices trace) t)
-                         x-val (cm/get-value (cm/get-submap step-cm :x))
+                         x-val (choice-val step-cm :x)
                          _ (mx/materialize! x-val)
                          w (ev weight)
                          x (ev x-val)
@@ -1568,8 +1552,8 @@
     :tags #{:mcmc :involutive}
     :check (fn [_]
              (let [inv-fn (fn [tcm acm]
-                            (let [x (cm/get-value (cm/get-submap tcm :x))
-                                  eps (cm/get-value (cm/get-submap acm :eps))
+                            (let [x (choice-val tcm :x)
+                                  eps (choice-val acm :eps)
                                   _ (mx/materialize! x eps)]
                               [(cm/set-value tcm :x (mx/add x eps))
                                (cm/set-value acm :eps (mx/negative eps))]))]
@@ -1583,8 +1567,8 @@
                          acm (cm/choicemap :eps (mx/scalar eps-val))
                          [tcm1 acm1] (inv-fn tcm acm)
                          [tcm2 acm2] (inv-fn tcm1 acm1)
-                         x-rt (ev (cm/get-value (cm/get-submap tcm2 :x)))
-                         eps-rt (ev (cm/get-value (cm/get-submap acm2 :eps)))]
+                         x-rt (choice-num tcm2 :x)
+                         eps-rt (choice-num acm2 :eps)]
                      (and (approx= x-val x-rt 1e-6)
                           (approx= eps-val eps-rt 1e-6)))))))}
 
@@ -1656,8 +1640,8 @@
                                   (trace :eps (dist/gaussian 0 0.5))))
                               '([_tcm] (trace :eps (dist/gaussian 0 0.5)))))
                    involution (fn [tcm acm]
-                                (let [x (cm/get-value (cm/get-submap tcm :x))
-                                      eps (cm/get-value (cm/get-submap acm :eps))
+                                (let [x (choice-val tcm :x)
+                                      eps (choice-val acm :eps)
                                       _ (mx/materialize! x eps)]
                                   [(cm/set-value tcm :x (mx/add x eps))
                                    (cm/set-value acm :eps (mx/negative eps))]))
@@ -1670,8 +1654,7 @@
                                (let [[k1 k2] (rng/split k)
                                      next-t (mcmc/involutive-mh-step
                                               t model proposal involution k1)
-                                     x-val (ev (cm/get-value
-                                                (cm/get-submap (:choices next-t) :x)))]
+                                     x-val (choice-num (:choices next-t) :x)]
                                  (recur next-t (inc i)
                                         (if (>= i 500) (conj acc x-val) acc)
                                         k2))))

--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -20,7 +20,7 @@
 
    Usage:
      (gfi/verify model args)              ;; run all laws
-     (gfi/verify model args {:laws [:update-density-ratio]})
+     (gfi/verify model args :law-names [:update-density-ratio])
      (gfi/check-law :score-decomposition model args)
 
    See also: genmlx.contracts (DEPRECATED — all 11 contracts subsumed here)
@@ -1690,9 +1690,9 @@
   "Run GFI laws against a model. Returns structured report.
 
    Options:
-     :laws     — subset of law keywords to run (default: all)
-     :tags     — subset of tag keywords; runs laws matching ANY tag
-     :n-trials — number of independent trials per law (default: 10)"
+     :law-names — subset of law keywords to run (default: all)
+     :tags      — subset of tag keywords; runs laws matching ANY tag
+     :n-trials  — number of independent trials per law (default: 10)"
   [model args & {:keys [law-names tags n-trials]
                  :or {n-trials 10}}]
   (let [model (dyn/auto-key model)

--- a/src/genmlx/gradients.cljs
+++ b/src/genmlx/gradients.cljs
@@ -12,12 +12,12 @@
    then return the generate weight under model/args. indexed-addrs is a vector
    of [i addr] pairs (index into params-arr)."
   [model args base-cm indexed-addrs params-arr]
-  (let [cm (reduce
-             (fn [cm [i addr]]
-               (cm/set-choice cm [addr] (mx/index params-arr i)))
-             base-cm
-             indexed-addrs)]
-    (:weight (p/generate model args cm))))
+  (let [acc (reduce
+              (fn [acc [i addr]]
+                (cm/set-choice acc [addr] (mx/index params-arr i)))
+              base-cm
+              indexed-addrs)]
+    (:weight (p/generate model args acc))))
 
 (defn choice-gradients
   "Compute gradients of the model's log-probability w.r.t. specified choices.

--- a/src/genmlx/gradients.cljs
+++ b/src/genmlx/gradients.cljs
@@ -7,6 +7,18 @@
             [genmlx.protocols :as p]
             [genmlx.dynamic :as dyn]))
 
+(defn- params->weight
+  "Set each indexed address on base-cm to the corresponding entry of params-arr,
+   then return the generate weight under model/args. indexed-addrs is a vector
+   of [i addr] pairs (index into params-arr)."
+  [model args base-cm indexed-addrs params-arr]
+  (let [cm (reduce
+             (fn [cm [i addr]]
+               (cm/set-choice cm [addr] (mx/index params-arr i)))
+             base-cm
+             indexed-addrs)]
+    (:weight (p/generate model args cm))))
+
 (defn choice-gradients
   "Compute gradients of the model's log-probability w.r.t. specified choices.
    model: generative function
@@ -34,12 +46,7 @@
           params (mx/array current-vals)
           ;; Score function: reconstruct choicemap with params, run generate
           score-fn (fn [params-arr]
-                     (let [cm (reduce
-                                (fn [cm [i addr]]
-                                  (cm/set-choice cm [addr] (mx/index params-arr i)))
-                                choices
-                                indexed-addrs)]
-                       (:weight (p/generate model args cm))))
+                     (params->weight model args choices indexed-addrs params-arr))
           ;; Compute gradient (uncompiled — compile-fn severs backward
           ;; pass when model body uses mx/eval!, returning silent zeros)
           grad-fn (mx/grad score-fn)
@@ -73,12 +80,7 @@
                        :params-shape (mx/shape params)})))
     (let [indexed-addrs (mapv vector (range) addresses)
           score-fn (fn [p]
-                     (let [cm (reduce
-                                (fn [cm [i addr]]
-                                  (cm/set-choice cm [addr] (mx/index p i)))
-                                observations
-                                indexed-addrs)]
-                       (:weight (p/generate model args cm))))
+                     (params->weight model args observations indexed-addrs p))
           vag (mx/value-and-grad score-fn)
           [score grad] (vag params)]
       (mx/materialize! score grad)

--- a/src/genmlx/gradients.cljs
+++ b/src/genmlx/gradients.cljs
@@ -53,10 +53,8 @@
           grad-arr (grad-fn params)]
       (mx/materialize! grad-arr)
       ;; Split gradient array into per-address map
-      (into {}
-        (map (fn [[i addr]]
-               [addr (mx/index grad-arr i)])
-             indexed-addrs)))))
+      (zipmap addresses
+              (map #(mx/index grad-arr %) (range (count addresses)))))))
 
 (defn score-gradient
   "Compute gradient of the model score w.r.t. a flat parameter array.

--- a/src/genmlx/handler.cljs
+++ b/src/genmlx/handler.cljs
@@ -297,6 +297,62 @@
   (or (not (mlx-array-like? v))
       (= [] (mx/shape v))))
 
+(defn- run-batched-particle
+  "Run one particle's GFI op against `gf`, dispatching on which scoped state
+   is present: selection => regenerate, old-choices => update, constraints =>
+   generate, else simulate. Returns {:choices :score :weight :discard :retval}."
+  [gf elem-args sub-selection old-i cons-i]
+  (cond
+    ;; Regenerate mode
+    sub-selection
+    (let [old-choices (or old-i cm/EMPTY)
+          elem-trace (tr/make-trace
+                      {:gen-fn gf :args elem-args
+                       :choices old-choices :retval nil
+                       :score (mx/scalar 0.0)})
+          {:keys [trace weight]} (p/regenerate gf elem-trace sub-selection)]
+      {:choices (:choices trace) :score (:score trace)
+       :weight weight :retval (:retval trace)})
+
+    ;; Update mode
+    (and old-i (not= old-i cm/EMPTY))
+    (let [c (or cons-i cm/EMPTY)
+          elem-trace (tr/make-trace
+                      {:gen-fn gf :args elem-args
+                       :choices old-i :retval nil
+                       :score (mx/scalar 0.0)})
+          {:keys [trace weight discard]} (p/update gf elem-trace c)]
+      {:choices (:choices trace) :score (:score trace)
+       :weight weight :discard discard :retval (:retval trace)})
+
+    ;; Generate with constraints
+    (and cons-i (not= cons-i cm/EMPTY))
+    (let [{:keys [trace weight]} (p/generate gf elem-args cons-i)]
+      {:choices (:choices trace) :score (:score trace)
+       :weight weight :retval (:retval trace)})
+
+    ;; Simulate
+    :else
+    (let [trace (p/simulate gf elem-args)]
+      {:choices (:choices trace) :score (:score trace)
+       :retval (:retval trace)})))
+
+(defn- stack-particle-results
+  "Stack a vector of per-particle result maps back into a single [N]-batched
+   sub-result {:choices :score :weight :discard :retval}."
+  [results]
+  {:choices (cm/stack-choicemaps (mapv :choices results) mx/stack)
+   :score (mx/stack (mapv :score results))
+   :weight (when (some :weight results)
+             (mx/stack (mapv #(or (:weight %) (mx/scalar 0.0)) results)))
+   :discard (when (some :discard results)
+              (let [discards (mapv #(or (:discard %) cm/EMPTY) results)]
+                (if (every? #(= % cm/EMPTY) discards)
+                  cm/EMPTY
+                  (cm/stack-choicemaps discards mx/stack))))
+   :retval (let [rvs (mapv :retval results)]
+             (if (every? mx/array? rvs) (mx/stack rvs) (vec rvs)))})
+
 (defn combinator-batched-fallback
   "Fallback for splicing a non-DynamicGF (e.g. VmapCombinator) in batched mode.
    Unstacks [N]-particle state, runs combinator GFI N times, stacks results."
@@ -328,64 +384,18 @@
                             (vec (repeat n sub-constraints))
                             (cm/unstack-choicemap sub-constraints n mx/index scalar-leaf-val?)))
         ;; Run per-particle
-        results
-        (mapv
-         (fn [i]
-           (let [elem-args (mapv #(extract-scalar-arg % i) args)
-                 old-i (when per-old-choices (nth per-old-choices i))
-                 cons-i (when per-constraints (nth per-constraints i))]
-             (cond
-                ;; Regenerate mode
-               sub-selection
-               (let [old-choices (or old-i cm/EMPTY)
-                     elem-trace (tr/make-trace
-                                 {:gen-fn gf :args elem-args
-                                  :choices old-choices :retval nil
-                                  :score (mx/scalar 0.0)})
-                     {:keys [trace weight]} (p/regenerate gf elem-trace sub-selection)]
-                 {:choices (:choices trace) :score (:score trace)
-                  :weight weight :retval (:retval trace)})
-
-                ;; Update mode
-               (and old-i (not= old-i cm/EMPTY))
-               (let [c (or cons-i cm/EMPTY)
-                     elem-trace (tr/make-trace
-                                 {:gen-fn gf :args elem-args
-                                  :choices old-i :retval nil
-                                  :score (mx/scalar 0.0)})
-                     {:keys [trace weight discard]} (p/update gf elem-trace c)]
-                 {:choices (:choices trace) :score (:score trace)
-                  :weight weight :discard discard :retval (:retval trace)})
-
-                ;; Generate with constraints
-               (and cons-i (not= cons-i cm/EMPTY))
-               (let [{:keys [trace weight]} (p/generate gf elem-args cons-i)]
-                 {:choices (:choices trace) :score (:score trace)
-                  :weight weight :retval (:retval trace)})
-
-                ;; Simulate
-               :else
-               (let [trace (p/simulate gf elem-args)]
-                 {:choices (:choices trace) :score (:score trace)
-                  :retval (:retval trace)}))))
-         (range n))
-        ;; Stack results
-        stacked-choices (cm/stack-choicemaps (mapv :choices results) mx/stack)
-        stacked-scores (mx/stack (mapv :score results))
-        stacked-weights (when (some :weight results)
-                          (mx/stack (mapv #(or (:weight %) (mx/scalar 0.0)) results)))
-        stacked-retval (let [rvs (mapv :retval results)]
-                         (if (every? mx/array? rvs) (mx/stack rvs) (vec rvs)))
-        stacked-discard (when (some :discard results)
-                          (let [discards (mapv #(or (:discard %) cm/EMPTY) results)]
-                            (if (every? #(= % cm/EMPTY) discards)
-                              cm/EMPTY
-                              (cm/stack-choicemaps discards mx/stack))))
-        ;; Merge into parent state
-        sub-result {:choices stacked-choices :score stacked-scores
-                    :weight stacked-weights :discard stacked-discard
-                    :retval stacked-retval}
+        results (mapv
+                 (fn [i]
+                   (run-batched-particle
+                    gf
+                    (mapv #(extract-scalar-arg % i) args)
+                    sub-selection
+                    (when per-old-choices (nth per-old-choices i))
+                    (when per-constraints (nth per-constraints i))))
+                 (range n))
+        ;; Stack results and merge into parent state
+        sub-result (stack-particle-results results)
         state' (-> state
                    (assoc :key k1)
                    (merge-sub-result addr sub-result))]
-    [state' stacked-retval]))
+    [state' (:retval sub-result)]))

--- a/src/genmlx/handler.cljs
+++ b/src/genmlx/handler.cljs
@@ -38,13 +38,11 @@
   (:require [genmlx.choicemap :as cm]
             [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
+            [genmlx.mlx.constants :refer [ZERO]]
             [genmlx.selection :as sel]
             [genmlx.dist.core :as dc]
             [genmlx.protocols :as p]
             [genmlx.trace :as tr]))
-
-;; Cached zero constant for init states and fallback log-probs
-(def ^:private ZERO (mx/scalar 0.0))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure state transitions
@@ -283,16 +281,20 @@
                                   (assoc :nested-splice-scores (:nested-splice-scores sub-result)))]
                     (assoc (or nss {}) addr sub-meta)))))))
 
+(defn- mlx-array-like?
+  "Duck-typing probe: does x look like an MLX array (has .shape and .item)?"
+  [x]
+  (and (some? x) (some? (.-shape x)) (some? (.-item x))))
+
 (defn- mlx-arr-batched?
   "Check if x is an MLX array with at least 1 dimension."
   [x]
-  (and (some? x) (some? (.-shape x)) (some? (.-item x))
-       (pos? (count (mx/shape x)))))
+  (and (mlx-array-like? x) (pos? (count (mx/shape x)))))
 
 (defn- scalar-leaf-val?
   "Check if a value is scalar (0-d or not an MLX array)."
   [v]
-  (or (not (and (some? v) (some? (.-shape v)) (some? (.-item v))))
+  (or (not (mlx-array-like? v))
       (= [] (mx/shape v))))
 
 (defn combinator-batched-fallback
@@ -329,11 +331,13 @@
         results
         (mapv
          (fn [i]
-           (let [elem-args (mapv #(extract-scalar-arg % i) args)]
+           (let [elem-args (mapv #(extract-scalar-arg % i) args)
+                 old-i (when per-old-choices (nth per-old-choices i))
+                 cons-i (when per-constraints (nth per-constraints i))]
              (cond
                 ;; Regenerate mode
                sub-selection
-               (let [old-choices (or (and per-old-choices (nth per-old-choices i)) cm/EMPTY)
+               (let [old-choices (or old-i cm/EMPTY)
                      elem-trace (tr/make-trace
                                  {:gen-fn gf :args elem-args
                                   :choices old-choices :retval nil
@@ -343,21 +347,19 @@
                   :weight weight :retval (:retval trace)})
 
                 ;; Update mode
-               (and per-old-choices (nth per-old-choices i)
-                    (not= (nth per-old-choices i) cm/EMPTY))
-               (let [c (or (and per-constraints (nth per-constraints i)) cm/EMPTY)
+               (and old-i (not= old-i cm/EMPTY))
+               (let [c (or cons-i cm/EMPTY)
                      elem-trace (tr/make-trace
                                  {:gen-fn gf :args elem-args
-                                  :choices (nth per-old-choices i) :retval nil
+                                  :choices old-i :retval nil
                                   :score (mx/scalar 0.0)})
                      {:keys [trace weight discard]} (p/update gf elem-trace c)]
                  {:choices (:choices trace) :score (:score trace)
                   :weight weight :discard discard :retval (:retval trace)})
 
                 ;; Generate with constraints
-               (and per-constraints (nth per-constraints i)
-                    (not= (nth per-constraints i) cm/EMPTY))
-               (let [{:keys [trace weight]} (p/generate gf elem-args (nth per-constraints i))]
+               (and cons-i (not= cons-i cm/EMPTY))
+               (let [{:keys [trace weight]} (p/generate gf elem-args cons-i)]
                  {:choices (:choices trace) :score (:score trace)
                   :weight weight :retval (:retval trace)})
 

--- a/src/genmlx/inference/adev.cljs
+++ b/src/genmlx/inference/adev.cljs
@@ -187,6 +187,16 @@
 ;; Optimization loop (uses vectorized path by default)
 ;; ---------------------------------------------------------------------------
 
+(defn- ema-update
+  "Exponential-moving-average baseline update. Returns nil when `decay` is
+   falsy (baseline off), `value` when there is no prior baseline, otherwise
+   decay*baseline + (1-decay)*value."
+  [decay baseline value]
+  (when decay
+    (if baseline
+      (+ (* decay baseline) (* (- 1.0 decay) value))
+      value)))
+
 (defn adev-optimize
   "Optimize E[cost] via ADEV gradient estimation with Adam.
    Uses vectorized (batched) execution by default — runs model body ONCE
@@ -229,11 +239,7 @@
               _ (mx/materialize! loss grad)
               _ (when (zero? (mod i 50)) (mx/sweep-dead-arrays!) (mx/clear-cache!))
               loss-val (mx/item loss)
-              new-baseline (when baseline-decay
-                             (if baseline
-                               (+ (* baseline-decay baseline)
-                                  (* (- 1.0 baseline-decay) loss-val))
-                               loss-val))
+              new-baseline (ema-update baseline-decay baseline loss-val)
               [new-params new-opt-st] (learn/adam-step params grad opt-st {:lr lr})]
           (when callback
             (callback {:iter i :loss loss-val :params new-params}))
@@ -283,11 +289,7 @@
                             #(grad-fn params key bl)
                             (fn [[l g]] [l g]))
               loss-val (mx/item loss)
-              new-baseline (when baseline-decay
-                             (if baseline
-                               (+ (* baseline-decay baseline)
-                                  (* (- 1.0 baseline-decay) loss-val))
-                               loss-val))
+              new-baseline (ema-update baseline-decay baseline loss-val)
               [new-params new-opt-st] (learn/adam-step params grad opt-st {:lr lr})]
           (when callback
             (callback {:iter i :loss loss-val :params new-params}))

--- a/src/genmlx/inference/adev.cljs
+++ b/src/genmlx/inference/adev.cljs
@@ -267,9 +267,7 @@
                   (let [store {:params (learn/array->params p param-names)}
                         gf' (vary-meta gf assoc :genmlx.dynamic/param-store store)]
                     (vadev-surrogate gf' args cost-fn n-samples key bl)))
-        grad-fn (fn [p key bl]
-                  (let [[loss grad] ((mx/value-and-grad loss-fn) p key bl)]
-                    [loss grad]))
+        vg (mx/value-and-grad loss-fn)
         opt-state (learn/adam-init init-params)]
     (loop [i 0
            params init-params
@@ -286,7 +284,7 @@
               ;; equivalent to "no baseline" on the first iteration.
               bl (mx/scalar (or baseline 0.0))
               [loss grad] (mx/tidy-run
-                            #(grad-fn params key bl)
+                            #(vg params key bl)
                             (fn [[l g]] [l g]))
               loss-val (mx/item loss)
               new-baseline (ema-update baseline-decay baseline loss-val)

--- a/src/genmlx/inference/amortized.cljs
+++ b/src/genmlx/inference/amortized.cljs
@@ -197,7 +197,7 @@
                   batch-indices (subvec order pos end)
                   batch (mapv #(nth dataset %) batch-indices)
                   loss (nn/training-step! enc-ref opt vg batch)]
-              (recur (inc i) (long end) order (conj! losses loss)))))))))
+              (recur (inc i) end order (conj! losses loss)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Neural importance sampling

--- a/src/genmlx/inference/amortized.cljs
+++ b/src/genmlx/inference/amortized.cljs
@@ -223,8 +223,7 @@
         results
         (mapv
           (fn [_]
-            (let [{:keys [choices weight]} (p/propose guide guide-args)
-                  guide-score weight
+            (let [{choices :choices guide-score :weight} (p/propose guide guide-args)
                   all-constraints (cm/merge-cm choices observations)
                   {:keys [trace weight]} (p/generate model model-args all-constraints)
                   log-w (mx/subtract weight guide-score)]

--- a/src/genmlx/inference/amortized.cljs
+++ b/src/genmlx/inference/amortized.cljs
@@ -24,6 +24,17 @@
 
 (def ^:private LOG-2PI (js/Math.log (* 2.0 js/Math.PI)))
 
+(defn- std-normal-logprob
+  "Per-dimension log-density of a reparameterized normal sample with
+   standardized noise `eps` and `log-sigs` = log standard deviations:
+   -(0.5*log(2π) + log-sigma + 0.5*eps²). Returns a [d]-shaped array;
+   callers sum over the latent dimension."
+  [log-sigs eps]
+  (mx/negative
+    (mx/add (mx/scalar (* 0.5 LOG-2PI))
+            log-sigs
+            (mx/multiply (mx/scalar 0.5) (mx/square eps)))))
+
 (def gaussian-posterior
   "Gaussian posterior family: encoder outputs [mu, log-sigma] per latent.
    Reparameterized sample: z = mu + sigma * eps."
@@ -34,11 +45,7 @@
                    sigs     (mx/exp log-sigs)
                    eps      (rng/normal key [d])]
                {:values (mx/add mus (mx/multiply sigs eps))
-                :log-prob (mx/sum
-                            (mx/negative
-                              (mx/add (mx/scalar (* 0.5 LOG-2PI))
-                                      log-sigs
-                                      (mx/multiply (mx/scalar 0.5) (mx/square eps)))))}))})
+                :log-prob (mx/sum (std-normal-logprob log-sigs eps))}))})
 
 (def log-normal-posterior
   "Log-normal posterior family: encoder outputs [mu, log-sigma] per latent.
@@ -53,11 +60,7 @@
                    log-z    (mx/add mus (mx/multiply sigs eps))
                    z        (mx/exp log-z)
                    log-prob (mx/subtract
-                              (mx/sum
-                                (mx/negative
-                                  (mx/add (mx/scalar (* 0.5 LOG-2PI))
-                                          log-sigs
-                                          (mx/multiply (mx/scalar 0.5) (mx/square eps)))))
+                              (mx/sum (std-normal-logprob log-sigs eps))
                               (mx/sum log-z))]
                {:values z
                 :log-prob log-prob}))})

--- a/src/genmlx/inference/auto_analytical.cljs
+++ b/src/genmlx/inference/auto_analytical.cljs
@@ -129,8 +129,9 @@
 ;; Generic handler builder (shared across all conjugate families)
 ;; ---------------------------------------------------------------------------
 
-(defn- make-conjugate-handlers
-  "Build address-based prior + obs handlers for a conjugate family.
+(defn- make-conjugate-handlers-core
+  "Build address-based prior + obs handlers for a conjugate family, parameterized
+   by `mode` (:generate or :regenerate) — mirroring make-kalman-handlers-core.
 
    prior-addr:     keyword address of the prior trace site
    obs-addrs:      vector of observation site addresses
@@ -138,33 +139,54 @@
    posterior-mean: (fn [posterior-map] -> MLX-scalar) — point estimate from posterior
    update-step:    (fn [posterior obs-value dist-params] -> {:posterior map :ll scalar})
 
+   :generate — prior returns posterior mean (always runs); obs reads
+     :constraints, ll → :score + :weight.
+   :regenerate — prior returns the old value and falls through (nil) when the
+     site is selected; obs reads :old-choices, requires an initialized posterior,
+     skips selected obs, ll → :score only.
+
    Returns {addr handler-fn} for prior + all obs addresses."
-  [prior-addr obs-addrs init-posterior posterior-mean update-step]
-  (let [prior-handler
+  [prior-addr obs-addrs init-posterior posterior-mean update-step mode]
+  (let [regenerate? (= mode :regenerate)
+        prior-handler
         (fn [state addr dist]
-          (let [posterior (init-posterior (:params dist))
-                post-mean (posterior-mean posterior)]
-            ;; Return prior mean; don't add to score (marginalized out)
-            [post-mean (-> state
-                           (assoc-in [:auto-posteriors prior-addr] posterior)
-                           (update :choices cm/set-value addr post-mean))]))
+          (when-not (and regenerate? (:selection state)
+                         (sel/selected? (:selection state) addr))
+            (let [posterior (init-posterior (:params dist))
+                  value (if regenerate?
+                          (cm/get-value (cm/get-submap (:old-choices state) addr))
+                          (posterior-mean posterior))]
+              ;; Return point estimate / old value; don't add to score (marginalized out)
+              [value (-> state
+                         (assoc-in [:auto-posteriors prior-addr] posterior)
+                         (update :choices cm/set-value addr value))])))
 
         obs-handler
         (fn [state addr dist]
-          (let [constraint (cm/get-submap (:constraints state) addr)]
-            (when (cm/has-value? constraint)
-              ;; Only handle constrained obs analytically
-              (let [obs-value (cm/get-value constraint)
-                    current-posterior (get-in state [:auto-posteriors prior-addr])
-                    {:keys [posterior ll]} (update-step current-posterior obs-value (:params dist))
-                    post-mean (posterior-mean posterior)]
-                [obs-value (-> state
-                               (assoc-in [:auto-posteriors prior-addr] posterior)
-                               (update :choices cm/set-value addr obs-value)
-                               (update :score #(mx/add % ll))
-                               (update :weight #(mx/add % ll))
-                             ;; Update prior's value to posterior mean
-                               (update :choices cm/set-value prior-addr post-mean))]))))]
+          ;; Regenerate: fall through if the prior was selected (no posterior).
+          (when-let [current-posterior (if regenerate?
+                                         (get-in state [:auto-posteriors prior-addr])
+                                         ::generate)]
+            ;; Regenerate: skip obs that are themselves being resampled.
+            (when-not (and regenerate? (:selection state)
+                           (sel/selected? (:selection state) addr))
+              (let [constraint (if regenerate?
+                                 (cm/get-submap (:old-choices state) addr)
+                                 (cm/get-submap (:constraints state) addr))]
+                (when (cm/has-value? constraint)
+                  (let [obs-value (cm/get-value constraint)
+                        cur-post (if regenerate?
+                                   current-posterior
+                                   (get-in state [:auto-posteriors prior-addr]))
+                        {:keys [posterior ll]} (update-step cur-post obs-value (:params dist))
+                        post-mean (posterior-mean posterior)]
+                    [obs-value (cond-> state
+                                 true (assoc-in [:auto-posteriors prior-addr] posterior)
+                                 true (update :choices cm/set-value addr obs-value)
+                                 true (update :score #(mx/add % ll))
+                                 (not regenerate?) (update :weight #(mx/add % ll))
+                                 ;; Update prior's value to posterior mean
+                                 true (update :choices cm/set-value prior-addr post-mean))]))))))]
     (merge {prior-addr prior-handler}
            (into {} (map (fn [oa] [oa obs-handler]) obs-addrs)))))
 
@@ -172,63 +194,51 @@
 ;; Per-family configs
 ;; ---------------------------------------------------------------------------
 
-(defn- make-auto-nn-handlers
-  "Build address-based handlers for a Normal-Normal conjugate pair."
-  [prior-addr obs-addrs]
-  (make-conjugate-handlers prior-addr obs-addrs
-                           (fn [{:keys [mu sigma]}]
-                             {:mean mu :var (mx/multiply sigma sigma)})
-                           :mean
-                           (fn [posterior obs-value {:keys [sigma]}]
-                             (let [obs-var (mx/multiply sigma sigma)
-                                   {:keys [mean var ll]} (nn-update-step posterior obs-value obs-var)]
-                               {:posterior {:mean mean :var var} :ll ll}))))
+;; Each family contributes the three closures that differ between conjugate
+;; pairs: how to seed the posterior from the prior dist params, the posterior
+;; point estimate, and the per-observation update. The handler control flow
+;; (generate vs regenerate, score/weight accounting) is shared in
+;; make-conjugate-handlers-core.
+(def ^:private conjugate-family-specs
+  {:normal-normal
+   {:init-posterior (fn [{:keys [mu sigma]}] {:mean mu :var (mx/multiply sigma sigma)})
+    :posterior-mean :mean
+    :update-step (fn [posterior obs-value {:keys [sigma]}]
+                   (let [obs-var (mx/multiply sigma sigma)
+                         {:keys [mean var ll]} (nn-update-step posterior obs-value obs-var)]
+                     {:posterior {:mean mean :var var} :ll ll}))}
+   :normal-iid-normal
+   {:init-posterior (fn [{:keys [mu sigma]}] {:mean mu :var (mx/multiply sigma sigma)})
+    :posterior-mean :mean
+    :update-step (fn [posterior obs-value {:keys [sigma]}]
+                   (let [obs-var (mx/multiply sigma sigma)
+                         {:keys [mean var ll]} (nn-iid-update-step posterior obs-value obs-var)]
+                     {:posterior {:mean mean :var var} :ll ll}))}
+   :beta-bernoulli
+   {:init-posterior (fn [{:keys [alpha beta-param]}] {:alpha alpha :beta beta-param})
+    :posterior-mean (fn [{:keys [alpha beta]}] (mx/divide alpha (mx/add alpha beta)))
+    :update-step (fn [posterior obs-value _params]
+                   (let [{:keys [alpha beta ll]} (bb-update-step posterior obs-value)]
+                     {:posterior {:alpha alpha :beta beta} :ll ll}))}
+   :gamma-poisson
+   {:init-posterior (fn [{:keys [shape-param rate]}] {:shape shape-param :rate rate})
+    :posterior-mean (fn [{:keys [shape rate]}] (mx/divide shape rate))
+    :update-step (fn [posterior obs-value _params]
+                   (let [{:keys [shape rate ll]} (gp-update-step posterior obs-value)]
+                     {:posterior {:shape shape :rate rate} :ll ll}))}
+   :gamma-exponential
+   {:init-posterior (fn [{:keys [shape-param rate]}] {:shape shape-param :rate rate})
+    :posterior-mean (fn [{:keys [shape rate]}] (mx/divide shape rate))
+    :update-step (fn [posterior obs-value _params]
+                   (let [{:keys [shape rate ll]} (ge-update-step posterior obs-value)]
+                     {:posterior {:shape shape :rate rate} :ll ll}))}})
 
-(defn- make-auto-nn-iid-handlers
-  "Build address-based handlers for a Normal prior + iid-gaussian obs pair.
-   Processes [T] observations at once via nn-iid-update-step."
-  [prior-addr obs-addrs]
-  (make-conjugate-handlers prior-addr obs-addrs
-                           (fn [{:keys [mu sigma]}]
-                             {:mean mu :var (mx/multiply sigma sigma)})
-                           :mean
-                           (fn [posterior obs-value {:keys [sigma]}]
-                             (let [obs-var (mx/multiply sigma sigma)
-                                   {:keys [mean var ll]} (nn-iid-update-step posterior obs-value obs-var)]
-                               {:posterior {:mean mean :var var} :ll ll}))))
-
-(defn- make-auto-bb-handlers
-  "Build address-based handlers for a Beta-Bernoulli conjugate pair."
-  [prior-addr obs-addrs]
-  (make-conjugate-handlers prior-addr obs-addrs
-                           (fn [{:keys [alpha beta-param]}]
-                             {:alpha alpha :beta beta-param})
-                           (fn [{:keys [alpha beta]}] (mx/divide alpha (mx/add alpha beta)))
-                           (fn [posterior obs-value _params]
-                             (let [{:keys [alpha beta ll]} (bb-update-step posterior obs-value)]
-                               {:posterior {:alpha alpha :beta beta} :ll ll}))))
-
-(defn- make-auto-gp-handlers
-  "Build address-based handlers for a Gamma-Poisson conjugate pair."
-  [prior-addr obs-addrs]
-  (make-conjugate-handlers prior-addr obs-addrs
-                           (fn [{:keys [shape-param rate]}]
-                             {:shape shape-param :rate rate})
-                           (fn [{:keys [shape rate]}] (mx/divide shape rate))
-                           (fn [posterior obs-value _params]
-                             (let [{:keys [shape rate ll]} (gp-update-step posterior obs-value)]
-                               {:posterior {:shape shape :rate rate} :ll ll}))))
-
-(defn- make-auto-ge-handlers
-  "Build address-based handlers for a Gamma-Exponential conjugate pair."
-  [prior-addr obs-addrs]
-  (make-conjugate-handlers prior-addr obs-addrs
-                           (fn [{:keys [shape-param rate]}]
-                             {:shape shape-param :rate rate})
-                           (fn [{:keys [shape rate]}] (mx/divide shape rate))
-                           (fn [posterior obs-value _params]
-                             (let [{:keys [shape rate ll]} (ge-update-step posterior obs-value)]
-                               {:posterior {:shape shape :rate rate} :ll ll}))))
+(defn- make-family-handlers
+  "Build conjugate handlers for `family` from conjugate-family-specs, in `mode`."
+  [family mode prior-addr obs-addrs]
+  (let [{:keys [init-posterior posterior-mean update-step]} (conjugate-family-specs family)]
+    (make-conjugate-handlers-core prior-addr obs-addrs
+                                  init-posterior posterior-mean update-step mode)))
 
 ;; ---------------------------------------------------------------------------
 ;; Auto-Kalman handlers (for detected linear-Gaussian chains)
@@ -467,38 +477,55 @@
             S1 (mx/subtract cov-matrix (mx/matmul cov-matrix M-inv-S0))]
         {:mean-vec m1 :cov-matrix S1 :ll ll}))))
 
-(defn- make-auto-mvn-handlers
-  "Build address-based handlers for a MVN-Normal conjugate pair."
-  [prior-addr obs-addrs]
-  (let [prior-handler
+(defn- make-mvn-handlers-core
+  "Build address-based handlers for a MVN-Normal conjugate pair, parameterized
+   by `mode` (:generate or :regenerate) — mirroring make-conjugate-handlers-core.
+   The MVN update keeps its ill-conditioned fallthrough (nil from mvn-update-step)."
+  [prior-addr obs-addrs mode]
+  (let [regenerate? (= mode :regenerate)
+        prior-handler
         (fn [state addr dist]
-          (let [params (:params dist)
-                mean-vec (:mean-vec params)
-                cov-matrix (:cov-matrix params)
-                posterior {:mean-vec mean-vec :cov-matrix cov-matrix}]
-            ;; Return prior mean; don't add to score (marginalized out)
-            [mean-vec (-> state
-                          (assoc-in [:auto-posteriors prior-addr] posterior)
-                          (update :choices cm/set-value addr mean-vec))]))
+          (when-not (and regenerate? (:selection state)
+                         (sel/selected? (:selection state) addr))
+            (let [params (:params dist)
+                  mean-vec (:mean-vec params)
+                  cov-matrix (:cov-matrix params)
+                  posterior {:mean-vec mean-vec :cov-matrix cov-matrix}
+                  value (if regenerate?
+                          (cm/get-value (cm/get-submap (:old-choices state) addr))
+                          mean-vec)]
+              ;; Return prior mean / old value; don't add to score (marginalized out)
+              [value (-> state
+                         (assoc-in [:auto-posteriors prior-addr] posterior)
+                         (update :choices cm/set-value addr value))])))
 
         obs-handler
         (fn [state addr dist]
-          (let [constraint (cm/get-submap (:constraints state) addr)]
-            (when (cm/has-value? constraint)
-              (let [obs-value (cm/get-value constraint)
-                    posterior (get-in state [:auto-posteriors prior-addr])
-                    obs-cov (:cov-matrix (:params dist))
-                    result (mvn-update-step posterior obs-value obs-cov)]
-                ;; Fallthrough if ill-conditioned
-                (when result
-                  (let [{:keys [mean-vec cov-matrix ll]} result]
-                    [obs-value (-> state
-                                   (assoc-in [:auto-posteriors prior-addr]
-                                             {:mean-vec mean-vec :cov-matrix cov-matrix})
-                                   (update :choices cm/set-value addr obs-value)
-                                   (update :score #(mx/add % ll))
-                                   (update :weight #(mx/add % ll))
-                                   (update :choices cm/set-value prior-addr mean-vec))]))))))]
+          (when-let [posterior (if regenerate?
+                                 (get-in state [:auto-posteriors prior-addr])
+                                 ::generate)]
+            (when-not (and regenerate? (:selection state)
+                           (sel/selected? (:selection state) addr))
+              (let [constraint (if regenerate?
+                                 (cm/get-submap (:old-choices state) addr)
+                                 (cm/get-submap (:constraints state) addr))]
+                (when (cm/has-value? constraint)
+                  (let [obs-value (cm/get-value constraint)
+                        cur-post (if regenerate?
+                                   posterior
+                                   (get-in state [:auto-posteriors prior-addr]))
+                        obs-cov (:cov-matrix (:params dist))
+                        result (mvn-update-step cur-post obs-value obs-cov)]
+                    ;; Fallthrough if ill-conditioned
+                    (when result
+                      (let [{:keys [mean-vec cov-matrix ll]} result]
+                        [obs-value (cond-> state
+                                     true (assoc-in [:auto-posteriors prior-addr]
+                                                    {:mean-vec mean-vec :cov-matrix cov-matrix})
+                                     true (update :choices cm/set-value addr obs-value)
+                                     true (update :score #(mx/add % ll))
+                                     (not regenerate?) (update :weight #(mx/add % ll))
+                                     true (update :choices cm/set-value prior-addr mean-vec))]))))))))]
     (merge {prior-addr prior-handler}
            (into {} (map (fn [oa] [oa obs-handler]) obs-addrs)))))
 
@@ -506,14 +533,21 @@
 ;; Factory dispatch
 ;; ---------------------------------------------------------------------------
 
+(defn- make-auto-handlers-for
+  "Generate-mode handler factory for `family`: a (fn [prior-addr obs-addrs])."
+  [family]
+  (if (= family :mvn-normal)
+    (fn [prior-addr obs-addrs] (make-mvn-handlers-core prior-addr obs-addrs :generate))
+    (fn [prior-addr obs-addrs] (make-family-handlers family :generate prior-addr obs-addrs))))
+
 (def family->handler-factory
   "Map from conjugate family keyword to handler factory function."
-  {:normal-normal make-auto-nn-handlers
-   :normal-iid-normal make-auto-nn-iid-handlers
-   :beta-bernoulli make-auto-bb-handlers
-   :gamma-poisson make-auto-gp-handlers
-   :gamma-exponential make-auto-ge-handlers
-   :mvn-normal make-auto-mvn-handlers})
+  {:normal-normal (make-auto-handlers-for :normal-normal)
+   :normal-iid-normal (make-auto-handlers-for :normal-iid-normal)
+   :beta-bernoulli (make-auto-handlers-for :beta-bernoulli)
+   :gamma-poisson (make-auto-handlers-for :gamma-poisson)
+   :gamma-exponential (make-auto-handlers-for :gamma-exponential)
+   :mvn-normal (make-auto-handlers-for :mvn-normal)})
 
 (defn build-auto-handlers
   "Build address-based handlers from detected conjugate pairs.
@@ -542,151 +576,25 @@
 ;;   If prior was selected (no posterior) → returns nil (fallthrough).
 ;; ---------------------------------------------------------------------------
 
-(defn- make-regenerate-conjugate-handlers
-  "Build regenerate-specific address-based handlers for a conjugate family.
+;; Regenerate handlers reuse the same per-family specs and mode-parameterized
+;; cores as generate (see make-conjugate-handlers-core / make-mvn-handlers-core);
+;; only the :regenerate mode flag differs.
 
-   Same structure as make-conjugate-handlers but with regenerate weight semantics:
-   - Prior: 0 score (marginalized), init posterior from old value. Nil if selected.
-   - Obs: marginal LL → :score ONLY (not :weight). Nil if prior was selected."
-  [prior-addr obs-addrs init-posterior posterior-mean update-step]
-  (let [prior-handler
-        (fn [state addr dist]
-          ;; Case A: prior is selected → fall through entirely
-          (when-not (and (:selection state)
-                         (sel/selected? (:selection state) addr))
-            ;; Case B: prior NOT selected → use old value, init posterior, 0 score
-            (let [old-val (cm/get-value (cm/get-submap (:old-choices state) addr))
-                  posterior (init-posterior (:params dist))]
-              [old-val (-> state
-                           (assoc-in [:auto-posteriors prior-addr] posterior)
-                           (update :choices cm/set-value addr old-val))])))
-
-        obs-handler
-        (fn [state addr dist]
-          ;; If prior was selected (no posterior initialized) → fall through
-          (when-let [current-posterior (get-in state [:auto-posteriors prior-addr])]
-            ;; Check old-choices directly (no regen-constraints needed)
-            ;; Skip if this obs is in the selection (being resampled)
-            (when-not (and (:selection state)
-                           (sel/selected? (:selection state) addr))
-              (let [old-sub (cm/get-submap (:old-choices state) addr)]
-                (when (cm/has-value? old-sub)
-                  ;; Obs is constrained → compute marginal LL
-                  ;; Add to :score ONLY, not :weight (weight tracks proposal ratio)
-                  (let [obs-value (cm/get-value old-sub)
-                        {:keys [posterior ll]} (update-step current-posterior obs-value (:params dist))
-                        post-mean (posterior-mean posterior)]
-                    [obs-value (-> state
-                                   (assoc-in [:auto-posteriors prior-addr] posterior)
-                                   (update :choices cm/set-value addr obs-value)
-                                   (update :score #(mx/add % ll))
-                                 ;; Update prior's value to posterior mean
-                                   (update :choices cm/set-value prior-addr post-mean))]))))))]
-    (merge {prior-addr prior-handler}
-           (into {} (map (fn [oa] [oa obs-handler]) obs-addrs)))))
-
-;; Per-family regenerate handler factories
-
-(defn- make-regenerate-nn-handlers
-  "Build regenerate-specific handlers for Normal-Normal."
-  [prior-addr obs-addrs]
-  (make-regenerate-conjugate-handlers prior-addr obs-addrs
-                                      (fn [{:keys [mu sigma]}]
-                                        {:mean mu :var (mx/multiply sigma sigma)})
-                                      :mean
-                                      (fn [posterior obs-value {:keys [sigma]}]
-                                        (let [obs-var (mx/multiply sigma sigma)
-                                              {:keys [mean var ll]} (nn-update-step posterior obs-value obs-var)]
-                                          {:posterior {:mean mean :var var} :ll ll}))))
-
-(defn- make-regenerate-nn-iid-handlers
-  "Build regenerate-specific handlers for Normal prior + iid-gaussian obs."
-  [prior-addr obs-addrs]
-  (make-regenerate-conjugate-handlers prior-addr obs-addrs
-                                      (fn [{:keys [mu sigma]}]
-                                        {:mean mu :var (mx/multiply sigma sigma)})
-                                      :mean
-                                      (fn [posterior obs-value {:keys [sigma]}]
-                                        (let [obs-var (mx/multiply sigma sigma)
-                                              {:keys [mean var ll]} (nn-iid-update-step posterior obs-value obs-var)]
-                                          {:posterior {:mean mean :var var} :ll ll}))))
-
-(defn- make-regenerate-bb-handlers
-  "Build regenerate-specific handlers for Beta-Bernoulli."
-  [prior-addr obs-addrs]
-  (make-regenerate-conjugate-handlers prior-addr obs-addrs
-                                      (fn [{:keys [alpha beta-param]}]
-                                        {:alpha alpha :beta beta-param})
-                                      (fn [{:keys [alpha beta]}] (mx/divide alpha (mx/add alpha beta)))
-                                      (fn [posterior obs-value _params]
-                                        (let [{:keys [alpha beta ll]} (bb-update-step posterior obs-value)]
-                                          {:posterior {:alpha alpha :beta beta} :ll ll}))))
-
-(defn- make-regenerate-gp-handlers
-  "Build regenerate-specific handlers for Gamma-Poisson."
-  [prior-addr obs-addrs]
-  (make-regenerate-conjugate-handlers prior-addr obs-addrs
-                                      (fn [{:keys [shape-param rate]}]
-                                        {:shape shape-param :rate rate})
-                                      (fn [{:keys [shape rate]}] (mx/divide shape rate))
-                                      (fn [posterior obs-value _params]
-                                        (let [{:keys [shape rate ll]} (gp-update-step posterior obs-value)]
-                                          {:posterior {:shape shape :rate rate} :ll ll}))))
-
-(defn- make-regenerate-ge-handlers
-  "Build regenerate-specific handlers for Gamma-Exponential."
-  [prior-addr obs-addrs]
-  (make-regenerate-conjugate-handlers prior-addr obs-addrs
-                                      (fn [{:keys [shape-param rate]}]
-                                        {:shape shape-param :rate rate})
-                                      (fn [{:keys [shape rate]}] (mx/divide shape rate))
-                                      (fn [posterior obs-value _params]
-                                        (let [{:keys [shape rate ll]} (ge-update-step posterior obs-value)]
-                                          {:posterior {:shape shape :rate rate} :ll ll}))))
-
-(defn- make-regenerate-mvn-handlers
-  "Build regenerate-specific handlers for MVN-Normal."
-  [prior-addr obs-addrs]
-  (let [prior-handler
-        (fn [state addr dist]
-          (when-not (and (:selection state)
-                         (sel/selected? (:selection state) addr))
-            (let [old-val (cm/get-value (cm/get-submap (:old-choices state) addr))
-                  params (:params dist)
-                  posterior {:mean-vec (:mean-vec params) :cov-matrix (:cov-matrix params)}]
-              [old-val (-> state
-                           (assoc-in [:auto-posteriors prior-addr] posterior)
-                           (update :choices cm/set-value addr old-val))])))
-
-        obs-handler
-        (fn [state addr dist]
-          (when-let [posterior (get-in state [:auto-posteriors prior-addr])]
-            (when-not (and (:selection state)
-                           (sel/selected? (:selection state) addr))
-              (let [old-sub (cm/get-submap (:old-choices state) addr)]
-                (when (cm/has-value? old-sub)
-                  (let [obs-value (cm/get-value old-sub)
-                        obs-cov (:cov-matrix (:params dist))
-                        result (mvn-update-step posterior obs-value obs-cov)]
-                    (when result
-                      (let [{:keys [mean-vec cov-matrix ll]} result]
-                        [obs-value (-> state
-                                       (assoc-in [:auto-posteriors prior-addr]
-                                                 {:mean-vec mean-vec :cov-matrix cov-matrix})
-                                       (update :choices cm/set-value addr obs-value)
-                                       (update :score #(mx/add % ll))
-                                       (update :choices cm/set-value prior-addr mean-vec))]))))))))]
-    (merge {prior-addr prior-handler}
-           (into {} (map (fn [oa] [oa obs-handler]) obs-addrs)))))
+(defn- make-regenerate-handlers-for
+  "Regenerate-mode handler factory for `family`: a (fn [prior-addr obs-addrs])."
+  [family]
+  (if (= family :mvn-normal)
+    (fn [prior-addr obs-addrs] (make-mvn-handlers-core prior-addr obs-addrs :regenerate))
+    (fn [prior-addr obs-addrs] (make-family-handlers family :regenerate prior-addr obs-addrs))))
 
 (def regenerate-family->handler-factory
   "Map from conjugate family keyword to regenerate-specific handler factory."
-  {:normal-normal make-regenerate-nn-handlers
-   :normal-iid-normal make-regenerate-nn-iid-handlers
-   :beta-bernoulli make-regenerate-bb-handlers
-   :gamma-poisson make-regenerate-gp-handlers
-   :gamma-exponential make-regenerate-ge-handlers
-   :mvn-normal make-regenerate-mvn-handlers})
+  {:normal-normal (make-regenerate-handlers-for :normal-normal)
+   :normal-iid-normal (make-regenerate-handlers-for :normal-iid-normal)
+   :beta-bernoulli (make-regenerate-handlers-for :beta-bernoulli)
+   :gamma-poisson (make-regenerate-handlers-for :gamma-poisson)
+   :gamma-exponential (make-regenerate-handlers-for :gamma-exponential)
+   :mvn-normal (make-regenerate-handlers-for :mvn-normal)})
 
 (defn build-regenerate-handlers
   "Build regenerate-specific address-based handlers from detected conjugate pairs.

--- a/src/genmlx/inference/auto_analytical.cljs
+++ b/src/genmlx/inference/auto_analytical.cljs
@@ -308,13 +308,12 @@
 (defn- kalman-init-belief
   "Initialize or predict Kalman belief for step i."
   [i steps state params]
-  (let [prev-latent (when (> i 0) (:latent (nth steps (dec i))))
-        prev-belief (when prev-latent
-                      (get-in state [:auto-kalman-beliefs prev-latent]))]
-    (if (nil? prev-belief)
-      {:mean (:mu params) :var (mx/multiply (:sigma params) (:sigma params))}
-      (kalman-predict-belief prev-belief (:transition (nth steps (dec i)))
-                             (mx/multiply (:sigma params) (:sigma params))))))
+  (let [prev-step (when (pos? i) (nth steps (dec i)))
+        noise-var (mx/multiply (:sigma params) (:sigma params))]
+    (if-some [prev-belief (some->> (:latent prev-step)
+                                   (get (:auto-kalman-beliefs state)))]
+      (kalman-predict-belief prev-belief (:transition prev-step) noise-var)
+      {:mean (:mu params) :var noise-var})))
 
 (defn- kalman-obs-update
   "Pure Kalman observation update math.

--- a/src/genmlx/inference/auto_analytical.cljs
+++ b/src/genmlx/inference/auto_analytical.cljs
@@ -487,9 +487,7 @@
         (fn [state addr dist]
           (when-not (and regenerate? (:selection state)
                          (sel/selected? (:selection state) addr))
-            (let [params (:params dist)
-                  mean-vec (:mean-vec params)
-                  cov-matrix (:cov-matrix params)
+            (let [{{:keys [mean-vec cov-matrix]} :params} dist
                   posterior {:mean-vec mean-vec :cov-matrix cov-matrix}
                   value (if regenerate?
                           (cm/get-value (cm/get-submap (:old-choices state) addr))
@@ -514,7 +512,7 @@
                         cur-post (if regenerate?
                                    posterior
                                    (get-in state [:auto-posteriors prior-addr]))
-                        obs-cov (:cov-matrix (:params dist))
+                        {{obs-cov :cov-matrix} :params} dist
                         result (mvn-update-step cur-post obs-value obs-cov)]
                     ;; Fallthrough if ill-conditioned
                     (when result

--- a/src/genmlx/inference/auto_analytical.cljs
+++ b/src/genmlx/inference/auto_analytical.cljs
@@ -183,12 +183,11 @@
                     [obs-value (cond-> state
                                  true (assoc-in [:auto-posteriors prior-addr] posterior)
                                  true (update :choices cm/set-value addr obs-value)
-                                 true (update :score #(mx/add % ll))
-                                 (not regenerate?) (update :weight #(mx/add % ll))
+                                 true (update :score mx/add ll)
+                                 (not regenerate?) (update :weight mx/add ll)
                                  ;; Update prior's value to posterior mean
                                  true (update :choices cm/set-value prior-addr post-mean))]))))))]
-    (merge {prior-addr prior-handler}
-           (into {} (map (fn [oa] [oa obs-handler]) obs-addrs)))))
+    (assoc (zipmap obs-addrs (repeat obs-handler)) prior-addr prior-handler)))
 
 ;; ---------------------------------------------------------------------------
 ;; Per-family configs
@@ -393,10 +392,10 @@
                                       state' (cond-> (-> state
                                                          (assoc-in [:auto-kalman-beliefs latent] new-belief)
                                                          (update :choices cm/set-value addr obs-value)
-                                                         (update :score #(mx/add % ll))
+                                                         (update :score mx/add ll)
                                                          (update :choices cm/set-value latent (:mean new-belief)))
                                                (not regenerate?)
-                                               (update :weight #(mx/add % ll)))
+                                               (update :weight mx/add ll))
                                       noise-vars (:auto-kalman-noise-vars state')
                                       state'' (if (and noise-vars (< (inc step-idx) n-steps))
                                                 (cascade-predictions steps step-idx state' noise-vars)
@@ -521,11 +520,10 @@
                                      true (assoc-in [:auto-posteriors prior-addr]
                                                     {:mean-vec mean-vec :cov-matrix cov-matrix})
                                      true (update :choices cm/set-value addr obs-value)
-                                     true (update :score #(mx/add % ll))
-                                     (not regenerate?) (update :weight #(mx/add % ll))
+                                     true (update :score mx/add ll)
+                                     (not regenerate?) (update :weight mx/add ll)
                                      true (update :choices cm/set-value prior-addr mean-vec))]))))))))]
-    (merge {prior-addr prior-handler}
-           (into {} (map (fn [oa] [oa obs-handler]) obs-addrs)))))
+    (assoc (zipmap obs-addrs (repeat obs-handler)) prior-addr prior-handler)))
 
 ;; ---------------------------------------------------------------------------
 ;; Factory dispatch

--- a/src/genmlx/inference/compiled_gradient.cljs
+++ b/src/genmlx/inference/compiled_gradient.cljs
@@ -46,7 +46,7 @@
       (if (>= t T)
         p
         (let [;; Extract noise for this step
-              row (mx/reshape (mx/take-idx noise-2d (mx/array [t] mx/int32) 0) [K])
+              row (mx/index noise-2d t)
               ;; Propose
               proposal (mx/add p (mx/multiply proposal-std row))
               ;; Score current and proposed

--- a/src/genmlx/inference/compiled_optimizer.cljs
+++ b/src/genmlx/inference/compiled_optimizer.cljs
@@ -19,6 +19,56 @@
             [genmlx.inference.vi :as vi]))
 
 ;; ---------------------------------------------------------------------------
+;; Shared Adam recurrence + loop policies
+;; ---------------------------------------------------------------------------
+
+(defn adam-scalars
+  "Pre-build the MLX scalar constants used by the Adam recurrence.
+   Returns a map consumed by `adam-update`."
+  [{:keys [lr beta1 beta2 epsilon]
+    :or {lr 0.001 beta1 0.9 beta2 0.999 epsilon 1e-8}}]
+  {:lr-s (mx/scalar lr)
+   :beta1-s (mx/scalar beta1)
+   :beta2-s (mx/scalar beta2)
+   :eps-s (mx/scalar epsilon)
+   :one-minus-b1 (mx/scalar (- 1.0 beta1))
+   :one-minus-b2 (mx/scalar (- 1.0 beta2))})
+
+(defn adam-update
+  "One Adam parameter update. Given current `params`, first/second moments
+   `m`/`v`, the `grad`, the scalar constants from `adam-scalars`, and the
+   bias-correction denominators `bias1` = 1 - beta1^t and `bias2` = 1 - beta2^t,
+   returns [new-params new-m new-v].
+
+   The bias denominators are passed in so callers may compute them either in
+   the graph (mx/power on a t-scalar) or host-side (js/Math.pow) — the rest of
+   the moment recurrence is identical."
+  [params m v grad {:keys [lr-s beta1-s beta2-s eps-s one-minus-b1 one-minus-b2]}
+   bias1 bias2]
+  (let [new-m (mx/add (mx/multiply beta1-s m)
+                      (mx/multiply one-minus-b1 grad))
+        new-v (mx/add (mx/multiply beta2-s v)
+                      (mx/multiply one-minus-b2 (mx/square grad)))
+        m-hat (mx/divide new-m bias1)
+        v-hat (mx/divide new-v bias2)
+        update-vec (mx/divide m-hat (mx/add (mx/sqrt v-hat) eps-s))
+        new-params (mx/subtract params (mx/multiply lr-s update-vec))]
+    [new-params new-m new-v]))
+
+(defn log-iter?
+  "True on the first iteration and every `log-every` iterations thereafter."
+  [i log-every]
+  (or (zero? i) (zero? (mod (inc i) log-every))))
+
+(defn maybe-cleanup!
+  "Periodic Metal cleanup: clear the cache and sweep dead arrays every 50
+   iterations (skipping iteration 0)."
+  [i]
+  (when (and (pos? i) (zero? (mod i 50)))
+    (mx/clear-cache!)
+    (mx/sweep-dead-arrays!)))
+
+;; ---------------------------------------------------------------------------
 ;; Compiled optimization step (WP-0)
 ;; ---------------------------------------------------------------------------
 
@@ -43,42 +93,25 @@
    Note: This handles deterministic score functions. WP-2 extends this
    pattern for stochastic score functions (MCMC/SMC) where noise must
    be passed as additional arguments."
-  [score-fn {:keys [lr beta1 beta2 epsilon]
-             :or {lr 0.001 beta1 0.9 beta2 0.999 epsilon 1e-8}}]
+  [score-fn opts]
   (let [;; We minimize negative score (= maximize score)
         neg-score-fn (fn [params] (mx/negative (score-fn params)))
         vg (mx/value-and-grad neg-score-fn)
 
         ;; Pre-create scalar constants for Adam hyperparams
-        lr-s (mx/scalar lr)
-        beta1-s (mx/scalar beta1)
-        beta2-s (mx/scalar beta2)
-        eps-s (mx/scalar epsilon)
+        scalars (adam-scalars opts)
+        {:keys [beta1-s beta2-s]} scalars
         one-s (mx/scalar 1.0)
-        one-minus-b1 (mx/scalar (- 1.0 beta1))
-        one-minus-b2 (mx/scalar (- 1.0 beta2))
 
         step-fn
         (fn [params m v t-scalar]
           (let [;; Forward + backward in one call
                 [loss grad] (vg params)
-
-                ;; Moment updates (exponential moving averages)
-                new-m (mx/add (mx/multiply beta1-s m)
-                              (mx/multiply one-minus-b1 grad))
-                new-v (mx/add (mx/multiply beta2-s v)
-                              (mx/multiply one-minus-b2 (mx/square grad)))
-
                 ;; Bias correction — mx/power keeps this inside the graph
-                m-hat (mx/divide new-m
-                                 (mx/subtract one-s (mx/power beta1-s t-scalar)))
-                v-hat (mx/divide new-v
-                                 (mx/subtract one-s (mx/power beta2-s t-scalar)))
-
-                ;; Parameter update
-                update (mx/divide m-hat
-                                  (mx/add (mx/sqrt v-hat) eps-s))
-                new-params (mx/subtract params (mx/multiply lr-s update))]
+                bias1 (mx/subtract one-s (mx/power beta1-s t-scalar))
+                bias2 (mx/subtract one-s (mx/power beta2-s t-scalar))
+                [new-params new-m new-v]
+                (adam-update params m v grad scalars bias1 bias2)]
             #js [new-params new-m new-v loss]))]
 
     (mx/compile-fn step-fn)))
@@ -134,8 +167,7 @@
               loss-arr (aget result 3)
 
               ;; Materialize loss only at log boundaries — avoids per-step eval cost
-              log? (or (zero? i) (zero? (mod (inc i) log-every)))
-              losses' (if log?
+              losses' (if (log-iter? i log-every)
                         (do
                           (mx/materialize! loss-arr)
                           (let [loss-val (mx/item loss-arr)]
@@ -144,10 +176,7 @@
                             (conj! losses loss-val)))
                         losses)]
 
-          ;; Periodic cleanup every 50 iterations
-          (when (and (pos? i) (zero? (mod i 50)))
-            (mx/clear-cache!)
-            (mx/sweep-dead-arrays!))
+          (maybe-cleanup! i)
 
           (recur (inc i) np nm nv losses'))))))
 
@@ -176,6 +205,61 @@
                (mx/divide (mx/subtract f-plus f-minus) two-h)))
            (range d)))))
 
+(defn- adam-train-loop
+  "Host-side Adam training loop over a pluggable loss-gradient function.
+   Used by both the handler (finite-difference) and compiled-generate (exact AD)
+   paths — they differ only in how `loss-grad-fn` produces [loss grad].
+
+   loss-grad-fn: (fn [params] -> [loss grad]) where loss is -score (minimize).
+   init-params: [D] MLX array.
+   opts: same as compiled-train.
+
+   Bias correction is computed host-side via js/Math.pow. Returns
+   {:params final-params :loss-history [numbers...]}."
+  [loss-grad-fn init-params
+   {:keys [iterations callback log-every]
+    :or {iterations 1000 log-every 50}
+    :as opts}]
+  (let [d (mx/shape init-params)
+        scalars (adam-scalars opts)
+        {:keys [beta1 beta2]
+         :or {beta1 0.9 beta2 0.999}} opts]
+    (loop [i 0
+           params init-params
+           m (mx/zeros d)
+           v (mx/zeros d)
+           losses (transient [])]
+      (if (>= i iterations)
+        (do
+          (mx/materialize! params)
+          {:params params :loss-history (persistent! losses)})
+        (let [[loss grad] (loss-grad-fn params)
+              ;; Break lazy graph — loss and grad needed for Adam update
+              _ (mx/materialize! loss grad)
+
+              ;; Adam moment updates (host-side bias correction)
+              t (double (inc i))
+              bias1 (mx/scalar (- 1.0 (js/Math.pow beta1 t)))
+              bias2 (mx/scalar (- 1.0 (js/Math.pow beta2 t)))
+              [new-params new-m new-v]
+              (adam-update params m v grad scalars bias1 bias2)
+
+              ;; Break lazy graph — params and moments carried to next iteration
+              _ (mx/materialize! new-params new-m new-v)
+
+              ;; Log loss at boundaries
+              loss-val (mx/item loss)
+              losses' (if (log-iter? i log-every)
+                        (do
+                          (when callback
+                            (callback {:iter i :loss loss-val :params new-params}))
+                          (conj! losses loss-val))
+                        losses)]
+
+          (maybe-cleanup! i)
+
+          (recur (inc i) new-params new-m new-v losses'))))))
+
 (defn- handler-train
   "Training loop for handler-based (non-differentiable) score functions.
    Uses finite-difference gradients with Adam optimization.
@@ -186,67 +270,12 @@
    opts: same as compiled-train plus :fd-h (finite diff step, default 1e-4).
 
    Returns {:params final-params :loss-history [numbers...]}."
-  [score-fn init-params
-   {:keys [iterations lr beta1 beta2 epsilon callback log-every fd-h]
-    :or {iterations 1000 lr 0.001 beta1 0.9 beta2 0.999
-         epsilon 1e-8 log-every 50 fd-h 1e-4}}]
-  (let [d (mx/shape init-params)
-        ;; Hoist closure and scalar constants outside the loop
-        neg-score (fn [p] (mx/negative (score-fn p)))
-        beta1-s (mx/scalar beta1)
-        beta2-s (mx/scalar beta2)
-        one-minus-b1-s (mx/scalar (- 1.0 beta1))
-        one-minus-b2-s (mx/scalar (- 1.0 beta2))
-        lr-s (mx/scalar lr)
-        eps-s (mx/scalar epsilon)]
-    (loop [i 0
-           params init-params
-           m (mx/zeros d)
-           v (mx/zeros d)
-           losses (transient [])]
-      (if (>= i iterations)
-        (do
-          (mx/materialize! params)
-          {:params params :loss-history (persistent! losses)})
-        (let [;; Compute loss = -score (minimize)
-              loss (neg-score params)
-              ;; Finite-difference gradient of loss
-              grad (finite-diff-grad neg-score params fd-h)
-
-              ;; Break lazy graph — loss and grad needed for Adam update
-              _ (mx/materialize! loss grad)
-
-              ;; Adam moment updates (host-side bias correction)
-              t (double (inc i))
-              new-m (mx/add (mx/multiply beta1-s m)
-                            (mx/multiply one-minus-b1-s grad))
-              new-v (mx/add (mx/multiply beta2-s v)
-                            (mx/multiply one-minus-b2-s (mx/square grad)))
-              m-hat (mx/divide new-m (mx/scalar (- 1.0 (js/Math.pow beta1 t))))
-              v-hat (mx/divide new-v (mx/scalar (- 1.0 (js/Math.pow beta2 t))))
-              update-vec (mx/divide m-hat
-                                    (mx/add (mx/sqrt v-hat) eps-s))
-              new-params (mx/subtract params (mx/multiply lr-s update-vec))
-
-              ;; Break lazy graph — params and moments carried to next iteration
-              _ (mx/materialize! new-params new-m new-v)
-
-              ;; Log loss at boundaries
-              log? (or (zero? i) (zero? (mod (inc i) log-every)))
-              loss-val (mx/item loss)
-              losses' (if log?
-                        (do
-                          (when callback
-                            (callback {:iter i :loss loss-val :params new-params}))
-                          (conj! losses loss-val))
-                        losses)]
-
-          ;; Periodic cleanup
-          (when (and (pos? i) (zero? (mod i 50)))
-            (mx/clear-cache!)
-            (mx/sweep-dead-arrays!))
-
-          (recur (inc i) new-params new-m new-v losses'))))))
+  [score-fn init-params {:keys [fd-h] :or {fd-h 1e-4} :as opts}]
+  (let [neg-score (fn [p] (mx/negative (score-fn p)))
+        loss-grad-fn (fn [params]
+                       [(neg-score params)
+                        (finite-diff-grad neg-score params fd-h)])]
+    (adam-train-loop loss-grad-fn init-params opts)))
 
 (defn- ad-train
   "Training loop for compiled-generate score functions.
@@ -258,63 +287,9 @@
    opts: same as compiled-train.
 
    Returns {:params final-params :loss-history [numbers...]}."
-  [score-fn init-params
-   {:keys [iterations lr beta1 beta2 epsilon callback log-every]
-    :or {iterations 1000 lr 0.001 beta1 0.9 beta2 0.999
-         epsilon 1e-8 log-every 50}}]
-  (let [d (mx/shape init-params)
-        neg-score (fn [p] (mx/negative (score-fn p)))
-        vg (mx/value-and-grad neg-score)
-        beta1-s (mx/scalar beta1)
-        beta2-s (mx/scalar beta2)
-        one-minus-b1-s (mx/scalar (- 1.0 beta1))
-        one-minus-b2-s (mx/scalar (- 1.0 beta2))
-        lr-s (mx/scalar lr)
-        eps-s (mx/scalar epsilon)]
-    (loop [i 0
-           params init-params
-           m (mx/zeros d)
-           v (mx/zeros d)
-           losses (transient [])]
-      (if (>= i iterations)
-        (do
-          (mx/materialize! params)
-          {:params params :loss-history (persistent! losses)})
-        (let [[loss grad] (vg params)
-              ;; Break lazy graph — loss and grad needed for Adam update
-              _ (mx/materialize! loss grad)
-
-              ;; Adam moment updates (host-side bias correction)
-              t (double (inc i))
-              new-m (mx/add (mx/multiply beta1-s m)
-                            (mx/multiply one-minus-b1-s grad))
-              new-v (mx/add (mx/multiply beta2-s v)
-                            (mx/multiply one-minus-b2-s (mx/square grad)))
-              m-hat (mx/divide new-m (mx/scalar (- 1.0 (js/Math.pow beta1 t))))
-              v-hat (mx/divide new-v (mx/scalar (- 1.0 (js/Math.pow beta2 t))))
-              update-vec (mx/divide m-hat
-                                    (mx/add (mx/sqrt v-hat) eps-s))
-              new-params (mx/subtract params (mx/multiply lr-s update-vec))
-
-              ;; Break lazy graph — params and moments carried to next iteration
-              _ (mx/materialize! new-params new-m new-v)
-
-              ;; Log loss at boundaries
-              log? (or (zero? i) (zero? (mod (inc i) log-every)))
-              loss-val (mx/item loss)
-              losses' (if log?
-                        (do
-                          (when callback
-                            (callback {:iter i :loss loss-val :params new-params}))
-                          (conj! losses loss-val))
-                        losses)]
-
-          ;; Periodic cleanup
-          (when (and (pos? i) (zero? (mod i 50)))
-            (mx/clear-cache!)
-            (mx/sweep-dead-arrays!))
-
-          (recur (inc i) new-params new-m new-v losses'))))))
+  [score-fn init-params opts]
+  (let [neg-score (fn [p] (mx/negative (score-fn p)))]
+    (adam-train-loop (mx/value-and-grad neg-score) init-params opts)))
 
 (defn make-compiled-loss-grad
   "Build a compiled loss+gradient function for parameter learning.
@@ -453,35 +428,24 @@
    Noise [T,K] and uniforms [T] are generated host-side each iteration.
    The compiled function fuses: chain -> score -> grad -> Adam into one
    Metal dispatch."
-  [score-fn chain-fn {:keys [lr beta1 beta2 epsilon]
-                      :or {lr 0.01 beta1 0.9 beta2 0.999 epsilon 1e-8}}]
+  [score-fn chain-fn opts]
   (let [;; Objective: run chain, return negative final score (minimize)
         neg-obj (fn [params noise uniforms]
                   (mx/negative (score-fn (chain-fn params noise uniforms))))
         vg (mx/value-and-grad neg-obj)
 
         ;; Pre-create scalar constants
-        lr-s (mx/scalar lr)
-        beta1-s (mx/scalar beta1)
-        beta2-s (mx/scalar beta2)
-        eps-s (mx/scalar epsilon)
+        scalars (adam-scalars (merge {:lr 0.01} opts))
+        {:keys [beta1-s beta2-s]} scalars
         one-s (mx/scalar 1.0)
-        one-minus-b1 (mx/scalar (- 1.0 beta1))
-        one-minus-b2 (mx/scalar (- 1.0 beta2))
 
         step-fn
         (fn [params m v t-scalar noise uniforms]
           (let [[loss grad] (vg params noise uniforms)
-                new-m (mx/add (mx/multiply beta1-s m)
-                              (mx/multiply one-minus-b1 grad))
-                new-v (mx/add (mx/multiply beta2-s v)
-                              (mx/multiply one-minus-b2 (mx/square grad)))
-                m-hat (mx/divide new-m
-                                 (mx/subtract one-s (mx/power beta1-s t-scalar)))
-                v-hat (mx/divide new-v
-                                 (mx/subtract one-s (mx/power beta2-s t-scalar)))
-                update-vec (mx/divide m-hat (mx/add (mx/sqrt v-hat) eps-s))
-                new-params (mx/subtract params (mx/multiply lr-s update-vec))]
+                bias1 (mx/subtract one-s (mx/power beta1-s t-scalar))
+                bias2 (mx/subtract one-s (mx/power beta2-s t-scalar))
+                [new-params new-m new-v]
+                (adam-update params m v grad scalars bias1 bias2)]
             #js [new-params new-m new-v loss]))]
 
     (mx/compile-fn step-fn)))
@@ -583,8 +547,7 @@
               loss-arr (aget result 3)
 
               ;; Materialize loss only at log boundaries — avoids per-step eval cost
-              log? (or (zero? i) (zero? (mod (inc i) log-every)))
-              losses' (if log?
+              losses' (if (log-iter? i log-every)
                         (do
                           (mx/materialize! loss-arr)
                           (let [loss-val (mx/item loss-arr)]
@@ -593,10 +556,7 @@
                             (conj! losses loss-val)))
                         losses)]
 
-          ;; Periodic cleanup every 50 iterations
-          (when (and (pos? i) (zero? (mod i 50)))
-            (mx/clear-cache!)
-            (mx/sweep-dead-arrays!))
+          (maybe-cleanup! i)
 
           (recur (inc i) np nm nv losses' rk'))))))
 

--- a/src/genmlx/inference/compiled_optimizer.cljs
+++ b/src/genmlx/inference/compiled_optimizer.cljs
@@ -160,11 +160,7 @@
           {:params params :loss-history (persistent! losses)})
         (let [;; Fresh MLX scalar each iteration — negligible vs Metal dispatch cost
               t-scalar (mx/scalar (double (inc i)))
-              result (opt-step params m v t-scalar)
-              np (aget result 0)
-              nm (aget result 1)
-              nv (aget result 2)
-              loss-arr (aget result 3)
+              [np nm nv loss-arr] (opt-step params m v t-scalar)
 
               ;; Materialize loss only at log boundaries — avoids per-step eval cost
               losses' (if (log-iter? i log-every)
@@ -540,11 +536,7 @@
 
               ;; Compiled step: chain + grad + Adam
               t-scalar (mx/scalar (double (inc i)))
-              result (opt-step params m v t-scalar noise uniforms)
-              np (aget result 0)
-              nm (aget result 1)
-              nv (aget result 2)
-              loss-arr (aget result 3)
+              [np nm nv loss-arr] (opt-step params m v t-scalar noise uniforms)
 
               ;; Materialize loss only at log boundaries — avoids per-step eval cost
               losses' (if (log-iter? i log-every)

--- a/src/genmlx/inference/compiled_optimizer.cljs
+++ b/src/genmlx/inference/compiled_optimizer.cljs
@@ -579,7 +579,7 @@
 
    Returns {:params :loss-history :compilation-level ...}"
   [model args observations addresses method
-   {:keys [] :as opts}]
+   opts]
   (case method
     :direct
     (learn model args observations addresses opts)

--- a/src/genmlx/inference/compiled_smc.cljs
+++ b/src/genmlx/inference/compiled_smc.cljs
@@ -124,7 +124,7 @@
         T (count obs-vec)
         static-sites (filterv :static? (:trace-sites schema))
         all-addrs (mapv :addr static-sites)
-        addr-index (into {} (map-indexed (fn [i a] [a i]) all-addrs))
+        addr-index (zipmap all-addrs (range))
         K (count all-addrs)
         N particles]
     (when-not extend-fn

--- a/src/genmlx/inference/compiled_smc.cljs
+++ b/src/genmlx/inference/compiled_smc.cljs
@@ -5,7 +5,7 @@
    noise transforms over N particles simultaneously.
 
    Supports three resampling methods:
-   - :systematic     — O(N²) broadcasting (default, non-differentiable)
+   - :systematic     — O(N) via searchsorted (default, non-differentiable)
    - :gumbel-top-k   — Gumbel-top-k trick (all-GPU, non-differentiable)
    - :gumbel-softmax — Gumbel-softmax relaxation (differentiable, for mx/grad)
 
@@ -104,7 +104,7 @@
    opts:
      :particles        — number of particles N (default 100)
      :key              — PRNG key
-     :callback         — (fn [{:step :ess :resampled?}]) called each step
+     :callback         — (fn [{:step :resampled?}]) called each step
      :resample-method  — :systematic (default), :gumbel-top-k, or :gumbel-softmax
      :tau              — temperature for :gumbel-softmax (default 1.0)
 

--- a/src/genmlx/inference/conjugate.cljs
+++ b/src/genmlx/inference/conjugate.cljs
@@ -236,6 +236,86 @@
   [v]
   (mx/shape v))
 
+(defn- accumulate-ll
+  "Add marginal log-likelihood `ll` into the state's :conjugate-ll accumulator,
+   initializing it to zeros shaped like `ref-val` (a posterior parameter) on
+   the first contribution."
+  [state ref-val ll]
+  (update state :conjugate-ll
+          #(mx/add (or % (mx/zeros (ll-shape ref-val))) ll)))
+
+;; Per-family specs driving make-conjugate-dispatch. Each spec captures only the
+;; parts that differ between the three conjugate families; the dispatch logic
+;; (self-initializing prior, posterior-mean substitution, masked obs update,
+;; marginal-LL accumulation) is shared.
+(def ^:private conjugate-specs
+  {:nn {:prior-key :nn-prior
+        :obs-key :nn-obs
+        :init-posterior (fn [dist]
+                          (let [{:keys [prior-mean prior-std]} (:params dist)]
+                            {:mean prior-mean :var (mx/multiply prior-std prior-std)}))
+        :prior-mean :mean
+        :ll-ref :mean
+        ;; Normal-Normal carries a known observation std on the obs dist.
+        :update (fn [posterior obs dist]
+                  (nn-update posterior obs
+                             (let [obs-std (:obs-std (:params dist))]
+                               (mx/multiply obs-std obs-std))
+                             (:mask (:params dist))))}
+   :bb {:prior-key :bb-prior
+        :obs-key :bb-obs
+        :init-posterior (fn [dist]
+                          (let [{:keys [alpha beta-param]} (:params dist)]
+                            {:alpha alpha :beta beta-param}))
+        ;; Posterior mean: α/(α+β)
+        :prior-mean (fn [{:keys [alpha beta]}] (mx/divide alpha (mx/add alpha beta)))
+        :ll-ref :alpha
+        :update (fn [posterior obs dist] (bb-update posterior obs (:mask (:params dist))))}
+   :gp {:prior-key :gp-prior
+        :obs-key :gp-obs
+        :init-posterior (fn [dist]
+                          (let [{:keys [shape-param rate-param]} (:params dist)]
+                            {:shape shape-param :rate rate-param}))
+        ;; Posterior mean: α/β
+        :prior-mean (fn [{:keys [shape rate]}] (mx/divide shape rate))
+        :ll-ref :shape
+        :update (fn [posterior obs dist] (gp-update posterior obs (:mask (:params dist))))}})
+
+(defn make-conjugate-dispatch
+  "Create a conjugate dispatch map from a family `spec` (see `conjugate-specs`)
+   and the prior site's `target-addr`.
+
+   Returns {prior-key prior-handler, obs-key obs-handler}.
+   The prior handler is self-initializing: the first encounter seeds the
+   posterior from the prior's hyperparams via :init-posterior, substitutes the
+   posterior mean for the site value, and stores the posterior. The obs handler
+   applies the family :update, stores the new posterior, and accumulates the
+   marginal LL."
+  [{:keys [prior-key obs-key init-posterior prior-mean ll-ref]
+    update-fn :update} target-addr]
+  {prior-key
+   (fn [state addr dist]
+     (when (= addr target-addr)
+       (let [posterior (or (get-in state [:conjugate-posteriors addr])
+                           (init-posterior dist))
+             post-mean (prior-mean posterior)]
+         [post-mean
+          (-> state
+              (assoc-in [:conjugate-posteriors addr] posterior)
+              (update :choices cm/set-value addr post-mean))])))
+
+   obs-key
+   (fn [state addr dist]
+     (when (= (:prior-addr (:params dist)) target-addr)
+       (let [posterior (get-in state [:conjugate-posteriors target-addr])
+             constraint (cm/get-submap (:constraints state) addr)
+             obs (cm/get-value constraint)
+             {new-posterior :posterior :keys [ll]} (update-fn posterior obs dist)]
+         [obs (-> state
+                  (assoc-in [:conjugate-posteriors target-addr] new-posterior)
+                  (update :choices cm/set-value addr obs)
+                  (accumulate-ll (ll-ref new-posterior) ll))])))})
+
 (defn make-nn-dispatch
   "Create Normal-Normal conjugate dispatch map.
 
@@ -244,32 +324,7 @@
    Returns dispatch map: {:nn-prior handler, :nn-obs handler}.
    Self-initializing: first encounter uses the prior's hyperparams."
   [target-addr]
-  {:nn-prior
-   (fn [state addr dist]
-     (when (= addr target-addr)
-       (let [{:keys [prior-mean prior-std]} (:params dist)
-             posterior (or (get-in state [:conjugate-posteriors addr])
-                          {:mean prior-mean
-                           :var (mx/multiply prior-std prior-std)})]
-         [(:mean posterior)
-          (-> state
-              (assoc-in [:conjugate-posteriors addr] posterior)
-              (update :choices cm/set-value addr (:mean posterior)))])))
-
-   :nn-obs
-   (fn [state addr dist]
-     (let [{:keys [prior-addr obs-std mask]} (:params dist)]
-       (when (= prior-addr target-addr)
-         (let [posterior (get-in state [:conjugate-posteriors target-addr])
-               constraint (cm/get-submap (:constraints state) addr)
-               obs (cm/get-value constraint)
-               obs-var (mx/multiply obs-std obs-std)
-               {:keys [posterior ll]} (nn-update posterior obs obs-var mask)]
-           [obs (-> state
-                    (assoc-in [:conjugate-posteriors target-addr] posterior)
-                    (update :choices cm/set-value addr obs)
-                    (update :conjugate-ll
-                      #(mx/add (or % (mx/zeros (ll-shape (:mean posterior)))) ll)))]))))})
+  (make-conjugate-dispatch (:nn conjugate-specs) target-addr))
 
 (defn make-bb-dispatch
   "Create Beta-Binomial conjugate dispatch map.
@@ -278,33 +333,7 @@
 
    Returns dispatch map: {:bb-prior handler, :bb-obs handler}."
   [target-addr]
-  {:bb-prior
-   (fn [state addr dist]
-     (when (= addr target-addr)
-       (let [{:keys [alpha beta-param]} (:params dist)
-             posterior (or (get-in state [:conjugate-posteriors addr])
-                          {:alpha alpha :beta beta-param})
-             ;; Posterior mean: α/(α+β)
-             post-mean (mx/divide (:alpha posterior)
-                                  (mx/add (:alpha posterior) (:beta posterior)))]
-         [post-mean
-          (-> state
-              (assoc-in [:conjugate-posteriors addr] posterior)
-              (update :choices cm/set-value addr post-mean))])))
-
-   :bb-obs
-   (fn [state addr dist]
-     (let [{:keys [prior-addr mask]} (:params dist)]
-       (when (= prior-addr target-addr)
-         (let [posterior (get-in state [:conjugate-posteriors target-addr])
-               constraint (cm/get-submap (:constraints state) addr)
-               obs (cm/get-value constraint)
-               {:keys [posterior ll]} (bb-update posterior obs mask)]
-           [obs (-> state
-                    (assoc-in [:conjugate-posteriors target-addr] posterior)
-                    (update :choices cm/set-value addr obs)
-                    (update :conjugate-ll
-                      #(mx/add (or % (mx/zeros (ll-shape (:alpha posterior)))) ll)))]))))})
+  (make-conjugate-dispatch (:bb conjugate-specs) target-addr))
 
 (defn make-gp-dispatch
   "Create Gamma-Poisson conjugate dispatch map.
@@ -313,32 +342,7 @@
 
    Returns dispatch map: {:gp-prior handler, :gp-obs handler}."
   [target-addr]
-  {:gp-prior
-   (fn [state addr dist]
-     (when (= addr target-addr)
-       (let [{:keys [shape-param rate-param]} (:params dist)
-             posterior (or (get-in state [:conjugate-posteriors addr])
-                          {:shape shape-param :rate rate-param})
-             ;; Posterior mean: α/β
-             post-mean (mx/divide (:shape posterior) (:rate posterior))]
-         [post-mean
-          (-> state
-              (assoc-in [:conjugate-posteriors addr] posterior)
-              (update :choices cm/set-value addr post-mean))])))
-
-   :gp-obs
-   (fn [state addr dist]
-     (let [{:keys [prior-addr mask]} (:params dist)]
-       (when (= prior-addr target-addr)
-         (let [posterior (get-in state [:conjugate-posteriors target-addr])
-               constraint (cm/get-submap (:constraints state) addr)
-               obs (cm/get-value constraint)
-               {:keys [posterior ll]} (gp-update posterior obs mask)]
-           [obs (-> state
-                    (assoc-in [:conjugate-posteriors target-addr] posterior)
-                    (update :choices cm/set-value addr obs)
-                    (update :conjugate-ll
-                      #(mx/add (or % (mx/zeros (ll-shape (:shape posterior)))) ll)))]))))})
+  (make-conjugate-dispatch (:gp conjugate-specs) target-addr))
 
 ;; ---------------------------------------------------------------------------
 ;; High-level API

--- a/src/genmlx/inference/conjugate.cljs
+++ b/src/genmlx/inference/conjugate.cljs
@@ -231,18 +231,13 @@
 ;; against the target-addr captured in the dispatch closure.
 ;; Returns nil for non-matching addrs (falls through via wrap-analytical).
 
-(defn- ll-shape
-  "Infer the shape for LL initialization from a posterior value."
-  [v]
-  (mx/shape v))
-
 (defn- accumulate-ll
   "Add marginal log-likelihood `ll` into the state's :conjugate-ll accumulator,
    initializing it to zeros shaped like `ref-val` (a posterior parameter) on
    the first contribution."
   [state ref-val ll]
   (update state :conjugate-ll
-          #(mx/add (or % (mx/zeros (ll-shape ref-val))) ll)))
+          #(mx/add (or % (mx/zeros (mx/shape ref-val))) ll)))
 
 ;; Per-family specs driving make-conjugate-dispatch. Each spec captures only the
 ;; parts that differ between the three conjugate families; the dispatch logic

--- a/src/genmlx/inference/conjugate.cljs
+++ b/src/genmlx/inference/conjugate.cljs
@@ -370,6 +370,15 @@
     (rt/run-handler transition init-state
       (fn [rt] (apply (:body-fn gf) rt args)))))
 
+(defn- add-ll
+  "Nil-safe marginal-LL accumulation: nil is the additive identity, so a
+   missing accumulator or step contribution is treated as the other operand
+   (and two nils stay nil)."
+  [acc-ll step-ll]
+  (if (and acc-ll step-ll)
+    (mx/add acc-ll step-ll)
+    (or acc-ll step-ll)))
+
 (defn conjugate-fold
   "Fold a per-step gen function over T timesteps under conjugate handler(s).
 
@@ -395,6 +404,4 @@
             step-ll (:conjugate-ll result)]
         (recur (inc t)
                (:conjugate-posteriors result)
-               (if (and acc-ll step-ll)
-                 (mx/add acc-ll step-ll)
-                 (or step-ll acc-ll)))))))
+               (add-ll acc-ll step-ll))))))

--- a/src/genmlx/inference/diagnostics.cljs
+++ b/src/genmlx/inference/diagnostics.cljs
@@ -3,6 +3,20 @@
   (:require [genmlx.mlx :as mx]))
 
 ;; ---------------------------------------------------------------------------
+;; Shared helpers
+;; ---------------------------------------------------------------------------
+
+(defn- flatten-samples
+  "Stack, materialize, and flatten a vector of parameter samples (MLX arrays)
+   to a CLJS seq of doubles. Scalar params pass through; array-valued params
+   contribute their first element."
+  [samples]
+  (let [stacked (mx/stack samples)]
+    (mx/materialize! stacked)
+    (let [raw-vals (mx/->clj stacked)]
+      (if (number? (first raw-vals)) raw-vals (map first raw-vals)))))
+
+;; ---------------------------------------------------------------------------
 ;; Effective Sample Size (ESS)
 ;; ---------------------------------------------------------------------------
 
@@ -12,11 +26,7 @@
    Returns a number."
   [samples]
   (let [n (count samples)
-        stacked (mx/stack samples)
-        _ (mx/materialize! stacked)
-        raw-vals (mx/->clj stacked)
-        ;; For scalar params
-        flat-vals (vec (if (number? (first raw-vals)) raw-vals (map first raw-vals)))
+        flat-vals (vec (flatten-samples samples))
         mu (/ (reduce + flat-vals) n)
         ;; Compute autocovariance
         centered (mapv #(- % mu) flat-vals)
@@ -59,16 +69,17 @@
                                    (if (mx/array? s) (mx/item s) s))
                                  chain))
                          chains)
+        ;; Sum of squared deviations of xs from their mean mu
+        ss (fn [xs mu] (reduce + (map #(let [d (- % mu)] (* d d)) xs)))
         ;; Chain means
         chain-means (mapv (fn [vals] (/ (reduce + vals) n)) chain-vals)
         overall-mean (/ (reduce + chain-means) m)
         ;; Between-chain variance
         B (* (/ n (dec m))
-             (reduce + (map #(let [d (- % overall-mean)] (* d d)) chain-means)))
+             (ss chain-means overall-mean))
         ;; Within-chain variance
         W (/ (reduce + (map (fn [vals mu]
-                              (/ (reduce + (map #(let [d (- % mu)] (* d d)) vals))
-                                 (dec n)))
+                              (/ (ss vals mu) (dec n)))
                             chain-vals chain-means))
              m)
         ;; R-hat
@@ -95,18 +106,14 @@
   "Compute quantiles of samples.
    Returns {:median :q025 :q975}."
   [samples]
-  (let [stacked (mx/stack samples)
-        n (first (mx/shape stacked))]
-    (mx/materialize! stacked)
-    (let [raw-vals (mx/->clj stacked)
-          flat-vals (if (number? (first raw-vals)) raw-vals (map first raw-vals))
-          sorted-vals (sort flat-vals)
-          idx-025 (int (* 0.025 n))
-          idx-50  (int (* 0.5 n))
-          idx-975 (int (* 0.975 n))]
-      {:median (nth sorted-vals idx-50)
-       :q025 (nth sorted-vals idx-025)
-       :q975 (nth sorted-vals idx-975)})))
+  (let [n (count samples)
+        sorted-vals (sort (flatten-samples samples))
+        idx-025 (int (* 0.025 n))
+        idx-50  (int (* 0.5 n))
+        idx-975 (int (* 0.975 n))]
+    {:median (nth sorted-vals idx-50)
+     :q025 (nth sorted-vals idx-025)
+     :q975 (nth sorted-vals idx-975)}))
 
 (defn summarize
   "Print summary statistics for MCMC samples."

--- a/src/genmlx/inference/diagnostics.cljs
+++ b/src/genmlx/inference/diagnostics.cljs
@@ -117,13 +117,13 @@
 
 (defn summarize
   "Print summary statistics for MCMC samples."
-  [samples & {:keys [name] :or {name "param"}}]
+  [samples & {label :name :or {label "param"}}]
   (let [mu (sample-mean samples)
         sd (sample-std samples)
         {:keys [median q025 q975]} (sample-quantiles samples)
         effective (ess samples)]
     (mx/materialize! mu sd)
-    {:name name
+    {:name label
      :mean (mx/item mu)
      :std (mx/item sd)
      :median median

--- a/src/genmlx/inference/differentiable.cljs
+++ b/src/genmlx/inference/differentiable.cljs
@@ -20,6 +20,16 @@
 ;; Core: IS-based loss functions for parameter learning
 ;; ---------------------------------------------------------------------------
 
+(defn- neg-log-ml
+  "Negated vectorized-IS log-ML estimate for parameter vector `p` under
+   `model` (already auto-keyed). Installs `p` as the param store and runs
+   vgenerate with the given particle count and PRNG key."
+  [model args observations param-names n-particles p key]
+  (let [store {:params (learn/array->params p param-names)}
+        gf (vary-meta model assoc :genmlx.dynamic/param-store store)
+        vtrace (dyn/vgenerate gf args observations n-particles key)]
+    (mx/negative (vec/vtrace-log-ml-estimate vtrace))))
+
 (defn make-is-loss-fn
   "Build a differentiable loss function: params → neg-log-ML via IS.
    Key is frozen in closure (same particles every call).
@@ -27,10 +37,7 @@
   [model args observations param-names n-particles key]
   (let [model (dyn/auto-key model)]
     (fn [p]
-      (let [store {:params (learn/array->params p param-names)}
-            gf (vary-meta model assoc :genmlx.dynamic/param-store store)
-            vtrace (dyn/vgenerate gf args observations n-particles key)]
-        (mx/negative (vec/vtrace-log-ml-estimate vtrace))))))
+      (neg-log-ml model args observations param-names n-particles p key))))
 
 (defn make-is-loss-grad-fn
   "Build (fn [params key] -> {:loss :grad}) for IS-based log-ML gradient.
@@ -39,10 +46,7 @@
   [model args observations param-names n-particles]
   (let [model (dyn/auto-key model)
         raw-fn (fn [p key]
-                 (let [store {:params (learn/array->params p param-names)}
-                       gf (vary-meta model assoc :genmlx.dynamic/param-store store)
-                       vtrace (dyn/vgenerate gf args observations n-particles key)]
-                   (mx/negative (vec/vtrace-log-ml-estimate vtrace))))
+                 (neg-log-ml model args observations param-names n-particles p key))
         vg (mx/value-and-grad raw-fn [0])]
     (fn [params key]
       ;; ensure-key guarantees a real uint32 PRNG key fills value-and-grad's

--- a/src/genmlx/inference/differentiable_resample.cljs
+++ b/src/genmlx/inference/differentiable_resample.cljs
@@ -35,6 +35,13 @@
     ;; Gumbel(0,1) = -log(-log(clamped))
     (-> clamped mx/log mx/negative mx/log mx/negative)))
 
+(defn- perturb
+  "Broadcast [N] log-weights to [1,N] and add the [N,N] Gumbel noise, giving a
+   [N,N] perturbation matrix — one independent perturbed row per output particle."
+  [log-weights gumbel-noise]
+  (let [N (first (mx/shape log-weights))]
+    (mx/add (mx/reshape log-weights [1 N]) gumbel-noise)))
+
 ;; =========================================================================
 ;; Mode 1: Gumbel-top-k (hard, exact, non-differentiable)
 ;; =========================================================================
@@ -56,9 +63,7 @@
    NOTE: argmax returns integer indices — no gradient flows through this op.
    Use gumbel-softmax for differentiable resampling."
   [particles log-weights gumbel-noise]
-  (let [N (first (mx/shape log-weights))
-        ;; Broadcast log-weights [N] → [1,N], add [N,N] noise → [N,N]
-        perturbed (mx/add (mx/reshape log-weights [1 N]) gumbel-noise)
+  (let [perturbed (perturb log-weights gumbel-noise)
         ;; argmax per row → [N] indices WITH replacement
         ancestors (mx/astype (mx/argmax perturbed 1) mx/int32)
         ;; Gather particles by ancestor indices
@@ -92,10 +97,8 @@
 
    Fully differentiable through mx/grad — gradient flows through softmax and matmul."
   [particles log-weights gumbel-noise tau]
-  (let [N (first (mx/shape log-weights))
-        ;; Broadcast log-weights [N] → [1,N], add [N,N] noise → [N,N]
-        ;; Each row i: log_w + gumbel[i,:] — independent perturbation per output particle
-        perturbed (mx/add (mx/reshape log-weights [1 N]) gumbel-noise)
+  (let [;; Each row i: log_w + gumbel[i,:] — independent perturbation per output particle
+        perturbed (perturb log-weights gumbel-noise)
         ;; Soft weights per output particle: softmax along axis 1 → [N,N]
         ;; Each row sums to 1
         weight-matrix (mx/softmax (mx/divide perturbed tau) 1)

--- a/src/genmlx/inference/ekf.cljs
+++ b/src/genmlx/inference/ekf.cljs
@@ -149,6 +149,7 @@
           (-> state
               (assoc :ekf-belief new-belief)
               (update :choices cm/set-value addr (:mean new-belief)))])
+       ;; Not our latent addr — return nil to fall through via wrap-analytical
        nil))
 
    :ekf-obs

--- a/src/genmlx/inference/ekf.cljs
+++ b/src/genmlx/inference/ekf.cljs
@@ -143,8 +143,7 @@
      (if (= addr latent-addr)
        (let [{:keys [transition-fn process-noise]} (:params dist)
              belief (or (:ekf-belief state)
-                        {:mean (mx/zeros [(:ekf-n state)])
-                         :var  (mx/zeros [(:ekf-n state)])})
+                        (kal/zero-belief (:ekf-n state)))
              new-belief (ekf-predict belief transition-fn process-noise)]
          [(:mean new-belief)
           (-> state
@@ -199,9 +198,7 @@
                             :key key
                             :constraints constraints
                             :ekf-n n
-                            :ekf-belief (or init-belief
-                                            {:mean (mx/zeros [n])
-                                             :var  (mx/zeros [n])})}
+                            :ekf-belief (or init-belief (kal/zero-belief n))}
                      param-store (assoc :param-store param-store))]
     (rt/run-handler transition init-state
       (fn [rt] (apply (:body-fn gf) rt args)))))
@@ -221,7 +218,7 @@
    Returns {:ll [P]-shaped total marginal LL, :belief final belief}."
   [step-fn latent-addr n T context-fn]
   (loop [t 0
-         belief {:mean (mx/zeros [n]) :var (mx/zeros [n])}
+         belief (kal/zero-belief n)
          acc-ll (mx/zeros [n])]
     (if (>= t T)
       {:ll acc-ll :belief belief}

--- a/src/genmlx/inference/ekf_nd.cljs
+++ b/src/genmlx/inference/ekf_nd.cljs
@@ -122,11 +122,10 @@
 
 (defn- cov-key
   "Canonical covariance key for a pair of latent addresses.
-   Uses position in addrs for consistent ordering."
-  [addrs a b]
-  (let [ia (.indexOf addrs a)
-        ib (.indexOf addrs b)]
-    (if (<= ia ib) [a b] [b a])))
+   idx is an {addr -> position} index map (e.g. (zipmap addrs (range)))
+   used as a function for consistent ordering."
+  [idx a b]
+  (if (<= (idx a) (idx b)) [a b] [b a]))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure ND EKF operations
@@ -137,10 +136,11 @@
 (defn- predict-one-core
   "Shared predict logic given pre-computed f(z0) and Jacobian A."
   [addrs addr means covs f-z0 A q]
-  (let [new-means (assoc means addr f-z0)
+  (let [idx (zipmap addrs (range))
+        new-means (assoc means addr f-z0)
         new-covs (reduce
                    (fn [cs other]
-                     (let [k (cov-key addrs addr other)
+                     (let [k (cov-key idx addr other)
                            p (get cs k)]
                        (assoc cs k
                               (if (= addr other)
@@ -180,12 +180,13 @@
    Uses scalar-decomposed Joseph form: P_ij -= mask * PH_i * PH_j / S."
   [addrs means covs obs pred H noise-std mask]
   (let [N (count addrs)
+        idx (zipmap addrs (range))
         innov (mx/subtract obs pred)
         ;; PH_i = sum_j P_ij * H_j
         PH (mapv (fn [i]
                    (reduce
                      (fn [acc j]
-                       (let [k (cov-key addrs (nth addrs i) (nth addrs j))]
+                       (let [k (cov-key idx (nth addrs i) (nth addrs j))]
                          (mx/add acc (mx/multiply (get covs k) (nth H j)))))
                      (mx/scalar 0.0)
                      (range N)))

--- a/src/genmlx/inference/ekf_nd.cljs
+++ b/src/genmlx/inference/ekf_nd.cljs
@@ -106,19 +106,15 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- make-zero-means [addrs n]
-  (reduce (fn [m addr] (assoc m addr (mx/zeros [n]))) {} addrs))
+  (into {} (map (fn [addr] [addr (mx/zeros [n])])) addrs))
 
 (defn- make-zero-covs
   "Initialize N*(N+1)/2 covariance entries to zeros.
    Keys are [addr-i addr-j] ordered by position in addrs."
   [addrs n]
   (let [N (count addrs)]
-    (reduce
-      (fn [m i]
-        (reduce (fn [m j]
-                  (assoc m [(nth addrs i) (nth addrs j)] (mx/zeros [n])))
-                m (range i N)))
-      {} (range N))))
+    (into {} (for [i (range N) j (range i N)]
+               [[(nth addrs i) (nth addrs j)] (mx/zeros [n])]))))
 
 (defn- cov-key
   "Canonical covariance key for a pair of latent addresses.

--- a/src/genmlx/inference/enumerate.cljs
+++ b/src/genmlx/inference/enumerate.cljs
@@ -33,7 +33,7 @@
   [model args observations addr-supports opts]
   (let [model (dyn/auto-key model)
         addrs (vec (keys addr-supports))
-        supports (mapv #(get addr-supports %) addrs)
+        supports (mapv addr-supports addrs)
         combos (cartesian-product supports)
         n-combos (count combos)
         max-combos (or (:max-combinations opts) 10000)]
@@ -45,10 +45,7 @@
                        :max-combinations max-combos
                        :addr-supports (into {} (map (fn [[a s]] [a (count s)]) addr-supports))})))
     (mapv (fn [combo]
-            (let [combo-cm (reduce (fn [acc [addr val]]
-                                    (cm/merge-cm acc (cm/choicemap addr val)))
-                                  (cm/choicemap)
-                                  (map vector addrs combo))
+            (let [combo-cm (cm/from-flat-map (zipmap addrs combo))
                   full-cm (if observations (cm/merge-cm observations combo-cm) combo-cm)
                   {:keys [weight]} (p/generate model args full-cm)]
               {:choices combo-cm :log-weight weight}))
@@ -92,7 +89,6 @@
                 :log-prob (mx/scalar lp)
                 :prob (js/Math.exp lp)}))
            entries)
-         vec
          (sort-by :prob >)))))
 
 (defn enumerate-marginals

--- a/src/genmlx/inference/enumerate.cljs
+++ b/src/genmlx/inference/enumerate.cljs
@@ -54,6 +54,15 @@
               {:choices combo-cm :log-weight weight}))
           combos)))
 
+(defn- realize-log-weights
+  "Materialize each entry's :log-weight and extract it as a JS number.
+   Returns a vector of doubles, one per entry."
+  [entries]
+  (mapv (fn [{:keys [log-weight]}]
+          (mx/materialize! log-weight)
+          (mx/item log-weight))
+        entries))
+
 ;; ---------------------------------------------------------------------------
 ;; Public API
 ;; ---------------------------------------------------------------------------
@@ -73,10 +82,7 @@
   ([model args observations addr-supports opts]
   (let [entries (enumerate-all model args observations addr-supports opts)
         ;; Realize all weights and extract as JS numbers
-        lw-vals (mapv (fn [{:keys [log-weight]}]
-                        (mx/materialize! log-weight)
-                        (mx/item log-weight))
-                      entries)
+        lw-vals (realize-log-weights entries)
         w-arr (mx/array (into-array lw-vals))
         log-z-val (mx/item (mx/logsumexp w-arr))]
     (->> (map-indexed
@@ -128,9 +134,6 @@
    (enumerate-marginal-likelihood model args observations addr-supports nil))
   ([model args observations addr-supports opts]
   (let [entries (enumerate-all model args observations addr-supports opts)
-        lw-vals (mapv (fn [{:keys [log-weight]}]
-                        (mx/materialize! log-weight)
-                        (mx/item log-weight))
-                      entries)
+        lw-vals (realize-log-weights entries)
         w-arr (mx/array (into-array lw-vals))]
     (mx/logsumexp w-arr))))

--- a/src/genmlx/inference/exact.cljs
+++ b/src/genmlx/inference/exact.cljs
@@ -718,7 +718,8 @@
          p (mx/exp (:log-probs m))
          _ (mx/eval! p)]
      (mx/item (mx/idx p value))))
-  ([model addr value given-kw given-addr given-value]
+  ([model addr value _given-kw given-addr given-value]
+   {:pre [(= _given-kw :given)]} ;; decorative :given keyword for readable call sites
    (mx/item (mx/idx (observes model given-addr given-value addr) value))))
 
 (defn mutual-info

--- a/src/genmlx/inference/exact.cljs
+++ b/src/genmlx/inference/exact.cljs
@@ -65,7 +65,7 @@
             lp (dc/dist-log-prob dist value)]
         [value (-> state
                    (update :choices cm/set-value addr value)
-                   (update :score #(mx/add % lp)))])
+                   (update :score mx/add lp))])
       ;; Free: enumerate all support values as new leftmost axis
       (let [support (dc/dist-support dist)
             k (count support)]
@@ -75,7 +75,7 @@
                 lp (dc/dist-log-prob dist value)]
             [value (-> state
                        (update :choices cm/set-value addr value)
-                       (update :score #(mx/add % lp)))])
+                       (update :score mx/add lp))])
           ;; Multiple values: create new tensor axis
           (let [ndim (:ndim state)
                 ;; Values: [k, 1, 1, ...] with ndim trailing 1s
@@ -98,7 +98,7 @@
                         lp-all)]
             [values-nd (-> state
                            (update :choices cm/set-value addr values-nd)
-                           (update :score #(mx/add % lp-nd))
+                           (update :score mx/add lp-nd)
                            (update :axes conj {:addr addr :size k :dim ndim
                                                :support support})
                            (update :ndim inc))]))))))

--- a/src/genmlx/inference/exact.cljs
+++ b/src/genmlx/inference/exact.cljs
@@ -224,7 +224,7 @@
                 result))))
       {::cache cache})))
 
-(defn clear-cache
+(defn clear-cache!
   "Clear the cache on a with-cache wrapped function."
   [f]
   (when-let [cache (::cache (meta f))] (reset! cache {})))

--- a/src/genmlx/inference/hmm_forward.cljs
+++ b/src/genmlx/inference/hmm_forward.cljs
@@ -228,7 +228,7 @@
                             :weight (mx/scalar 0.0)
                             :key key
                             :constraints constraints
-                            :hmm-n (if (pos? n) n nil)
+                            :hmm-n (when (pos? n) n)
                             :hmm-belief (or init-belief uniform-prior)}
                      param-store (assoc :param-store param-store))]
     (rt/run-handler transition init-state

--- a/src/genmlx/inference/hmm_forward.cljs
+++ b/src/genmlx/inference/hmm_forward.cljs
@@ -124,6 +124,15 @@
   (let [predicted (hmm-predict log-alpha log-trans)]
     (hmm-update predicted log-emission-probs mask)))
 
+(defn uniform-log-alpha
+  "Uniform prior belief over K HMM states: log(1/K) = -log(K) for every state.
+   Shaped [n K] when `n` is a positive batch size, else [K]. Accepts nil or 0
+   for the unbatched case (unifying the dispatch nil-guard and the
+   hmm-generate pos?-guard)."
+  [K n]
+  (mx/multiply (mx/scalar (- (js/Math.log K)))
+               (mx/ones (if (and n (pos? n)) [n K] [K]))))
+
 ;; ---------------------------------------------------------------------------
 ;; Handler middleware (Level 2)
 ;; ---------------------------------------------------------------------------
@@ -151,8 +160,7 @@
              n (:hmm-n state)
              log-alpha (or (:hmm-belief state)
                            ;; Uniform prior: log(1/K) = -log(K)
-                           (mx/multiply (mx/scalar (- (js/Math.log K)))
-                                        (mx/ones (if n [n K] [K]))))
+                           (uniform-log-alpha K n))
              new-alpha (hmm-predict log-alpha log-trans)
              ;; Return MAP state as the "sampled" value (for choices)
              map-state (mx/argmax new-alpha -1)]
@@ -214,8 +222,7 @@
   [gf args constraints latent-addr log-trans n K key & [opts]]
   (let [{:keys [param-store init-belief]} opts
         transition (make-hmm-transition latent-addr log-trans)
-        uniform-prior (mx/multiply (mx/scalar (- (js/Math.log K)))
-                                   (mx/ones (if (pos? n) [n K] [K])))
+        uniform-prior (uniform-log-alpha K n)
         init-state (cond-> {:choices cm/EMPTY
                             :score (mx/scalar 0.0)
                             :weight (mx/scalar 0.0)

--- a/src/genmlx/inference/hmm_forward.cljs
+++ b/src/genmlx/inference/hmm_forward.cljs
@@ -174,9 +174,9 @@
    :hmm-obs
    (fn [state addr dist]
      (let [{:keys [log-emission-probs mask]} (:params dist)
-           log-alpha (:hmm-belief state)
            n (:hmm-n state)
-           {:keys [log-alpha ll]} (hmm-update log-alpha log-emission-probs mask)
+           {:keys [log-alpha ll]} (hmm-update (:hmm-belief state)
+                                              log-emission-probs mask)
            ;; Store constrained observation in choices
            constraint (cm/get-submap (:constraints state) addr)
            obs (when (cm/has-value? constraint) (cm/get-value constraint))]

--- a/src/genmlx/inference/importance.cljs
+++ b/src/genmlx/inference/importance.cljs
@@ -140,12 +140,8 @@
     ;; Resample
     (mapv (fn [ki]
             (let [u (mx/realize (rng/uniform ki []))
-                  result (reduce (fn [cumsum [i p]]
-                                   (let [cumsum' (+ cumsum p)]
-                                     (if (>= cumsum' u)
-                                       (reduced (nth traces i))
-                                       cumsum')))
-                                 0.0
-                                 (map-indexed vector probs))]
-              (if (number? result) (last traces) result)))
+                  idx (->> (reductions + probs)
+                           (keep-indexed (fn [i c] (when (>= c u) i)))
+                           first)]
+              (nth traces (or idx (dec (count traces))))))
           keys)))

--- a/src/genmlx/inference/importance.cljs
+++ b/src/genmlx/inference/importance.cljs
@@ -5,6 +5,7 @@
             [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
             [genmlx.inference.util :as u]
+            [genmlx.inference.smc :as smc]
             [genmlx.dynamic :as dyn]
             [genmlx.vectorized :as vec]))
 
@@ -17,6 +18,14 @@
   (if-let [schema (:schema model)]
     (assoc model :schema (dissoc schema :auto-handlers :conjugate-pairs))
     model))
+
+(defn- log-ml-from-weights
+  "Marginal-likelihood estimate from JS-number log-weights:
+   logsumexp(ws) - log(n), via the numerically stable max-shift."
+  [ws n]
+  (let [max-w (apply max ws)
+        lse (+ max-w (js/Math.log (reduce + (map #(js/Math.exp (- % max-w)) ws))))]
+    (- lse (js/Math.log n))))
 
 (defn importance-sampling
   "Importance sampling. Generate traces constrained by observations,
@@ -44,8 +53,7 @@
         log-weights (mapv :weight results)
         ;; log marginal likelihood estimate = logsumexp(weights) - log(N)
         weights-arr (u/materialize-weights log-weights)
-        log-ml (mx/subtract (mx/logsumexp weights-arr)
-                             (mx/scalar (js/Math.log samples)))]
+        log-ml (smc/log-ml-increment weights-arr samples)]
     {:traces traces
      :log-weights log-weights
      :log-ml-estimate log-ml}))
@@ -73,9 +81,7 @@
                          (mx/item weight)))
                      (fn [_] [])))  ;; nothing to preserve — weight extracted as JS number
                  keys)
-        max-w (apply max ws)
-        lse (+ max-w (js/Math.log (reduce + (map #(js/Math.exp (- % max-w)) ws))))
-        log-ml (- lse (js/Math.log samples))]
+        log-ml (log-ml-from-weights ws samples)]
     {:log-weights ws
      :log-ml-estimate log-ml}))
 

--- a/src/genmlx/inference/importance.cljs
+++ b/src/genmlx/inference/importance.cljs
@@ -108,7 +108,7 @@
    then resamples on GPU. ~10-100x faster than importance-resampling for
    models without splice or data-dependent branching.
 
-   opts: {:samples N :particles M :key prng-key}
+   opts: {:particles M :key prng-key}
    Returns {:vtrace VectorizedTrace (resampled, uniform weights)
             :log-ml-estimate MLX-scalar}"
   [{:keys [particles key] :or {particles 1000}} model args observations]

--- a/src/genmlx/inference/kalman.cljs
+++ b/src/genmlx/inference/kalman.cljs
@@ -76,6 +76,13 @@
   [n]
   {:mean (mx/zeros [n]) :var (mx/ones [n])})
 
+(defn zero-belief
+  "Zero-variance initial belief {:mean zeros, :var zeros} of size n.
+   The handler always predicts on kalman-latent, so at t=0 this yields the
+   N(0, q²) prior — no skip-predict flag needed."
+  [n]
+  {:mean (mx/zeros [n]) :var (mx/zeros [n])})
+
 (defn kalman-predict
   "Kalman predict step: z_{t|t-1} from z_{t-1|t-1}.
    belief:           {:mean array, :var array}
@@ -87,7 +94,7 @@
     {:mean (mx/multiply transition-coeff mean)
      :var  (mx/add (mx/multiply transition-coeff
                      (mx/multiply transition-coeff var))
-                   (mx/multiply process-noise process-noise))}))
+                   (mx/square process-noise))}))
 
 (defn kalman-update
   "Kalman update step: incorporate one observation.
@@ -100,7 +107,7 @@
    Returns {:belief updated-belief, :ll per-element marginal LL}."
   [belief obs base-mean loading noise-std mask]
   (let [{:keys [mean var]} belief
-        r2       (mx/multiply noise-std noise-std)
+        r2       (mx/square noise-std)
         pred-obs (mx/add base-mean (mx/multiply loading mean))
         innov    (mx/subtract obs pred-obs)
         S        (mx/add (mx/multiply loading (mx/multiply loading var)) r2)
@@ -109,7 +116,7 @@
         ll       (mx/multiply (mx/scalar -0.5)
                    (mx/add (mx/scalar LOG-2PI)
                      (mx/add (mx/log S)
-                       (mx/divide (mx/multiply innov innov) S))))
+                       (mx/divide (mx/square innov) S))))
         ;; Masked update: if mask=0, belief unchanged, ll=0
         new-mean (mx/add mean (mx/multiply mask (mx/multiply K innov)))
         new-var  (mx/subtract var
@@ -167,8 +174,7 @@
      (if (= addr latent-addr)
        (let [{:keys [transition-coeff process-noise]} (:params dist)
              belief (or (:kalman-belief state)
-                        {:mean (mx/zeros [(:kalman-n state)])
-                         :var  (mx/zeros [(:kalman-n state)])})
+                        (zero-belief (:kalman-n state)))
              new-belief (kalman-predict belief transition-coeff process-noise)]
          [(:mean new-belief)
           (-> state
@@ -235,9 +241,7 @@
                             :key key
                             :constraints constraints
                             :kalman-n n
-                            :kalman-belief (or init-belief
-                                              {:mean (mx/zeros [n])
-                                               :var  (mx/zeros [n])})}
+                            :kalman-belief (or init-belief (zero-belief n))}
                      param-store (assoc :param-store param-store))]
     (rt/run-handler transition init-state
       (fn [rt] (apply (:body-fn gf) rt args)))))
@@ -258,7 +262,7 @@
    Returns [P]-shaped total marginal LL (not summed — caller aggregates)."
   [step-fn latent-addr n T context-fn]
   (loop [t 0
-         belief {:mean (mx/zeros [n]) :var (mx/zeros [n])}
+         belief (zero-belief n)
          acc-ll (mx/zeros [n])]
     (if (>= t T)
       acc-ll

--- a/src/genmlx/inference/kernel.cljs
+++ b/src/genmlx/inference/kernel.cljs
@@ -243,23 +243,21 @@
   "Gaussian random-walk MH kernel. Symmetric by default.
    Single address: (random-walk :x 0.5) — proposes x' = x + N(0, 0.5).
    Multi-address:  (random-walk {:x 0.5 :y 0.1}) — chains per-address walks."
-  ([addr-or-map std]
-   (if (map? addr-or-map)
-     (apply chain (map (fn [[a s]] (random-walk a s)) addr-or-map))
-     (symmetric-kernel
-       (fn [trace key]
-         (let [gf (dyn/auto-key (:gen-fn trace))
-               [k1 k2] (rng/split (rng/ensure-key key))
-               cur-val (cm/get-choice (:choices trace) [addr-or-map])
-               noise   (mx/multiply (rng/normal k1 (mx/shape cur-val))
-                                    (mx/scalar std))
-               proposed (mx/add cur-val noise)
-               constraints (cm/choicemap addr-or-map proposed)
-               result (p/update gf trace constraints)
-               w (mx/realize (:weight result))]
-           (if (u/accept-mh? w k2)
-             (:trace result)
-             trace))))))
+  ([addr std]
+   (symmetric-kernel
+     (fn [trace key]
+       (let [gf (dyn/auto-key (:gen-fn trace))
+             [k1 k2] (rng/split (rng/ensure-key key))
+             cur-val (cm/get-choice (:choices trace) [addr])
+             noise   (mx/multiply (rng/normal k1 (mx/shape cur-val))
+                                  (mx/scalar std))
+             proposed (mx/add cur-val noise)
+             constraints (cm/choicemap addr proposed)
+             result (p/update gf trace constraints)
+             w (mx/realize (:weight result))]
+         (if (u/accept-mh? w k2)
+           (:trace result)
+           trace)))))
   ([addr-map]
    (if (map? addr-map)
      (apply chain (map (fn [[a s]] (random-walk a s)) addr-map))

--- a/src/genmlx/inference/mcmc.cljs
+++ b/src/genmlx/inference/mcmc.cljs
@@ -323,12 +323,12 @@
                     accept? (mx/greater log-alpha log-u)
                     new-p (mx/where accept? proposal p)
                     ;; Record every thin steps (host-side decision)
-                    is-record (zero? (mod i thin))
-                    new-samples (if is-record
+                    record? (zero? (mod i thin))
+                    new-samples (if record?
                                   (write-sample-row samples new-p sample-count
                                                     n-samples n-params)
                                   samples)
-                    new-count (if is-record
+                    new-count (if record?
                                 (mx/add sample-count (mx/astype (mx/array [1]) mx/int32))
                                 sample-count)]
                 (recur new-p (inc i) new-count new-samples)))))
@@ -367,12 +367,12 @@
                     new-accept-count (mx/add accept-count (mx/astype accept? mx/float32))
                     ;; After burn-in, record every thin steps
                     past-burn? (>= i n-burn)
-                    is-record (and past-burn? (zero? (mod (- i n-burn) thin)))
-                    new-samples (if is-record
+                    record? (and past-burn? (zero? (mod (- i n-burn) thin)))
+                    new-samples (if record?
                                   (write-sample-row samples new-p sample-count
                                                     n-samples n-params)
                                   samples)
-                    new-count (if is-record
+                    new-count (if record?
                                 (mx/add sample-count (mx/astype (mx/array [1]) mx/int32))
                                 sample-count)]
                 (recur new-p (inc i) new-count new-samples new-accept-count)))))
@@ -970,13 +970,13 @@
                     new-accept-count (mx/add accept-count (mx/astype accept? mx/float32))
                     ;; Record logic (host-side decision)
                     past-burn? (>= i n-burn)
-                    is-record (and past-burn? (zero? (mod (- i n-burn) thin)))
-                    new-samples (if is-record
+                    record? (and past-burn? (zero? (mod (- i n-burn) thin)))
+                    new-samples (if record?
                                   (write-vectorized-sample-row
                                    samples new-p sample-count
                                    n-samples n-chains n-params)
                                   samples)
-                    new-count (if is-record
+                    new-count (if record?
                                 (mx/add sample-count (mx/astype (mx/array [1]) mx/int32))
                                 sample-count)]
                 (recur new-p (inc i) new-count new-samples new-accept-count)))))
@@ -1530,12 +1530,12 @@
                     new-accept-count (mx/add accept-count (mx/astype accept? mx/float32))
                     ;; After burn-in, record every thin steps
                     past-burn? (>= i n-burn)
-                    is-record (and past-burn? (zero? (mod (- i n-burn) thin)))
-                    new-samples (if is-record
+                    record? (and past-burn? (zero? (mod (- i n-burn) thin)))
+                    new-samples (if record?
                                   (write-sample-row samples new-q sample-count
                                                     n-samples n-params)
                                   samples)
-                    new-count (if is-record
+                    new-count (if record?
                                 (mx/add sample-count (mx/astype (mx/array [1]) mx/int32))
                                 sample-count)]
                 (recur new-q new-sq new-gq (inc i)
@@ -2170,12 +2170,12 @@
                     new-accept-count (mx/add accept-count (mx/astype accept? mx/float32))
                     ;; After burn-in, record every thin steps
                     past-burn? (>= i n-burn)
-                    is-record (and past-burn? (zero? (mod (- i n-burn) thin)))
-                    new-samples (if is-record
+                    record? (and past-burn? (zero? (mod (- i n-burn) thin)))
+                    new-samples (if record?
                                   (write-sample-row samples new-q sample-count
                                                     n-samples n-params)
                                   samples)
-                    new-count (if is-record
+                    new-count (if record?
                                 (mx/add sample-count (mx/astype (mx/array [1]) mx/int32))
                                 sample-count)]
                 (recur new-q (inc i) new-count new-samples new-accept-count)))))

--- a/src/genmlx/inference/mcmc.cljs
+++ b/src/genmlx/inference/mcmc.cljs
@@ -237,6 +237,28 @@
                    total-steps " total steps). " (.-message e)
                    ". Use the block-compiled version instead."))))))
 
+(defn- run-blocks
+  "Drive a block-compiled chain phase: run `n-blocks` iterations of `step`,
+   breaking the lazy graph after each block and clearing the Metal cache on
+   the configured cadence. Centralizes the loop/materialize!/clear-cache!
+   control flow shared by the compiled burn-in phases.
+
+   `init` is the starting threaded state. `step` is (fn [state b] -> [state'
+   to-materialize]) where `to-materialize` is a seq of MLX arrays whose graph
+   is broken before the next block. `:clear-cache` controls the clear-cache!
+   cadence: true = every block, integer N = every Nth block, falsey = never.
+   Returns the final state."
+  [n-blocks init step {:keys [clear-cache] :or {clear-cache true}}]
+  (loop [state init, b 0]
+    (if (>= b n-blocks)
+      state
+      (let [[state' to-materialize] (step state b)]
+        ;; Break lazy graph between blocks
+        (apply mx/materialize! to-materialize)
+        (when (if (number? clear-cache) (zero? (mod b clear-cache)) clear-cache)
+          (mx/clear-cache!))
+        (recur state' (inc b))))))
+
 (defn- make-fused-burn-in
   "Compile a function that runs n-burn MH steps in one Metal dispatch.
    Returns compiled fn: (params [D], noise [B,D], uniforms [B]) → params [D].
@@ -444,16 +466,14 @@
             [params rk]
             (if (and burn-chain (> burn 0))
               (let [n-blocks (js/Math.ceil (/ burn burn-block-size))]
-                (loop [p init-params, b 0, rk rk]
-                  (if (>= b n-blocks) [p rk]
-                      (let [[k1 k2 rk'] (rng/split-n rk 3)
-                            noise (rng/normal k1 [burn-block-size n-params])
-                            uniforms (rng/uniform k2 [burn-block-size])
-                            p' (burn-chain p noise uniforms)]
-                        ;; Break lazy graph between burn-in blocks
-                        (mx/materialize! p')
-                        (mx/clear-cache!)
-                        (recur p' (inc b) rk')))))
+                (run-blocks n-blocks [init-params rk]
+                  (fn [[p rk] _]
+                    (let [[k1 k2 rk'] (rng/split-n rk 3)
+                          noise (rng/normal k1 [burn-block-size n-params])
+                          uniforms (rng/uniform k2 [burn-block-size])
+                          p' (burn-chain p noise uniforms)]
+                      [[p' rk'] [p']]))
+                  {}))
               [init-params rk])
         ;; Phase 2: Collect samples
             result
@@ -883,19 +903,18 @@
               [params rk]
               (if (> burn 0)
                 (let [n-burn-blocks (js/Math.ceil (/ burn k))]
-                  (loop [p init-params, b 0, rk rk]
-                    (if (>= b n-burn-blocks) [p rk]
-                        (let [[k1 k2 rk'] (rng/split-n rk 3)
-                              noise (rng/normal k1 [k n-chains n-params])
-                              uniforms (rng/uniform k2 [k n-chains])
-                              traj (chain p noise uniforms)]
-                          ;; Break lazy graph between burn-in blocks
-                          (mx/materialize! traj)
-                        ;; Extract last step [N,D] from trajectory [K,N,D]
-                          (let [p' (mx/reshape
-                                    (mx/take-idx traj (mx/array [(dec k)] mx/int32) 0)
-                                    [n-chains n-params])]
-                            (recur p' (inc b) rk'))))))
+                  (run-blocks n-burn-blocks [init-params rk]
+                    (fn [[p rk] _]
+                      (let [[k1 k2 rk'] (rng/split-n rk 3)
+                            noise (rng/normal k1 [k n-chains n-params])
+                            uniforms (rng/uniform k2 [k n-chains])
+                            traj (chain p noise uniforms)
+                            ;; Extract last step [N,D] from trajectory [K,N,D]
+                            p' (mx/reshape
+                                (mx/take-idx traj (mx/array [(dec k)] mx/int32) 0)
+                                [n-chains n-params])]
+                        [[p' rk'] [traj]]))
+                    {:clear-cache false}))
                 [init-params rk])
 
               ;; Phase 2: Collect via trajectory blocks, pool across chains
@@ -1263,17 +1282,15 @@
             [params score grad rk]
             (if (and burn-chain (> burn 0))
               (let [n-blocks (js/Math.ceil (/ burn burn-block-size))]
-                (loop [q init-q, sq init-score, gq init-grad, b 0, rk rk]
-                  (if (>= b n-blocks) [q sq gq rk]
-                      (let [[k1 k2 rk'] (rng/split-n rk 3)
-                            noise (rng/normal k1 [burn-block-size n-params])
-                            uniforms (rng/uniform k2 [burn-block-size])
-                            r (burn-chain q sq gq noise uniforms)
-                            q' (aget r 0) sq' (aget r 1) gq' (aget r 2)]
-                        ;; Break lazy graph between burn-in blocks
-                        (mx/materialize! q' sq' gq')
-                        (mx/clear-cache!)
-                        (recur q' sq' gq' (inc b) rk')))))
+                (run-blocks n-blocks [init-q init-score init-grad rk]
+                  (fn [[q sq gq rk] _]
+                    (let [[k1 k2 rk'] (rng/split-n rk 3)
+                          noise (rng/normal k1 [burn-block-size n-params])
+                          uniforms (rng/uniform k2 [burn-block-size])
+                          r (burn-chain q sq gq noise uniforms)
+                          q' (aget r 0) sq' (aget r 1) gq' (aget r 2)]
+                      [[q' sq' gq' rk'] [q' sq' gq']]))
+                  {}))
               [init-q init-score init-grad rk])
         ;; Phase 2: Collect samples (tidy-run prevents Metal resource leak)
             result (loop [q params, sq score, gq grad, acc (transient []), i 0, rk rk]
@@ -1948,16 +1965,14 @@
             [params rk]
             (if (and burn-chain (> burn 0))
               (let [n-blocks (js/Math.ceil (/ burn burn-block-size))]
-                (loop [q init-q, b 0, rk rk]
-                  (if (>= b n-blocks) [q rk]
-                      (let [[k1 k2 rk'] (rng/split-n rk 3)
-                            momentum (rng/normal k1 [burn-block-size n-params])
-                            uniforms (rng/uniform k2 [burn-block-size])
-                            q' (burn-chain q momentum uniforms)]
-                        ;; Break lazy graph between burn-in blocks
-                        (mx/materialize! q')
-                        (mx/clear-cache!)
-                        (recur q' (inc b) rk')))))
+                (run-blocks n-blocks [init-q rk]
+                  (fn [[q rk] _]
+                    (let [[k1 k2 rk'] (rng/split-n rk 3)
+                          momentum (rng/normal k1 [burn-block-size n-params])
+                          uniforms (rng/uniform k2 [burn-block-size])
+                          q' (burn-chain q momentum uniforms)]
+                      [[q' rk'] [q']]))
+                  {}))
               [init-q rk])
         ;; Phase 2: Collect samples (tidy-materialize prevents Metal resource leak)
             result (loop [q params, acc (transient []), i 0, rk rk]

--- a/src/genmlx/inference/pmcmc.cljs
+++ b/src/genmlx/inference/pmcmc.cljs
@@ -179,8 +179,7 @@
         obs-seq (if (vector? observations) observations [observations])
         extract (or extract-fn
                     (fn [trace]
-                      (mapv #(mx/item (cm/get-choice (:choices trace) [%]))
-                            param-addrs)))
+                      (mapv mx/item (extract-param-vals trace param-addrs))))
         ;; Build param MH kernel from kern/random-walk
         stds-map (if (number? proposal-std)
                    (zipmap param-addrs (repeat proposal-std))

--- a/src/genmlx/inference/pmcmc.cljs
+++ b/src/genmlx/inference/pmcmc.cljs
@@ -113,9 +113,9 @@
               [propose-key est-key accept-key] (rng/split-n step-key 3)
               ;; Propose θ' via random walk (inline — no helper needed)
               propose-keys (rng/split-n propose-key (count param-addrs))
-              proposed (mapv (fn [val std ki]
-                               (mx/add val (mx/multiply (rng/normal ki [])
-                                                        (mx/scalar std))))
+              proposed (mapv (fn [pval std ki]
+                               (mx/add pval (mx/multiply (rng/normal ki [])
+                                                         (mx/scalar std))))
                              params stds propose-keys)
               _ (doseq [v proposed] (mx/materialize! v))
               ;; IS estimate of log p(θ', y)

--- a/src/genmlx/inference/smc.cljs
+++ b/src/genmlx/inference/smc.cljs
@@ -154,10 +154,9 @@
                                 (vec (repeat particles (mx/scalar 0.0)))])
                              [traces log-weights])
         ;; Update each particle with new observations
-        results       (into [] (map-indexed
-                        (fn [i trace]
-                          (break-particle-graph! (p/update (:gen-fn trace) trace obs) i))
-                        traces'))
+        results       (mapv (fn [i trace]
+                               (break-particle-graph! (p/update (:gen-fn trace) trace obs) i))
+                             (range) traces')
         new-traces    (mapv :trace results)
         update-weights (mapv :weight results)
         new-weights   (mapv mx/add weights' update-weights)

--- a/src/genmlx/inference/smc.cljs
+++ b/src/genmlx/inference/smc.cljs
@@ -22,10 +22,10 @@
   "Break the lazy graph for a per-particle generate/update result, preventing
    N-deep accumulation. Materializes the result's weight and score, then sweeps
    dead arrays every 50 particles. Returns the result unchanged."
-  [r i]
-  (mx/materialize! (:weight r) (:score (:trace r)))
+  [result i]
+  (mx/materialize! (:weight result) (:score (:trace result)))
   (when (zero? (mod (inc i) 50)) (mx/sweep-dead-arrays!))
-  r)
+  result)
 
 (defn rejuvenate-trace
   "Apply `steps` MH rejuvenation moves to a single trace over `selection`.

--- a/src/genmlx/inference/smc.cljs
+++ b/src/genmlx/inference/smc.cljs
@@ -139,9 +139,13 @@
 
 (defn- smc-step
   "Subsequent timestep: resample (if ESS low), update particles, rejuvenate.
+   cfg holds the fixed per-filter config (:model :particles :ess-threshold
+   :rejuvenation-steps :rejuvenation-selection :resample-method); the remaining
+   positional args are the per-step loop state.
    Returns {:traces :log-weights :log-ml-increment}."
-  [traces log-weights model obs particles ess-threshold
-   rejuvenation-steps rejuvenation-selection resample-method key]
+  [{:keys [model particles ess-threshold rejuvenation-steps
+           rejuvenation-selection resample-method]}
+   traces log-weights obs key]
   (let [;; Check ESS and resample if needed
         ess        (u/compute-ess log-weights)
         resample?  (< ess (* ess-threshold particles))
@@ -219,9 +223,12 @@
               (recur (inc t) traces log-weights
                      (mx/add log-ml log-ml-increment) next-key))
             (let [{:keys [traces log-weights log-ml-increment ess resampled?]}
-                  (smc-step traces log-weights model obs-t particles ess-threshold
-                            rejuvenation-steps rejuvenation-selection
-                            resample-method step-key)]
+                  (smc-step {:model model :particles particles
+                             :ess-threshold ess-threshold
+                             :rejuvenation-steps rejuvenation-steps
+                             :rejuvenation-selection rejuvenation-selection
+                             :resample-method resample-method}
+                            traces log-weights obs-t step-key)]
               (when callback
                 (callback {:step t :ess ess :resampled? resampled?}))
               (recur (inc t) traces log-weights

--- a/src/genmlx/inference/smc.cljs
+++ b/src/genmlx/inference/smc.cljs
@@ -11,6 +11,34 @@
             [genmlx.combinators :as comb]))
 
 
+(defn log-ml-increment
+  "Marginal-likelihood increment for one SMC step: logsumexp(weights) - log N.
+   `w-arr` is a materialized [N]-shaped MLX weight array; `n` is the particle count."
+  [w-arr n]
+  (mx/subtract (mx/logsumexp w-arr)
+               (mx/scalar (js/Math.log n))))
+
+(defn break-particle-graph!
+  "Break the lazy graph for a per-particle generate/update result, preventing
+   N-deep accumulation. Materializes the result's weight and score, then sweeps
+   dead arrays every 50 particles. Returns the result unchanged."
+  [r i]
+  (mx/materialize! (:weight r) (:score (:trace r)))
+  (when (zero? (mod (inc i) 50)) (mx/sweep-dead-arrays!))
+  r)
+
+(defn rejuvenate-trace
+  "Apply `steps` MH rejuvenation moves to a single trace over `selection`.
+   Each step regenerates the selection and accepts via the MH ratio.
+   `step-keys` is a per-step sequence of PRNG keys (or nils)."
+  [trace selection step-keys]
+  (reduce (fn [t rk]
+            (let [gf     (:gen-fn t)
+                  result (p/regenerate gf t selection)
+                  w      (mx/realize (:weight result))]
+              (if (u/accept-mh? w rk) (:trace result) t)))
+          trace step-keys))
+
 (defn- strip-analytical
   "Strip analytical handlers from a model for particle-based inference.
    The analytical path returns deterministic posterior means, eliminating
@@ -90,17 +118,12 @@
    Returns {:traces :log-weights :log-ml-increment}."
   [model args obs particles]
   (let [results    (mapv (fn [i]
-                          (let [r (p/generate model args obs)]
-                            ;; Break lazy graph per particle — prevents N-deep accumulation
-                            (mx/materialize! (:weight r) (:score (:trace r)))
-                            (when (zero? (mod (inc i) 50)) (mx/sweep-dead-arrays!))
-                            r))
+                          (break-particle-graph! (p/generate model args obs) i))
                         (range particles))
         traces     (mapv :trace results)
         log-weights (mapv :weight results)
         w-arr      (u/materialize-weights log-weights)
-        ml-inc     (mx/subtract (mx/logsumexp w-arr)
-                                (mx/scalar (js/Math.log particles)))]
+        ml-inc     (log-ml-increment w-arr particles)]
     {:traces traces :log-weights log-weights :log-ml-increment ml-inc}))
 
 (defn- smc-rejuvenate
@@ -112,12 +135,7 @@
       (mapv (fn [trace ki]
               (let [trace-keys (if ki (rng/split-n ki rejuvenation-steps)
                                       (repeat rejuvenation-steps nil))]
-                (reduce (fn [t rk]
-                          (let [gf     (:gen-fn t)
-                                result (p/regenerate gf t rejuvenation-selection)
-                                w      (mx/realize (:weight result))]
-                            (if (u/accept-mh? w rk) (:trace result) t)))
-                        trace trace-keys)))
+                (rejuvenate-trace trace rejuvenation-selection trace-keys)))
             traces keys))
     traces))
 
@@ -140,11 +158,7 @@
         ;; Update each particle with new observations
         results       (into [] (map-indexed
                         (fn [i trace]
-                          (let [r (p/update (:gen-fn trace) trace obs)]
-                            ;; Break lazy graph per particle — prevents N-deep accumulation
-                            (mx/materialize! (:weight r) (:score (:trace r)))
-                            (when (zero? (mod (inc i) 50)) (mx/sweep-dead-arrays!))
-                            r))
+                          (break-particle-graph! (p/update (:gen-fn trace) trace obs) i))
                         traces'))
         new-traces    (mapv :trace results)
         update-weights (mapv :weight results)
@@ -154,8 +168,7 @@
                                        rejuvenation-selection rejuv-key)
         ;; log ml increment
         w-arr         (u/materialize-weights new-weights)
-        ml-inc        (mx/subtract (mx/logsumexp w-arr)
-                                    (mx/scalar (js/Math.log particles)))]
+        ml-inc        (log-ml-increment w-arr particles)]
     {:traces final-traces :log-weights new-weights :log-ml-increment ml-inc
      :ess ess :resampled? resample?}))
 
@@ -263,21 +276,17 @@
               _ (when (and (pos? t) (zero? (mod t 5))) (mx/clear-cache!))]
           (if (zero? t)
             ;; Init step: reference trace at index 0, rest from prior
-            (let [other-results (mapv (fn [_]
-                                        (let [r (p/generate particle-model args obs-t)]
-                                          ;; Break lazy graph per particle
-                                          (mx/materialize! (:weight r) (:score (:trace r)))
-                                          r))
+            (let [other-results (mapv (fn [i]
+                                        (break-particle-graph!
+                                         (p/generate particle-model args obs-t) i))
                                       (range (dec particles)))
                   ;; Use reference trace at index 0 (the core of cSMC)
-                  ref-result (let [r (p/generate model args (:choices reference-trace))]
-                               (mx/materialize! (:weight r) (:score (:trace r)))
-                               r)
+                  ref-result (break-particle-graph!
+                              (p/generate model args (:choices reference-trace)) 0)
                   traces (into [(:trace ref-result)] (mapv :trace other-results))
                   log-weights (into [(:weight ref-result)] (mapv :weight other-results))
                   w-arr (u/materialize-weights log-weights)
-                  ml-inc (mx/subtract (mx/logsumexp w-arr)
-                                       (mx/scalar (js/Math.log particles)))]
+                  ml-inc (log-ml-increment w-arr particles)]
               (when callback
                 (callback {:step t :ess (u/compute-ess log-weights)}))
               (recur (inc t) traces log-weights
@@ -296,12 +305,10 @@
                                           (vec (repeat particles (mx/scalar 0.0)))])
                                        [traces log-weights])
                   ;; Update all particles
-                  results (mapv (fn [trace]
-                                  (let [r (p/update (:gen-fn trace) trace obs-t)]
-                                    ;; Break lazy graph per particle
-                                    (mx/materialize! (:weight r) (:score (:trace r)))
-                                    r))
-                                traces')
+                  results (mapv (fn [i trace]
+                                  (break-particle-graph!
+                                   (p/update (:gen-fn trace) trace obs-t) i))
+                                (range particles) traces')
                   new-traces (mapv :trace results)
                   update-weights (mapv :weight results)
                   new-weights (mapv mx/add weights' update-weights)
@@ -313,19 +320,14 @@
                                    (mapv (fn [i trace ki]
                                            (if (= i ref-idx)
                                              trace  ;; Don't rejuvenate reference
-                                             (reduce (fn [t rk]
-                                                       (let [gf (:gen-fn t)
-                                                             result (p/regenerate gf t rejuvenation-selection)
-                                                             w (mx/realize (:weight result))]
-                                                         (if (u/accept-mh? w rk) (:trace result) t)))
-                                                     trace
-                                                     (if ki (rng/split-n ki rejuvenation-steps)
-                                                            (repeat rejuvenation-steps nil)))))
+                                             (rejuvenate-trace
+                                              trace rejuvenation-selection
+                                              (if ki (rng/split-n ki rejuvenation-steps)
+                                                     (repeat rejuvenation-steps nil)))))
                                          (range particles) new-traces keys))
                                  new-traces)
                   w-arr (u/materialize-weights new-weights)
-                  ml-inc (mx/subtract (mx/logsumexp w-arr)
-                                       (mx/scalar (js/Math.log particles)))]
+                  ml-inc (log-ml-increment w-arr particles)]
               (when callback
                 (callback {:step t :ess ess :resampled? resample?}))
               (recur (inc t) final-traces new-weights
@@ -373,8 +375,7 @@
                         step-weights (mapv :weight results)
                         new-traces (mapv :trace results)
                         w-arr (u/materialize-weights step-weights)
-                        ml-inc (mx/subtract (mx/logsumexp w-arr)
-                                            (mx/scalar (js/Math.log particles)))
+                        ml-inc (log-ml-increment w-arr particles)
                         ;; Materialize before resampling uses ml-inc as JS number
                         _ (mx/materialize! ml-inc)
                         indices (u/systematic-resample step-weights particles resample-key)
@@ -443,8 +444,7 @@
               ;; 2. Log-ML increment
               ;; Break lazy graph — weights needed for resampling below
               _ (mx/materialize! step-weights)
-              ml-inc (mx/subtract (mx/logsumexp step-weights)
-                                  (mx/scalar (js/Math.log particles)))
+              ml-inc (log-ml-increment step-weights particles)
               ;; Materialize ml-inc before accumulation in next iteration
               _ (mx/materialize! ml-inc)
               ;; 3. Resample (handles array, map, or nil state)

--- a/src/genmlx/inference/smc.cljs
+++ b/src/genmlx/inference/smc.cljs
@@ -33,10 +33,8 @@
    `step-keys` is a per-step sequence of PRNG keys (or nils)."
   [trace selection step-keys]
   (reduce (fn [t rk]
-            (let [gf     (:gen-fn t)
-                  result (p/regenerate gf t selection)
-                  w      (mx/realize (:weight result))]
-              (if (u/accept-mh? w rk) (:trace result) t)))
+            (let [{:keys [trace weight]} (p/regenerate (:gen-fn t) t selection)]
+              (if (u/accept-mh? (mx/realize weight) rk) trace t)))
           trace step-keys))
 
 (defn- strip-analytical

--- a/src/genmlx/inference/smcp3.cljs
+++ b/src/genmlx/inference/smcp3.cljs
@@ -13,6 +13,7 @@
             [genmlx.mlx.random :as rng]
             [genmlx.edit :as edit]
             [genmlx.dynamic :as dyn]
+            [genmlx.inference.smc :as smc]
             [genmlx.inference.util :as u]))
 
 
@@ -56,8 +57,7 @@
         traces (mapv :trace results)
         log-weights (mapv :weight results)
         w-arr (u/materialize-weights log-weights)
-        ml-inc (mx/subtract (mx/logsumexp w-arr)
-                             (mx/scalar (js/Math.log particles)))]
+        ml-inc (smc/log-ml-increment w-arr particles)]
     {:traces traces :log-weights log-weights :log-ml-increment ml-inc}))
 
 ;; ---------------------------------------------------------------------------
@@ -126,8 +126,7 @@
                        new-traces)
         ;; log-ML increment
         w-arr (u/materialize-weights new-weights)
-        ml-inc (mx/subtract (mx/logsumexp w-arr)
-                             (mx/scalar (js/Math.log particles)))]
+        ml-inc (smc/log-ml-increment w-arr particles)]
     {:traces final-traces :log-weights new-weights :log-ml-increment ml-inc
      :ess ess :resampled? resample?}))
 

--- a/src/genmlx/inference/smcp3.cljs
+++ b/src/genmlx/inference/smcp3.cljs
@@ -38,9 +38,8 @@
                   (fn [_]
                     (if proposal-gf
                       ;; Use proposal to generate initial choices
-                      (let [proposal-result (p/propose proposal-gf [])
-                            proposal-choices (:choices proposal-result)
-                            proposal-score (:weight proposal-result)
+                      (let [{proposal-choices :choices proposal-score :weight}
+                            (p/propose proposal-gf [])
                             ;; Merge proposal choices with observations
                             merged (cm/merge-cm proposal-choices observations)
                             ;; Generate model trace with merged constraints
@@ -108,13 +107,13 @@
                                       ;; This changes weight semantics: no backward/forward proposal
                                       ;; correction is applied — weight is pure update weight only.
                                       (edit/constraint-edit observations))
-                            result (edit/edit (:gen-fn trace) trace edit-req)]
-                        (mx/materialize! (:weight result))
-                        {:trace (:trace result) :weight (:weight result)})
+                            {:keys [trace weight]} (edit/edit (:gen-fn trace) trace edit-req)]
+                        (mx/materialize! weight)
+                        {:trace trace :weight weight})
                       ;; Standard update
-                      (let [result (p/update (:gen-fn trace) trace observations)]
-                        (mx/materialize! (:weight result))
-                        {:trace (:trace result) :weight (:weight result)})))
+                      (let [{:keys [trace weight]} (p/update (:gen-fn trace) trace observations)]
+                        (mx/materialize! weight)
+                        {:trace trace :weight weight})))
                   traces')
         new-traces (mapv :trace results)
         update-weights (mapv :weight results)

--- a/src/genmlx/inference/util.cljs
+++ b/src/genmlx/inference/util.cljs
@@ -230,7 +230,7 @@
   "Compute effective sample size from log-weights."
   [log-weights]
   (let [{:keys [probs]} (normalize-log-weights log-weights)]
-    (/ 1.0 (reduce + (map #(* % %) probs)))))
+    (/ 1.0 (transduce (map #(* % %)) + probs))))
 
 (defn- walk-value-arrays
   "Recursively find all MLX arrays in a value that may be a scalar, vector, or map."
@@ -252,8 +252,7 @@
                 (let [v (cm/get-value cm)]
                   (when (mx/array? v) (vswap! arrays conj! v)))
                 (instance? cm/Node cm)
-                (doseq [[_ sub] (cm/-submaps cm)]
-                  (walk sub))))]
+                (run! (fn [[_ sub]] (walk sub)) (cm/-submaps cm))))]
       (when-let [choices (:choices trace)]
         (walk choices)))
     (when-let [s (:score trace)]

--- a/src/genmlx/inference/util.cljs
+++ b/src/genmlx/inference/util.cljs
@@ -407,7 +407,7 @@
   [trace latent-index]
   (let [choices (:choices trace)
         pairs (sort-by val latent-index)]
-    (mx/stack (mapv (fn [[addr _]]
+    (mx/stack (mapv (fn [[addr]]
                       (cm/get-value (cm/get-submap choices addr)))
                     pairs))))
 

--- a/src/genmlx/inference/vi.cljs
+++ b/src/genmlx/inference/vi.cljs
@@ -43,6 +43,82 @@
 ;; VI main
 ;; ---------------------------------------------------------------------------
 
+(defn- advi-sample-fn
+  "Build the posterior sampler returned by ADVI: draws n reparameterized
+   samples from the mean-field Gaussian q(mu, sigma). For d==1 returns a
+   vector of CLJS doubles; otherwise the [n,d] sample array as nested CLJS."
+  [mu sigma d rk]
+  (fn [n]
+    (let [sample-key (if rk rk (rng/fresh-key))
+          eps (rng/normal sample-key [n d])
+          samples (mx/add mu (mx/multiply sigma eps))]
+      (mx/materialize! samples)
+      (if (= d 1)
+        (mapv #(mx/item (mx/index samples %)) (range n))
+        (mx/->clj samples)))))
+
+(defn- run-advi
+  "Shared ADVI driver for `vi` and `compiled-vi`. Builds the mean-field
+   Gaussian guide, optimizes the negative ELBO via Adam, and returns
+   {:mu :sigma :elbo-history :sample-fn}.
+
+   When `compile?` is true the gradient and ELBO functions are wrapped in
+   mx/compile-fn, and ELBO logging uses the compiled forward pass (fresh
+   key, like the original compiled-vi); otherwise ELBO logging re-estimates
+   with the iteration key (like the original vi). The tidy/materialize
+   boundaries are identical to the original per-function loops."
+  [{:keys [iterations learning-rate elbo-samples beta1 beta2 epsilon callback key
+           vectorized-log-density compile?]
+    :or {iterations 1000 learning-rate 0.01 elbo-samples 10
+         beta1 0.9 beta2 0.999 epsilon 1e-8}}
+   log-density init-params]
+  (let [d (or (first (mx/shape init-params)) 1)
+        init-mu (if (zero? (mx/ndim init-params))
+                  (mx/reshape init-params [1])
+                  init-params)
+        init-log-sigma (mx/zeros [d])
+        init-vp (mx/tidy-materialize
+                 #(mx/concatenate [init-mu init-log-sigma]))
+        vmapped-log-density (or vectorized-log-density (mx/vmap log-density))
+        neg-elbo-fn (fn [vp]
+                      (mx/negative (elbo-estimate vp log-density elbo-samples d vmapped-log-density nil)))
+        grad-neg-elbo (cond-> (mx/grad neg-elbo-fn) compile? mx/compile-fn)
+        neg-elbo-compiled (when compile? (mx/compile-fn neg-elbo-fn))
+        ;; ELBO value at the new params, recomputed at log points only.
+        elbo-at (if compile?
+                  (fn [vp' _iter-key] (mx/negative (neg-elbo-compiled vp')))
+                  (fn [vp' iter-key]
+                    (elbo-estimate vp' log-density elbo-samples d vmapped-log-density iter-key)))]
+    (loop [i 0, vp init-vp
+           opt-state (learn/adam-init init-vp)
+           elbo-history (transient [])
+           rk key]
+      (if (>= i iterations)
+        (let [final-mu (mx/slice vp 0 d)
+              final-log-sigma (mx/slice vp d (* 2 d))
+              final-sigma (mx/exp final-log-sigma)]
+          (mx/materialize! final-mu final-sigma)
+          {:mu final-mu
+           :sigma final-sigma
+           :elbo-history (persistent! elbo-history)
+           :sample-fn (advi-sample-fn final-mu final-sigma d rk)})
+        (let [[iter-key next-key] (rng/split-or-nils rk)
+              ;; Tidy-materialize gradient — frees intermediate graph nodes
+              g (mx/tidy-materialize #(grad-neg-elbo vp))
+              [vp' opt-state'] (learn/adam-step vp g opt-state
+                                                {:lr learning-rate :beta1 beta1 :beta2 beta2 :epsilon epsilon})
+              ;; Tidy-materialize ELBO — prevents graph accumulation at log points
+              elbo-val (when (zero? (mod i (max 1 (quot iterations 100))))
+                         (mx/item (mx/tidy-materialize #(elbo-at vp' iter-key))))]
+          (when (and callback elbo-val)
+            (callback {:iter i :elbo elbo-val :params (mx/->clj vp')}))
+          (when (zero? (mod i 50)) (mx/sweep-dead-arrays!) (mx/clear-cache!))
+          (recur (inc i) vp' opt-state'
+                 (if elbo-val
+                   (conj! elbo-history elbo-val)
+                   elbo-history)
+                 next-key))))))
+
 (defn vi
   "Variational Inference via ADVI.
    Uses a mean-field Gaussian guide and optimizes ELBO via Adam.
@@ -57,58 +133,8 @@
             :sample-fn (fn [n] -> samples)}
 
    For compiled (faster) VI with pure tensor log-density, use compiled-vi."
-  [{:keys [iterations learning-rate elbo-samples beta1 beta2 epsilon callback key
-           vectorized-log-density]
-    :or {iterations 1000 learning-rate 0.01 elbo-samples 10
-         beta1 0.9 beta2 0.999 epsilon 1e-8}}
-   log-density init-params]
-  (let [d (or (first (mx/shape init-params)) 1)
-        init-mu (if (zero? (mx/ndim init-params))
-                  (mx/reshape init-params [1])
-                  init-params)
-        init-log-sigma (mx/zeros [d])
-        init-vp (mx/tidy-materialize
-                 #(mx/concatenate [init-mu init-log-sigma]))
-        vmapped-log-density (or vectorized-log-density (mx/vmap log-density))
-        neg-elbo-fn (fn [vp]
-                      (mx/negative (elbo-estimate vp log-density elbo-samples d vmapped-log-density nil)))
-        grad-neg-elbo (mx/grad neg-elbo-fn)]
-    (loop [i 0, vp init-vp
-           opt-state (learn/adam-init init-vp)
-           elbo-history (transient [])
-           rk key]
-      (if (>= i iterations)
-        (let [final-mu (mx/slice vp 0 d)
-              final-log-sigma (mx/slice vp d (* 2 d))
-              final-sigma (mx/exp final-log-sigma)]
-          (mx/materialize! final-mu final-sigma)
-          {:mu final-mu
-           :sigma final-sigma
-           :elbo-history (persistent! elbo-history)
-           :sample-fn (fn [n]
-                        (let [sample-key (if rk rk (rng/fresh-key))
-                              eps (rng/normal sample-key [n d])
-                              samples (mx/add final-mu (mx/multiply final-sigma eps))]
-                          (mx/materialize! samples)
-                          (if (= d 1)
-                            (mapv #(mx/item (mx/index samples %)) (range n))
-                            (mx/->clj samples))))})
-        (let [[iter-key next-key] (rng/split-or-nils rk)
-              ;; Tidy-materialize gradient — frees intermediate graph nodes
-              g (mx/tidy-materialize #(grad-neg-elbo vp))
-              [vp' opt-state'] (learn/adam-step vp g opt-state
-                                                {:lr learning-rate :beta1 beta1 :beta2 beta2 :epsilon epsilon})
-              ;; Tidy-materialize ELBO — prevents graph accumulation at log points
-              elbo-val (when (zero? (mod i (max 1 (quot iterations 100))))
-                         (mx/item (mx/tidy-materialize #(elbo-estimate vp' log-density elbo-samples d vmapped-log-density iter-key))))]
-          (when (and callback elbo-val)
-            (callback {:iter i :elbo elbo-val :params (mx/->clj vp')}))
-          (when (zero? (mod i 50)) (mx/sweep-dead-arrays!) (mx/clear-cache!))
-          (recur (inc i) vp' opt-state'
-                 (if elbo-val
-                   (conj! elbo-history elbo-val)
-                   elbo-history)
-                 next-key))))))
+  [opts log-density init-params]
+  (run-advi (assoc opts :compile? false) log-density init-params))
 
 ;; ---------------------------------------------------------------------------
 ;; Compiled VI (ADVI with mx/compile-fn)
@@ -136,61 +162,10 @@
    Returns {:mu MLX-array :sigma MLX-array :elbo-history [numbers]
             :sample-fn (fn [n] -> samples)}
    Default device: :cpu (faster for scalar parameters)."
-  [{:keys [iterations learning-rate elbo-samples beta1 beta2 epsilon callback key device
-           vectorized-log-density]
-    :or {iterations 1000 learning-rate 0.01 elbo-samples 10
-         beta1 0.9 beta2 0.999 epsilon 1e-8 device :cpu}}
-   log-density init-params]
+  [{:keys [device] :or {device :cpu} :as opts} log-density init-params]
   (with-device device
     (fn []
-      (let [d (or (first (mx/shape init-params)) 1)
-            init-mu (if (zero? (mx/ndim init-params))
-                      (mx/reshape init-params [1])
-                      init-params)
-            init-log-sigma (mx/zeros [d])
-            init-vp (mx/tidy-materialize
-                     #(mx/concatenate [init-mu init-log-sigma]))
-            vmapped-log-density (or vectorized-log-density (mx/vmap log-density))
-            neg-elbo-fn (fn [vp]
-                          (mx/negative (elbo-estimate vp log-density elbo-samples d vmapped-log-density nil)))
-            grad-neg-elbo (mx/compile-fn (mx/grad neg-elbo-fn))
-            neg-elbo-compiled (mx/compile-fn neg-elbo-fn)]
-        (loop [i 0, vp init-vp
-               opt-state (learn/adam-init init-vp)
-               elbo-history (transient [])
-               rk key]
-          (if (>= i iterations)
-            (let [final-mu (mx/slice vp 0 d)
-                  final-log-sigma (mx/slice vp d (* 2 d))
-                  final-sigma (mx/exp final-log-sigma)]
-              (mx/materialize! final-mu final-sigma)
-              {:mu final-mu
-               :sigma final-sigma
-               :elbo-history (persistent! elbo-history)
-               :sample-fn (fn [n]
-                            (let [sample-key (if rk rk (rng/fresh-key))
-                                  eps (rng/normal sample-key [n d])
-                                  samples (mx/add final-mu (mx/multiply final-sigma eps))]
-                              (mx/materialize! samples)
-                              (if (= d 1)
-                                (mapv (fn [idx] (mx/item (mx/index samples idx))) (range n))
-                                (mx/->clj samples))))})
-            (let [[iter-key next-key] (rng/split-or-nils rk)
-                  ;; Tidy-materialize gradient — frees intermediate graph nodes
-                  g (mx/tidy-materialize #(grad-neg-elbo vp))
-                  [vp' opt-state'] (learn/adam-step vp g opt-state
-                                                    {:lr learning-rate :beta1 beta1 :beta2 beta2 :epsilon epsilon})
-                  ;; Tidy-materialize ELBO — prevents graph accumulation at log points
-                  elbo-val (when (zero? (mod i (max 1 (quot iterations 100))))
-                             (mx/item (mx/tidy-materialize #(mx/negative (neg-elbo-compiled vp')))))]
-              (when (and callback elbo-val)
-                (callback {:iter i :elbo elbo-val :params (mx/->clj vp')}))
-              (when (zero? (mod i 50)) (mx/sweep-dead-arrays!) (mx/clear-cache!))
-              (recur (inc i) vp' opt-state'
-                     (if elbo-val
-                       (conj! elbo-history elbo-val)
-                       elbo-history)
-                     next-key))))))))
+      (run-advi (assoc opts :compile? true) log-density init-params))))
 
 ;; ---------------------------------------------------------------------------
 ;; VI from model (convenience)
@@ -344,6 +319,27 @@
       ;; Surrogate loss: gradient equals VIMCO estimator
       (mx/add L-hat reinforce-term))))
 
+(defn- estimate-objective
+  "Compute the (negated) programmable-VI objective for one batch of `samples`.
+   Rebuilds the guide log-density at the current `params`, dispatches the
+   objective (:elbo/:iwelbo/:vimco/:pwake/:qwake or a custom fn), applies the
+   estimator (:reparam or :reinforce), and returns the negated objective
+   (the quantity to minimize)."
+  [objective estimator log-p-fn log-q-fn params samples]
+  (let [log-q-curr (fn [z] (log-q-fn z params))
+        obj-fn (case objective
+                 :elbo (elbo-objective log-p-fn log-q-curr)
+                 :iwelbo (iwelbo-objective log-p-fn log-q-curr)
+                 :vimco (vimco-objective log-p-fn log-q-curr)
+                 :pwake (pwake-objective log-p-fn log-q-curr)
+                 :qwake (qwake-objective log-p-fn log-q-curr)
+                 (fn [s] (objective log-p-fn log-q-curr s)))
+        obj-val (if (= estimator :reinforce)
+                  ((reinforce-estimator obj-fn log-q-curr) samples)
+                  (obj-fn samples))]
+    ;; We minimize negative objective
+    (mx/negative obj-val)))
+
 (defn programmable-vi
   "Programmable variational inference with pluggable objectives and estimators.
 
@@ -368,21 +364,9 @@
    log-p-fn log-q-fn sample-fn init-params]
   (let [;; Build loss function (parameterized)
         loss-fn (fn [params iter-key]
-                  (let [samples (sample-fn params iter-key n-samples)
-                        ;; Rebuild objective with current params
-                        log-q-curr (fn [z] (log-q-fn z params))
-                        obj-fn (case objective
-                                 :elbo (elbo-objective log-p-fn log-q-curr)
-                                 :iwelbo (iwelbo-objective log-p-fn log-q-curr)
-                                 :vimco (vimco-objective log-p-fn log-q-curr)
-                                 :pwake (pwake-objective log-p-fn log-q-curr)
-                                 :qwake (qwake-objective log-p-fn log-q-curr)
-                                 (fn [s] (objective log-p-fn log-q-curr s)))
-                        obj-val (if (= estimator :reinforce)
-                                  ((reinforce-estimator obj-fn log-q-curr) samples)
-                                  (obj-fn samples))]
-                    ;; We minimize negative objective
-                    (mx/negative obj-val)))
+                  (let [samples (sample-fn params iter-key n-samples)]
+                    (estimate-objective objective estimator log-p-fn log-q-fn
+                                        params samples)))
         grad-loss (fn [params iter-key]
                     (let [g (mx/grad (fn [p] (loss-fn p iter-key)))]
                       {:loss (loss-fn params iter-key) :grad (g params)}))]
@@ -428,19 +412,9 @@
       ;; missing the ∂loss/∂samples · ∂samples/∂params path entirely.
       (let [make-loss (fn [iter-key n]
                         (fn [params]
-                          (let [samples (sample-fn params iter-key n)
-                                log-q-curr (fn [z] (log-q-fn z params))
-                                obj-fn (case objective
-                                         :elbo (elbo-objective log-p-fn log-q-curr)
-                                         :iwelbo (iwelbo-objective log-p-fn log-q-curr)
-                                         :vimco (vimco-objective log-p-fn log-q-curr)
-                                         :pwake (pwake-objective log-p-fn log-q-curr)
-                                         :qwake (qwake-objective log-p-fn log-q-curr)
-                                         (fn [s] (objective log-p-fn log-q-curr s)))
-                                obj-val (if (= estimator :reinforce)
-                                          ((reinforce-estimator obj-fn log-q-curr) samples)
-                                          (obj-fn samples))]
-                            (mx/negative obj-val))))]
+                          (let [samples (sample-fn params iter-key n)]
+                            (estimate-objective objective estimator log-p-fn log-q-fn
+                                                params samples))))]
         (loop [i 0 params init-params
                opt-state (learn/adam-init init-params)
                losses (transient [])

--- a/src/genmlx/inference/vi.cljs
+++ b/src/genmlx/inference/vi.cljs
@@ -298,26 +298,26 @@
           log-p (vmapped-p samples)
           log-q (vmapped-q samples)
           log-w (mx/subtract log-p log-q)
-          K (first (mx/shape samples))
-          log-K (mx/scalar (js/Math.log K))
+          k (first (mx/shape samples))
+          log-k (mx/scalar (js/Math.log k))
           ;; IWELBO estimate: L̂ = logsumexp(log_w) - log(K)
-          L-hat (mx/subtract (mx/logsumexp log-w) log-K)
+          l-hat (mx/subtract (mx/logsumexp log-w) log-k)
           ;; Leave-one-out geometric means:
           ;; loo_mean_k = (sum(log_w) - log_w_k) / (K-1)
           loo-mean (mx/divide (mx/subtract (mx/sum log-w) log-w)
-                              (mx/scalar (dec K)))
+                              (mx/scalar (dec k)))
           ;; Build [K,K] matrix: row k has all log_w values,
           ;; with diagonal (k,k) replaced by loo_mean_k
-          off-diag (mx/broadcast-to (mx/reshape log-w [1 K]) [K K])
-          loo-bcast (mx/broadcast-to (mx/reshape loo-mean [K 1]) [K K])
-          loo-matrix (mx/where (mx/eye K) loo-bcast off-diag)
+          off-diag (mx/broadcast-to (mx/reshape log-w [1 k]) [k k])
+          loo-bcast (mx/broadcast-to (mx/reshape loo-mean [k 1]) [k k])
+          loo-matrix (mx/where (mx/eye k) loo-bcast off-diag)
           ;; Baselines: L̂_{-k} = logsumexp(loo_matrix[k,:]) - log(K)
-          baselines (mx/subtract (mx/logsumexp loo-matrix [1]) log-K)
+          baselines (mx/subtract (mx/logsumexp loo-matrix [1]) log-k)
           ;; REINFORCE signal with leave-one-out baseline
-          signal (mx/stop-gradient (mx/subtract L-hat baselines))
+          signal (mx/stop-gradient (mx/subtract l-hat baselines))
           reinforce-term (mx/mean (mx/multiply signal log-q))]
       ;; Surrogate loss: gradient equals VIMCO estimator
-      (mx/add L-hat reinforce-term))))
+      (mx/add l-hat reinforce-term))))
 
 (defn- estimate-objective
   "Compute the (negated) programmable-VI objective for one batch of `samples`.

--- a/src/genmlx/inference/vi.cljs
+++ b/src/genmlx/inference/vi.cljs
@@ -49,7 +49,7 @@
    vector of CLJS doubles; otherwise the [n,d] sample array as nested CLJS."
   [mu sigma d rk]
   (fn [n]
-    (let [sample-key (if rk rk (rng/fresh-key))
+    (let [sample-key (or rk (rng/fresh-key))
           eps (rng/normal sample-key [n d])
           samples (mx/add mu (mx/multiply sigma eps))]
       (mx/materialize! samples)

--- a/src/genmlx/inspect.cljs
+++ b/src/genmlx/inspect.cljs
@@ -8,18 +8,16 @@
   [:simulate :generate :update :regenerate :assess :project :propose])
 
 (def ^:private compiled-schema-keys
-  {:simulate :compiled-simulate,   :generate :compiled-generate
-   :update :compiled-update,       :regenerate :compiled-regenerate
-   :assess :compiled-assess,       :project :compiled-project})
+  [:compiled-simulate :compiled-generate :compiled-update
+   :compiled-regenerate :compiled-assess :compiled-project])
 
 (def ^:private prefix-schema-keys
-  {:simulate :compiled-prefix,     :generate :compiled-prefix-generate
-   :update :compiled-prefix-update, :regenerate :compiled-prefix-regenerate
-   :assess :compiled-prefix-assess, :project :compiled-prefix-project})
+  [:compiled-prefix :compiled-prefix-generate :compiled-prefix-update
+   :compiled-prefix-regenerate :compiled-prefix-assess :compiled-prefix-project])
 
 (defn- compilation-level [schema]
-  (let [has-compiled? (some #(get schema (val %)) compiled-schema-keys)
-        has-prefix?   (some #(get schema (val %)) prefix-schema-keys)]
+  (let [has-compiled? (some #(get schema %) compiled-schema-keys)
+        has-prefix?   (some #(get schema %) prefix-schema-keys)]
     (cond
       (and has-compiled? (:static? schema))       :L1-M2
       (and has-compiled? (:has-branches? schema))  :L1-M4

--- a/src/genmlx/learning.cljs
+++ b/src/genmlx/learning.cljs
@@ -169,10 +169,7 @@
   (let [model (dyn/auto-key model)]
     (fn [params-array key]
     (let [loss-fn (fn [p]
-                    (let [store {:params (into {}
-                                          (map-indexed
-                                            (fn [i nm] [nm (mx/index p i)])
-                                            param-names-vec))}
+                    (let [store {:params (array->params p param-names-vec)}
                           model' (vary-meta model assoc :genmlx.dynamic/param-store store)
                           {:keys [weight]} (p/generate model' args observations)]
                       ;; Negative log-joint (minimize)
@@ -185,6 +182,14 @@
 ;; ---------------------------------------------------------------------------
 ;; Wake-Sleep Learning
 ;; ---------------------------------------------------------------------------
+
+(defn- params->guide-cm
+  "Build a guide choicemap by setting each indexed address from params.
+   indexed-addrs is a vector of [i addr] pairs (index into params)."
+  [params indexed-addrs]
+  (reduce (fn [cm [i addr]]
+            (cm/set-choice cm [addr] (mx/index params i)))
+          cm/EMPTY indexed-addrs))
 
 (defn wake-phase-loss
   "Wake phase: minimize KL(q||p) by optimizing guide parameters.
@@ -202,10 +207,7 @@
             [k1 k2] (rng/split (rng/ensure-key key))
             loss-fn (fn [params]
                       (let [;; Build guide choicemap from params
-                            guide-cm (reduce
-                                       (fn [cm [i addr]]
-                                         (cm/set-choice cm [addr] (mx/index params i)))
-                                       cm/EMPTY indexed-addrs)
+                            guide-cm (params->guide-cm params indexed-addrs)
                             ;; Sample from guide
                             {:keys [trace weight]}
                             (p/generate (vary-meta guide assoc :genmlx.dynamic/key k1) args guide-cm)
@@ -239,10 +241,7 @@
           model-choices (:choices model-trace)
           ;; Score guide on model's choices
           loss-fn (fn [params]
-                    (let [guide-cm (reduce
-                                     (fn [cm [i addr]]
-                                       (cm/set-choice cm [addr] (mx/index params i)))
-                                     cm/EMPTY indexed-addrs)
+                    (let [guide-cm (params->guide-cm params indexed-addrs)
                           {:keys [weight]}
                           (p/generate (vary-meta guide assoc :genmlx.dynamic/key k2) args
                                       (cm/merge-cm guide-cm model-choices))]

--- a/src/genmlx/learning.cljs
+++ b/src/genmlx/learning.cljs
@@ -184,12 +184,12 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- params->guide-cm
-  "Build a guide choicemap by setting each indexed address from params.
-   indexed-addrs is a vector of [i addr] pairs (index into params)."
-  [params indexed-addrs]
-  (reduce (fn [cm [i addr]]
-            (cm/set-choice cm [addr] (mx/index params i)))
-          cm/EMPTY indexed-addrs))
+  "Build a guide choicemap by setting each address from params, where the
+   address's position in the addresses vector is its index into params."
+  [params addresses]
+  (reduce-kv (fn [cm i addr]
+               (cm/set-choice cm [addr] (mx/index params i)))
+             cm/EMPTY addresses))
 
 (defn wake-phase-loss
   "Wake phase: minimize KL(q||p) by optimizing guide parameters.
@@ -203,11 +203,10 @@
   [model guide args observations guide-addresses]
   (let [model (dyn/auto-key model)]
     (fn [guide-params key]
-      (let [indexed-addrs (mapv vector (range) guide-addresses)
-            [k1 k2] (rng/split (rng/ensure-key key))
+      (let [[k1 k2] (rng/split (rng/ensure-key key))
             loss-fn (fn [params]
                       (let [;; Build guide choicemap from params
-                            guide-cm (params->guide-cm params indexed-addrs)
+                            guide-cm (params->guide-cm params guide-addresses)
                             ;; Sample from guide
                             {:keys [trace weight]}
                             (p/generate (vary-meta guide assoc :genmlx.dynamic/key k1) args guide-cm)
@@ -234,14 +233,13 @@
   [model guide args guide-addresses]
   (let [model (dyn/auto-key model)]
     (fn [guide-params key]
-      (let [indexed-addrs (mapv vector (range) guide-addresses)
-            [k1 k2] (rng/split (rng/ensure-key key))
+      (let [[k1 k2] (rng/split (rng/ensure-key key))
             ;; Sample from model prior (simulate)
             model-trace (p/simulate (vary-meta model assoc :genmlx.dynamic/key k1) args)
           model-choices (:choices model-trace)
           ;; Score guide on model's choices
           loss-fn (fn [params]
-                    (let [guide-cm (params->guide-cm params indexed-addrs)
+                    (let [guide-cm (params->guide-cm params guide-addresses)
                           {:keys [weight]}
                           (p/generate (vary-meta guide assoc :genmlx.dynamic/key k2) args
                                       (cm/merge-cm guide-cm model-choices))]

--- a/src/genmlx/llm/backend.cljs
+++ b/src/genmlx/llm/backend.cljs
@@ -203,34 +203,31 @@
                        "<|im_start|>assistant\n" think-skip)
          eos-id (eos-token-id tokenizer)
          greedy? (or (nil? temperature) (<= temperature 0))
-         inv-temp (when-not greedy? (mx/scalar (/ 1.0 temperature)))]
+         inv-temp (when-not greedy? (mx/scalar (/ 1.0 temperature)))
+         decode-acc (fn [acc]
+                      (decode tokenizer (js/Uint32Array.from (clj->js acc))))
+         ;; Pick the next token id and advance the PRNG key. Greedy ignores
+         ;; the key and takes the argmax; sampled splits the key and draws.
+         pick (if greedy?
+                (fn [logits rk] [(mx/item (mx/argmax logits)) rk])
+                (fn [logits rk]
+                  (let [[sample-key next-key] (rng/split rk)]
+                    [(mx/item (rng/categorical sample-key (mx/multiply logits inv-temp)))
+                     next-key])))]
      (p/let [ids-raw (encode tokenizer chat-str true)
              prompt-ids (vec ids-raw)]
        (init-cache! model)
        (try
-         (let [logits (forward-prefill model prompt-ids)]
-           (if greedy?
-             (loop [i 0, acc [], logits logits]
-               (if (>= i max-tokens)
-                 (p/let [text (decode tokenizer (js/Uint32Array.from (clj->js acc)))]
-                   text)
-                 (let [tok-id (mx/item (mx/argmax logits))]
-                   (if (= tok-id eos-id)
-                     (p/let [text (decode tokenizer (js/Uint32Array.from (clj->js acc)))]
-                       text)
-                     (let [next-logits (forward-step model tok-id)]
-                       (recur (inc i) (conj acc tok-id) next-logits))))))
-             (let [rk (rng/ensure-key (when seed (rng/fresh-key seed)))]
-               (loop [i 0, acc [], logits logits, rk rk]
-                 (if (>= i max-tokens)
-                   (p/let [text (decode tokenizer (js/Uint32Array.from (clj->js acc)))]
-                     text)
-                   (let [[sample-key next-key] (rng/split rk)
-                         tok-id (mx/item (rng/categorical sample-key (mx/multiply logits inv-temp)))]
-                     (if (= tok-id eos-id)
-                       (p/let [text (decode tokenizer (js/Uint32Array.from (clj->js acc)))]
-                         text)
-                       (let [next-logits (forward-step model tok-id)]
-                         (recur (inc i) (conj acc tok-id) next-logits next-key)))))))))
+         (loop [i 0
+                acc []
+                logits (forward-prefill model prompt-ids)
+                rk (rng/ensure-key (when seed (rng/fresh-key seed)))]
+           (if (>= i max-tokens)
+             (decode-acc acc)
+             (let [[tok-id next-rk] (pick logits rk)]
+               (if (= tok-id eos-id)
+                 (decode-acc acc)
+                 (recur (inc i) (conj acc tok-id)
+                        (forward-step model tok-id) next-rk)))))
          (finally
            (reset-cache! model)))))))

--- a/src/genmlx/llm/bytes.cljs
+++ b/src/genmlx/llm/bytes.cljs
@@ -251,11 +251,11 @@
    Not safe for concurrent execution on the same model instance."
   ([model-map] (make-byte-llm-gf model-map {}))
   ([model-map opts]
-   (let [{:keys [model]} model-map
+   (let [{:keys [model tokenizer]} model-map
          {:keys [token-index trie]}
          (if (and (:token-index opts) (:trie opts))
            opts
-           (prepare (:tokenizer model-map)))]
+           (prepare tokenizer))]
      (dyn/auto-key
       (gen [prompt-ids max-bytes]
            (if (zero? max-bytes)
@@ -322,14 +322,14 @@
    Generation stops when the DFA has no valid continuations."
   ([model-map constraint] (constrain-bytes model-map constraint {}))
   ([model-map constraint opts]
-   (let [{:keys [model]} model-map
+   (let [{:keys [model tokenizer]} model-map
          dfa (if (string? constraint)
                (grammar/compile-regex constraint)
                constraint)
          {:keys [trie]}
          (if (:trie opts)
            opts
-           (prepare (:tokenizer model-map)))
+           (prepare tokenizer))
          alive (:alive dfa)]
      (dyn/auto-key
       (gen [prompt-ids max-bytes]

--- a/src/genmlx/llm/bytes.cljs
+++ b/src/genmlx/llm/bytes.cljs
@@ -195,6 +195,29 @@
   [node]
   (first (:token-ids node)))
 
+(defn with-byte-cache
+  "Run thunk under the model's KV-cache lifecycle: initialize the cache,
+   run the body, and reset the cache in a finally block. Returns the body's
+   value. The thunk closes over the gen body's trace/state."
+  [model thunk]
+  (llm/init-cache! model)
+  (try
+    (thunk)
+    (finally
+      (llm/reset-cache! model))))
+
+(defn trie-advance
+  "Advance trie position after choosing chosen-byte at trie-pos. Returns
+   [next-trie-pos next-logprobs]. At a leaf the accumulated bytes form a
+   complete token: reset to the trie root and commit the token via a cached
+   forward step, yielding fresh logprobs. Otherwise descend and keep the
+   current logprobs."
+  [model trie trie-pos logprobs chosen-byte]
+  (let [next-node (get-in trie-pos [:children chosen-byte])]
+    (if (trie-leaf? next-node)
+      [trie (logits->logprobs (llm/forward-step model (commit-token-id next-node)))]
+      [next-node logprobs])))
+
 ;; ============================================================
 ;; Public API: unconstrained byte-level generation
 ;; ============================================================
@@ -233,9 +256,8 @@
       (gen [prompt-ids max-bytes]
            (if (zero? max-bytes)
              []
-             (do
-               (llm/init-cache! model)
-               (try
+             (with-byte-cache model
+               (fn []
                  (loop [i 0
                         trie-pos trie
                         logprobs (logits->logprobs
@@ -249,18 +271,11 @@
 
                            idx (trace (keyword (str "b" i)) dist)
                            chosen-byte (nth chars (mx/item idx))
-                           next-node (get-in trie-pos [:children chosen-byte])]
+                           [next-pos next-logprobs]
+                           (trie-advance model trie trie-pos logprobs chosen-byte)]
 
-                       (if (trie-leaf? next-node)
-                         (recur (inc i) trie
-                                (logits->logprobs
-                                 (llm/forward-step model
-                                                   (commit-token-id next-node)))
-                                (conj bytes-acc chosen-byte))
-                         (recur (inc i) next-node logprobs
-                                (conj bytes-acc chosen-byte))))))
-                 (finally
-                   (llm/reset-cache! model))))))))))
+                       (recur (inc i) next-pos next-logprobs
+                              (conj bytes-acc chosen-byte)))))))))))))
 
 ;; ============================================================
 ;; Byte trace decoding
@@ -316,9 +331,8 @@
       (gen [prompt-ids max-bytes]
            (if (zero? max-bytes)
              []
-             (do
-               (llm/init-cache! model)
-               (try
+             (with-byte-cache model
+               (fn []
                  (loop [i 0
                         trie-pos trie
                         dfa-state (:start dfa)
@@ -342,18 +356,11 @@
                                idx (trace (keyword (str "b" i)) dist)
                                chosen-byte (nth chars (mx/item idx))
                                next-dfa (grammar/dfa-advance dfa dfa-state chosen-byte)
-                               next-node (get-in trie-pos [:children chosen-byte])]
+                               [next-pos next-logprobs]
+                               (trie-advance model trie trie-pos logprobs chosen-byte)]
 
-                           (if (trie-leaf? next-node)
-                             (recur (inc i) trie next-dfa
-                                    (logits->logprobs
-                                     (llm/forward-step model
-                                                       (commit-token-id next-node)))
-                                    (conj bytes-acc chosen-byte))
-                             (recur (inc i) next-node next-dfa logprobs
-                                    (conj bytes-acc chosen-byte))))))))
-                 (finally
-                   (llm/reset-cache! model))))))))))
+                           (recur (inc i) next-pos next-dfa next-logprobs
+                                  (conj bytes-acc chosen-byte)))))))))))))))
 
 
 

--- a/src/genmlx/llm/bytes.cljs
+++ b/src/genmlx/llm/bytes.cljs
@@ -150,10 +150,14 @@
    After sampling index i from the categorical, the chosen byte character
    is (nth chars i)."
   [byte-lps]
-  (let [entries (vec byte-lps)
-        chars (mapv first entries)
-        logits (mx/array (mapv second entries))]
-    {:dist (dist/categorical logits)
+  (let [{:keys [chars values]}
+        (reduce-kv (fn [acc ch lp]
+                     (-> acc
+                         (update :chars conj ch)
+                         (update :values conj lp)))
+                   {:chars [] :values []}
+                   byte-lps)]
+    {:dist (dist/categorical (mx/array values))
      :chars chars}))
 
 ;; ============================================================

--- a/src/genmlx/llm/codegen.cljs
+++ b/src/genmlx/llm/codegen.cljs
@@ -147,8 +147,9 @@ Syntax: (fn [args] body), (let [bindings] body), (case val clauses default),
 
     ;; Fenced code block
     (re-find #"```(?:clojure|cljs|clojurescript|clj)?\s*\n" text)
-    (let [m (re-find #"```(?:clojure|cljs|clojurescript|clj)?\s*\n([\s\S]*?)```" text)]
-      (if m (str/trim (nth m 1)) ""))
+    (if-let [m (re-find #"```(?:clojure|cljs|clojurescript|clj)?\s*\n([\s\S]*?)```" text)]
+      (str/trim (nth m 1))
+      "")
 
     ;; Starts with paren -- raw code
     (str/starts-with? (str/trim text) "(")
@@ -156,8 +157,9 @@ Syntax: (fn [args] body), (let [bindings] body), (case val clauses default),
 
     ;; Strip prefix to first paren
     :else
-    (let [idx (str/index-of text "(")]
-      (if idx (subs text idx) ""))))
+    (if-let [idx (str/index-of text "(")]
+      (subs text idx)
+      "")))
 
 ;; ============================================================
 ;; 7.5 Reader-constrained byte GF

--- a/src/genmlx/llm/codegen.cljs
+++ b/src/genmlx/llm/codegen.cljs
@@ -203,8 +203,7 @@ Syntax: (fn [args] body), (let [bindings] body), (case val clauses default),
                                        (suppress-complete constraint)
                                        constraint)
                            valid-lps (into {}
-                                           (filter (fn [[ch _]]
-                                                     (contains? effective ch)))
+                                           (filter (fn [[ch _]] (effective ch)))
                                            raw-lps)]
                        (if (empty? valid-lps)
                          bytes-acc
@@ -463,7 +462,7 @@ Syntax: (fn [args] body), (let [bindings] body), (case val clauses default),
   [form sym]
   (cond
     (= form sym) 1
-    (sequential? form) (reduce + 0 (map #(count-occurrences % sym) form))
+    (sequential? form) (transduce (map #(count-occurrences % sym)) + 0 form)
     :else 0))
 
 (defn- returns-map-literals?

--- a/src/genmlx/llm/codegen.cljs
+++ b/src/genmlx/llm/codegen.cljs
@@ -479,6 +479,10 @@ Syntax: (fn [args] body), (let [bindings] body), (case val clauses default),
     (sequential? form) (some returns-map-literals? form)
     :else false))
 
+(def ^:private occurrence-weights
+  "Per-occurrence penalty weights for commonly misused patterns."
+  {'assoc -2 'assoc-in -3 'update-in -3 'cond-> -4})
+
 (defn score-structure
   "Score the structural quality of a ClojureScript form.
    Higher = more idiomatic for transition functions.
@@ -491,10 +495,8 @@ Syntax: (fn [args] body), (let [bindings] body), (case val clauses default),
      (if (form-contains? form 'dec) 3 0)
      (if (form-contains? form 'inc) 3 0)
      (if (form-contains? form :keys) 2 0)
-     (* -2 (count-occurrences form 'assoc))
-     (* -3 (count-occurrences form 'assoc-in))
-     (* -3 (count-occurrences form 'update-in))
-     (* -4 (count-occurrences form 'cond->))))
+     (reduce-kv (fn [acc sym w] (+ acc (* w (count-occurrences form sym))))
+                0 occurrence-weights)))
 
 ;; ============================================================
 ;; 7.12 Scored generation

--- a/src/genmlx/llm/codegen.cljs
+++ b/src/genmlx/llm/codegen.cljs
@@ -11,7 +11,7 @@
    invalid ones to -inf. The LLM can only produce syntactically valid code.
 
    Layers:
-     7.1  Reader constraint (prefix-status, valid-next-bytes, reader-constraint)
+     7.1  Reader constraint (prefix-status, next-valid-bytes, reader-constraint)
      7.2  Post-hoc validation (valid-cljs?, fn-form?, transition-fn-form?)
      7.3  Chat template (format-chat, code-system-prompt)
      7.4  Code extraction (extract-code)
@@ -77,7 +77,7 @@
                   (when (not= :invalid s) [b s]))))
         candidate-bytes))
 
-(defn valid-next-bytes
+(defn next-valid-bytes
   "Return the set of bytes that maintain a valid prefix."
   [prefix]
   (set (keys (reader-constraint prefix))))

--- a/src/genmlx/llm/codegen.cljs
+++ b/src/genmlx/llm/codegen.cljs
@@ -56,18 +56,16 @@
            :incomplete
            :invalid))))
 
+(defn parse-form
+  "Parse a string into a ClojureScript form via edamame, returning nil if it
+   does not parse. Used to recover a form from generated code best-effort."
+  [s]
+  (try (eda/parse-string s eda-opts) (catch :default _ nil)))
+
 (def ^:private candidate-bytes
   "Printable ASCII + whitespace bytes as single-char strings."
   (into (mapv #(js/String.fromCharCode %) (range 32 127))
         ["\n" "\t"]))
-
-(defn valid-next-bytes
-  "Return the set of bytes that maintain a valid prefix."
-  [prefix]
-  (into #{}
-        (filter (fn [b]
-                  (#{:incomplete :complete} (prefix-status (str prefix b)))))
-        candidate-bytes))
 
 (defn reader-constraint
   "Return a map of {char -> :incomplete|:complete} for valid next bytes.
@@ -78,6 +76,11 @@
                 (let [s (prefix-status (str prefix b))]
                   (when (not= :invalid s) [b s]))))
         candidate-bytes))
+
+(defn valid-next-bytes
+  "Return the set of bytes that maintain a valid prefix."
+  [prefix]
+  (set (keys (reader-constraint prefix))))
 
 (defn suppress-complete
   "Before min-bytes, treat :complete as :incomplete to prevent
@@ -268,8 +271,7 @@ Syntax: (fn [args] body), (let [bindings] body), (case val clauses default),
                                            :system-prompt system-prompt})
                   code (extract-code text)
                   valid (valid-cljs? code)
-                  form (when valid
-                         (try (eda/parse-string code eda-opts) (catch :default _ nil)))]
+                  form (when valid (parse-form code))]
            {:code code
             :valid? valid
             :form form
@@ -285,8 +287,7 @@ Syntax: (fn [args] body), (let [bindings] body), (case val clauses default),
                   text (apply str (:retval trace))
                   code (extract-code text)
                   valid (valid-cljs? code)
-                  form (when valid
-                         (try (eda/parse-string code eda-opts) (catch :default _ nil)))]
+                  form (when valid (parse-form code))]
            {:code code
             :valid? valid
             :form form
@@ -516,8 +517,7 @@ Syntax: (fn [args] body), (let [bindings] body), (case val clauses default),
                       :system-prompt system-prompt})
               code (extract-code text)
               valid (valid-cljs? code)
-              form (when valid
-                     (try (eda/parse-string code eda-opts) (catch :default _ nil)))
+              form (when valid (parse-form code))
               ;; Score via GFI: encode generated tokens, constrain all
               gen-ids (llm/encode tokenizer text false)
               gen-vec (vec gen-ids)

--- a/src/genmlx/llm/core.cljs
+++ b/src/genmlx/llm/core.cljs
@@ -98,5 +98,5 @@
         tokens (->> (range)
                     (map #(cm/get-submap choices (t-addr %)))
                     (take-while cm/has-value?)
-                    (mapv #(mx/item (cm/get-value %))))]
+                    (mapv (comp mx/item cm/get-value)))]
     (llm/decode tokenizer (js/Uint32Array.from (clj->js tokens)))))

--- a/src/genmlx/llm/core.cljs
+++ b/src/genmlx/llm/core.cljs
@@ -18,6 +18,11 @@
             [genmlx.choicemap :as cm])
   (:require-macros [genmlx.gen :refer [gen]]))
 
+(defn- t-addr
+  "Trace address for the i-th generated token: :t0, :t1, ..."
+  [i]
+  (keyword (str "t" i)))
+
 (defn make-llm-gf
   "Create a generative function from a loaded LLM.
 
@@ -52,7 +57,7 @@
                   (loop [i 0, context prompt-ids, logits logits]
                     (if (>= i max-tokens)
                       context
-                      (let [tok (trace (keyword (str "t" i)) (dist/categorical logits))
+                      (let [tok (trace (t-addr i) (dist/categorical logits))
                             tok-id (mx/item tok)]
                         (if (= tok-id eos)
                           (conj context tok-id)
@@ -74,7 +79,7 @@
             (if (>= i max-tokens)
               context
               (let [logits (llm/forward-pass model context)
-                    tok (trace (keyword (str "t" i)) (dist/categorical logits))
+                    tok (trace (t-addr i) (dist/categorical logits))
                     tok-id (mx/item tok)]
                 (if (= tok-id eos)
                   (conj context tok-id)
@@ -91,7 +96,7 @@
   [tokenizer trace]
   (let [choices (:choices trace)
         tokens (->> (range)
-                    (map #(cm/get-submap choices (keyword (str "t" %))))
+                    (map #(cm/get-submap choices (t-addr %)))
                     (take-while cm/has-value?)
                     (mapv #(mx/item (cm/get-value %))))]
     (llm/decode tokenizer (js/Uint32Array.from (clj->js tokens)))))

--- a/src/genmlx/llm/grammar.cljs
+++ b/src/genmlx/llm/grammar.cljs
@@ -167,33 +167,31 @@
          nfa (ast->nfa nfa ast start accept)]
      (assoc nfa :start start :accept accept)))
   ([nfa ast start accept]
-   (case (first ast)
-     :lit   (add-transition nfa start (second ast) accept)
-     :class (add-transition nfa start (second ast) accept)
-     :empty (add-epsilon nfa start accept)
-     :cat   (let [[_ a b] ast
-                   [mid nfa] (fresh-state nfa)
-                   nfa (ast->nfa nfa a start mid)]
-              (ast->nfa nfa b mid accept))
-     :alt   (let [[_ a b] ast
-                   [[s1 f1 s2 f2] nfa] (fresh-states nfa 4)
-                   nfa (-> nfa
-                           (add-epsilon start s1)
-                           (add-epsilon start s2)
-                           (ast->nfa a s1 f1)
-                           (ast->nfa b s2 f2)
-                           (add-epsilon f1 accept)
-                           (add-epsilon f2 accept))]
-              nfa)
-     :star  (let [[_ a] ast
-                   [[s1 f1] nfa] (fresh-states nfa 2)
-                   nfa (-> nfa
-                           (add-epsilon start s1)
-                           (ast->nfa a s1 f1)
-                           (add-epsilon f1 s1)
-                           (add-epsilon start accept)
-                           (add-epsilon f1 accept))]
-              nfa))))
+   (let [[tag a b] ast]
+     (case tag
+       :lit   (add-transition nfa start a accept)
+       :class (add-transition nfa start a accept)
+       :empty (add-epsilon nfa start accept)
+       :cat   (let [[mid nfa] (fresh-state nfa)
+                    nfa (ast->nfa nfa a start mid)]
+                (ast->nfa nfa b mid accept))
+       :alt   (let [[[s1 f1 s2 f2] nfa] (fresh-states nfa 4)
+                    nfa (-> nfa
+                            (add-epsilon start s1)
+                            (add-epsilon start s2)
+                            (ast->nfa a s1 f1)
+                            (ast->nfa b s2 f2)
+                            (add-epsilon f1 accept)
+                            (add-epsilon f2 accept))]
+                nfa)
+       :star  (let [[[s1 f1] nfa] (fresh-states nfa 2)
+                    nfa (-> nfa
+                            (add-epsilon start s1)
+                            (ast->nfa a s1 f1)
+                            (add-epsilon f1 s1)
+                            (add-epsilon start accept)
+                            (add-epsilon f1 accept))]
+                nfa)))))
 
 ;; ============================================================
 ;; Subset construction (NFA → DFA)

--- a/src/genmlx/llm/grammar.cljs
+++ b/src/genmlx/llm/grammar.cljs
@@ -117,15 +117,15 @@
        :opt        (fn [] :opt)
        :repeat-exact (fn [n] [:repeat n n])
        :repeat-range (fn [n & [m]] [:repeat n (or m max-unbounded-repeat)])
-       :quant      (fn [atom & [q]]
+       :quant      (fn [node & [q]]
                      (cond
-                       (nil? q)     atom
-                       (= q :star)  [:star atom]
-                       (= q :plus)  [:cat atom [:star atom]]
-                       (= q :opt)   [:alt atom [:empty]]
+                       (nil? q)     node
+                       (= q :star)  [:star node]
+                       (= q :plus)  [:cat node [:star node]]
+                       (= q :opt)   [:alt node [:empty]]
                        (vector? q)  (let [[_ lo hi] q
-                                          required (repeat lo atom)
-                                          optional (repeat (- hi lo) [:alt atom [:empty]])]
+                                          required (repeat lo node)
+                                          optional (repeat (- hi lo) [:alt node [:empty]])]
                                       (reduce (fn [a b] [:cat a b])
                                               (concat required optional)))))
        :cat        (fn [& items]

--- a/src/genmlx/llm/msa.cljs
+++ b/src/genmlx/llm/msa.cljs
@@ -253,9 +253,7 @@
    (let [{:keys [max-tokens temperature]
           :or {max-tokens 150 temperature 0.5}} opts
          {:keys [variables]} task
-         prompt (build-prompt task)
-         messages [{:role "system" :content msa-system-prompt}
-                   {:role "user" :content prompt}]]
+         prompt (build-prompt task)]
      (pr/let [sess (ChatSession. (:model model-map)
                                 (clj->js {:system msa-system-prompt
                                           :maxNewTokens max-tokens
@@ -303,9 +301,7 @@ Output ONLY the lines. No explanation.")
   ([model-map task opts]
    (let [{:keys [max-tokens temperature]
           :or {max-tokens 120 temperature 0.5}} opts
-         {:keys [variables]} task
-         messages [{:role "system" :content knowledge-system-prompt}
-                   {:role "user" :content (build-knowledge-prompt task)}]]
+         {:keys [variables]} task]
      (pr/let [sess (ChatSession. (:model model-map)
                                 (clj->js {:system knowledge-system-prompt
                                           :maxNewTokens max-tokens
@@ -430,6 +426,13 @@ Output ONLY the lines. No explanation.")
      :log-weights (mapv (fn [{:keys [weight]}] (mx/item weight)) particles)
      :query query}))
 
+(defn- exp-normalize
+  "Exponentiate log-weights after subtracting their max, for numerically
+   stable normalization. Returns the vector of unnormalized weights."
+  [log-weights]
+  (let [max-w (apply max log-weights)]
+    (mapv #(js/Math.exp (- % max-w)) log-weights)))
+
 (defn infer-answer
   "Compute posterior mean and variance from importance sampling results.
    Normalizes log-weights via log-sum-exp for numerical stability.
@@ -439,8 +442,7 @@ Output ONLY the lines. No explanation.")
 
    Returns {:mean number, :variance number, :ess number, :query keyword}."
   [{:keys [values log-weights query]}]
-  (let [max-w (apply max log-weights)
-        unnorm (mapv #(js/Math.exp (- % max-w)) log-weights)
+  (let [unnorm (exp-normalize log-weights)
         total (reduce + unnorm)
         probs (mapv #(/ % total) unnorm)
         mean (reduce + (map * values probs))

--- a/src/genmlx/llm/msa.cljs
+++ b/src/genmlx/llm/msa.cljs
@@ -419,12 +419,16 @@ Output ONLY the lines. No explanation.")
    Returns {:values [numbers] :log-weights [numbers] :query keyword}."
   [gf observations query n]
   (let [obs-cm (observations->choicemap observations)
-        particles (repeatedly n #(p/generate gf [] obs-cm))]
-    {:values (mapv (fn [{:keys [trace]}]
-                     (mx/item (cm/get-value (cm/get-submap (:choices trace) query))))
-                   particles)
-     :log-weights (mapv (fn [{:keys [weight]}] (mx/item weight)) particles)
-     :query query}))
+        {:keys [values log-weights]}
+        (reduce (fn [acc _]
+                  (let [{:keys [trace weight]} (p/generate gf [] obs-cm)]
+                    (-> acc
+                        (update :values conj
+                                (mx/item (cm/get-value (cm/get-submap (:choices trace) query))))
+                        (update :log-weights conj (mx/item weight)))))
+                {:values [] :log-weights []}
+                (range n))]
+    {:values values :log-weights log-weights :query query}))
 
 (defn- exp-normalize
   "Exponentiate log-weights after subtracting their max, for numerically

--- a/src/genmlx/llm/vision.cljs
+++ b/src/genmlx/llm/vision.cljs
@@ -117,11 +117,8 @@
                     (conj acc [r c label])))
                 (pr/resolved [])
                 coords)]
-       (let [lookup (into {} (map (fn [[r c lbl]] [[r c] lbl]) results))]
-         {:rows rows :cols cols
-          :labels (vec (for [r (range rows)]
-                         (vec (for [c (range cols)]
-                                (get lookup [r c] "?")))))})))))
+       {:rows rows :cols cols
+        :labels (mapv vec (partition cols (map peek results)))}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Sync GFI layer

--- a/src/genmlx/llm/vision.cljs
+++ b/src/genmlx/llm/vision.cljs
@@ -131,26 +131,25 @@
 
 (defn label->index
   "Look up a label in `cell-types` (case-insensitive). Accepts string or map
-   options. Returns -1 if not found."
+   options. Returns nil if not found."
   [cell-types label]
   (let [target (str/lower-case (or label ""))]
-    (or (first (keep-indexed
-                 (fn [i v]
-                   (when (= (str/lower-case (option->label v)) target) i))
-                 cell-types))
-        -1)))
+    (first (keep-indexed
+             (fn [i v]
+               (when (= (str/lower-case (option->label v)) target) i))
+             cell-types))))
 
 (defn labels->constraints
   "Build a choicemap-friendly map from a 2D label grid plus `cell-types`,
    suitable for passing to `p/generate`. Cells whose label is unrecognized
-   (label->index returns -1) are simply omitted."
+   (label->index returns nil) are simply omitted."
   [labels cell-types]
   (into {}
         (for [r (range (count labels))
               c (range (count (first labels)))
               :let [lbl (get-in labels [r c])
                     idx (label->index cell-types lbl)]
-              :when (>= idx 0)]
+              :when idx]
           [(cell-addr r c) (mx/scalar idx mx/int32)])))
 
 (defn make-grid-gf

--- a/src/genmlx/method_selection.cljs
+++ b/src/genmlx/method_selection.cljs
@@ -43,12 +43,11 @@
    Accepts either a ChoiceMap Node (with :m internal map) or nil.
    Returns a set of keyword addresses."
   [observations]
-  (cond
-    (nil? observations) #{}
-    ;; ChoiceMap Node — record field :m holds the internal map
-    (map? (:m observations))
-    (set (keys (:m observations)))
-    :else #{}))
+  ;; ChoiceMap Node — record field :m holds the internal map; nil and non-map
+  ;; inputs (including a nil :m) fall through to #{}.
+  (if-let [m (:m observations)]
+    (if (map? m) (set (keys m)) #{})
+    #{}))
 
 (defn- residual-addrs
   "Trace-site addresses NOT eliminated by analytical plan.

--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -71,9 +71,9 @@
 (defn- flatten-nested
   "Recursively flatten a nested collection to a flat vector of numbers."
   [coll]
-  (if (or (vector? coll) (seq? coll) (sequential? coll) (js/Array.isArray coll))
+  (if (or (sequential? coll) (js/Array.isArray coll))
     (let [first-el (first coll)]
-      (if (or (vector? first-el) (seq? first-el) (sequential? first-el) (js/Array.isArray first-el))
+      (if (or (sequential? first-el) (js/Array.isArray first-el))
         (into [] (mapcat flatten-nested coll))
         (vec coll)))
     [coll]))
@@ -84,9 +84,9 @@
    flatten-nested's predicates so the dtype/shape arities of `array` shape
    JS-array inputs correctly (not as 0-dim scalars)."
   [coll]
-  (if (or (vector? coll) (seq? coll) (sequential? coll) (js/Array.isArray coll))
+  (if (or (sequential? coll) (js/Array.isArray coll))
     (let [first-el (first coll)]
-      (if (or (vector? first-el) (seq? first-el) (sequential? first-el) (js/Array.isArray first-el))
+      (if (or (sequential? first-el) (js/Array.isArray first-el))
         (let [[_ inner-shape] (infer-shape first-el)]
           [(flatten-nested coll) (into [(count coll)] inner-shape)])
         [(vec coll) [(count coll)]]))
@@ -588,10 +588,7 @@
                         (sum (multiply result cotangents-arr)))))
         result (.valueAndGrad M surrogate (to-array (vec primals)))
         fval (apply f (vec primals))
-        grads (let [gs #js []]
-                (dotimes [i (dec (.-length result))]
-                  (.push gs (aget result (inc i))))
-                gs)]
+        grads (into-array (map #(aget result (inc %)) (range (dec (.-length result)))))]
     [fval grads]))
 
 ;; =========================================================================

--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -193,10 +193,22 @@
   ([x] (if (number? x) (scalar x) x))
   ([x dt] (if (number? x) (scalar x dt) x)))
 
-(defn eq?  [a b] (.astype (equal (->cmp a int32) (->cmp b int32)) float32))
-(defn neq? [a b] (.astype (not-equal (->cmp a int32) (->cmp b int32)) float32))
-(defn gt?  [a b] (.astype (greater (->cmp a) (->cmp b)) float32))
-(defn lt?  [a b] (.astype (less (->cmp a) (->cmp b)) float32))
+(defn eq?
+  "Element-wise a == b. Promotes integer operands (int32) and returns a
+   float32 mask (1.0/0.0), so it composes with float arithmetic."
+  [a b] (.astype (equal (->cmp a int32) (->cmp b int32)) float32))
+(defn neq?
+  "Element-wise a != b. Promotes integer operands (int32) and returns a
+   float32 mask (1.0/0.0)."
+  [a b] (.astype (not-equal (->cmp a int32) (->cmp b int32)) float32))
+(defn gt?
+  "Element-wise a > b. Promotes scalars at the float32 default and returns a
+   float32 mask (1.0/0.0)."
+  [a b] (.astype (greater (->cmp a) (->cmp b)) float32))
+(defn lt?
+  "Element-wise a < b. Promotes scalars at the float32 default and returns a
+   float32 mask (1.0/0.0)."
+  [a b] (.astype (less (->cmp a) (->cmp b)) float32))
 (defn and* [a b] (multiply a b))
 (defn or*  [a b] (maximum a b))
 
@@ -261,6 +273,9 @@
   ([a axis] (argsort* a axis)))
 
 (defn searchsorted
+  "Insertion indices for values into the sorted sorted-arr. side defaults to
+   :left (index of the first element >= value); :right gives the index past
+   the last element <= value. side maps to the native right? boolean."
   ([sorted-arr values] (.searchsorted c sorted-arr values))
   ([sorted-arr values side] (.searchsorted c sorted-arr values (= side :right))))
 
@@ -269,7 +284,10 @@
   ([a] (sort* a))
   ([a axis] (sort* a axis)))
 
-(defn topk [a k] (.topk c a k))
+(defn topk
+  "Return the k largest *values* of a (not indices, not a value/index pair),
+   along the last axis. The result is partition-ordered, not sorted."
+  [a k] (.topk c a k))
 
 (def ^:private cumsum* (.-cumsum c))
 (defn cumsum
@@ -324,6 +342,8 @@
     :else                        (.astype indices int32)))
 
 (defn take-idx
+  "Gather elements of a at indices along axis (0-indexed; defaults to axis 0).
+   indices are coerced to int32 — MLX gather crashes on float index dtypes."
   ([a indices]
    (.take c a (ensure-int-indices indices) 0))
   ([a indices axis]

--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -187,14 +187,16 @@
 (def where         (.-where c))
 
 ;; Model-level helpers -- auto-promote integers, return float32.
-(defn eq?  [a b] (.astype (equal (if (number? a) (scalar a int32) a)
-                                 (if (number? b) (scalar b int32) b)) float32))
-(defn neq? [a b] (.astype (not-equal (if (number? a) (scalar a int32) a)
-                                     (if (number? b) (scalar b int32) b)) float32))
-(defn gt?  [a b] (.astype (greater (if (number? a) (scalar a) a)
-                                   (if (number? b) (scalar b) b)) float32))
-(defn lt?  [a b] (.astype (less (if (number? a) (scalar a) a)
-                                (if (number? b) (scalar b) b)) float32))
+(defn- ->cmp
+  "Coerce a number to a comparison operand; pass MLX arrays through.
+   eq?/neq? promote integers (dt int32); gt?/lt? use the float32 default."
+  ([x] (if (number? x) (scalar x) x))
+  ([x dt] (if (number? x) (scalar x dt) x)))
+
+(defn eq?  [a b] (.astype (equal (->cmp a int32) (->cmp b int32)) float32))
+(defn neq? [a b] (.astype (not-equal (->cmp a int32) (->cmp b int32)) float32))
+(defn gt?  [a b] (.astype (greater (->cmp a) (->cmp b)) float32))
+(defn lt?  [a b] (.astype (less (->cmp a) (->cmp b)) float32))
 (defn and* [a b] (multiply a b))
 (defn or*  [a b] (maximum a b))
 
@@ -499,6 +501,11 @@
            a)
          args))))
 
+(defn- ->argnum-vec
+  "Normalize an argnums spec (int or vector) to a vector of arg indices."
+  [argnums]
+  (if (vector? argnums) argnums [argnums]))
+
 (defn grad
   "Returns a function that computes gradients of f w.r.t. its arguments.
    The returned function builds a backward-pass graph lazily — gradient
@@ -514,7 +521,7 @@
    (fn [& args]
      (swap! grad-depth inc)
      (try
-       (let [argnum-vec (if (vector? argnums) argnums [argnums])
+       (let [argnum-vec (->argnum-vec argnums)
              grads (.computeGradients M f (grad-args args))]
          (if (= 1 (count argnum-vec))
            (aget grads (first argnum-vec))
@@ -537,7 +544,7 @@
      (try
        (let [result (.valueAndGrad M f (grad-args args))
              v (aget result 0)
-             argnum-vec (if (vector? argnums) argnums [argnums])
+             argnum-vec (->argnum-vec argnums)
              g (if (= 1 (count argnum-vec))
                  (aget result (inc (first argnum-vec)))
                  (mapv #(aget result (inc %)) argnum-vec))]
@@ -741,6 +748,15 @@
 
 (def ^:private cache-pressure-threshold (* 512 1024 1024))
 
+(defn- cleanup-if-cache-pressure!
+  "Run a GC/cache sweep when the Metal cache exceeds the pressure threshold."
+  []
+  (when (> (get-cache-memory) cache-pressure-threshold)
+    (jsc-cleanup!)
+    (when gc-fn (gc-fn))
+    (sweep-dead-arrays!)
+    (clear-cache!)))
+
 (defn tidy-materialize [f]
   (let [r (tidy f)] (eval! r) r))
 
@@ -752,11 +768,7 @@
               (when (seq arrays) (apply eval! arrays))
               (vreset! result-vol result)
               (to-array arrays))))
-    (when (> (get-cache-memory) cache-pressure-threshold)
-      (jsc-cleanup!)
-      (when gc-fn (gc-fn))
-      (sweep-dead-arrays!)
-      (clear-cache!))
+    (cleanup-if-cache-pressure!)
     @result-vol))
 
 (defn tidy-scalar [f]
@@ -766,11 +778,7 @@
               (eval! arr)
               (vreset! result-vol (item arr))
               (to-array [arr]))))
-    (when (> (get-cache-memory) cache-pressure-threshold)
-      (jsc-cleanup!)
-      (when gc-fn (gc-fn))
-      (sweep-dead-arrays!)
-      (clear-cache!))
+    (cleanup-if-cache-pressure!)
     @result-vol))
 
 (defn force-gc! []

--- a/src/genmlx/mlx/constants.cljs
+++ b/src/genmlx/mlx/constants.cljs
@@ -1,0 +1,28 @@
+(ns genmlx.mlx.constants
+  "Shared cached MLX scalar constants and log constants.
+
+   Defined once here and referenced everywhere, instead of re-allocating the
+   same (mx/scalar 0.0) etc. in each consumer. MLX arrays are immutable —
+   mx/add and friends always create new arrays — so a single cached scalar is
+   safe to share across namespaces.
+
+   This is a leaf namespace: it requires only genmlx.mlx, which every consumer
+   already reaches, so it introduces no circular dependency."
+  (:require [genmlx.mlx :as mx]))
+
+;; Plain numeric log constant (host-side, for arithmetic before mx/scalar).
+(def LOG-2PI (js/Math.log (* 2.0 js/Math.PI)))
+
+;; Cached MLX scalar constants.
+(def ZERO (mx/scalar 0.0))
+(def ONE (mx/scalar 1.0))
+(def TWO (mx/scalar 2.0))
+(def THREE (mx/scalar 3.0))
+(def HALF (mx/scalar 0.5))
+(def NEG-INF (mx/scalar ##-Inf))
+(def LOG-2 (mx/scalar (js/Math.log 2.0)))
+(def LOG-2PI-HALF (mx/scalar (* 0.5 LOG-2PI)))
+(def LOG-PI (mx/scalar (js/Math.log js/Math.PI)))
+(def MLX-PI (mx/scalar js/Math.PI))
+(def SQRT-TWO (mx/scalar (js/Math.sqrt 2.0)))
+(def TINY (mx/scalar 1e-30))

--- a/src/genmlx/mlx/random.cljs
+++ b/src/genmlx/mlx/random.cljs
@@ -82,10 +82,17 @@
     (fresh-key)
     (do (check-key key "ensure-key") key)))
 
-(defn split-or-nils [key]
+(defn split-or-nils
+  "Split key like split, but return [nil nil] when key is nil (no-key mode).
+   Lets callers thread sub-keys unconditionally while preserving nil-as-no-
+   entropy."
+  [key]
   (if key (split key) [nil nil]))
 
-(defn split-n-or-nils [key n]
+(defn split-n-or-nils
+  "Split key into n sub-keys like split-n, but return n nils when key is nil
+   (no-key mode), preserving nil-as-no-entropy for unconditional threading."
+  [key n]
   (if key (split-n key n) (vec (repeat n nil))))
 
 ;; =========================================================================
@@ -93,33 +100,54 @@
 ;; Shapes are plain clj->js number[] -- no to-big-shape conversion.
 ;; =========================================================================
 
-(defn normal [key shape]
+(defn normal
+  "Standard-normal N(0,1) samples of the given shape (a clj shape vector)."
+  [key shape]
   (.keyNormal c key (clj->js shape)))
 
-(defn uniform [key shape]
+(defn uniform
+  "Uniform [0,1) samples of the given shape (a clj shape vector)."
+  [key shape]
   (.keyUniform c key (clj->js shape)))
 
-(defn bernoulli [key p shape]
+(defn bernoulli
+  "Bernoulli(p) 0/1 samples of the given shape (a clj shape vector)."
+  [key p shape]
   (.keyBernoulli c key p (clj->js shape)))
 
-(defn categorical [key logits]
+(defn categorical
+  "Sample category indices from unnormalized logits along its last axis;
+   returns one index per leading-batch row."
+  [key logits]
   (.keyCategorical c key logits))
 
-(defn randint [key lo hi shape]
+(defn randint
+  "Uniform integers in [lo, hi) of the given shape (a clj shape vector)."
+  [key lo hi shape]
   (.keyRandint c key lo hi (clj->js shape)))
 
-(defn gumbel [key shape]
+(defn gumbel
+  "Standard Gumbel samples of the given shape (a clj shape vector)."
+  [key shape]
   (.keyGumbel c key (clj->js shape)))
 
-(defn laplace [key shape]
+(defn laplace
+  "Standard Laplace samples of the given shape (a clj shape vector)."
+  [key shape]
   (.keyLaplace c key (clj->js shape)))
 
-(defn truncated-normal [key lower upper shape]
+(defn truncated-normal
+  "Standard-normal samples truncated to [lower, upper], of the given shape
+   (a clj shape vector). Bounds are coerced to MLX arrays."
+  [key lower upper shape]
   (.keyTruncatedNormal c key
     (mx/ensure-array lower) (mx/ensure-array upper)
     (clj->js shape)))
 
 (defn multivariate-normal
+  "Multivariate-normal samples with the given mean vector and covariance
+   matrix; shape (a clj shape vector, default []) gives extra leading batch
+   dims. mean/cov are coerced to MLX arrays."
   ;; mx/array passes MLX arrays through unchanged, so no array?-guard is needed.
   ([key mean cov] (multivariate-normal key mean cov []))
   ([key mean cov shape]

--- a/src/genmlx/mlx/random.cljs
+++ b/src/genmlx/mlx/random.cljs
@@ -120,16 +120,11 @@
     (clj->js shape)))
 
 (defn multivariate-normal
-  ([key mean cov]
-   (.keyMultivariateNormal c key
-     (if (mx/array? mean) mean (mx/array mean))
-     (if (mx/array? cov) cov (mx/array cov))
-     #js []))
+  ;; mx/array passes MLX arrays through unchanged, so no array?-guard is needed.
+  ([key mean cov] (multivariate-normal key mean cov []))
   ([key mean cov shape]
    (.keyMultivariateNormal c key
-     (if (mx/array? mean) mean (mx/array mean))
-     (if (mx/array? cov) cov (mx/array cov))
-     (clj->js shape))))
+     (mx/array mean) (mx/array cov) (clj->js shape))))
 
 (defn- permutation
   ([key n]

--- a/src/genmlx/nn.cljs
+++ b/src/genmlx/nn.cljs
@@ -127,7 +127,7 @@
 (defn parameters
   "Parameter arrays in deterministic sorted order."
   [layer]
-  (mapv #(get (:params layer) %) (param-keys layer)))
+  (mapv (:params layer) (param-keys layer)))
 
 ;; ---------------------------------------------------------------------------
 ;; Rebuild layer with new parameter values
@@ -196,13 +196,11 @@
                             ;; prefixed keys. Uses direct `get` on new-params
                             ;; to preserve traced array identity for autograd.
                             child-param-keys (keys (:params child))
-                            child-params (reduce
-                                           (fn [acc ck]
-                                             (let [pk (keyword (str prefix (name ck)))]
-                                               (if-let [v (get new-params pk)]
-                                                 (assoc acc ck v)
-                                                 acc)))
-                                           {} child-param-keys)]
+                            child-params (into {}
+                                               (keep (fn [ck]
+                                                       (when-let [v (get new-params (keyword (str prefix (name ck))))]
+                                                         [ck v])))
+                                               child-param-keys)]
                         (if (empty? child-params)
                           child
                           (rebuild-with-params child child-params))))
@@ -301,7 +299,7 @@
                         (let [new-params (zipmap keys-sorted (vec param-args))
                               new-layer  (rebuild-with-params layer new-params)]
                           (apply loss-fn (:forward new-layer) inputs)))
-          param-arrays (mapv #(get (:params layer) %) keys-sorted)
+          param-arrays (mapv (:params layer) keys-sorted)
           argnums     (vec (range n-params))
           vg-fn       (mx/value-and-grad flat-fn argnums)
           [loss grads] (apply vg-fn param-arrays)
@@ -316,9 +314,9 @@
 (defn- sgd-step [lr]
   (let [lr-s (mx/scalar lr)]
     (fn [params grads]
-      (into {} (map (fn [[k v]]
-                      [k (mx/subtract v (mx/multiply lr-s (get grads k)))])
-                    params)))))
+      (reduce-kv (fn [acc k v]
+                   (assoc acc k (mx/subtract v (mx/multiply lr-s (get grads k)))))
+                 {} params))))
 
 (defn- adam-step [lr {:keys [beta1 beta2 eps] :or {beta1 0.9 beta2 0.999 eps 1e-8}}]
   (let [state (atom {:m {} :v {} :t 0})]
@@ -361,7 +359,9 @@
                    wds (mx/scalar (- 1.0 (* lr wd)))
                    inner (adam-step lr opts)]
                (fn [params grads]
-                 (inner (into {} (map (fn [[k v]] [k (mx/multiply v wds)]) params))
+                 (inner (reduce-kv (fn [acc k v]
+                                     (assoc acc k (mx/multiply v wds)))
+                                   {} params)
                         grads))))))
 
 ;; ---------------------------------------------------------------------------

--- a/src/genmlx/nn.cljs
+++ b/src/genmlx/nn.cljs
@@ -353,15 +353,16 @@
   "Create an optimizer function: (fn [params grads] -> new-params).
    type: :sgd, :adam, or :adamw."
   [type lr & {:as opts}]
-  (case type
-    :sgd   (sgd-step lr)
-    :adam  (adam-step lr (or opts {}))
-    :adamw (let [wd  (or (:weight-decay opts) 0.01)
-                 wds (mx/scalar (- 1.0 (* lr wd)))
-                 inner (adam-step lr (or opts {}))]
-             (fn [params grads]
-               (inner (into {} (map (fn [[k v]] [k (mx/multiply v wds)]) params))
-                      grads)))))
+  (let [opts (or opts {})]
+    (case type
+      :sgd   (sgd-step lr)
+      :adam  (adam-step lr opts)
+      :adamw (let [wd  (:weight-decay opts 0.01)
+                   wds (mx/scalar (- 1.0 (* lr wd)))
+                   inner (adam-step lr opts)]
+               (fn [params grads]
+                 (inner (into {} (map (fn [[k v]] [k (mx/multiply v wds)]) params))
+                        grads))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Training

--- a/src/genmlx/nn.cljs
+++ b/src/genmlx/nn.cljs
@@ -217,43 +217,50 @@
 ;; NeuralNetGF — wraps a layer as a deterministic generative function
 ;; ---------------------------------------------------------------------------
 
+;; Deterministic GF: score and all weights/projections are zero.
+(def ^:private ZERO (mx/scalar 0.0))
+
+(defn- run-forward
+  "Run the wrapped layer's forward pass on the first arg."
+  [layer-ref args]
+  ((:forward @layer-ref) (first args)))
+
 (defrecord NeuralNetGF [layer-ref]
   ;; layer-ref is an atom containing a layer map.
   p/IGenerativeFunction
   (simulate [this args]
-    (let [layer @layer-ref
-          retval ((:forward layer) (first args))]
+    (let [retval (run-forward layer-ref args)]
       (tr/make-trace {:gen-fn this :args args
                       :choices cm/EMPTY :retval retval
-                      :score (mx/scalar 0.0)})))
+                      :score ZERO})))
 
   p/IGenerate
   (generate [this args constraints]
-    {:trace (p/simulate this args) :weight (mx/scalar 0.0)})
+    {:trace (p/simulate this args) :weight ZERO})
 
   p/IAssess
   (assess [this args choices]
-    {:retval ((:forward @layer-ref) (first args)) :weight (mx/scalar 0.0)})
+    {:retval (run-forward layer-ref args) :weight ZERO})
 
   p/IPropose
   (propose [this args]
-    {:choices cm/EMPTY :weight (mx/scalar 0.0)
-     :retval ((:forward @layer-ref) (first args))})
+    {:choices cm/EMPTY :weight ZERO
+     :retval (run-forward layer-ref args)})
 
   p/IUpdate
   (update [this trace constraints]
     {:trace (p/simulate this (:args trace))
-     :weight (mx/scalar 0.0)
+     :weight ZERO
      :discard cm/EMPTY})
 
   p/IRegenerate
   (regenerate [this trace selection]
     {:trace (p/simulate this (:args trace))
-     :weight (mx/scalar 0.0)})
+     :weight ZERO})
 
   p/IProject
   (project [this trace selection]
-    (mx/scalar 0.0))
+    ZERO)
 
   p/IHasArgumentGrads
   (has-argument-grads [_] [true]))

--- a/src/genmlx/program.cljs
+++ b/src/genmlx/program.cljs
@@ -205,7 +205,7 @@
                     v var-names]
                 [(keyword (str (name v) i))
                  (mx/scalar (get t (keyword (str (name v) "-next"))))])]
-    (apply cm/choicemap (mapcat identity pairs))))
+    (apply cm/choicemap (apply concat pairs))))
 
 (defn- log-sum-exp
   "Numerically stable log(sum(exp(xs)))."
@@ -288,10 +288,7 @@
 ;; ============================================================
 
 (defn- dot [a b]
-  (let [n (count a)]
-    (loop [i 0, acc 0.0]
-      (if (>= i n) acc
-          (recur (inc i) (+ acc (* (nth a i) (nth b i))))))))
+  (reduce + 0.0 (map * a b)))
 
 (defn- vsub [a b] (mapv - a b))
 

--- a/src/genmlx/program.cljs
+++ b/src/genmlx/program.cljs
@@ -328,8 +328,8 @@
       (if (< k 0) x
           (let [sum (reduce + (map (fn [j] (* (get-in aug [k j]) (nth x j)))
                                    (range (inc k) p)))
-                val (/ (- (get-in aug [k p]) sum) (get-in aug [k k]))]
-            (recur (dec k) (assoc x k val)))))))
+                x-k (/ (- (get-in aug [k p]) sum) (get-in aug [k k]))]
+            (recur (dec k) (assoc x k x-k)))))))
 
 (defn- mat-log-det
   "Log absolute determinant of a p*p matrix via Gaussian elimination."
@@ -471,9 +471,9 @@
       (let [xx (get-in gram [0 0])
             xr (nth Xtr 0)
             tau-sq (nth s0 0)
-            m-val (+ xx (/ sigma-sq tau-sq))
+            m-diag (+ xx (/ sigma-sq tau-sq))
             log-det (js/Math.log (+ 1.0 (/ (* tau-sq xx) sigma-sq)))
-            quad (/ (- rr (/ (* xr xr) m-val)) sigma-sq)]
+            quad (/ (- rr (/ (* xr xr) m-diag)) sigma-sq)]
         (+ (* -0.5 n (js/Math.log (* 2.0 js/Math.PI sigma-sq)))
            (* -0.5 log-det)
            (* -0.5 quad)))
@@ -1003,10 +1003,10 @@
                                           (fn [m var-key col-i]
                                             (if col-i
                                               (let [raw (nth fields col-i "")
-                                                    val (when (and (seq raw) (not= raw "NA"))
-                                                          (js/parseFloat raw))]
-                                                (if (and val (not (js/isNaN val)))
-                                                  (assoc m var-key val)
+                                                    x-val (when (and (seq raw) (not= raw "NA"))
+                                                            (js/parseFloat raw))]
+                                                (if (and x-val (not (js/isNaN x-val)))
+                                                  (assoc m var-key x-val)
                                                   m))
                                               m))
                                           {}

--- a/src/genmlx/rewrite.cljs
+++ b/src/genmlx/rewrite.cljs
@@ -29,6 +29,15 @@
   (-apply [this graph schema constraints]
     "Apply the rule. Returns {:graph' :handlers :eliminated :description}"))
 
+(defn- prune-eliminated
+  "Remove the `eliminated` address set from the graph's nodes and drop any
+   edge originating at an eliminated node."
+  [graph eliminated]
+  (-> graph
+      (update :nodes #(reduce disj % eliminated))
+      (update :edges (fn [edges]
+                       (into #{} (remove (fn [[a _]] (contains? eliminated a))) edges)))))
+
 ;; ---------------------------------------------------------------------------
 ;; ConjugacyRule — eliminates conjugate prior via marginalization
 ;; ---------------------------------------------------------------------------
@@ -41,10 +50,7 @@
   (-apply [this graph schema constraints]
     (let [factory (get auto/family->handler-factory family)
           handlers (when factory (factory prior-addr obs-addrs))
-          graph' (-> graph
-                   (update :nodes disj prior-addr)
-                   (update :edges (fn [edges]
-                                    (into #{} (remove (fn [[a _]] (= a prior-addr))) edges))))]
+          graph' (prune-eliminated graph #{prior-addr})]
       {:graph' graph'
        :handlers (or handlers {})
        :eliminated #{prior-addr}
@@ -63,10 +69,7 @@
   (-apply [this graph schema constraints]
     (let [handlers (auto/make-auto-kalman-handlers chain)
           latents (set (:latent-addrs chain))
-          graph' (-> graph
-                   (update :nodes #(reduce disj % latents))
-                   (update :edges (fn [edges]
-                                    (into #{} (remove (fn [[a _]] (contains? latents a))) edges))))]
+          graph' (prune-eliminated graph latents)]
       {:graph' graph'
        :handlers handlers
        :eliminated latents
@@ -136,33 +139,24 @@
                                 conjugate-pairs)
         grouped (group-by :prior-addr remaining-pairs)
 
-        ;; For each grouped prior, check if it has non-conjugate children
-        conjugacy-rules
-        (vec
-          (keep
-            (fn [[prior-addr pairs]]
-              (let [family (:family (first pairs))
-                    obs-addrs (mapv :obs-addr pairs)
-                    non-conj (find-non-conjugate-children schema prior-addr obs-addrs)]
-                (when-not (seq non-conj)
-                  ;; Pure conjugate — can eliminate (shared priors become RaoBlackwell below)
-                  (->ConjugacyRule family prior-addr obs-addrs))))
-            grouped))
-
-        ;; RaoBlackwell rules for shared priors
-        rb-rules
-        (vec
-          (keep
-            (fn [[prior-addr pairs]]
-              (let [family (:family (first pairs))
-                    obs-addrs (mapv :obs-addr pairs)
-                    non-conj (find-non-conjugate-children schema prior-addr obs-addrs)]
-                (when (seq non-conj)
-                  (->RaoBlackwellRule prior-addr obs-addrs non-conj family))))
-            grouped))]
+        ;; One pass over grouped priors: compute non-conjugate children once and
+        ;; classify each prior as a pure-conjugate elimination (no non-conjugate
+        ;; children) or a Rao-Blackwell (shared prior with non-conjugate children).
+        classified
+        (mapv
+          (fn [[prior-addr pairs]]
+            (let [family (:family (first pairs))
+                  obs-addrs (mapv :obs-addr pairs)
+                  non-conj (find-non-conjugate-children schema prior-addr obs-addrs)]
+              (if (seq non-conj)
+                {:rb (->RaoBlackwellRule prior-addr obs-addrs non-conj family)}
+                {:conjugacy (->ConjugacyRule family prior-addr obs-addrs)})))
+          grouped)]
 
     ;; Priority ordering: Kalman first, then conjugacy, then RB
-    (vec (concat kalman-rules conjugacy-rules rb-rules))))
+    (vec (concat kalman-rules
+                 (keep :conjugacy classified)
+                 (keep :rb classified)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Rewrite engine

--- a/src/genmlx/rewrite.cljs
+++ b/src/genmlx/rewrite.cljs
@@ -110,11 +110,11 @@
   [schema prior-addr conjugate-obs-addrs]
   (let [conj-set (set conjugate-obs-addrs)
         all-sites (:trace-sites schema)]
-    (vec (keep (fn [site]
-                 (when (and (contains? (:deps site) prior-addr)
-                            (not (contains? conj-set (:addr site))))
-                   (:addr site)))
-               all-sites))))
+    (into [] (keep (fn [site]
+                     (when (and (contains? (:deps site) prior-addr)
+                                (not (contains? conj-set (:addr site))))
+                       (:addr site))))
+          all-sites)))
 
 (defn generate-rewrite-rules
   "Generate rewrite rules from schema conjugacy metadata.

--- a/src/genmlx/runtime.cljs
+++ b/src/genmlx/runtime.cljs
@@ -24,15 +24,19 @@
             [genmlx.choicemap :as cm]
             [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
+            [genmlx.mlx.constants :refer [ZERO]]
             [genmlx.selection :as sel]
             [genmlx.protocols :as p]
             [genmlx.dist.core :as dc]))
 
-(def ^:private ZERO (mx/scalar 0.0))
-
 ;; Validation hook atom. No-op by default.
 ;; genmlx.dev/start! swaps this with a real validator.
 (defonce validate-fn (atom (fn [_schema-key _value _context])))
+
+(defn- non-empty-cm?
+  "Is cm a present, non-empty choicemap?"
+  [cm]
+  (and cm (not= cm cm/EMPTY)))
 
 (defn run-handler
   "Execute body-fn under a transition-based handler, returning final state map.
@@ -79,37 +83,35 @@
                       sub-selection (when-let [s (:selection state)]
                                       (sel/get-subselection s addr))
                       sub-body-fn (:body-fn gf)
+                      ;; Common init-state keys for every batched sub-execution.
+                      base-init {:choices cm/EMPTY :score ZERO :key k2
+                                 :batch-size n :batched? true}
                       ;; Choose transition + build init-state based on mode
                       [sub-transition sub-init-state]
                       (cond
                         sub-selection
                         [h/batched-regenerate-transition
-                         {:choices cm/EMPTY :score ZERO
-                          :weight ZERO :key k2
-                          :selection sub-selection
-                          :old-choices (or sub-old-choices cm/EMPTY)
-                          :batch-size n :batched? true}]
+                         (merge base-init
+                                {:weight ZERO
+                                 :selection sub-selection
+                                 :old-choices (or sub-old-choices cm/EMPTY)})]
 
-                        (and sub-old-choices (not= sub-old-choices cm/EMPTY))
+                        (non-empty-cm? sub-old-choices)
                         [h/batched-update-transition
-                         {:choices cm/EMPTY :score ZERO
-                          :weight ZERO :key k2
-                          :constraints (or sub-constraints cm/EMPTY)
-                          :old-choices sub-old-choices
-                          :discard cm/EMPTY
-                          :batch-size n :batched? true}]
+                         (merge base-init
+                                {:weight ZERO
+                                 :constraints (or sub-constraints cm/EMPTY)
+                                 :old-choices sub-old-choices
+                                 :discard cm/EMPTY})]
 
-                        (and sub-constraints (not= sub-constraints cm/EMPTY))
+                        (non-empty-cm? sub-constraints)
                         [h/batched-generate-transition
-                         {:choices cm/EMPTY :score ZERO
-                          :weight ZERO :key k2
-                          :constraints sub-constraints
-                          :batch-size n :batched? true}]
+                         (merge base-init
+                                {:weight ZERO
+                                 :constraints sub-constraints})]
 
                         :else
-                        [h/batched-simulate-transition
-                         {:choices cm/EMPTY :score ZERO
-                          :key k2 :batch-size n :batched? true}])
+                        [h/batched-simulate-transition base-init])
                       ;; Propagate param-store to sub-execution
                       sub-init-state (if-let [ps (:param-store state)]
                                        (assoc sub-init-state :param-store ps)

--- a/src/genmlx/runtime.cljs
+++ b/src/genmlx/runtime.cljs
@@ -61,11 +61,8 @@
         ;; param closure: read a trainable parameter
         param-fn
         (fn [name default-value]
-          (let [default (if (mx/array? default-value) default-value (mx/scalar default-value))
-                ps (:param-store @vol)]
-            (if ps
-              (or (get-in ps [:params name]) default)
-              default)))
+          (let [default (if (mx/array? default-value) default-value (mx/scalar default-value))]
+            (or (get-in @vol [:param-store :params name]) default)))
 
         ;; splice closure: call a sub-generative-function
         splice-fn

--- a/src/genmlx/schema.cljs
+++ b/src/genmlx/schema.cljs
@@ -174,28 +174,13 @@
                        (or pairs []))]
       (walk-forms acc' env' body))))
 
-(defn- handle-branch [acc env args]
-  ;; For if/when/when-not/if-let/when-let/if-not
-  (let [has-trace? (some contains-gen-call? args)]
-    (cond-> (walk-forms acc env args)
-      has-trace? (assoc :has-branches? true))))
-
-(defn- handle-cond [acc env args]
-  (let [has-trace? (some contains-gen-call? args)]
-    (cond-> (walk-forms acc env args)
-      has-trace? (assoc :has-branches? true))))
-
-(defn- handle-case [acc env args]
-  ;; case: (case expr val1 result1 val2 result2 ... default?)
-  (let [has-trace? (some contains-gen-call? (rest args))]
-    (cond-> (walk-forms acc env args)
-      has-trace? (assoc :has-branches? true))))
-
-(defn- handle-and-or [acc env args]
-  ;; and/or with traces → branches (short-circuit = conditional execution)
-  (let [has-trace? (some contains-gen-call? args)]
-    (cond-> (walk-forms acc env args)
-      has-trace? (assoc :has-branches? true))))
+(defn- handle-branching
+  ;; if/when/cond/and/or/case — walk every arg, but a trace anywhere in `scan`
+  ;; means execution is conditional, so flag :has-branches?. `scan` is the full
+  ;; arg list for everything except case, where the dispatch expr is skipped.
+  [acc env args scan]
+  (cond-> (walk-forms acc env args)
+    (some contains-gen-call? scan) (assoc :has-branches? true)))
 
 ;; =========================================================================
 ;; Loop analysis helpers (VIS-M3)
@@ -556,16 +541,16 @@
       "splice" (handle-splice acc env args)
       "param" (handle-param acc env args)
       "let" (handle-let acc env args)
-      "if" (handle-branch acc env args)
-      "when" (handle-branch acc env args)
-      "when-not" (handle-branch acc env args)
-      "when-let" (handle-branch acc env args)
-      "if-let" (handle-branch acc env args)
-      "if-not" (handle-branch acc env args)
-      "cond" (handle-cond acc env args)
-      "case" (handle-case acc env args)
-      "and" (handle-and-or acc env args)
-      "or" (handle-and-or acc env args)
+      "if" (handle-branching acc env args args)
+      "when" (handle-branching acc env args args)
+      "when-not" (handle-branching acc env args args)
+      "when-let" (handle-branching acc env args args)
+      "if-let" (handle-branching acc env args args)
+      "if-not" (handle-branching acc env args args)
+      "cond" (handle-branching acc env args args)
+      "case" (handle-branching acc env args (rest args))
+      "and" (handle-branching acc env args args)
+      "or" (handle-branching acc env args args)
       "do" (walk-forms acc env args)
       "doseq" (handle-loop-form (assoc acc :current-loop-type :doseq) env args)
       "dotimes" (handle-loop-form (assoc acc :current-loop-type :dotimes) env args)

--- a/src/genmlx/schema.cljs
+++ b/src/genmlx/schema.cljs
@@ -41,29 +41,45 @@
     (vector? form) (into #{} (mapcat find-symbols) form)
     :else #{}))
 
+(defn- deps-of-syms
+  "Resolve a set of symbols to the union of trace addresses they depend on,
+   given the current binding environment (env maps symbols to #{trace-addrs})."
+  [env syms]
+  (reduce (fn [deps sym]
+            (if-let [trace-addrs (get env sym)]
+              (into deps trace-addrs)
+              deps))
+          #{}
+          syms))
+
 (defn- compute-deps
   "Compute the set of trace addresses that a form depends on,
    given the current binding environment.
    env maps symbols to #{trace-addrs} they depend on."
   [env form]
-  (let [syms (find-symbols form)]
-    (reduce (fn [deps sym]
-              (if-let [trace-addrs (get env sym)]
-                (into deps trace-addrs)
-                deps))
-            #{}
-            syms)))
+  (deps-of-syms env (find-symbols form)))
+
+(defn- head-sym
+  "The head symbol of a non-empty list form, or nil."
+  [form]
+  (when (and (seq? form) (seq form) (symbol? (first form)))
+    (first form)))
+
+(defn- call-named?
+  "True when form is a call whose head symbol's name is n
+   (e.g. (call-named? form \"trace\"))."
+  [form n]
+  (when-let [h (head-sym form)]
+    (= n (name h))))
 
 (defn- contains-gen-call?
   "Does this form recursively contain any trace, splice, or param calls?"
   [form]
   (cond
     (and (seq? form) (seq form))
-    (let [head (first form)]
-      (or (and (symbol? head)
-               (let [n (name head)]
-                 (or (= n "trace") (= n "splice") (= n "param"))))
-          (some contains-gen-call? form)))
+    (or (when-let [h (head-sym form)]
+          (contains? #{"trace" "splice" "param"} (name h)))
+        (some contains-gen-call? form))
 
     (and (vector? form) (seq form))
     (some contains-gen-call? form)
@@ -140,10 +156,7 @@
                               ;; Simple symbol binding — track deps in env
                              (let [val-deps (compute-deps env val-form)
                                     ;; If val-form is a trace call, include the trace addr
-                                   is-trace? (and (seq? val-form)
-                                                  (seq val-form)
-                                                  (symbol? (first val-form))
-                                                  (= "trace" (name (first val-form))))
+                                   is-trace? (call-named? val-form "trace")
                                    trace-addr (when (and is-trace?
                                                          (keyword? (second val-form)))
                                                 (second val-form))
@@ -330,14 +343,11 @@
 (defn- contains-branch-with-trace?
   "Check if forms contain a branch (if/when/cond) that has trace calls."
   [forms]
-  (let [trace-call? (fn [f]
-                      (and (seq? f) (seq f)
-                           (symbol? (first f))
-                           (= "trace" (name (first f)))))]
+  (let [trace-call? #(call-named? % "trace")]
     (some (fn check [form]
             (cond
-              (and (seq? form) (seq form) (symbol? (first form)))
-              (let [n (name (first form))]
+              (head-sym form)
+              (let [n (name (head-sym form))]
                 (if (#{"if" "when" "when-not" "cond" "case" "if-let" "when-let" "if-not"} n)
                   (seq (find-all-calls (rest form) trace-call?))
                   (some check (rest form))))
@@ -351,18 +361,9 @@
    loop-syms: set of symbols bound by the loop (element + index).
    env: outer binding environment."
   [body loop-syms env]
-  (let [trace-call? (fn [f]
-                      (and (seq? f) (seq f)
-                           (symbol? (first f))
-                           (= "trace" (name (first f)))))
-        splice-call? (fn [f]
-                       (and (seq? f) (seq f)
-                            (symbol? (first f))
-                            (= "splice" (name (first f)))))
-        param-call? (fn [f]
-                      (and (seq? f) (seq f)
-                           (symbol? (first f))
-                           (= "param" (name (first f)))))
+  (let [trace-call? #(call-named? % "trace")
+        splice-call? #(call-named? % "splice")
+        param-call? #(call-named? % "param")
         traces (find-all-calls body trace-call?)
         splices (find-all-calls body splice-call?)
         params (find-all-calls body param-call?)]
@@ -376,12 +377,7 @@
                    all-syms (find-symbols dist-form)
                    element-deps (set/intersection all-syms loop-syms)
                    outer-dep-syms (set/difference all-syms loop-syms)
-                   outer-deps (reduce (fn [deps sym]
-                                        (if-let [addrs (get env sym)]
-                                          (into deps addrs)
-                                          deps))
-                                      #{}
-                                      outer-dep-syms)]
+                   outer-deps (deps-of-syms env outer-dep-syms)]
                {:addr :dynamic
                 :addr-form addr-form
                 :addr-pattern (detect-addr-pattern addr-form)

--- a/src/genmlx/schema.cljs
+++ b/src/genmlx/schema.cljs
@@ -136,10 +136,11 @@
         (cond-> (not static?) (assoc :dynamic-addresses? true)))))
 
 (defn- handle-param [acc env args]
-  (let [acc' (when (second args)
-               (walk-form acc env (second args)))]
-    (update (or acc' acc) :param-sites conj {:name (first args)
-                                             :default-form (second args)})))
+  (let [acc' (if-let [default (second args)]
+               (walk-form acc env default)
+               acc)]
+    (update acc' :param-sites conj {:name (first args)
+                                    :default-form (second args)})))
 
 (defn- handle-let [acc env args]
   (if (empty? args)

--- a/src/genmlx/schema.cljs
+++ b/src/genmlx/schema.cljs
@@ -438,15 +438,17 @@
             ;; (handle-call passes the form type via the acc's :current-loop-type)
             loop-type (or (:current-loop-type acc) :doseq)
             ;; Analyze bindings based on type
-            bind-info (case loop-type
-                        :doseq (analyze-doseq-bindings bindings-form)
-                        :dotimes (analyze-dotimes-bindings bindings-form)
-                        :for (analyze-for-bindings bindings-form)
-                        nil)
+            {:keys [element-sym index-sym collection-form]
+             count-form* :count-form}
+            (case loop-type
+              :doseq (analyze-doseq-bindings bindings-form)
+              :dotimes (analyze-dotimes-bindings bindings-form)
+              :for (analyze-for-bindings bindings-form)
+              nil)
             ;; Collect loop binding symbols for dep classification
             loop-syms (into #{}
                             (filter symbol?)
-                            [(:element-sym bind-info) (:index-sym bind-info)])
+                            [element-sym index-sym])
             ;; Extract loop-specific trace/splice/param sites
             loop-body-info (extract-loop-trace-sites body loop-syms env)
             loop-traces (:trace-sites loop-body-info)
@@ -457,18 +459,18 @@
             ;; Infer count expression
             count-form (cond
                          (= loop-type :dotimes)
-                         (:count-form bind-info)
+                         count-form*
                          ;; For doseq/for, count is (count collection)
-                         (:collection-form bind-info)
-                         (list 'count (:collection-form bind-info))
+                         collection-form
+                         (list 'count collection-form)
                          :else nil)
             ;; Build loop-site entry
             loop-site (merge
                        {:type loop-type
                         :bindings-form bindings-form
-                        :element-sym (:element-sym bind-info)
-                        :index-sym (:index-sym bind-info)
-                        :collection-form (:collection-form bind-info)
+                        :element-sym element-sym
+                        :index-sym index-sym
+                        :collection-form collection-form
                         :count-form count-form
                         :trace-sites loop-traces
                         :splice-sites loop-splices

--- a/src/genmlx/schemas.cljs
+++ b/src/genmlx/schemas.cljs
@@ -28,11 +28,6 @@
   [x]
   (instance? tr/Trace x))
 
-(defn mlx-array?
-  "True if x is an MLX array (has .shape property)."
-  [x]
-  (and (some? x) (some? (.-shape x))))
-
 ;; Named leaf schemas — reference these instead of repeating the [:fn ...] form.
 (def ChoiceMap
   "A GenMLX choice map (Node or Value)."

--- a/src/genmlx/schemas.cljs
+++ b/src/genmlx/schemas.cljs
@@ -33,6 +33,15 @@
   [x]
   (and (some? x) (some? (.-shape x))))
 
+;; Named leaf schemas — reference these instead of repeating the [:fn ...] form.
+(def ChoiceMap
+  "A GenMLX choice map (Node or Value)."
+  [:fn {:error/message "should be a ChoiceMap"} choicemap?])
+
+(def Trace
+  "A GenMLX Trace record."
+  [:fn {:error/message "should be a Trace"} trace?])
+
 ;; ---------------------------------------------------------------------------
 ;; Handler state schemas
 ;; ---------------------------------------------------------------------------
@@ -41,7 +50,7 @@
   "[T] section 2.3.1 trace ADT internal state. Keys common to all handler modes."
   [:map
    [:key some?]
-   [:choices [:fn {:error/message "should be a ChoiceMap"} choicemap?]]
+   [:choices ChoiceMap]
    [:score some?]
    [:executor {:optional true} fn?]])
 
@@ -54,7 +63,7 @@
   (mu/merge BaseState
     [:map
      [:weight some?]
-     [:constraints [:fn {:error/message "should be a ChoiceMap"} choicemap?]]]))
+     [:constraints ChoiceMap]]))
 
 (def AssessState
   "Handler state for assess mode. Same shape as generate."
@@ -64,15 +73,15 @@
   "[T] section 2.3.1, Def 2.3.1 h_update. Adds :old-choices and :discard."
   (mu/merge GenerateState
     [:map
-     [:old-choices [:fn {:error/message "should be a ChoiceMap"} choicemap?]]
-     [:discard [:fn {:error/message "should be a ChoiceMap"} choicemap?]]]))
+     [:old-choices ChoiceMap]
+     [:discard ChoiceMap]]))
 
 (def RegenerateState
   "[T] section 4.1.2 regenerate with internal proposal. Adds :old-choices and :selection."
   (mu/merge BaseState
     [:map
      [:weight some?]
-     [:old-choices [:fn {:error/message "should be a ChoiceMap"} choicemap?]]
+     [:old-choices ChoiceMap]
      [:selection some?]]))
 
 (def ProjectState
@@ -80,9 +89,9 @@
   (mu/merge BaseState
     [:map
      [:weight some?]
-     [:old-choices [:fn {:error/message "should be a ChoiceMap"} choicemap?]]
+     [:old-choices ChoiceMap]
      [:selection some?]
-     [:constraints [:fn {:error/message "should be a ChoiceMap"} choicemap?]]]))
+     [:constraints ChoiceMap]]))
 
 ;; ---------------------------------------------------------------------------
 ;; Sub-result schema (merge-sub-result input)
@@ -94,11 +103,11 @@
    (present only in generate/update modes). :weight may be nil in
    simulate mode (combinators set it explicitly to nil)."
   [:map
-   [:choices [:fn {:error/message "should be a ChoiceMap"} choicemap?]]
+   [:choices ChoiceMap]
    [:score some?]
    [:retval {:optional true} any?]
    [:weight {:optional true} any?]
-   [:discard {:optional true} [:or nil? [:fn {:error/message "should be a ChoiceMap"} choicemap?]]]
+   [:discard {:optional true} [:or nil? ChoiceMap]]
    [:splice-scores {:optional true} map?]])
 
 ;; ---------------------------------------------------------------------------
@@ -107,27 +116,27 @@
 
 (def SimulateReturn
   "[T] Def 2.1.16, section 2.3.1 SIMULATE. Return value of p/simulate: a Trace."
-  [:fn {:error/message "should be a Trace"} trace?])
+  Trace)
 
 (def GenerateReturn
   "[T] section 2.3.1 GENERATE. Return value: {:trace Trace :weight MLX-scalar}."
   [:map
-   [:trace [:fn {:error/message "should be a Trace"} trace?]]
+   [:trace Trace]
    [:weight some?]
    [:unused-constraints {:optional true} set?]])
 
 (def UpdateReturn
   "[T] section 2.3.1 UPDATE. Return value: {:trace Trace :weight MLX-scalar :discard ChoiceMap}."
   [:map
-   [:trace [:fn {:error/message "should be a Trace"} trace?]]
+   [:trace Trace]
    [:weight some?]
-   [:discard [:fn {:error/message "should be a ChoiceMap"} choicemap?]]
+   [:discard ChoiceMap]
    [:unused-constraints {:optional true} set?]])
 
 (def RegenerateReturn
   "[T] section 4.1.2, Eq 4.1. Return value: {:trace Trace :weight MLX-scalar}."
   [:map
-   [:trace [:fn {:error/message "should be a Trace"} trace?]]
+   [:trace Trace]
    [:weight some?]])
 
 (def AssessReturn
@@ -139,7 +148,7 @@
 (def ProposeReturn
   "[D] propose. Return value: {:choices ChoiceMap :weight MLX-scalar :retval any}."
   [:map
-   [:choices [:fn {:error/message "should be a ChoiceMap"} choicemap?]]
+   [:choices ChoiceMap]
    [:weight some?]
    [:retval some?]])
 

--- a/src/genmlx/selection.cljs
+++ b/src/genmlx/selection.cljs
@@ -7,26 +7,25 @@
   (selected?        [s addr] "Is this address selected?")
   (get-subselection [s addr] "Get the selection for addresses under this one."))
 
-;; Select all addresses
 (def all
+  "Selection that selects every address; its subselection is itself."
   (reify ISelection
     (selected? [_ _] true)
     (get-subselection [_ _] all)))
 
-;; Select no addresses
 (def none
+  "Selection that selects no address; its subselection is itself."
   (reify ISelection
     (selected? [_ _] false)
     (get-subselection [_ _] none)))
 
-;; Select specific addresses (flat)
 (defrecord SelectAddrs [addrs]
   ISelection
   (selected? [_ addr] (contains? addrs addr))
   (get-subselection [_ _] all))
 
 (defn select
-  "Create a selection of specific addresses.
+  "Create a flat selection of specific addresses.
    (select :x :y :z)"
   [& addrs]
   (->SelectAddrs (set addrs)))

--- a/src/genmlx/serialize.cljs
+++ b/src/genmlx/serialize.cljs
@@ -78,10 +78,8 @@
         {:type "clj" :value (pr-str v)}))
 
     (instance? cm/Node cm-node)
-    (into {}
-      (map (fn [[k sub]]
-             [(name k) (choicemap->data sub)])
-           (cm/-submaps cm-node)))
+    (-> (update-keys (:m cm-node) name)
+        (update-vals choicemap->data))
 
     :else {}))
 
@@ -105,11 +103,8 @@
 
     ;; Node: map of string -> sub
     (map? data)
-    (cm/->Node
-      (into {}
-        (map (fn [[k v]]
-               [(keyword k) (data->choicemap v)])
-             data)))
+    (cm/->Node (-> (update-keys data keyword)
+                   (update-vals data->choicemap)))
 
     :else cm/EMPTY))
 
@@ -123,7 +118,7 @@
   (cond
     (mx/array? v)   (mlx-value->data v)
     (sequential? v) (mapv serialize-value v)
-    (map? v)        (into {} (map (fn [[k val]] [(name k) (serialize-value val)]) v))
+    (map? v)        (-> (update-keys v name) (update-vals serialize-value))
     (keyword? v)    {:type "keyword" :value (name v)}
     :else           v))
 
@@ -138,7 +133,7 @@
     (keyword (:value v))
 
     (sequential? v) (mapv deserialize-value v)
-    (map? v)        (into {} (map (fn [[k val]] [(keyword k) (deserialize-value val)]) v))
+    (map? v)        (-> (update-keys v keyword) (update-vals deserialize-value))
     :else           v))
 
 ;; ---------------------------------------------------------------------------

--- a/src/genmlx/serialize.cljs
+++ b/src/genmlx/serialize.cljs
@@ -85,13 +85,18 @@
 
     :else {}))
 
+(defn- mlx-data?
+  "Is data a serialized MLX leaf (a map tagged :type \"scalar\" or \"array\")?"
+  [data]
+  (and (map? data) (contains? data :type)
+       (or (= "scalar" (:type data)) (= "array" (:type data)))))
+
 (defn- data->choicemap
   "Recursively convert serializable data back to a ChoiceMap."
   [data]
   (cond
     ;; Leaf: MLX scalar or array
-    (and (map? data) (contains? data :type)
-         (or (= "scalar" (:type data)) (= "array" (:type data))))
+    (mlx-data? data)
     (cm/->Value (data->mlx-value data))
 
     ;; Leaf: CLJ value (pr-str'd)
@@ -126,8 +131,7 @@
   "Deserialize a value that may contain MLX arrays."
   [v]
   (cond
-    (and (map? v) (contains? v :type)
-         (or (= "scalar" (:type v)) (= "array" (:type v))))
+    (mlx-data? v)
     (data->mlx-value v)
 
     (and (map? v) (= "keyword" (:type v)))
@@ -152,14 +156,19 @@
                gen-fn-id (assoc :gen-fn-id gen-fn-id))]
     (js/JSON.stringify (clj->js data) nil 2)))
 
-(defn load-choices
-  "Deserialize a JSON string to a ChoiceMap."
+(defn- parse-versioned
+  "Parse a JSON string and assert it is serialization version 1."
   [json-str]
   (let [data (js->clj (js/JSON.parse json-str) :keywordize-keys true)]
     (when (not= 1 (:version data))
       (throw (ex-info "Unsupported serialization version"
                       {:expected 1 :got (:version data)})))
-    (data->choicemap (:choices data))))
+    data))
+
+(defn load-choices
+  "Deserialize a JSON string to a ChoiceMap."
+  [json-str]
+  (data->choicemap (:choices (parse-versioned json-str))))
 
 (defn reconstruct-trace
   "Reconstruct a full trace from a gen-fn, args, and serialized choices JSON.
@@ -197,14 +206,11 @@
   "Deserialize a full trace JSON string. Requires the gen-fn.
    Reconstructs the trace via generate with the saved choices and args."
   [gen-fn json-str]
-  (let [data (js->clj (js/JSON.parse json-str) :keywordize-keys true)]
-    (when (not= 1 (:version data))
-      (throw (ex-info "Unsupported serialization version"
-                      {:expected 1 :got (:version data)})))
-    (let [choices (data->choicemap (:choices data))
-          args (mapv deserialize-value (:args data))
-          {:keys [trace]} (p/generate gen-fn args choices)]
-      trace)))
+  (let [data (parse-versioned json-str)
+        choices (data->choicemap (:choices data))
+        args (mapv deserialize-value (:args data))
+        {:keys [trace]} (p/generate gen-fn args choices)]
+    trace))
 
 ;; ---------------------------------------------------------------------------
 ;; File I/O convenience

--- a/src/genmlx/tensor_trace.cljs
+++ b/src/genmlx/tensor_trace.cljs
@@ -80,14 +80,12 @@
   "Pack {addr → MLX-scalar} map into [K] tensor using addr-index ordering."
   [values-map addr-index]
   (let [pairs (sort-by val addr-index)]
-    (mx/stack (mapv (fn [[addr _]] (get values-map addr)) pairs))))
+    (mx/stack (mapv (fn [[addr]] (values-map addr)) pairs))))
 
 (defn unpack-values
   "Unpack [K] tensor into {addr → MLX-scalar} map."
   [values-tensor addr-index]
-  (into {} (map (fn [[addr idx]]
-                  [addr (mx/index values-tensor idx)])
-                addr-index)))
+  (update-vals addr-index #(mx/index values-tensor %)))
 
 (defn tensor-trace->trace
   "Convert TensorTrace to standard Trace (for interop)."
@@ -105,9 +103,9 @@
    Extracts values at each address from the trace's choicemap."
   [trace addr-index]
   (let [choices (:choices trace)
-        values-map (into {} (map (fn [[addr _]]
-                                   [addr (cm/get-value (cm/get-submap choices addr))])
-                                 addr-index))
+        values-map (into {} (map (fn [addr]
+                                   [addr (cm/get-value (cm/get-submap choices addr))]))
+                         (keys addr-index))
         values-tensor (pack-values values-map addr-index)]
     (make-tensor-trace {:gen-fn (:gen-fn trace)
                         :args (:args trace)

--- a/src/genmlx/tensor_trace.cljs
+++ b/src/genmlx/tensor_trace.cljs
@@ -51,13 +51,17 @@
 ;; addr-index construction
 ;; =========================================================================
 
+(defn- sites->index
+  "Build {addr → index} from a seq of trace-sites in source order."
+  [sites]
+  (into {} (map-indexed (fn [i s] [(:addr s) i]) sites)))
+
 (defn make-addr-index
   "Build address → tensor index mapping from schema's static trace-sites.
    Uses source order (same as L1 compiled paths in prepare-static-sites),
    NOT dep-order (which may reorder independent sites)."
   [schema]
-  (let [static-sites (filterv :static? (:trace-sites schema))]
-    (into {} (map-indexed (fn [i s] [(:addr s) i]) static-sites))))
+  (sites->index (filterv :static? (:trace-sites schema))))
 
 (defn make-latent-addr-index
   "Build address → tensor index for latent sites only (excluding observed).
@@ -65,9 +69,8 @@
    observations: a ChoiceMap — addresses present in it are excluded."
   [schema observations]
   (let [obs-addrs (set (map first (cm/addresses observations)))
-        static-sites (filterv :static? (:trace-sites schema))
-        latent-sites (remove #(obs-addrs (:addr %)) static-sites)]
-    (into {} (map-indexed (fn [i s] [(:addr s) i]) latent-sites))))
+        static-sites (filterv :static? (:trace-sites schema))]
+    (sites->index (remove #(obs-addrs (:addr %)) static-sites))))
 
 ;; =========================================================================
 ;; Pack / Unpack utilities

--- a/src/genmlx/vectorized.cljs
+++ b/src/genmlx/vectorized.cljs
@@ -65,8 +65,8 @@
         choice-map))  ;; scalar constraints stay unchanged
 
     (instance? cm/Node choice-map)
-    (cm/->Node (into {} (map (fn [[k sub]] [k (child-fn k sub)])
-                             (cm/-submaps choice-map))))
+    (cm/->Node (reduce-kv (fn [acc k sub] (assoc acc k (child-fn k sub)))
+                          {} (:m choice-map)))
 
     :else choice-map))
 
@@ -89,7 +89,7 @@
     (mx/take-idx state indices)
 
     (map? state)
-    (into {} (map (fn [[k v]] [k (reindex-state v indices)]) state))
+    (update-vals state #(reindex-state % indices))
 
     (vector? state)
     (mapv #(reindex-state % indices) state)
@@ -155,4 +155,4 @@
         probs     (mx/exp log-probs)
         _         (mx/materialize! probs)
         probs-clj (mx/->clj probs)]
-    (/ 1.0 (reduce + (map #(* % %) probs-clj)))))
+    (/ 1.0 (transduce (map #(* % %)) + probs-clj))))

--- a/src/genmlx/vectorized.cljs
+++ b/src/genmlx/vectorized.cljs
@@ -121,6 +121,16 @@
   (mx/subtract (mx/logsumexp (:weight vtrace))
                (mx/scalar (js/Math.log (:n-particles vtrace)))))
 
+(defn vtrace-ess
+  "Effective sample size from a VectorizedTrace's [N] weights."
+  [vtrace]
+  (let [w (:weight vtrace)
+        log-probs (mx/subtract w (mx/logsumexp w))
+        probs     (mx/exp log-probs)
+        _         (mx/materialize! probs)
+        probs-clj (mx/->clj probs)]
+    (/ 1.0 (transduce (map #(* % %)) + probs-clj))))
+
 ;; ---------------------------------------------------------------------------
 ;; Merge two VectorizedTraces by boolean mask (for per-particle MH accept/reject)
 ;; ---------------------------------------------------------------------------
@@ -144,17 +154,3 @@
   (assoc current
     :choices (merge-choicemap-by-mask (:choices current) (:choices proposed) mask)
     :score   (mx/where mask (:score proposed) (:score current))))
-
-;; ---------------------------------------------------------------------------
-;; Diagnostics
-;; ---------------------------------------------------------------------------
-
-(defn vtrace-ess
-  "Effective sample size from a VectorizedTrace's [N] weights."
-  [vtrace]
-  (let [w (:weight vtrace)
-        log-probs (mx/subtract w (mx/logsumexp w))
-        probs     (mx/exp log-probs)
-        _         (mx/materialize! probs)
-        probs-clj (mx/->clj probs)]
-    (/ 1.0 (transduce (map #(* % %)) + probs-clj))))

--- a/src/genmlx/vectorized.cljs
+++ b/src/genmlx/vectorized.cljs
@@ -130,7 +130,9 @@
    Where mask=true takes from proposed, where false keeps current."
   [current proposed mask]
   (walk-choicemap current
-                  (fn [cv] (mx/where mask (cm/get-value proposed) cv))
+                  (fn [cv]
+                    (let [pv (cm/get-value proposed)]
+                      (mx/where mask pv cv)))
                   (fn [k sub] (merge-choicemap-by-mask
                                 sub (cm/-get-submap proposed k) mask))))
 

--- a/src/genmlx/vectorized.cljs
+++ b/src/genmlx/vectorized.cljs
@@ -16,21 +16,27 @@
 ;; Systematic resampling (returns indices as MLX int32 array)
 ;; ---------------------------------------------------------------------------
 
-(defn systematic-resample-indices
-  "Systematic resampling from [N]-shaped log-weights.
-   Returns [N] int32 MLX array of ancestor indices.
+(defn- resample-from-u0
+  "Systematic resampling core: [N] log-weights + pre-scaled u0 ([1] MLX array
+   already divided by n) → [N] int32 ancestor indices.
    GPU-accelerated: uses cumsum + searchsorted (O(N) memory and compute)."
-  [log-weights n key]
+  [log-weights n u0-scaled]
   (let [log-probs (mx/subtract log-weights (mx/logsumexp log-weights))
         probs     (mx/exp log-probs)
         cdf       (mx/cumsum probs)
-        u0        (mx/divide (rng/uniform (rng/ensure-key key) [1])
-                             (mx/scalar n))
-        thresholds (mx/add u0 (mx/divide (mx/arange 0 n 1)
-                                          (mx/scalar (float n))))
+        thresholds (mx/add u0-scaled (mx/divide (mx/arange 0 n 1)
+                                                (mx/scalar (float n))))
         indices   (mx/searchsorted cdf thresholds)
         indices   (mx/minimum indices (mx/scalar (dec n)))]
     (.astype indices mx/int32)))
+
+(defn systematic-resample-indices
+  "Systematic resampling from [N]-shaped log-weights.
+   Returns [N] int32 MLX array of ancestor indices."
+  [log-weights n key]
+  (resample-from-u0 log-weights n
+                    (mx/divide (rng/uniform (rng/ensure-key key) [1])
+                               (mx/scalar n))))
 
 (defn systematic-resample-indices-deterministic
   "Systematic resampling with pre-generated uniform u0.
@@ -38,40 +44,39 @@
    instead of a PRNG key. Suitable for use inside mx/compile-fn where
    random generation must happen outside the compiled function."
   [log-weights n u0]
-  (let [log-probs (mx/subtract log-weights (mx/logsumexp log-weights))
-        probs     (mx/exp log-probs)
-        cdf       (mx/cumsum probs)
-        u0-scaled (mx/divide u0 (mx/scalar n))
-        thresholds (mx/add u0-scaled (mx/divide (mx/arange 0 n 1)
-                                                  (mx/scalar (float n))))
-        indices   (mx/searchsorted cdf thresholds)
-        indices   (mx/minimum indices (mx/scalar (dec n)))]
-    (.astype indices mx/int32)))
+  (resample-from-u0 log-weights n (mx/divide u0 (mx/scalar n))))
 
 ;; ---------------------------------------------------------------------------
 ;; Reindex choicemap leaves
 ;; ---------------------------------------------------------------------------
 
-(defn- reindex-value
-  "Reindex a single [N]-shaped array by ancestor indices."
-  [arr indices]
-  (mx/take-idx arr indices))
+(defn- walk-choicemap
+  "Recursively walk a choicemap, dispatching on has-value?/Node/else.
+   leaf-fn is called on a [N]-shaped array leaf value and returns its
+   replacement; scalar leaves (failing the array+shape guard) pass through.
+   child-fn is called with [k sub] for each Node entry to produce the
+   recursed child."
+  [choice-map leaf-fn child-fn]
+  (cond
+    (cm/has-value? choice-map)
+    (let [v (cm/get-value choice-map)]
+      (if (and (mx/array? v) (pos? (count (mx/shape v))))
+        (cm/->Value (leaf-fn v))
+        choice-map))  ;; scalar constraints stay unchanged
+
+    (instance? cm/Node choice-map)
+    (cm/->Node (into {} (map (fn [[k sub]] [k (child-fn k sub)])
+                             (cm/-submaps choice-map))))
+
+    :else choice-map))
 
 (defn- reindex-choicemap
   "Recursively reindex all leaves of a choicemap using ancestor indices."
   [choice-map indices]
-  (cond
-    (nil? choice-map) choice-map
-    (cm/has-value? choice-map)
-    (let [v (cm/get-value choice-map)]
-      (if (and (mx/array? v) (pos? (count (mx/shape v))))
-        (cm/->Value (reindex-value v indices))
-        choice-map))  ;; scalar constraints stay unchanged
-    (instance? cm/Node choice-map)
-    (cm/->Node (into {} (map (fn [[k sub]]
-                               [k (reindex-choicemap sub indices)])
-                             (cm/-submaps choice-map))))
-    :else choice-map))
+  (when (some? choice-map)
+    (walk-choicemap choice-map
+                    (fn [v] (mx/take-idx v indices))
+                    (fn [_ sub] (reindex-choicemap sub indices)))))
 
 (defn reindex-state
   "Reindex a structured state (plain ClojureScript map or MLX array) by ancestor indices.
@@ -124,19 +129,10 @@
   "Recursively merge two identically-structured choicemaps using an [N] boolean mask.
    Where mask=true takes from proposed, where false keeps current."
   [current proposed mask]
-  (cond
-    (cm/has-value? current)
-    (let [cv (cm/get-value current)]
-      (if (and (mx/array? cv) (pos? (count (mx/shape cv))))
-        (cm/->Value (mx/where mask (cm/get-value proposed) cv))
-        current))  ;; scalar constraints stay unchanged
-
-    (instance? cm/Node current)
-    (cm/->Node (into {} (map (fn [[k sub]]
-                               [k (merge-choicemap-by-mask
-                                    sub (cm/-get-submap proposed k) mask)])
-                             (cm/-submaps current))))
-    :else current))
+  (walk-choicemap current
+                  (fn [cv] (mx/where mask (cm/get-value proposed) cv))
+                  (fn [k sub] (merge-choicemap-by-mask
+                                sub (cm/-get-submap proposed k) mask))))
 
 (defn merge-vtraces-by-mask
   "Merge two VectorizedTraces per-particle using an [N] boolean mask.

--- a/src/genmlx/verify.cljs
+++ b/src/genmlx/verify.cljs
@@ -189,7 +189,7 @@
    Returns violations vector (empty if all trials succeed)."
   [gf args n-trials key]
   (try
-    (let [keys (rng/split-n (rng/ensure-key key) n-trials)]
+    (let [keys (rng/split-n key n-trials)]
       (doseq [k keys]
         (p/simulate (dyn/with-key gf k) args))
       [])
@@ -231,7 +231,7 @@
                                          (check-no-hof-gen-fns source)))
          ;; Runtime trials — execution-based checks
          base-key (or key (rng/fresh-key))
-         trial-keys (rng/split-n (rng/ensure-key base-key) n-trials)
+         trial-keys (rng/split-n base-key n-trials)
          trial-results (mapv #(run-validation-trial gf args %) trial-keys)
          trial-violations (->> (mapcat :violations trial-results)
                                (into [] (distinct)))

--- a/src/genmlx/verify.cljs
+++ b/src/genmlx/verify.cljs
@@ -238,7 +238,7 @@
          ;; Halting check — DML restriction 1
          halts-violations (check-halts gf args n-trials base-key)
          ;; Merge all violations
-         all-violations (-> (vec source-violations)
+         all-violations (-> source-violations
                             (into trial-violations)
                             (into halts-violations))
          last-trace (:trace (peek trial-results))

--- a/src/genmlx/verify.cljs
+++ b/src/genmlx/verify.cljs
@@ -33,16 +33,27 @@
 ;; Source analysis (no execution needed)
 ;; ---------------------------------------------------------------------------
 
+(defn- tree-violations
+  "Walk the source form tree, keeping nodes matching node-pred and mapping
+   each to a violation map via ->violation. nil source yields nil."
+  [source node-pred ->violation]
+  (when source
+    (->> (tree-seq coll? seq source)
+         (filter node-pred)
+         (mapv ->violation))))
+
+(defn- symbol-violations
+  "tree-violations restricted to symbols whose name matches sym-pred."
+  [source sym-pred ->violation]
+  (tree-violations source (every-pred symbol? sym-pred) ->violation))
+
 (defn- check-source-materialization
   "Walk the source form tree looking for eval! or item symbols."
   [source]
-  (when source
-    (->> (tree-seq coll? seq source)
-         (filter symbol?)
-         (filter #(#{"eval!" "item"} (name %)))
-         (mapv (fn [s] {:type :materialization-in-body
-                        :severity :warning
-                        :message (str "Found " s " in model body — breaks vectorized execution")})))))
+  (symbol-violations source #(#{"eval!" "item"} (name %))
+    (fn [s] {:type :materialization-in-body
+             :severity :warning
+             :message (str "Found " s " in model body — breaks vectorized execution")})))
 
 (defn- external-random?
   "True if sym refers to an untraced source of randomness."
@@ -58,14 +69,11 @@
   "Walk the source form tree for untraced randomness symbols.
    DML restriction 3: no external randomness affecting control flow."
   [source]
-  (when source
-    (->> (tree-seq coll? seq source)
-         (filter symbol?)
-         (filter external-random?)
-         (mapv (fn [s]
-                 {:type :external-randomness
-                  :severity :warning
-                  :message (str "Found " s " in model body — untraced randomness violates DML restriction 3")})))))
+  (symbol-violations source external-random?
+    (fn [s]
+      {:type :external-randomness
+       :severity :warning
+       :message (str "Found " s " in model body — untraced randomness violates DML restriction 3")})))
 
 (def ^:private mutation-syms
   "Symbols that indicate mutation in model body."
@@ -75,14 +83,11 @@
   "Walk the source form tree for mutation symbols.
    DML restriction 4: no mutation in model body."
   [source]
-  (when source
-    (->> (tree-seq coll? seq source)
-         (filter symbol?)
-         (filter #(mutation-syms (name %)))
-         (mapv (fn [s]
-                 {:type :mutation
-                  :severity :warning
-                  :message (str "Found " s " in model body — mutation violates DML restriction 4")})))))
+  (symbol-violations source #(mutation-syms (name %))
+    (fn [s]
+      {:type :mutation
+       :severity :warning
+       :message (str "Found " s " in model body — mutation violates DML restriction 4")})))
 
 (def ^:private hof-syms
   "Higher-order function symbols that should not receive gen fns."
@@ -97,18 +102,17 @@
   "Walk the source form tree for gen fns passed to higher-order functions.
    DML restriction 5: use combinators (Map, Unfold, etc.) instead."
   [source]
-  (when source
-    (->> (tree-seq coll? seq source)
-         (filter seq?)
-         (filter (fn [form]
-                   (and (symbol? (first form))
-                        (hof-syms (name (first form)))
-                        (some gen-form? (rest form)))))
-         (mapv (fn [form]
-                 {:type :hof-gen-fn
-                  :severity :warning
-                  :message (str "Found gen fn passed to " (first form)
-                                " — use combinators (Map, Unfold, etc.) instead")})))))
+  (tree-violations source
+    (fn [form]
+      (and (seq? form)
+           (symbol? (first form))
+           (hof-syms (name (first form)))
+           (some gen-form? (rest form))))
+    (fn [form]
+      {:type :hof-gen-fn
+       :severity :warning
+       :message (str "Found gen fn passed to " (first form)
+                     " — use combinators (Map, Unfold, etc.) instead")})))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure validation transition (replaces validate-handler)

--- a/src/genmlx/vmap.cljs
+++ b/src/genmlx/vmap.cljs
@@ -126,61 +126,22 @@
     ;; Non-hierarchical (SelectAddrs, all, none, etc.) → shared
     selection))
 
+(defn- scalar-value-leaf?
+  "Check if a single leaf value is scalar (not [N]-shaped)."
+  [v]
+  (or (not (mlx-arr? v)) (= [] (mx/shape v))))
+
 (defn- stack-choices
   "Stack N choicemaps into one with [N]-shaped leaves.
    All N choicemaps must have the same address structure."
   [cms]
-  (cond
-    ;; All empty
-    (every? #(= % cm/EMPTY) cms)
-    cm/EMPTY
-
-    ;; Value leaves: stack the values
-    (cm/has-value? (first cms))
-    (cm/->Value (mx/stack (mapv cm/get-value cms)))
-
-    ;; Node: recurse per sub-address
-    (instance? cm/Node (first cms))
-    (let [addrs (keys (:m (first cms)))]
-      (cm/->Node
-       (into {}
-             (map (fn [addr]
-                    [addr (stack-choices (mapv #(cm/get-submap % addr) cms))])
-                  addrs))))
-
-    :else cm/EMPTY))
+  (cm/stack-choicemaps cms mx/stack))
 
 (defn- unstack-choices
   "Split a choicemap with [N]-shaped leaves into N scalar choicemaps.
    Scalar leaves are replicated to all N elements."
   [cm n]
-  (cond
-    (= cm cm/EMPTY)
-    (vec (repeat n cm/EMPTY))
-
-    (cm/has-value? cm)
-    (let [v (cm/get-value cm)]
-      (if (or (not (mlx-arr? v)) (= [] (mx/shape v)))
-        ;; Scalar leaf: replicate to all N
-        (vec (repeat n cm))
-        ;; [N,...]-shaped: index per element
-        (mapv #(cm/->Value (mx/index v %)) (range n))))
-
-    (instance? cm/Node cm)
-    (let [addrs (keys (:m cm))
-          ;; Recurse for each sub-address, getting vectors of N sub-cms
-          addr-vecs (map (fn [addr]
-                           [addr (unstack-choices (cm/get-submap cm addr) n)])
-                         addrs)]
-      ;; Zip: for each i, build a node with all sub-addresses
-      (mapv (fn [i]
-              (cm/->Node
-               (into {}
-                     (map (fn [[addr v]] [addr (nth v i)])
-                          addr-vecs))))
-            (range n)))
-
-    :else (vec (repeat n cm/EMPTY))))
+  (cm/unstack-choicemap cm n mx/index scalar-value-leaf?))
 
 (defn- stack-retvals
   "Stack N return values into a single value."
@@ -189,6 +150,20 @@
     (every? mx/array? retvals) (mx/stack retvals)
     (every? number? retvals) (mx/array retvals)
     :else (vec retvals)))
+
+(defn- mx-sum-by
+  "Sum (f r) over results, starting from a scalar-0.0 accumulator."
+  [f results]
+  (reduce (fn [acc r] (mx/add acc (f r))) (mx/scalar 0.0) results))
+
+(defn- element-trace
+  "Reconstruct the kernel trace for element i from stored per-element state.
+   Score falls back to scalar 0.0 when no element-scores were recorded."
+  [kernel args choices element-scores i]
+  (tr/make-trace
+   {:gen-fn kernel :args args
+    :choices choices :retval nil
+    :score (if element-scores (nth element-scores i) (mx/scalar 0.0))}))
 
 (defn- kernel-update
   "Update a kernel trace. Falls back to generate if IUpdate not implemented."
@@ -240,8 +215,7 @@
                             (range n))
               choices (stack-choices (mapv :choices results))
               retvals (stack-retvals (mapv :retval results))
-              score (reduce (fn [acc r] (mx/add acc (:score r)))
-                            (mx/scalar 0.0) results)
+              score (mx-sum-by :score results)
               element-scores (mapv :score results)]
           (with-meta
             (tr/make-trace {:gen-fn this :args args
@@ -280,10 +254,8 @@
                             (range n))
               choices (stack-choices (mapv (comp :choices :trace) results))
               retvals (stack-retvals (mapv (comp :retval :trace) results))
-              score (reduce (fn [acc r] (mx/add acc (:score (:trace r))))
-                            (mx/scalar 0.0) results)
-              weight (reduce (fn [acc r] (mx/add acc (:weight r)))
-                             (mx/scalar 0.0) results)
+              score (mx-sum-by (comp :score :trace) results)
+              weight (mx-sum-by :weight results)
               element-scores (mapv (comp :score :trace) results)]
           {:trace (with-meta
                     (tr/make-trace {:gen-fn this :args args
@@ -302,20 +274,15 @@
           old-element-scores (::element-scores (meta trace))
           results (mapv (fn [i]
                           (let [elem-args (extract-element-args (:args trace) in-axes i)
-                                old-trace (tr/make-trace
-                                           {:gen-fn kernel :args elem-args
-                                            :choices (nth old-per-choices i)
-                                            :retval nil
-                                            :score (if old-element-scores
-                                                     (nth old-element-scores i)
-                                                     (mx/scalar 0.0))})]
+                                old-trace (element-trace kernel elem-args
+                                                         (nth old-per-choices i)
+                                                         old-element-scores i)]
                             (kernel-update kernel old-trace
                                            (if scalar-c? constraints (nth new-per-constraints i)))))
                         (range n))
           choices (stack-choices (mapv (comp :choices :trace) results))
           retvals (stack-retvals (mapv (comp :retval :trace) results))
-          score (reduce (fn [acc r] (mx/add acc (:score (:trace r))))
-                        (mx/scalar 0.0) results)
+          score (mx-sum-by (comp :score :trace) results)
           weight (mx/subtract score (:score trace))
           discard (let [discards (mapv :discard results)]
                     (if (every? #(= % cm/EMPTY) discards)
@@ -338,20 +305,15 @@
           old-element-scores (::element-scores (meta trace))
           results (mapv (fn [i]
                           (let [elem-args (extract-element-args (:args trace) in-axes i)
-                                old-trace (tr/make-trace
-                                           {:gen-fn kernel :args elem-args
-                                            :choices (nth old-per-choices i)
-                                            :retval nil
-                                            :score (if old-element-scores
-                                                     (nth old-element-scores i)
-                                                     (mx/scalar 0.0))})]
+                                old-trace (element-trace kernel elem-args
+                                                         (nth old-per-choices i)
+                                                         old-element-scores i)]
                             (kernel-regenerate kernel old-trace
                                                (extract-element-selection selection i))))
                         (range n))
           choices (stack-choices (mapv (comp :choices :trace) results))
           retvals (stack-retvals (mapv (comp :retval :trace) results))
-          score (reduce (fn [acc r] (mx/add acc (:score (:trace r))))
-                        (mx/scalar 0.0) results)
+          score (mx-sum-by (comp :score :trace) results)
           weight (mx/subtract score (:score trace))
           element-scores (mapv (comp :score :trace) results)]
       {:trace (with-meta
@@ -371,8 +333,7 @@
                                     (extract-element-args args in-axes i)
                                     (if scalar? choices (nth per-choices i))))
                         (range n))
-          weight (reduce (fn [acc r] (mx/add acc (:weight r)))
-                         (mx/scalar 0.0) results)]
+          weight (mx-sum-by :weight results)]
       {:retval (stack-retvals (mapv :retval results))
        :weight weight}))
 
@@ -383,8 +344,7 @@
                           (p/propose kernel (extract-element-args args in-axes i)))
                         (range n))
           choices (stack-choices (mapv :choices results))
-          weight (reduce (fn [acc r] (mx/add acc (:weight r)))
-                         (mx/scalar 0.0) results)]
+          weight (mx-sum-by :weight results)]
       {:choices choices
        :weight weight
        :retval (stack-retvals (mapv :retval results))})))
@@ -403,13 +363,9 @@
       (reduce
        (fn [acc i]
          (let [elem-args (extract-element-args (:args trace) (:in-axes this) i)
-               elem-trace (tr/make-trace
-                           {:gen-fn (:kernel this) :args elem-args
-                            :choices (nth old-per-choices i)
-                            :retval nil
-                            :score (if old-element-scores
-                                     (nth old-element-scores i)
-                                     (mx/scalar 0.0))})]
+               elem-trace (element-trace (:kernel this) elem-args
+                                         (nth old-per-choices i)
+                                         old-element-scores i)]
            (mx/add acc (p/project (:kernel this) elem-trace
                                   (extract-element-selection selection i)))))
        (mx/scalar 0.0)

--- a/src/genmlx/vmap.cljs
+++ b/src/genmlx/vmap.cljs
@@ -15,10 +15,9 @@
 ;; Helpers
 ;; ---------------------------------------------------------------------------
 
-(defn- mlx-arr?
+(def ^:private mlx-arr?
   "Check if x is an MLX array."
-  [x]
-  (mx/array? x))
+  mx/array?)
 
 (defn- axis-size-of
   "Get the leading dimension size of an arg."

--- a/src/genmlx/vmap.cljs
+++ b/src/genmlx/vmap.cljs
@@ -41,18 +41,16 @@
 
     ;; No in-axes: all args batched, N from first arg
     (nil? in-axes)
-    (let [a (first args)
-          n (axis-size-of a)]
-      (if n n
+    (let [a (first args)]
+      (or (axis-size-of a)
           (throw (ex-info "vmap: cannot determine axis-size from arg" {:arg a}))))
 
     ;; in-axes provided: find first non-nil axis
     :else
     (let [idx (first (keep-indexed (fn [i ax] (when ax i)) in-axes))]
       (if idx
-        (let [a (nth args idx)
-              n (axis-size-of a)]
-          (if n n
+        (let [a (nth args idx)]
+          (or (axis-size-of a)
               (throw (ex-info "vmap: cannot determine axis-size" {:arg a}))))
         (throw (ex-info "vmap: all in-axes are nil and no axis-size provided" {}))))))
 

--- a/test/genmlx/llm_codegen_test.cljs
+++ b/test/genmlx/llm_codegen_test.cljs
@@ -69,11 +69,11 @@
 (assert-equal "#{1 2 3} complete" :complete (cg/prefix-status "#{1 2 3}"))
 (assert-equal "(let [a 1] a) complete" :complete (cg/prefix-status "(let [a 1] a)"))
 
-;; -- 1.2 valid-next-bytes --
+;; -- 1.2 next-valid-bytes --
 
-(println "\n== valid-next-bytes ==")
+(println "\n== next-valid-bytes ==")
 
-(let [valid (cg/valid-next-bytes "(fn [x")]
+(let [valid (cg/next-valid-bytes "(fn [x")]
   (assert-true "']' valid after '(fn [x'" (contains? valid "]"))
   (assert-true "' ' valid after '(fn [x'" (contains? valid " "))
   (assert-true "'a' valid after '(fn [x'" (contains? valid "a"))


### PR DESCRIPTION
## Idiomatic ClojureScript excellence (milestone `genmlx-b3nx`)

Behavior-preserving idiomatic-ClojureScript cleanups across the codebase — **form only, never semantics**. The handler remains ground truth; this is polish of *how* the code reads, not *what* it computes.

**49 of 50 planned tasks landed** (the 50th is partially done — see *Deferred* below).

### Scope
**69 files changed, net −316 lines.** Categories: control-flow flattening, nil-handling idioms (`or`/`when-let`/`if-some`), declarative collection transforms, destructuring over repeated key lookups, naming conventions, docstring/comment honesty, protocol/multimethod dispatch, data-driven tables, and DRY consolidation of repeated guards/walks/kernels/constants.

### How it was sequenced
The tasks are organized by *category* but cut across the same *files* (e.g. `choicemap.cljs`, `schema.cljs`, and the inference modules are each touched by several tasks). To apply them safely in parallel, the file-conflict graph was colored into **5 conflict-free waves** — within a wave no two tasks share a file; waves run in order so files touched repeatedly are edited sequentially. Each wave: parallel edits → namespace-load smoke gate → commit. Commits are one-per-wave plus a final completion commit.

### Verification
- **Namespace-load smoke gate passed every wave with zero repairs.**
- Independent full re-run afterward: **22/22 suites green** — core data, handler, dist, combinators, inference, exact, gradients (fd + score), clip-contract, **L0 + L4 certification**, **L1 compilation** (schema/simulate/partial/combinator), **`gen.clj` + GenJAX compat**, and vmap/vectorized/tensor-trace.
- Caveat: the LLM modules (`llm/*`) aren't exercised at runtime by these suites (they need model weights); their changes were namespace-load-verified, and the reader-grammar path (`codegen.cljs`) passes `llm_codegen_test`.

### Deferred (intentionally left for a focused pass)
`genmlx-heal` landed the bulk of its core-layer DRY work but **2 sub-items were deliberately deferred** as too risky to land mechanically:
1. **`program.cljs` conjugate-log-ML kernel factoring** — the candidate kernels are *similar but not byte-identical*, so collapsing them risks silent floating-point divergence; the address/key "builders" also splice SCI-evaluated source-code strings where a one-character change breaks model compilation. Needs an equivalence-verified pass.
2. **`LOG-2PI` cross-file standardization** — the shared constant now exists (`genmlx.mlx.constants`); wiring the 4 inference files to it needs a float32-vs-float64 provenance check first.

These are tracked on the `genmlx-heal` task; this branch leaves them untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
