### PR TITLE
refactor(idiomatic): complete genmlx-heal — share log-ML kernel, reuse compute-posterior, centralize LOG-2PI

### DIFF
--- a/src/genmlx/inference/amortized.cljs
+++ b/src/genmlx/inference/amortized.cljs
@@ -11,6 +11,7 @@
    Encoders are nn layer maps (or atoms wrapping them). See genmlx.nn for
    the layer representation."
   (:require [genmlx.mlx :as mx]
+            [genmlx.mlx.constants :refer [LOG-2PI]]
             [genmlx.mlx.random :as rng]
             [genmlx.nn :as nn]
             [genmlx.protocols :as p]
@@ -21,8 +22,6 @@
 ;; ---------------------------------------------------------------------------
 ;; Posterior families (20.2)
 ;; ---------------------------------------------------------------------------
-
-(def ^:private LOG-2PI (js/Math.log (* 2.0 js/Math.PI)))
 
 (defn- std-normal-logprob
   "Per-dimension log-density of a reparameterized normal sample with

--- a/src/genmlx/inference/auto_analytical.cljs
+++ b/src/genmlx/inference/auto_analytical.cljs
@@ -23,6 +23,7 @@
    - :gamma-poisson    {:shape MLX-scalar, :rate MLX-scalar}
    - :gamma-exponential {:shape MLX-scalar, :rate MLX-scalar}"
   (:require [genmlx.mlx :as mx]
+            [genmlx.mlx.constants :refer [LOG-2PI]]
             [genmlx.choicemap :as cm]
             [genmlx.conjugacy :as conj]
             [genmlx.affine :as affine]
@@ -33,7 +34,6 @@
 ;; Pure update functions — thin wrappers over conjugate.cljs
 ;; ---------------------------------------------------------------------------
 
-(def ^:private LOG-2PI 1.8378770664093453)
 (def ^:private MASK-ON (mx/scalar 1.0))
 
 (defn nn-update-step

--- a/src/genmlx/inference/conjugate.cljs
+++ b/src/genmlx/inference/conjugate.cljs
@@ -30,6 +30,7 @@
    - :conjugate-posteriors  {addr -> posterior-map}
    - :conjugate-ll          accumulated marginal LL"
   (:require [genmlx.mlx :as mx]
+            [genmlx.mlx.constants :refer [LOG-2PI]]
             [genmlx.dist :as dist]
             [genmlx.dist.core :as dc]
             [genmlx.choicemap :as cm]
@@ -42,8 +43,6 @@
 ;; ---------------------------------------------------------------------------
 ;; Pure conjugate update functions (Level 1)
 ;; ---------------------------------------------------------------------------
-
-(def ^:private LOG-2PI 1.8378770664093453)
 
 (defn nn-update
   "Normal-Normal conjugate update.

--- a/src/genmlx/inference/ekf_nd.cljs
+++ b/src/genmlx/inference/ekf_nd.cljs
@@ -18,6 +18,7 @@
 
    Composes with wrap-analytical/compose-middleware."
   (:require [genmlx.mlx :as mx]
+            [genmlx.mlx.constants :refer [LOG-2PI]]
             [genmlx.dist :as dist]
             [genmlx.dist.core :as dc]
             [genmlx.choicemap :as cm]
@@ -126,8 +127,6 @@
 ;; ---------------------------------------------------------------------------
 ;; Pure ND EKF operations
 ;; ---------------------------------------------------------------------------
-
-(def ^:private LOG-2PI 1.8378770664093453)
 
 (defn- predict-one-core
   "Shared predict logic given pre-computed f(z0) and Jacobian A."

--- a/src/genmlx/inference/kalman.cljs
+++ b/src/genmlx/inference/kalman.cljs
@@ -19,6 +19,7 @@
 
    Both levels produce identical results."
   (:require [genmlx.mlx :as mx]
+            [genmlx.mlx.constants :refer [LOG-2PI]]
             [genmlx.dist :as dist]
             [genmlx.dist.core :as dc]
             [genmlx.choicemap :as cm]
@@ -67,8 +68,6 @@
 ;; ---------------------------------------------------------------------------
 ;; Pure Kalman operations (Level 1)
 ;; ---------------------------------------------------------------------------
-
-(def ^:private LOG-2PI 1.8378770664093453)
 
 (defn kalman-init
   "Initial belief state: N(0, 1) prior.

--- a/src/genmlx/program.cljs
+++ b/src/genmlx/program.cljs
@@ -103,6 +103,20 @@
       :x-next (:x nxt) :y-next (:y nxt)})))
 
 ;; ============================================================
+;; Runtime address builders
+;; ============================================================
+;; These construct keyword addresses / data-map keys at RUNTIME. They are
+;; deliberately NOT used by the SCI source-string builders below (mean-expr,
+;; param-bindings, build-transition-source, build-scaffold), which emit the same
+;; "ar-"/"-prev"/"-next" fragments into generated code — unifying the two would
+;; risk a one-character change silently altering compiled models.
+
+(defn- obs-addr  [v i] (keyword (str (name v) i)))
+(defn- prev-key  [v]   (keyword (str (name v) "-prev")))
+(defn- next-key  [v]   (keyword (str (name v) "-next")))
+(defn- sigma-key [v]   (keyword (str "sigma-" (name v))))
+
+;; ============================================================
 ;; Model source construction
 ;; ============================================================
 
@@ -203,8 +217,8 @@
   [transitions var-names]
   (let [pairs (for [[i t] (map-indexed vector transitions)
                     v var-names]
-                [(keyword (str (name v) i))
-                 (mx/scalar (get t (keyword (str (name v) "-next"))))])]
+                [(obs-addr v i)
+                 (mx/scalar (get t (next-key v)))])]
     (apply cm/choicemap (apply concat pairs))))
 
 (defn- log-sum-exp
@@ -263,8 +277,8 @@
     (reduce
       (fn [[cms pairs] [i t]]
         (let [new-pairs (mapcat (fn [v]
-                                  [(keyword (str (name v) i))
-                                   (mx/scalar (get t (keyword (str (name v) "-next"))))])
+                                  [(obs-addr v i)
+                                   (mx/scalar (get t (next-key v)))])
                                 var-names)
               all-pairs (into pairs new-pairs)]
           [(conj cms (apply cm/choicemap all-pairs)) all-pairs]))
@@ -280,7 +294,7 @@
                          :when (and (not= src tgt)
                                     (get edges [(name src) (name tgt)]))]
                      (keyword (str "beta-" (name src) "->" (name tgt))))
-        sigma-addrs (map #(keyword (str "sigma-" (name %))) var-names)]
+        sigma-addrs (map sigma-key var-names)]
     (apply sel/select (concat ar-addrs beta-addrs sigma-addrs))))
 
 ;; ============================================================
@@ -361,42 +375,66 @@
                    (+ log-det (js/Math.log (js/Math.abs pivot-val)))
                    (if (neg? pivot-val) (- sign) sign))))))))
 
-(defn- log-ml-general
-  "Analytical log-ML for one variable's regression with p predictors.
-   Uses Gaussian elimination for general p*p matrices."
-  [y X-cols sigma-sq]
-  (let [n (count y)
-        p (count X-cols)
-        m0 (mapv :prior-mean X-cols)
-        s0-diag (mapv :prior-var X-cols)
-        Xm0 (reduce (fn [acc j]
-                      (let [xj (:values (nth X-cols j))
-                            mj (nth m0 j)]
-                        (mapv + acc (mapv #(* mj %) xj))))
-                    (vec (repeat n 0.0))
-                    (range p))
-        r (vsub y Xm0)
-        rr (dot r r)
+(defn- log-ml-suffstat-terms
+  "The three additive terms of the analytical log marginal likelihood for one
+   target variable, computed from precomputed sufficient statistics rather than
+   raw residual vectors: returns [const-term log-det-term quad-term].
+
+   Returning the terms (rather than their sum) lets each caller fold them in its
+   own accumulation order, preserving the pre-refactor floating-point association
+   bit-for-bit: score-all-structures sums them into a running per-graph total
+   via (+ total t1 t2 t3); score-parent-sets-for-variable sums them standalone
+   via (+ t1 t2 t3). Pre-summing here would re-associate the addition and shift
+   least-significant bits in score-all-structures' totals.
+
+   Shared kernel for score-all-structures and score-parent-sets-for-variable
+   (their inner per-target bodies were byte-identical). `preds` is
+   [target & parents] in the caller's chosen order; the result is invariant to
+   predictor ordering up to floating point. all-dots/xty-dots/yty hold the
+   Gram dot products, X^T y dots, and y^T y respectively, keyed by variable.
+
+   The closed-form 2-var path (log-ml-variable) deliberately does NOT route
+   through here: it inlines the p<=2 determinant/solve as an optimization, and
+   folding it in would shift least-significant bits and remove that fast path."
+  [target preds n all-dots xty-dots yty known-sigma ar-prior-mean ar-var beta-var]
+  (let [p (count preds)
+        m0 (into [ar-prior-mean] (repeat (dec p) 0.0))
+        s0 (into [ar-var] (repeat (dec p) beta-var))
         gram (vec (for [i (range p)]
                     (vec (for [j (range p)]
-                           (dot (:values (nth X-cols i))
-                                (:values (nth X-cols j)))))))
-        Xtr (mapv (fn [j] (dot (:values (nth X-cols j)) r)) (range p))
+                           (get all-dots [(nth preds i) (nth preds j)])))))
+        Xty (mapv (fn [j] (get xty-dots [(nth preds j) target])) (range p))
+        gram-m0 (mapv (fn [i]
+                        (reduce + (map (fn [j] (* (get-in gram [i j]) (nth m0 j)))
+                                       (range p))))
+                      (range p))
+        Xtr (mapv - Xty gram-m0)
+        m0Xty (reduce + (map * m0 Xty))
+        m0Gram-m0 (reduce + (map * m0 gram-m0))
+        rr (+ (get yty target) (* -2.0 m0Xty) m0Gram-m0)
+        sigma-sq (if-let [s (get known-sigma target)]
+                   (* s s)
+                   (if (<= n p)
+                     1.0
+                     (let [beta-hat (mat-lu-solve gram Xty)
+                           Xbeta-y (reduce + (map * beta-hat Xty))
+                           rss (- (get yty target) Xbeta-y)]
+                       (/ (max rss 0.001) n))))
         M (vec (for [i (range p)]
                  (vec (for [j (range p)]
                         (+ (get-in gram [i j])
-                           (if (= i j) (/ sigma-sq (nth s0-diag i)) 0))))))
+                           (if (= i j) (/ sigma-sq (nth s0 i)) 0))))))
         Minv-Xtr (mat-lu-solve M Xtr)
-        quad-correction (reduce + (map * Xtr Minv-Xtr))
+        quad-corr (reduce + (map * Xtr Minv-Xtr))
         A (vec (for [i (range p)]
                  (vec (for [j (range p)]
                         (+ (if (= i j) 1.0 0.0)
-                           (/ (* (nth s0-diag i) (get-in gram [i j])) sigma-sq))))))
+                           (/ (* (nth s0 i) (get-in gram [i j])) sigma-sq))))))
         log-det-A (mat-log-det A)
-        quad (/ (- rr quad-correction) sigma-sq)]
-    (+ (* -0.5 n (js/Math.log (* 2.0 js/Math.PI sigma-sq)))
-       (* -0.5 log-det-A)
-       (* -0.5 quad))))
+        quad (/ (- rr quad-corr) sigma-sq)]
+    [(* -0.5 n (js/Math.log (* 2.0 js/Math.PI sigma-sq)))
+     (* -0.5 log-det-A)
+     (* -0.5 quad)]))
 
 (defn- extract-regression-data
   "Build regression components for one variable's transition equation.
@@ -405,15 +443,15 @@
    {:keys [ar-prior-mean ar-prior-std beta-prior-mean beta-prior-std]
     :or {ar-prior-mean 0.5 ar-prior-std 0.15
          beta-prior-mean 0.0 beta-prior-std 3.0}}]
-  (let [y (mapv #(get % (keyword (str (name target) "-next"))) transitions)
-        ar-col {:values (mapv #(get % (keyword (str (name target) "-prev"))) transitions)
+  (let [y (mapv #(get % (next-key target)) transitions)
+        ar-col {:values (mapv #(get % (prev-key target)) transitions)
                 :prior-mean ar-prior-mean
                 :prior-var (* ar-prior-std ar-prior-std)}
         cross-cols (vec
                     (for [src var-names
                           :when (and (not= src target)
                                      (get edges [(name src) (name target)]))]
-                      {:values (mapv #(get % (keyword (str (name src) "-prev"))) transitions)
+                      {:values (mapv #(get % (prev-key src)) transitions)
                        :prior-mean beta-prior-mean
                        :prior-var (* beta-prior-std beta-prior-std)}))]
     {:y y :cols (into [ar-col] cross-cols)}))
@@ -516,8 +554,7 @@
    (reduce
     (fn [total v]
       (let [reg (extract-regression-data transitions v var-names edges opts)
-            sigma-key (keyword (str "sigma-" (name v)))
-            known-sigma (get opts sigma-key)
+            known-sigma (get opts (sigma-key v))
             sigma-sq (if known-sigma
                        (* known-sigma known-sigma)
                        (estimate-sigma-sq reg))]
@@ -665,24 +702,28 @@
   (vec (for [src var-names, tgt var-names :when (not= src tgt)]
          [src tgt])))
 
+(defn- subsets
+  "All 2^(count coll) subsets of coll, as a vector of sets ordered by bit-mask
+   index i (bit j set => coll's j-th element present)."
+  [coll]
+  (mapv (fn [i]
+          (set (keep-indexed (fn [j x] (when (bit-test i j) x)) coll)))
+        (range (bit-shift-left 1 (count coll)))))
+
 (defn enumerate-all-structures
   "Enumerate all 2^(K*(K-1)) directed graphs for K variables.
    Returns [{:edges #{[:a :b] ...} :name \"a->b, c->a\"} ...]"
   [var-names]
-  (let [all-edges (enumerate-edges var-names)
-        n-edges (count all-edges)]
-    (mapv (fn [i]
-            (let [active (set (keep-indexed
-                               (fn [j edge]
-                                 (when (bit-test i j) edge))
-                               all-edges))
-                  nm (if (empty? active)
-                       "independent"
-                       (str/join ", "
-                                 (map (fn [[s t]] (str (name s) "->" (name t)))
-                                      (sort-by str active))))]
-              {:edges active :name nm :index i}))
-          (range (bit-shift-left 1 n-edges)))))
+  (vec
+   (map-indexed
+    (fn [i active]
+      (let [nm (if (empty? active)
+                 "independent"
+                 (str/join ", "
+                           (map (fn [[s t]] (str (name s) "->" (name t)))
+                                (sort-by str active))))]
+        {:edges active :name nm :index i}))
+    (subsets (enumerate-edges var-names)))))
 
 (defn score-all-structures
   "Score all 2^(K*(K-1)) directed graphs with precomputed sufficient statistics.
@@ -730,45 +771,10 @@
                    (fn [total target]
                      (let [sources (vec (filter #(contains? edges [% target]) var-names))
                            preds (into [target] sources)
-                           p (count preds)
-                           m0 (into [ar-prior-mean] (repeat (count sources) 0.0))
-                           s0 (into [ar-var] (repeat (count sources) beta-var))
-                           gram (vec (for [i (range p)]
-                                       (vec (for [j (range p)]
-                                              (get all-dots [(nth preds i) (nth preds j)])))))
-                           Xty (mapv (fn [j] (get xty-dots [(nth preds j) target])) (range p))
-                           gram-m0 (mapv (fn [i]
-                                           (reduce + (map (fn [j] (* (get-in gram [i j]) (nth m0 j)))
-                                                          (range p))))
-                                         (range p))
-                           Xtr (mapv - Xty gram-m0)
-                           m0Xty (reduce + (map * m0 Xty))
-                           m0Gram-m0 (reduce + (map * m0 gram-m0))
-                           rr (+ (get yty target) (* -2.0 m0Xty) m0Gram-m0)
-                           sigma-sq (if-let [s (get known-sigma target)]
-                                      (* s s)
-                                      (if (<= n p)
-                                        1.0
-                                        (let [beta-hat (mat-lu-solve gram Xty)
-                                              Xbeta-y (reduce + (map * beta-hat Xty))
-                                              rss (- (get yty target) Xbeta-y)]
-                                          (/ (max rss 0.001) n))))
-                           M (vec (for [i (range p)]
-                                    (vec (for [j (range p)]
-                                           (+ (get-in gram [i j])
-                                              (if (= i j) (/ sigma-sq (nth s0 i)) 0))))))
-                           Minv-Xtr (mat-lu-solve M Xtr)
-                           quad-corr (reduce + (map * Xtr Minv-Xtr))
-                           A (vec (for [i (range p)]
-                                    (vec (for [j (range p)]
-                                           (+ (if (= i j) 1.0 0.0)
-                                              (/ (* (nth s0 i) (get-in gram [i j])) sigma-sq))))))
-                           log-det-A (mat-log-det A)
-                           quad (/ (- rr quad-corr) sigma-sq)]
-                       (+ total
-                          (* -0.5 n (js/Math.log (* 2.0 js/Math.PI sigma-sq)))
-                          (* -0.5 log-det-A)
-                          (* -0.5 quad))))
+                           [t1 t2 t3] (log-ml-suffstat-terms
+                                       target preds n all-dots xty-dots yty
+                                       known-sigma ar-prior-mean ar-var beta-var)]
+                       (+ total t1 t2 t3)))
                    0.0
                    var-names)]
           (assoc structure :log-ml lml)))
@@ -778,14 +784,13 @@
   "Compute marginal posterior probability for each possible directed edge.
    Takes scored structures (with :log-ml) and returns {[src tgt] -> probability}."
   [var-names scored]
-  (let [log-mls (mapv :log-ml scored)
-        log-norm (log-sum-exp log-mls)]
+  (let [posts (compute-posterior scored)]
     (into {}
           (map (fn [edge]
                  [edge (reduce + (keep (fn [s]
                                          (when (contains? (:edges s) edge)
-                                           (js/Math.exp (- (:log-ml s) log-norm))))
-                                       scored))])
+                                           (:posterior s)))
+                                       posts))])
                (enumerate-edges var-names)))))
 
 (defn discover-structure
@@ -804,10 +809,7 @@
    (let [t0 (js/Date.now)
          scored (score-all-structures transitions var-names opts)
          elapsed (- (js/Date.now) t0)
-         log-mls (mapv :log-ml scored)
-         log-norm (log-sum-exp log-mls)
-         ranked (->> scored
-                     (map #(assoc % :posterior (js/Math.exp (- (:log-ml %) log-norm))))
+         ranked (->> (compute-posterior scored)
                      (sort-by :posterior >)
                      vec)]
      {:ranked ranked
@@ -824,50 +826,14 @@
    Uses precomputed sufficient statistics."
   [target candidates n all-dots xty-dots yty known-sigma
    ar-prior-mean ar-var beta-var]
-  (let [n-cand (count candidates)]
-    (mapv
-     (fn [i]
-       (let [parents (set (keep-indexed (fn [j c] (when (bit-test i j) c)) candidates))
-             preds (into [target] (vec (sort-by name parents)))
-             p (count preds)
-             m0 (into [ar-prior-mean] (repeat (dec p) 0.0))
-             s0 (into [ar-var] (repeat (dec p) beta-var))
-             gram (vec (for [a (range p)]
-                         (vec (for [b (range p)]
-                                (get all-dots [(nth preds a) (nth preds b)])))))
-             Xty (mapv (fn [j] (get xty-dots [(nth preds j) target])) (range p))
-             gram-m0 (mapv (fn [ii]
-                             (reduce + (map (fn [j] (* (get-in gram [ii j]) (nth m0 j)))
-                                            (range p))))
-                           (range p))
-             Xtr (mapv - Xty gram-m0)
-             m0Xty (reduce + (map * m0 Xty))
-             m0Gram-m0 (reduce + (map * m0 gram-m0))
-             rr (+ (get yty target) (* -2.0 m0Xty) m0Gram-m0)
-             sigma-sq (if-let [s (get known-sigma target)]
-                        (* s s)
-                        (if (<= n p) 1.0
-                            (let [bh (mat-lu-solve gram Xty)
-                                  Xby (reduce + (map * bh Xty))
-                                  rss (- (get yty target) Xby)]
-                              (/ (max rss 0.001) n))))
-             M (vec (for [a (range p)]
-                      (vec (for [b (range p)]
-                             (+ (get-in gram [a b])
-                                (if (= a b) (/ sigma-sq (nth s0 a)) 0))))))
-             Minv-Xtr (mat-lu-solve M Xtr)
-             quad-corr (reduce + (map * Xtr Minv-Xtr))
-             A (vec (for [a (range p)]
-                      (vec (for [b (range p)]
-                             (+ (if (= a b) 1.0 0.0)
-                                (/ (* (nth s0 a) (get-in gram [a b])) sigma-sq))))))
-             log-det-A (mat-log-det A)
-             quad (/ (- rr quad-corr) sigma-sq)
-             lml (+ (* -0.5 n (js/Math.log (* 2.0 js/Math.PI sigma-sq)))
-                    (* -0.5 log-det-A)
-                    (* -0.5 quad))]
-         {:parents parents :log-ml lml}))
-     (range (bit-shift-left 1 n-cand)))))
+  (mapv
+   (fn [parents]
+     (let [preds (into [target] (vec (sort-by name parents)))
+           [t1 t2 t3] (log-ml-suffstat-terms
+                       target preds n all-dots xty-dots yty
+                       known-sigma ar-prior-mean ar-var beta-var)]
+       {:parents parents :log-ml (+ t1 t2 t3)}))
+   (subsets candidates)))
 
 (defn discover-structure-decomposed
   "Decomposed structure discovery: search parent sets independently per variable.
@@ -914,11 +880,7 @@
                             parent-sets (score-parent-sets-for-variable
                                          target candidates n all-dots xty-dots yty known-sigma
                                          ar-prior-mean ar-var beta-var)
-                            log-mls (mapv :log-ml parent-sets)
-                            log-norm (log-sum-exp log-mls)
-                            posteriors (mapv #(assoc % :posterior
-                                                     (js/Math.exp (- (:log-ml %) log-norm)))
-                                             parent-sets)
+                            posteriors (compute-posterior parent-sets)
                             best (apply max-key :posterior posteriors)]
                         [target {:parent-sets posteriors
                                  :best-parents (:parents best)

--- a/test/genmlx/conjugate_posterior_test.cljs
+++ b/test/genmlx/conjugate_posterior_test.cljs
@@ -281,6 +281,16 @@
 ;; ---------------------------------------------------------------------------
 ;; Tier B: Importance sampling convergence — Normal-Inverse-Gamma
 ;; ---------------------------------------------------------------------------
+;;
+;; These use the PRIOR as the IS proposal. The NIG posterior mean (mu~2.35) sits
+;; far in the tail of the prior mu ~ N(0, sigma), so the proposal is poor:
+;; measured effective sample size is only ~26 of 5000 (range 13-44 across seeds).
+;; The estimator is UNBIASED — averaged over 14 seeds, mu=2.366 (truth 2.3545)
+;; and sigma^2=0.896 (truth 0.9119) — but any SINGLE 5000-sample run scatters
+;; widely (mu in [2.29, 2.43], sigma^2 in [0.80, 1.03]). The tolerances below are
+;; therefore ~3x the measured IS standard error, not machine precision; tightening
+;; them would need far more samples or a better proposal (genmlx-x8i7). Single
+;; fixed seeds keep the tests deterministic.
 
 (deftest nig-is-posterior-mean-mu-converges
   (testing "IS weighted mean of mu converges to E[mu|data]"
@@ -289,8 +299,8 @@
           obs (observations-from-indexed data)
           result (is/importance-sampling {:samples 5000 :key (rng/fresh-key 77)}
                                          nig-model [data mu0 kappa0 alpha0 beta0] obs)]
-      (is (th/close? mean-mu (weighted-scalar-mean result :mu) 0.05)
-          "IS posterior mean of mu within 0.05 of 2.3545"))))
+      (is (th/close? mean-mu (weighted-scalar-mean result :mu) 0.12)
+          "IS posterior mean of mu within 0.12 of 2.3545 (prior-proposal IS, ESS~26)"))))
 
 (deftest nig-is-posterior-mean-sigma-sq-converges
   (testing "IS weighted mean of sigma^2 converges to E[sigma^2|data]"
@@ -299,8 +309,8 @@
           obs (observations-from-indexed data)
           result (is/importance-sampling {:samples 5000 :key (rng/fresh-key 88)}
                                          nig-model [data mu0 kappa0 alpha0 beta0] obs)]
-      (is (th/close? mean-sig2 (weighted-scalar-mean result :sigma-sq) 0.10)
-          "IS posterior mean of sigma^2 within 0.10 of 0.9119"))))
+      (is (th/close? mean-sig2 (weighted-scalar-mean result :sigma-sq) 0.20)
+          "IS posterior mean of sigma^2 within 0.20 of 0.9119 (prior-proposal IS, ESS~26)"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Tier B: Importance sampling convergence — Dirichlet-Categorical

--- a/test/genmlx/program_golden_test.cljs
+++ b/test/genmlx/program_golden_test.cljs
@@ -1,0 +1,154 @@
+(ns genmlx.program-golden-test
+  "Byte-exact golden tests for genmlx.program analytical kernels.
+
+   Guards the DRY refactor of program.cljs (bean genmlx-heal): extracting the
+   shared sufficient-statistics log-ML kernel from score-all-structures and
+   score-parent-sets-for-variable, reusing compute-posterior, and naming the
+   runtime keyword builders. Every value below was captured from the pre-refactor
+   code on FIXED, deterministic inputs (no randn / Math.random) and is asserted
+   with EXACT = — the refactor is behavior-preserving only if all of these still
+   hold bit-for-bit.
+
+   Run: bun run --bun nbb test/genmlx/program_golden_test.cljs"
+  (:require [genmlx.program :as prog]
+            [genmlx.mlx :as mx]
+            [genmlx.choicemap :as cm]))
+
+;; ============================================================
+;; Test harness
+;; ============================================================
+
+(def ^:private pass-count (atom 0))
+(def ^:private fail-count (atom 0))
+
+(defn- assert-true [msg v]
+  (if v
+    (do (swap! pass-count inc) (println "  PASS:" msg))
+    (do (swap! fail-count inc) (println "  FAIL:" msg))))
+
+(defn- assert-exact [msg expected actual]
+  (assert-true (str msg (when-not (= expected actual)
+                          (str " (expected " (pr-str expected) ", got " (pr-str actual) ")")))
+               (= expected actual)))
+
+(defn- report []
+  (let [p @pass-count f @fail-count]
+    (println (str "\n=== " p "/" (+ p f) " PASS ==="))
+    (when (pos? f) (println (str "!!! " f " FAILURES !!!")))))
+
+;; ============================================================
+;; Fixed deterministic inputs
+;; ============================================================
+
+(def tx2
+  [{:x-prev 1.0 :y-prev 2.0 :x-next 1.5 :y-next 2.5}
+   {:x-prev 1.5 :y-prev 2.5 :x-next 1.8 :y-next 2.9}
+   {:x-prev 1.8 :y-prev 2.9 :x-next 2.0 :y-next 3.1}
+   {:x-prev 2.0 :y-prev 3.1 :x-next 2.3 :y-next 3.6}
+   {:x-prev 2.3 :y-prev 3.6 :x-next 2.6 :y-next 4.0}])
+
+(def edges-xy {["x" "y"] true ["y" "x"] false})
+(def edges-none {["x" "y"] false ["y" "x"] false})
+
+(def txk
+  [{:prev {:a 1.0 :b 2.0 :c 0.5} :next {:a 1.2 :b 2.1 :c 0.7}}
+   {:prev {:a 1.2 :b 2.1 :c 0.7} :next {:a 1.1 :b 2.3 :c 0.9}}
+   {:prev {:a 1.1 :b 2.3 :c 0.9} :next {:a 1.4 :b 2.0 :c 1.1}}
+   {:prev {:a 1.4 :b 2.0 :c 1.1} :next {:a 1.3 :b 2.4 :c 0.8}}
+   {:prev {:a 1.3 :b 2.4 :c 0.8} :next {:a 1.6 :b 2.2 :c 1.0}}
+   {:prev {:a 1.6 :b 2.2 :c 1.0} :next {:a 1.5 :b 2.5 :c 1.2}}])
+
+(def kvars [:a :b :c])
+
+(defn- cm->items [c]
+  (into (sorted-map) (map (fn [[k v]] [k (mx/item v)]) (cm/to-map c))))
+
+;; ============================================================
+;; Golden values captured from pre-refactor program.cljs
+;; ============================================================
+
+(def GOLDEN
+  {;; B — log-ml-variable (closed-form path, left untouched by the refactor)
+   :b-xy-est   -16.879380883904552
+   :b-none-est -16.63021629134939
+   :b-xy-known -13.612325614243108
+
+   ;; C — score-all-structures (shared suffstat kernel; 64 structures)
+   :c-names ["independent" "a->b" "a->c" "a->b, a->c" "b->a" "a->b, b->a" "a->c, b->a" "a->b, a->c, b->a" "b->c" "a->b, b->c" "a->c, b->c" "a->b, a->c, b->c" "b->a, b->c" "a->b, b->a, b->c" "a->c, b->a, b->c" "a->b, a->c, b->a, b->c" "c->a" "a->b, c->a" "a->c, c->a" "a->b, a->c, c->a" "b->a, c->a" "a->b, b->a, c->a" "a->c, b->a, c->a" "a->b, a->c, b->a, c->a" "b->c, c->a" "a->b, b->c, c->a" "a->c, b->c, c->a" "a->b, a->c, b->c, c->a" "b->a, b->c, c->a" "a->b, b->a, b->c, c->a" "a->c, b->a, b->c, c->a" "a->b, a->c, b->a, b->c, c->a" "c->b" "a->b, c->b" "a->c, c->b" "a->b, a->c, c->b" "b->a, c->b" "a->b, b->a, c->b" "a->c, b->a, c->b" "a->b, a->c, b->a, c->b" "b->c, c->b" "a->b, b->c, c->b" "a->c, b->c, c->b" "a->b, a->c, b->c, c->b" "b->a, b->c, c->b" "a->b, b->a, b->c, c->b" "a->c, b->a, b->c, c->b" "a->b, a->c, b->a, b->c, c->b" "c->a, c->b" "a->b, c->a, c->b" "a->c, c->a, c->b" "a->b, a->c, c->a, c->b" "b->a, c->a, c->b" "a->b, b->a, c->a, c->b" "a->c, b->a, c->a, c->b" "a->b, a->c, b->a, c->a, c->b" "b->c, c->a, c->b" "a->b, b->c, c->a, c->b" "a->c, b->c, c->a, c->b" "a->b, a->c, b->c, c->a, c->b" "b->a, b->c, c->a, c->b" "a->b, b->a, b->c, c->a, c->b" "a->c, b->a, b->c, c->a, c->b" "a->b, a->c, b->a, b->c, c->a, c->b"]
+   :c-log-mls [-17.89773910829456 -12.228468292776318 -14.39091671067874 -8.7216458951605 -13.024136636675115 -7.354865821156874 -9.517314239059296 -3.8480434235410548 -13.687149418818382 -8.017878603300142 -16.169044267775654 -10.499773452257411 -8.813546947198938 -3.1442761316806984 -11.295441796156208 -5.626170980637967 -15.556092463150387 -9.886821647632146 -12.049270065534566 -6.3799992500163265 -15.553515802302645 -9.884244986784402 -12.046693404686826 -6.377422589168583 -11.34550277367421 -5.67623195815597 -13.82739762263148 -8.15812680711324 -11.342926112826468 -5.673655297308228 -13.824820961783738 -8.155550146265497 -14.554443567834403 -13.96912421715451 -11.047621170218584 -10.462301819538691 -9.680841096214959 -9.095521745535066 -6.174018698599139 -5.5886993479192455 -10.343853878358226 -9.758534527678334 -12.825748727315496 -12.240429376635603 -5.470251406738782 -4.88493205605889 -7.952146255696052 -7.366826905016159 -12.21279692269023 -11.627477572010338 -8.70597452507441 -8.120655174394518 -12.210220261842487 -11.624900911162594 -8.703397864226666 -8.118078513546774 -8.002207233214055 -7.416887882534162 -10.484102082171324 -9.898782731491432 -7.999630572366311 -7.414311221686418 -10.48152542132358 -9.896206070643688]
+   :c-edge-marginals {[:a :b] 0.9207716148153358, [:a :c] 0.3629954734170935, [:b :a] 0.9253129580017428, [:b :c] 0.6801564552764906, [:c :a] 0.13644497761828112, [:c :b] 0.2139318930973213}
+
+   ;; compute-posterior (reuse target)
+   :cp-posteriors [0.6652409557748217 0.09003057317038043 0.24472847105479759]
+
+   ;; D — score-parent-sets-for-variable via discover-structure-decomposed
+   :d-marginals {[:a :b] 0.9207716148153356, [:a :c] 0.3629954734170935, [:b :a] 0.9253129580017428, [:b :c] 0.6801564552764907, [:c :a] 0.13644497761828103, [:c :b] 0.21393189309732136}
+   :d-per-var-logmls {:a [[[] -5.39265643018128] [["b"] -0.5190539585618352] [["c"] -3.051009785037108] [["b" "c"] -3.0484331241893643]]
+                      :b [[[] -7.267972397525671] [["a"] -1.5987015820074313] [["c"] -3.9246768570655153] [["a" "c"] -3.3393575063856225]]
+                      :c [[[] -5.237110280587608] [["a"] -1.7302878829717878] [["b"] -1.026520591111432] [["a" "b"] -3.508415440068701]]}
+
+   ;; discover-structure (enum path, compute-posterior reuse target)
+   :ds-best-name "a->b, b->a, b->c"
+   :ds-best-logml -3.1442761316806984
+   :ds-ranked-logmls [-3.1442761316806984 -3.8480434235410548 -4.88493205605889 -5.470251406738782 -5.5886993479192455 -5.626170980637967 -5.673655297308228 -5.67623195815597 -6.174018698599139 -6.377422589168583 -6.3799992500163265 -7.354865821156874 -7.366826905016159 -7.414311221686418 -7.416887882534162 -7.952146255696052 -7.999630572366311 -8.002207233214055 -8.017878603300142 -8.118078513546774 -8.120655174394518 -8.155550146265497 -8.15812680711324 -8.703397864226666 -8.70597452507441 -8.7216458951605 -8.813546947198938 -9.095521745535066 -9.517314239059296 -9.680841096214959 -9.758534527678334 -9.884244986784402 -9.886821647632146 -9.896206070643688 -9.898782731491432 -10.343853878358226 -10.462301819538691 -10.48152542132358 -10.484102082171324 -10.499773452257411 -11.047621170218584 -11.295441796156208 -11.342926112826468 -11.34550277367421 -11.624900911162594 -11.627477572010338 -12.046693404686826 -12.049270065534566 -12.210220261842487 -12.21279692269023 -12.228468292776318 -12.240429376635603 -12.825748727315496 -13.024136636675115 -13.687149418818382 -13.824820961783738 -13.82739762263148 -13.96912421715451 -14.39091671067874 -14.554443567834403 -15.553515802302645 -15.556092463150387 -16.169044267775654 -17.89773910829456]
+
+   ;; keyword/constraint builders (obs-addr / next-key / sigma-key)
+   :bc {:x0 1.5, :x1 1.7999999523162842, :x2 2, :x3 2.299999952316284, :x4 2.5999999046325684, :y0 2.5, :y1 2.9000000953674316, :y2 3.0999999046325684, :y3 3.5999999046325684, :y4 4}
+   :bsc [{:x0 1.5, :y0 2.5}
+         {:x0 1.5, :x1 1.7999999523162842, :y0 2.5, :y1 2.9000000953674316}
+         {:x0 1.5, :x1 1.7999999523162842, :x2 2, :y0 2.5, :y1 2.9000000953674316, :y2 3.0999999046325684}
+         {:x0 1.5, :x1 1.7999999523162842, :x2 2, :x3 2.299999952316284, :y0 2.5, :y1 2.9000000953674316, :y2 3.0999999046325684, :y3 3.5999999046325684}
+         {:x0 1.5, :x1 1.7999999523162842, :x2 2, :x3 2.299999952316284, :x4 2.5999999046325684, :y0 2.5, :y1 2.9000000953674316, :y2 3.0999999046325684, :y3 3.5999999046325684, :y4 4}]
+   :psel "#genmlx.selection.SelectAddrs{:addrs #{:ar-x :ar-y :beta-x->y :sigma-x :sigma-y}}"})
+
+;; ============================================================
+;; Assertions
+;; ============================================================
+
+(println "\n== B: score-model-analytical (closed-form, untouched) ==")
+(assert-exact "log-ML xy estimated-sigma" (:b-xy-est GOLDEN)
+              (prog/score-model-analytical tx2 [:x :y] edges-xy {}))
+(assert-exact "log-ML none estimated-sigma" (:b-none-est GOLDEN)
+              (prog/score-model-analytical tx2 [:x :y] edges-none {}))
+(assert-exact "log-ML xy known-sigma" (:b-xy-known GOLDEN)
+              (prog/score-model-analytical tx2 [:x :y] edges-xy {:sigma-x 0.5 :sigma-y 0.7}))
+
+(println "\n== C: score-all-structures (shared suffstat kernel) ==")
+(let [scored (prog/score-all-structures txk kvars)]
+  (assert-exact "structure names" (:c-names GOLDEN) (mapv :name scored))
+  (assert-exact "all 64 log-MLs" (:c-log-mls GOLDEN) (mapv :log-ml scored))
+  (assert-exact "edge-marginals (compute-posterior reuse)"
+                (:c-edge-marginals GOLDEN) (prog/edge-marginals kvars scored)))
+
+(println "\n== compute-posterior ==")
+(assert-exact "posteriors" (:cp-posteriors GOLDEN)
+              (mapv :posterior (prog/compute-posterior
+                                [{:name "a" :log-ml -5.0}
+                                 {:name "b" :log-ml -7.0}
+                                 {:name "c" :log-ml -6.0}])))
+
+(println "\n== D: discover-structure-decomposed (shared suffstat kernel) ==")
+(let [d (prog/discover-structure-decomposed txk kvars)]
+  (assert-exact "marginals" (:d-marginals GOLDEN) (:marginals d))
+  (assert-exact "per-variable parent-set log-MLs"
+                (:d-per-var-logmls GOLDEN)
+                (into {} (for [[v info] (:per-variable d)]
+                           [v (mapv (juxt #(vec (sort (map name (:parents %)))) :log-ml)
+                                    (:parent-sets info))]))))
+
+(println "\n== discover-structure (enum path, compute-posterior reuse) ==")
+(let [ds (prog/discover-structure kvars txk)]
+  (assert-exact "best name" (:ds-best-name GOLDEN) (:name (:best ds)))
+  (assert-exact "best log-ML" (:ds-best-logml GOLDEN) (:log-ml (:best ds)))
+  (assert-exact "ranked log-MLs" (:ds-ranked-logmls GOLDEN) (mapv :log-ml (:ranked ds))))
+
+(println "\n== builders: build-constraints / build-sequential-constraints / param-selection ==")
+(assert-exact "build-constraints addrs+vals" (:bc GOLDEN)
+              (cm->items (prog/build-constraints tx2 [:x :y])))
+(assert-exact "build-sequential-constraints cumulative" (:bsc GOLDEN)
+              (mapv cm->items (prog/build-sequential-constraints tx2 [:x :y])))
+(assert-exact "param-selection addresses" (:psel GOLDEN)
+              (pr-str (prog/param-selection [:x :y] edges-xy)))
+
+(mx/force-gc!)
+(report)


### PR DESCRIPTION
Completes **genmlx-heal** (the two items deferred from wave 0 of milestone genmlx-b3nx): a behavior-preserving DRY pass over `program.cljs`’s conjugate log-ML kernels and the analytical-inference `LOG-2PI` constant. Also folds in the **genmlx-x8i7** test fix (see below).

## `program.cljs`
- **Delete dead `log-ml-general`** — unreferenced repo-wide (deletion is the right DRY resolution for dead code, not “factor”).
- **Extract `log-ml-suffstat-terms`** — the shared sufficient-statistics kernel for `score-all-structures` and `score-parent-sets-for-variable`, whose per-target bodies were byte-identical. It returns the **three additive log-ML terms** (not their sum) so each caller folds them in its *original* floating-point association — `(+ total t1 t2 t3)` vs `(+ t1 t2 t3)` — preserving least-significant bits. (Pre-summing in the kernel re-associated the addition and shifted all 64 of `score-all-structures`’ totals at the LSB; the golden test caught it.) `log-ml-variable` (closed-form p≤2 fast path) is left untouched on purpose.
- **Reuse `compute-posterior`** in `discover-structure`, `discover-structure-decomposed`, and `edge-marginals`.
- **Extract runtime address builders** `obs-addr`/`prev-key`/`next-key`/`sigma-key`, applied only at runtime sites. The SCI source-string builders are deliberately left separate — a one-char change there would alter compiled models.
- **Extract `subsets`** (bit-mask powerset) shared by `enumerate-all-structures` and `score-parent-sets-for-variable`.

## `LOG-2PI` centralization
Replaced the local `(def ^:private LOG-2PI 1.8378770664093453)` with `genmlx.mlx.constants/LOG-2PI` in `inference/kalman`, `conjugate`, `ekf_nd`, `auto_analytical`, and `amortized`. The literal equals `(js/Math.log (* 2.0 js/Math.PI))` exactly and every use is wrapped in `mx/scalar`, so float32 results are byte-identical; no dependency cycle (`constants` requires only `genmlx.mlx`).

## genmlx-x8i7 — NIG importance-sampling tolerances
`conjugate_posterior_test`’s two `nig-is-*-converges` tests were failing. Diagnosed as **Monte-Carlo variance, not bias**: they use the *prior* as the IS proposal, but the posterior mean (~2.35) sits far in the prior’s tail, so effective sample size is only ~26 of 5000. A 14-seed sweep shows the estimator is unbiased (mu avg 2.366 vs 2.3545; σ² avg 0.896 vs 0.9119) while single 5000-sample runs scatter widely (mu ∈ [2.29, 2.43], σ² ∈ [0.80, 1.03]); seeds 77/88 were unlucky draws. Fix (test-only): widened tolerances to ~3× the measured IS standard error (mu 0.05→0.12, σ² 0.10→0.20), kept the deterministic seeds, and documented the rationale inline. Inference behavior is unchanged.

## Verification
New `test/genmlx/program_golden_test.cljs` pins **exact `=`** outputs of the B/C/D log-ML kernels, `compute-posterior`, `edge-marginals`, `discover-structure(-decomposed)`, and the constraint/selection builders on fixed deterministic inputs. Captured pre-refactor; **15/15** after → bit-for-bit behavior-preserving.

Green (0 failures): `program` 174/174, `program_golden` 15/15, `smc_scoring` 41/41, `kalman`, `ekf`, `ekf_nd`, `multistep_kalman_ekf`, `conjugate`, `conjugate_posterior`, `conjugate_bb`, `conjugate_gp`, `conjugacy`, `auto_analytical`, `analytical_posterior_referee`, `iid_conjugacy`, `l3_5_combinator_conjugacy`.

## Remaining pre-existing failure (not from this PR)
- `amortized_test` — flaky due to unseeded `rng/fresh-key` in NN training (tracked in genmlx-jekm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
