### PR TITLE
feat(agentmodels): ergonomic PPL helpers (factor-dist, softmax-action, value-carrying draws)

### DIFF
--- a/examples/agentmodels/helpers.cljs
+++ b/examples/agentmodels/helpers.cljs
@@ -1,0 +1,143 @@
+(ns agentmodels.helpers
+  "Ergonomic helpers for the agentmodels examples library.
+
+   Closes the 'partial' PPL-ergonomics gaps with a tiny shared namespace —
+   zero core/engine change. Every helper composes existing GenMLX primitives:
+
+   - `factor-dist`   soft conditioning via the handler's :score path
+                     (defdist, mirroring dist/delta)
+   - `softmax-action` Boltzmann policy = Categorical(softmax(alpha * EU))
+                     (the GenMLX realization of agentmodels' factor(alpha * EU))
+   - `uniform-draw` / `weighted-draw`  value-carrying categorical draws
+                     (generalizes llm/bytes byte-marginals->categorical out of
+                     the LLM layer)
+   - `boxed-choice`  distribution-as-value via a :kind index + SwitchCombinator
+
+   These belong in an examples library, not the engine: they are conveniences
+   over the GFI, not new GFI machinery."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.combinators :as comb]
+            [genmlx.inference.exact :as exact])
+  (:require-macros [genmlx.gen :refer [gen]]
+                   [genmlx.dist.macros :refer [defdist]]))
+
+;; ---------------------------------------------------------------------------
+;; factor-dist — soft conditioning
+;; ---------------------------------------------------------------------------
+;;
+;; The handler's transitions all do `score += dist-log-prob(value)` (see
+;; handler.cljs). A distribution whose log-prob is a constant w — independent
+;; of the drawn value — therefore injects exactly w into the trace score. That
+;; is precisely WebPPL/agentmodels' `factor(w)`: a soft observation that
+;; reweights the trace without binding a random variable.
+;;
+;; Structurally this mirrors dist/delta (deterministic draw, point support) but
+;; replaces delta's 0/-inf indicator log-prob with the free scalar w.
+
+(defdist factor-dist
+  "Soft-conditioning pseudo-distribution. Deterministically draws 0 and
+   contributes log-weight w to the trace :score for *any* drawn value, so
+
+     (trace :soft (factor-dist (mx/scalar 2.3)))   ; score += 2.3
+
+   realizes agentmodels' factor(2.3). Mirrors dist/delta but injects an
+   arbitrary scalar log-factor rather than a 0/-inf point-mass indicator."
+  [w]
+  (sample [_key] (mx/scalar 0.0))
+  (log-prob [_value] w)
+  (support [] [(mx/scalar 0.0)]))
+
+;; Batch-sampling support so factor-dist works under vsimulate/vgenerate too:
+;; the draw is the constant 0 broadcast to [n] (log-prob already broadcasts w).
+(defmethod genmlx.dist.core/dist-sample-n* :factor-dist [_d _key n]
+  (mx/broadcast-to (mx/scalar 0.0) [n]))
+
+;; ---------------------------------------------------------------------------
+;; softmax-action — Boltzmann / soft-max policy
+;; ---------------------------------------------------------------------------
+;;
+;; agentmodels selects actions with `factor(alpha * EU(action))` inside an
+;; enumerated action choice, which is mathematically Categorical(softmax(alpha *
+;; EU)). dist/categorical already treats its argument as logits and normalizes
+;; via log_softmax, so passing `alpha * EU` directly yields the Boltzmann
+;; policy. This is the same construction proven in examples/memo/mdp.cljs
+;; (logits = alpha * Q, then dist/categorical).
+;;
+;; As alpha -> inf the policy concentrates on argmax(EU); we make that limit
+;; exact (and uniformly tie-broken) by delegating to exact/categorical-argmax.
+
+(defn softmax-action
+  "Boltzmann action policy: returns a Categorical distribution over actions
+   with logits `alpha * eu`, i.e. action ~ Categorical(softmax(alpha * eu)).
+
+   `eu` is a vector/array of expected utilities, one per action. `alpha` is the
+   (inverse-temperature) rationality parameter. With alpha = ##Inf the policy is
+   the deterministic argmax, delegated to exact/categorical-argmax so ties break
+   uniformly. This is the primary GenMLX realization of factor(alpha * EU)."
+  [alpha eu]
+  (if (= alpha ##Inf)
+    (exact/categorical-argmax eu)
+    (dist/categorical (mx/multiply (mx/scalar alpha) eu))))
+
+;; ---------------------------------------------------------------------------
+;; uniform-draw / weighted-draw — value-carrying categorical
+;; ---------------------------------------------------------------------------
+;;
+;; A categorical samples an *index*; the modeller almost always wants the value
+;; behind that index. `byte-marginals->categorical` in llm/bytes.cljs solved
+;; exactly this for byte characters ({:dist ... :chars ...} + (nth chars i)).
+;; These helpers lift that pattern out of the LLM layer into a generic
+;; {:dist ... :values ...} box with a gather-by-index lookup.
+
+(defn weighted-draw
+  "Value-carrying weighted categorical. Given parallel `values` and `weights`
+   vectors, returns {:dist (dist/weighted weights) :values (vec values)}.
+   Sampling :dist yields an index i; (draw-value the-box i) recovers the value.
+   Generalizes llm/bytes byte-marginals->categorical."
+  [values weights]
+  {:dist   (dist/weighted (vec weights))
+   :values (vec values)})
+
+(defn uniform-draw
+  "Value-carrying uniform categorical — weighted-draw with equal weights over
+   `values`. Sampling :dist yields an index i; (draw-value the-box i) recovers
+   the value."
+  [values]
+  (weighted-draw values (repeat (count values) 1.0)))
+
+(defn draw-value
+  "Gather the value selected by index `idx` from a uniform-/weighted-draw box.
+   `idx` may be a plain integer or an MLX integer scalar (as returned by a
+   categorical sample)."
+  [draw idx]
+  (let [i (if (mx/array? idx) (mx/item idx) idx)]
+    (nth (:values draw) (int i))))
+
+;; ---------------------------------------------------------------------------
+;; Distribution-as-value via a :kind index + SwitchCombinator
+;; ---------------------------------------------------------------------------
+;;
+;; agentmodels often draws *which sub-model* to run (e.g. which agent type,
+;; which goal-prior) and then runs it. In GenMLX the idiomatic encoding is:
+;;
+;;   1. trace a discrete :kind index from a categorical (uniform-/weighted-draw
+;;      gives you the value box if the branches carry payloads);
+;;   2. dispatch on that index with a SwitchCombinator (combinators.cljs), whose
+;;      simulate runs branch `kind` with the supplied branch args.
+;;
+;; The SwitchCombinator is a first-class generative function, so the chosen
+;; sub-model is itself a value living in the trace — distribution-as-value
+;; without leaving the GFI. `boxed-choice` packages the two-step convention.
+
+(defn boxed-choice
+  "Box a sub-model selection as a single generative function. Returns a
+   SwitchCombinator over `branches` (each a generative function). Call its GFI
+   ops with args `[kind & branch-args]`: index `kind` selects the branch, and
+   the selected sub-model's choices/score live in the resulting trace under the
+   :kind path — distribution-as-value without leaving the GFI.
+
+     (def choose (boxed-choice [model-a model-b]))
+     (p/simulate choose [kind arg0 arg1])   ; runs branch `kind`"
+  [branches]
+  (apply comb/switch-combinator branches))

--- a/nbb.edn
+++ b/nbb.edn
@@ -1,1 +1,1 @@
-{:paths ["src" "test" "test.check" "malli/src" "instaparse/src"]}
+{:paths ["src" "test" "examples" "test.check" "malli/src" "instaparse/src"]}

--- a/test/genmlx/agentmodels_helpers_test.cljs
+++ b/test/genmlx/agentmodels_helpers_test.cljs
@@ -1,0 +1,148 @@
+;; Unit tests for agentmodels.helpers — the ergonomic PPL helpers used across
+;; the agentmodels examples library (factor-dist, softmax-action, value-carrying
+;; draws, boxed-choice). Self-contained; no test framework.
+;;
+;; Ground truth: factor-dist injects the exact scalar log-weight into the trace
+;; :score path; softmax-action reproduces a hand-computed Boltzmann distribution.
+;;
+;; Run: bun run --bun nbb test/genmlx/agentmodels_helpers_test.cljs
+
+(ns genmlx.agentmodels-helpers-test
+  (:require [agentmodels.helpers :as h]
+            [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.gen :refer-macros [gen]]))
+
+;; -----------------------------------------------------------------------------
+;; Test infrastructure
+;; -----------------------------------------------------------------------------
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+
+(defn assert-true [msg cond]
+  (if cond
+    (do (vswap! passed inc) (println " PASS" msg))
+    (do (vswap! failed inc) (println " FAIL" msg))))
+
+(defn assert-close [msg expected actual tol]
+  (let [diff (Math/abs (- expected actual))]
+    (if (<= diff tol)
+      (do (vswap! passed inc) (println " PASS" msg "  =" actual))
+      (do (vswap! failed inc)
+          (println " FAIL" msg "  expected:" expected "  got:" actual "  diff:" diff)))))
+
+(defn assert-equal [msg expected actual]
+  (if (= expected actual)
+    (do (vswap! passed inc) (println " PASS" msg "  =" actual))
+    (do (vswap! failed inc)
+        (println " FAIL" msg "  expected:" expected "  got:" actual))))
+
+(def tol 1e-5)
+
+;; -----------------------------------------------------------------------------
+;; Section 1: factor-dist injects the exact scalar into :score
+;; -----------------------------------------------------------------------------
+
+(println "\n== Section 1: factor-dist score injection ==")
+
+;; A factor-only model: simulate starts score at 0 and adds log-prob = w, so the
+;; trace score must equal w exactly — proving the injection is exact, not merely
+;; monotone.
+(let [w     2.3
+      model (dyn/auto-key (gen [] (let [_ (trace :soft (h/factor-dist (mx/scalar w)))] 0)))
+      tr    (p/simulate model [])]
+  (assert-close "single factor: score == w" w (mx/item (:score tr)) tol))
+
+;; Two factors accumulate additively: score == w1 + w2.
+(let [w1 1.5 w2 -0.75
+      model (dyn/auto-key
+              (gen []
+                (let [_ (trace :f1 (h/factor-dist (mx/scalar w1)))
+                      _ (trace :f2 (h/factor-dist (mx/scalar w2)))]
+                  0)))
+      tr (p/simulate model [])]
+  (assert-close "two factors: score == w1 + w2" (+ w1 w2) (mx/item (:score tr)) tol))
+
+;; The draw is deterministically 0 regardless of w (point support at 0).
+(let [d (h/factor-dist (mx/scalar 9.9))]
+  (assert-close "factor-dist draws 0" 0.0 (mx/item (dist/sample d)) tol)
+  (assert-close "factor-dist log-prob == w for any value"
+                9.9 (mx/item (dist/log-prob d (mx/scalar 123.0))) tol))
+
+;; -----------------------------------------------------------------------------
+;; Section 2: softmax-action == hand-computed Boltzmann
+;; -----------------------------------------------------------------------------
+
+(println "\n== Section 2: softmax-action Boltzmann policy ==")
+
+;; eu = [1, 2, 0], alpha = 0.5 -> logits z = [0.5, 1.0, 0.0].
+;; Boltzmann probs = softmax(z):
+;;   exp = [e^0.5, e^1, e^0] = [1.6487212707, 2.7182818285, 1.0], sum = 5.3670030992
+;;   p   = [0.30719739, 0.50647924, 0.18632337]
+(let [eu      (mx/array #js [1.0 2.0 0.0])
+      d       (h/softmax-action 0.5 eu)
+      exps    [(Math/exp 0.5) (Math/exp 1.0) (Math/exp 0.0)]
+      z       (reduce + exps)
+      hand    (mapv #(/ % z) exps)]
+  (doseq [i (range 3)]
+    (let [p-i (Math/exp (mx/item (dist/log-prob d (mx/scalar i mx/int32))))]
+      (assert-close (str "softmax-action P(action " i ") matches Boltzmann")
+                    (nth hand i) p-i tol))))
+
+;; alpha = ##Inf -> deterministic argmax over eu (index 1, eu = 2.0). The
+;; resulting categorical places all mass on the argmax: P(1) == 1.
+(let [eu (mx/array #js [1.0 2.0 0.0])
+      d  (h/softmax-action ##Inf eu)]
+  (assert-close "alpha=Inf: P(argmax index 1) == 1"
+                1.0 (Math/exp (mx/item (dist/log-prob d (mx/scalar 1 mx/int32)))) tol))
+
+;; -----------------------------------------------------------------------------
+;; Section 3: value-carrying draws (uniform-draw / weighted-draw)
+;; -----------------------------------------------------------------------------
+
+(println "\n== Section 3: value-carrying draws ==")
+
+(let [box (h/weighted-draw [:a :b :c] [1.0 2.0 1.0])]
+  (assert-equal "weighted-draw stores values" [:a :b :c] (:values box))
+  (assert-true  "weighted-draw :dist is a Distribution" (some? (:dist box)))
+  ;; gather by MLX index scalar (as a categorical sample would yield)
+  (assert-equal "draw-value gathers by MLX index" :b (h/draw-value box (mx/scalar 1 mx/int32)))
+  ;; gather by plain integer
+  (assert-equal "draw-value gathers by plain int" :c (h/draw-value box 2))
+  ;; weights normalize correctly: P = [1/4, 2/4, 1/4]
+  (doseq [[i pi] (map vector (range 3) [0.25 0.5 0.25])]
+    (assert-close (str "weighted-draw P(" i ")") pi
+                  (Math/exp (mx/item (dist/log-prob (:dist box) (mx/scalar i mx/int32)))) tol)))
+
+(let [box (h/uniform-draw [:x :y :z :w])]
+  (assert-equal "uniform-draw stores values" [:x :y :z :w] (:values box))
+  (doseq [i (range 4)]
+    (assert-close (str "uniform-draw P(" i ") == 1/4") 0.25
+                  (Math/exp (mx/item (dist/log-prob (:dist box) (mx/scalar i mx/int32)))) tol)))
+
+;; -----------------------------------------------------------------------------
+;; Section 4: distribution-as-value via boxed-choice (SwitchCombinator)
+;; -----------------------------------------------------------------------------
+
+(println "\n== Section 4: boxed-choice sub-model selection ==")
+
+(let [model-a (dyn/auto-key (gen [] (let [_ (trace :v (dist/delta (mx/scalar 10.0)))] (mx/scalar 10.0))))
+      model-b (dyn/auto-key (gen [] (let [_ (trace :v (dist/delta (mx/scalar 20.0)))] (mx/scalar 20.0))))
+      choose  (h/boxed-choice [model-a model-b])
+      tr0     (p/simulate choose [0])
+      tr1     (p/simulate choose [1])]
+  (assert-close "boxed-choice kind 0 runs branch A" 10.0 (mx/item (:retval tr0)) tol)
+  (assert-close "boxed-choice kind 1 runs branch B" 20.0 (mx/item (:retval tr1)) tol))
+
+;; -----------------------------------------------------------------------------
+;; Summary
+;; -----------------------------------------------------------------------------
+
+(println "\n========================================")
+(println "  PASSED:" @passed "   FAILED:" @failed)
+(println "========================================")
+(when (pos? @failed)
+  (js/process.exit 1))


### PR DESCRIPTION
## Summary

Adds `examples/agentmodels/helpers.cljs` — the foundation namespace for the agentmodels examples library. **Zero core/engine change**; every helper composes existing GenMLX primitives.

| Helper | What it does | Composes |
|---|---|---|
| `factor-dist` | Soft conditioning — injects exact scalar `w` into trace `:score` | `defdist` + handler's `score += log-prob` path |
| `softmax-action` | Boltzmann policy `Categorical(softmax(α·EU))`; `α=##Inf` → deterministic argmax | `dist/categorical`, `exact/categorical-argmax` |
| `uniform-draw`/`weighted-draw` + `draw-value` | Value-carrying categorical with gather-by-index | `dist/weighted` (lifts the `llm/bytes` pattern out of the LLM layer) |
| `boxed-choice` | Distribution-as-value: `:kind` index + branch dispatch | `combinators/switch-combinator` |

`factor-dist` mirrors `dist/delta` (deterministic draw `0`, point support) but its `log-prob` returns the free scalar `w` for *any* value, so the handler's `score += dist-log-prob(value)` path injects exactly `w` — the GenMLX realization of WebPPL's `factor(w)`. A `dist-sample-n*` method keeps it working under `vsimulate`/`vgenerate`.

## Infra

Adds `"examples"` to `nbb.edn` `:paths` so the shared library is requirable off the parent classpath. Verified empirically that nbb needs this; confirmed no namespace collisions with `src`/`test`.

## Tests

`test/genmlx/agentmodels_helpers_test.cljs` — **22/22 pass**:
- Exact score injection (single factor + additive accumulation)
- Hand-computed Boltzmann distribution, including the `α=##Inf` argmax limit
- Value-carrying draw normalization + gather-by-index (MLX scalar and plain int)
- `boxed-choice` branch dispatch

Core suites (`dist`, `combinators`, `level0_certification`) remain green after the classpath change.

## Context

First deliverable of the agentmodels foundation epic. Unblocks the downstream gridworld / agent / presentation / TUI-gallery work (the classpath change in particular is a shared dependency).

Bean: `genmlx-gcq4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
