### PR TITLE
fix(llm): build [1 N] model input directly, dodge reshape stream bug (genmlx-7siy)

### DIFF
--- a/src/genmlx/llm/backend.cljs
+++ b/src/genmlx/llm/backend.cljs
@@ -84,6 +84,20 @@
   [token-ids]
   (if (vector? token-ids) token-ids (vec token-ids)))
 
+(defn- ids->input
+  "Build a [1 N] int32 model-input MxArray from token ids.
+
+   Constructs the [1 N] array directly (fromInt32 with the shape baked in)
+   rather than building [N] and reshaping to [1 N]. A reshaped array can be
+   bound to a non-default GPU stream in some mlx-node/MLX builds; feeding it to
+   the model then crashes the attention kernel with
+   'no Stream(gpu, 1) in current thread' on certain GPUs (reproduced on M2 Max,
+   not on M4). Baking the shape into construction keeps the input on the default
+   GPU stream. See bean genmlx-7siy."
+  [ids]
+  (let [v (->id-vec ids)]
+    (mx/array v [1 (count v)] mx/int32)))
+
 (defn forward-pass
   "Run a forward pass through the model.
 
@@ -94,7 +108,7 @@
   [model token-ids]
   (let [ids (->id-vec token-ids)
         n (count ids)
-        input (mx/reshape (mx/array ids mx/int32) [1 n])
+        input (ids->input ids)
         logits (.forward model input)]
     (-> logits (mx/index 0) (mx/index (dec n)))))
 
@@ -141,9 +155,7 @@
 
    Must call init-cache! before this."
   [model token-ids]
-  (let [ids (->id-vec token-ids)
-        n (count ids)
-        input (mx/reshape (mx/array ids mx/int32) [1 n])
+  (let [input (ids->input token-ids)
         logits (forward-with-cache model input)]
     (-> logits (mx/index 0) (mx/index 0))))
 
@@ -155,7 +167,7 @@
 
    Constant time in sequence length — does not recompute the full context."
   [model token-id]
-  (let [input (mx/reshape (mx/scalar token-id mx/int32) [1 1])
+  (let [input (ids->input [token-id])
         logits (forward-with-cache model input)]
     (-> logits (mx/index 0) (mx/index 0))))
 


### PR DESCRIPTION
## Problem
`forward-pass` / `forward-prefill` / `forward-step` in `genmlx.llm.backend` built
the model input as a `[N]` array then `reshape([1 N])`. On some GPUs (reproduced on
an Apple **M2 Max**, not on M4) a reshaped array binds to a **non-default GPU stream**;
feeding it to the model crashes the attention kernel with
`mlx_fused_attention_output: no Stream(gpu, 1) in current thread` (MLX's new
thread-local `CommandEncoder`). A collaborator isolated it to two lines: shape-at-
construction works, `fromInt32([N]) + reshape([1,N])` fails — only the reshape differs.

## Fix
Construct the `[1 N]` int32 input **directly** via `mx/array`'s 3-arity
(`fromInt32` with the shape baked in) through a new `ids->input` helper — no reshape,
so the input stays on the default GPU stream. Works on any chip, no native rebuild.

## Verified on M4 (parity, no behavior change)
- `llm_backend_test` 25/0
- `llm_core_test` 36/0
- `qwen2_coder_test` 13/0
- `llm_grammar_test` clean

The mlx-node-side root cause (`core.reshape` binding to the generation stream) is the
proper fix and is tracked separately (bean genmlx-7siy, Fix A); this PR is the
chip-independent genmlx-side resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)