### PR TITLE
feat(agentmodels-tui): gridworld MDP demo — first TUI vertical slice

### DIFF
--- a/examples/agentmodels-tui/README.md
+++ b/examples/agentmodels-tui/README.md
@@ -12,10 +12,15 @@ headless test; everything here above the seam is just reagent + Ink turning that
 same data into colored cells.
 
 ```
-gridworld.cljs ─► agent.cljs ─► presentation.cljs ─►║ Frame ║─► views.cljs ─► gallery/ch3_demo
-   (env tensors)   (VI + GFI      (pure producers +  ║ SEAM  ║   (Ink views)    (this sub-app)
-                    policy)        ASCII renderers)   ╚═══════╝
+gridworld.cljs ─► agent.cljs ─► presentation.cljs ─►║ Frame  ║─► views.cljs ─► gallery / demos
+   (env tensors)   (VI + GFI      (pure producers +  ║ Bars   ║   (Ink views)    (this sub-app)
+   inverse.cljs    policy)        ASCII renderers)    ║ SEAM   ║
+   (assess-based goal inference)                      ╚════════╝
 ```
+
+Two demos: **Ch 3** (an MDP agent walking a maze) and **Ch 5** (inverse goal
+inference — infer what the agent wants from how it moves, watching the posterior
+sharpen live).
 
 ## Run it
 
@@ -42,8 +47,17 @@ reagent/nbb/@mlx-node from the repo root via `NODE_PATH`) and adds an explicit
 | Ch 3 demo | `+` / `-` | raise / lower the rationality alpha (`+` toward optimal) |
 | Ch 3 demo | `n` | cycle the transition noise (0 → 0.1 → 0.2 → 0.4) |
 | Ch 3 demo | `q` / `esc` | back to the menu |
+| Ch 5 demo | `space` | reveal the next observed action |
+| Ch 5 demo | `r` | resample a fresh walk |
+| Ch 5 demo | `t` | toggle the agent's true goal (A / B) |
+| Ch 5 demo | `q` / `esc` | back to the menu |
 
-The agent auto-walks a maze where a wall belt forces a detour. Two separable
+**Ch 5** plays the true agent's walk on the left and the observer's `P(goal)`
+bars on the right; the bars stay flat while the agent heads down the symmetry
+axis, then snap to the true goal the instant it turns. The likelihood is
+`p/assess` on each goal's policy — the forward agent model, inverted.
+
+The Ch 3 agent auto-walks a maze where a wall belt forces a detour. Two separable
 sources of randomness: **alpha** is *decision* noise (low alpha → worse actions;
 `INF` → optimal), while **n** sets *environment* noise — the agentmodels
 orthogonal slip, where the intended move slips to a perpendicular one. Raise
@@ -55,7 +69,7 @@ the high-utility goal `B`; add noise and the same policy visibly skids off cours
 The whole pipeline below the seam is verified without a terminal:
 
 ```bash
-bun run --bun nbb test/genmlx/agentmodels_slice_test.cljs   # 39/39
+bun run --bun nbb test/genmlx/agentmodels_slice_test.cljs   # 45/45
 ```
 
 Because the views are pure functions of the data that test validates, a passing

--- a/examples/agentmodels-tui/README.md
+++ b/examples/agentmodels-tui/README.md
@@ -40,18 +40,22 @@ reagent/nbb/@mlx-node from the repo root via `NODE_PATH`) and adds an explicit
 | Ch 3 demo | `space` | step the agent one frame |
 | Ch 3 demo | `r` | resample the rollout at the current alpha |
 | Ch 3 demo | `+` / `-` | raise / lower the rationality alpha (`+` toward optimal) |
+| Ch 3 demo | `n` | cycle the transition noise (0 → 0.1 → 0.2 → 0.4) |
 | Ch 3 demo | `q` / `esc` | back to the menu |
 
-The agent also auto-walks on a timer. Raise alpha toward `INF` and the path
-snaps to the sharp optimal route around the wall to the high-utility goal `B`;
-lower it and the path wanders.
+The agent auto-walks a maze where a wall belt forces a detour. Two separable
+sources of randomness: **alpha** is *decision* noise (low alpha → worse actions;
+`INF` → optimal), while **n** sets *environment* noise — the agentmodels
+orthogonal slip, where the intended move slips to a perpendicular one. Raise
+alpha toward `INF` at noise 0 and the path snaps to the sharp optimal route to
+the high-utility goal `B`; add noise and the same policy visibly skids off course.
 
 ## What proves it works
 
 The whole pipeline below the seam is verified without a terminal:
 
 ```bash
-bun run --bun nbb test/genmlx/agentmodels_slice_test.cljs   # 27/27
+bun run --bun nbb test/genmlx/agentmodels_slice_test.cljs   # 39/39
 ```
 
 Because the views are pure functions of the data that test validates, a passing

--- a/examples/agentmodels-tui/README.md
+++ b/examples/agentmodels-tui/README.md
@@ -18,10 +18,12 @@ gridworld.cljs ─► agent.cljs ─► presentation.cljs ─►║ Frame  ║�
    pomdp{,_env}.cljs (QMDP belief filtering)          ╚════════╝
 ```
 
-Three demos: **Ch 3** (an MDP agent walking a maze), **Ch 3c** (a POMDP agent
+Four demos: **Ch 3** (an MDP agent walking a maze), **Ch 3c** (a POMDP agent
 acting under uncertainty about which goal pays, its belief snapping to the truth
-when it reaches a signpost), and **Ch 5** (inverse goal inference — infer what an
-agent wants from how it moves, watching the posterior sharpen live).
+when it reaches a signpost), **Ch 3d** (bandits — Beta belief per arm, Thompson
+posterior sampling concentrating pulls on the best arm), and **Ch 5** (inverse
+goal inference — infer what an agent wants from how it moves, watching the
+posterior sharpen live).
 
 ## Run it
 
@@ -52,6 +54,10 @@ reagent/nbb/@mlx-node from the repo root via `NODE_PATH`) and adds an explicit
 | Ch 3c demo | `r` | resample a fresh belief-filtered rollout |
 | Ch 3c demo | `t` | toggle which goal is actually rewarding |
 | Ch 3c demo | `q` / `esc` | back to the menu |
+| Ch 3d demo | `space` | step one pull |
+| Ch 3d demo | `r` | resample a fresh bandit run |
+| Ch 3d demo | `t` | toggle Thompson ↔ softmax-greedy |
+| Ch 3d demo | `q` / `esc` | back to the menu |
 | Ch 5 demo | `space` | reveal the next observed action |
 | Ch 5 demo | `r` | resample a fresh walk |
 | Ch 5 demo | `t` | toggle the agent's true goal (A / B) |
@@ -76,6 +82,7 @@ The whole pipeline below the seam is verified without a terminal:
 ```bash
 bun run --bun nbb test/genmlx/agentmodels_slice_test.cljs   # 51/51  (Ch3/Ch5 + recursive==tensor)
 bun run --bun nbb test/genmlx/agentmodels_pomdp_test.cljs   # 22/22  (Ch3c belief filtering + QMDP)
+bun run --bun nbb test/genmlx/bandit_test.cljs              # 18/18  (Ch3d Beta filter + Thompson)
 ```
 
 Because the views are pure functions of the data that test validates, a passing

--- a/examples/agentmodels-tui/README.md
+++ b/examples/agentmodels-tui/README.md
@@ -15,12 +15,13 @@ same data into colored cells.
 gridworld.cljs ─► agent.cljs ─► presentation.cljs ─►║ Frame  ║─► views.cljs ─► gallery / demos
    (env tensors)   (VI + GFI      (pure producers +  ║ Bars   ║   (Ink views)    (this sub-app)
    inverse.cljs    policy)        ASCII renderers)    ║ SEAM   ║
-   (assess-based goal inference)                      ╚════════╝
+   pomdp{,_env}.cljs (QMDP belief filtering)          ╚════════╝
 ```
 
-Two demos: **Ch 3** (an MDP agent walking a maze) and **Ch 5** (inverse goal
-inference — infer what the agent wants from how it moves, watching the posterior
-sharpen live).
+Three demos: **Ch 3** (an MDP agent walking a maze), **Ch 3c** (a POMDP agent
+acting under uncertainty about which goal pays, its belief snapping to the truth
+when it reaches a signpost), and **Ch 5** (inverse goal inference — infer what an
+agent wants from how it moves, watching the posterior sharpen live).
 
 ## Run it
 
@@ -47,6 +48,10 @@ reagent/nbb/@mlx-node from the repo root via `NODE_PATH`) and adds an explicit
 | Ch 3 demo | `+` / `-` | raise / lower the rationality alpha (`+` toward optimal) |
 | Ch 3 demo | `n` | cycle the transition noise (0 → 0.1 → 0.2 → 0.4) |
 | Ch 3 demo | `q` / `esc` | back to the menu |
+| Ch 3c demo | `space` | step the agent one frame |
+| Ch 3c demo | `r` | resample a fresh belief-filtered rollout |
+| Ch 3c demo | `t` | toggle which goal is actually rewarding |
+| Ch 3c demo | `q` / `esc` | back to the menu |
 | Ch 5 demo | `space` | reveal the next observed action |
 | Ch 5 demo | `r` | resample a fresh walk |
 | Ch 5 demo | `t` | toggle the agent's true goal (A / B) |
@@ -69,7 +74,8 @@ the high-utility goal `B`; add noise and the same policy visibly skids off cours
 The whole pipeline below the seam is verified without a terminal:
 
 ```bash
-bun run --bun nbb test/genmlx/agentmodels_slice_test.cljs   # 45/45
+bun run --bun nbb test/genmlx/agentmodels_slice_test.cljs   # 51/51  (Ch3/Ch5 + recursive==tensor)
+bun run --bun nbb test/genmlx/agentmodels_pomdp_test.cljs   # 22/22  (Ch3c belief filtering + QMDP)
 ```
 
 Because the views are pure functions of the data that test validates, a passing

--- a/examples/agentmodels-tui/README.md
+++ b/examples/agentmodels-tui/README.md
@@ -1,0 +1,65 @@
+# agentmodels TUI gallery
+
+A terminal gallery for the [agentmodels.org](https://agentmodels.org) port —
+watch GenMLX agents plan and walk through gridworlds, right in your terminal.
+This is the **demo gallery** (distinct from the Studio TUI, bean `genmlx-tw52`).
+
+## The architecture in one line
+
+Everything below the **render-agnostic data seam** (`agentmodels.presentation`:
+`Frame` / `Trajectory` / `PosteriorBars`) is pure CLJS + MLX and is proven by a
+headless test; everything here above the seam is just reagent + Ink turning that
+same data into colored cells.
+
+```
+gridworld.cljs ─► agent.cljs ─► presentation.cljs ─►║ Frame ║─► views.cljs ─► gallery/ch3_demo
+   (env tensors)   (VI + GFI      (pure producers +  ║ SEAM  ║   (Ink views)    (this sub-app)
+                    policy)        ASCII renderers)   ╚═══════╝
+```
+
+## Run it
+
+```bash
+cd examples/agentmodels-tui
+npm install            # ink + react into local node_modules (one time)
+./run.sh               # interactive gallery (needs a real terminal)
+./run.sh views         # static views smoke (renders sample data, then exits)
+```
+
+`run.sh` mirrors `examples/genmlx-tui/run.sh` (ink from local `node_modules`,
+reagent/nbb/@mlx-node from the repo root via `NODE_PATH`) and adds an explicit
+`--classpath` so the multi-file sub-app and the `agentmodels.*` library resolve.
+
+## Keys
+
+| screen | key | action |
+|--------|-----|--------|
+| menu | `↑`/`↓` | select a demo |
+| menu | `enter` | open the selected demo |
+| menu | `q` | quit |
+| Ch 3 demo | `space` | step the agent one frame |
+| Ch 3 demo | `r` | resample the rollout at the current alpha |
+| Ch 3 demo | `+` / `-` | raise / lower the rationality alpha (`+` toward optimal) |
+| Ch 3 demo | `q` / `esc` | back to the menu |
+
+The agent also auto-walks on a timer. Raise alpha toward `INF` and the path
+snaps to the sharp optimal route around the wall to the high-utility goal `B`;
+lower it and the path wanders.
+
+## What proves it works
+
+The whole pipeline below the seam is verified without a terminal:
+
+```bash
+bun run --bun nbb test/genmlx/agentmodels_slice_test.cljs   # 27/27
+```
+
+Because the views are pure functions of the data that test validates, a passing
+test means the live TUI renders correct pictures by construction.
+
+## Adding a demo
+
+Append one entry to `demos` in `gallery.cljs`:
+`{:id … :title … :view … :on-key … :enter … :leave …}`. No nav code to touch.
+View primitives (`grid-view`, `bars-view`, `frames-view`, `status-bar`) live in
+`views.cljs` and consume only `agentmodels.presentation` data shapes.

--- a/examples/agentmodels-tui/ch3_demo.cljs
+++ b/examples/agentmodels-tui/ch3_demo.cljs
@@ -1,0 +1,80 @@
+(ns ch3-demo
+  "Ch 3 gridworld MDP demo — the end-to-end vertical slice.
+
+   Real GenMLX inference drives the picture: tensor value iteration -> Q, a
+   softmax-action rollout to a terminal, then the render-agnostic Frame producer.
+   The agent then walks the sampled path in the terminal. +/- change the
+   rationality alpha (alpha = infinity -> deterministic optimal); the path
+   visibly changes. Pure data crosses the seam; this file only wires + renders.
+
+   Demo state lives in one r/atom (the proven reactive model); the gallery routes
+   keys here via on-key and starts/stops the autoplay timer via enter!/leave!."
+  (:require ["ink" :refer [Text Box]]
+            [reagent.core :as r]
+            [agentmodels.gridworld :as gw]
+            [agentmodels.agent :as agent]
+            [agentmodels.presentation :as pres]
+            [views]))
+
+;; The demo world (top row first; screen coords).  A = util 1, B = util 5.
+;;   A . .
+;;   . # .
+;;   . . B
+(def grid [[:A     :empty :empty]
+           [:empty :wall  :empty]
+           [:empty :empty :B]])
+
+(def mdp (gw/build-mdp {:grid grid
+                        :utilities {:A 1.0 :B 5.0 :timeCost -0.1}
+                        :start [1 0] :gamma 1.0}))
+
+(def alpha-ladder [0.3 1.0 3.0 10.0 100.0 ##Inf])
+
+(defonce ds (r/atom {:alpha-i 4 :idx 0 :frames [] :timer nil}))
+
+(defn- alpha-label [a] (if (= a ##Inf) "INF (optimal)" (str a)))
+
+(defn- rollout!
+  "Recompute the agent + a fresh rollout at the current alpha; reset to step 0.
+   This is the whole pipeline: value-iteration -> Q -> softmax rollout -> frames."
+  []
+  (let [a      (nth alpha-ladder (:alpha-i @ds))
+        ag     (agent/make-mdp-agent {:mdp mdp :alpha a :gamma 1.0 :n-iters 24})
+        roll   (agent/simulate-mdp ag (:start-idx mdp) 12)
+        frames (pres/env->trajectory mdp roll (:V ag))]
+    (swap! ds assoc :frames frames :idx 0)))
+
+(defn- step! []
+  (swap! ds update :idx #(min (dec (count (:frames @ds))) (inc %))))
+
+(defn enter! []
+  (rollout!)
+  (when-not (:timer @ds)
+    (swap! ds assoc :timer (js/setInterval step! 550))))
+
+(defn leave! []
+  (when-let [t (:timer @ds)] (js/clearInterval t) (swap! ds assoc :timer nil)))
+
+(defn on-key [k]
+  (case k
+    :space  (step!)
+    :replay (rollout!)
+    :plus   (do (swap! ds update :alpha-i #(min (dec (count alpha-ladder)) (inc %))) (rollout!))
+    :minus  (do (swap! ds update :alpha-i #(max 0 (dec %))) (rollout!))
+    nil))
+
+(defn view []
+  (let [{:keys [alpha-i idx frames]} @ds
+        a (nth alpha-ladder alpha-i)
+        n (max 1 (count frames))
+        i (min idx (dec n))
+        f (when (seq frames) (nth frames i))]
+    [:> Box {:flexDirection "column" :padding 1}
+     [views/status-bar {:title "Ch 3: Gridworld MDP"
+                        :status (str "alpha = " (alpha-label a) "    step " i "/" (dec n))}]
+     (when f [views/grid-view f])
+     [:> Text {:dimColor true}
+      (str " action: " (or (some-> f :meta :action name) "-")
+           "   [space] step  [r] resample  [+/-] alpha  [q/esc] menu")]
+     [:> Text {:color "gray"}
+      " @ agent   A/B goals (util 1 / 5)   block = wall   shading = value fn"]]))

--- a/examples/agentmodels-tui/ch3_demo.cljs
+++ b/examples/agentmodels-tui/ch3_demo.cljs
@@ -2,10 +2,12 @@
   "Ch 3 gridworld MDP demo — the end-to-end vertical slice.
 
    Real GenMLX inference drives the picture: tensor value iteration -> Q, a
-   softmax-action rollout to a terminal, then the render-agnostic Frame producer.
-   The agent then walks the sampled path in the terminal. +/- change the
-   rationality alpha (alpha = infinity -> deterministic optimal); the path
-   visibly changes. Pure data crosses the seam; this file only wires + renders.
+   softmax-action rollout (decision noise from alpha) through a stochastic
+   environment (transition noise from the gridworld slip), then the
+   render-agnostic Frame producer. The agent walks the sampled path in the
+   terminal. +/- change the rationality alpha (alpha = infinity -> deterministic
+   choices); n cycles the transition noise. Pure data crosses the seam; this file
+   only wires + renders.
 
    Demo state lives in one r/atom (the proven reactive model); the gallery routes
    keys here via on-key and starts/stops the autoplay timer via enter!/leave!."
@@ -16,31 +18,36 @@
             [agentmodels.presentation :as pres]
             [views]))
 
-;; The demo world (top row first; screen coords).  A = util 1, B = util 5.
-;;   A . .
-;;   . # .
-;;   . . B
-(def grid [[:A     :empty :empty]
-           [:empty :wall  :empty]
-           [:empty :empty :B]])
-
-(def mdp (gw/build-mdp {:grid grid
-                        :utilities {:A 1.0 :B 5.0 :timeCost -0.1}
-                        :start [1 0] :gamma 1.0}))
+;; A maze where the wall belt forces a detour (top row first; screen coords).
+;;   . . . . . .
+;;   . # # # # .
+;;   . . . . # .
+;;   # # # . # .
+;;   A . . . . B     start top-left; A = util 1, B = util 5
+(def grid [[:empty :empty :empty :empty :empty :empty]
+           [:empty :wall  :wall  :wall  :wall  :empty]
+           [:empty :empty :empty :empty :wall  :empty]
+           [:wall  :wall  :wall  :empty :wall  :empty]
+           [:A     :empty :empty :empty :empty :B]])
+(def utilities {:A 1.0 :B 5.0 :timeCost -0.1})
 
 (def alpha-ladder [0.3 1.0 3.0 10.0 100.0 ##Inf])
+(def noise-ladder [0.0 0.1 0.2 0.4])
 
-(defonce ds (r/atom {:alpha-i 4 :idx 0 :frames [] :timer nil}))
+(defonce ds (r/atom {:alpha-i 4 :noise-i 1 :idx 0 :frames [] :timer nil}))
 
 (defn- alpha-label [a] (if (= a ##Inf) "INF (optimal)" (str a)))
 
 (defn- rollout!
-  "Recompute the agent + a fresh rollout at the current alpha; reset to step 0.
-   This is the whole pipeline: value-iteration -> Q -> softmax rollout -> frames."
+  "Rebuild the MDP at the current noise, plan (value iteration -> Q), sample a
+   softmax rollout, and produce the frames. The whole pipeline, in five lines."
   []
-  (let [a      (nth alpha-ladder (:alpha-i @ds))
-        ag     (agent/make-mdp-agent {:mdp mdp :alpha a :gamma 1.0 :n-iters 24})
-        roll   (agent/simulate-mdp ag (:start-idx mdp) 12)
+  (let [alpha  (nth alpha-ladder (:alpha-i @ds))
+        noise  (nth noise-ladder (:noise-i @ds))
+        mdp    (gw/build-mdp {:grid grid :utilities utilities :start [0 0]
+                              :gamma 1.0 :noise noise})
+        ag     (agent/make-mdp-agent {:mdp mdp :alpha alpha :gamma 1.0 :n-iters 40})
+        roll   (agent/simulate-mdp ag (:start-idx mdp) 30)
         frames (pres/env->trajectory mdp roll (:V ag))]
     (swap! ds assoc :frames frames :idx 0)))
 
@@ -50,7 +57,7 @@
 (defn enter! []
   (rollout!)
   (when-not (:timer @ds)
-    (swap! ds assoc :timer (js/setInterval step! 550))))
+    (swap! ds assoc :timer (js/setInterval step! 450))))
 
 (defn leave! []
   (when-let [t (:timer @ds)] (js/clearInterval t) (swap! ds assoc :timer nil)))
@@ -61,20 +68,24 @@
     :replay (rollout!)
     :plus   (do (swap! ds update :alpha-i #(min (dec (count alpha-ladder)) (inc %))) (rollout!))
     :minus  (do (swap! ds update :alpha-i #(max 0 (dec %))) (rollout!))
+    :noise  (do (swap! ds update :noise-i #(mod (inc %) (count noise-ladder))) (rollout!))
     nil))
 
 (defn view []
-  (let [{:keys [alpha-i idx frames]} @ds
+  (let [{:keys [alpha-i noise-i idx frames]} @ds
         a (nth alpha-ladder alpha-i)
+        e (nth noise-ladder noise-i)
         n (max 1 (count frames))
         i (min idx (dec n))
         f (when (seq frames) (nth frames i))]
     [:> Box {:flexDirection "column" :padding 1}
      [views/status-bar {:title "Ch 3: Gridworld MDP"
-                        :status (str "alpha = " (alpha-label a) "    step " i "/" (dec n))}]
+                        :status (str "alpha = " (alpha-label a)
+                                     "    noise = " e
+                                     "    step " i "/" (dec n))}]
      (when f [views/grid-view f])
      [:> Text {:dimColor true}
       (str " action: " (or (some-> f :meta :action name) "-")
-           "   [space] step  [r] resample  [+/-] alpha  [q/esc] menu")]
+           "   [space] step  [r] resample  [+/-] alpha  [n] noise  [q/esc] menu")]
      [:> Text {:color "gray"}
       " @ agent   A/B goals (util 1 / 5)   block = wall   shading = value fn"]]))

--- a/examples/agentmodels-tui/ch3c_demo.cljs
+++ b/examples/agentmodels-tui/ch3c_demo.cljs
@@ -1,0 +1,79 @@
+(ns ch3c-demo
+  "Ch 3c POMDP belief filtering — the agent acts UNDER UNCERTAINTY about which
+   goal pays, and we watch its belief update as it gathers evidence.
+
+   A QMDP agent (belief-weighted over per-goal MDPs) walks a corridor toward two
+   candidate goals. It does not know which is rewarding, so its P(world) bars sit
+   flat at the prior while it crosses the corridor — then SNAP to the truth the
+   instant it reaches the centre signpost, after which it commits to the right
+   goal. Grid (left) and belief bars (right) advance in lockstep, exactly like the
+   Ch5 viewer. Pure data crosses the seam; this file only wires + renders."
+  (:require ["ink" :refer [Text Box]]
+            [reagent.core :as r]
+            [agentmodels.pomdp :as pomdp]
+            [agentmodels.pomdp-env :as env]
+            [agentmodels.presentation :as pres]
+            [views]))
+
+;;   A . B
+;;   # . #
+;;   # P #   P = signpost (idx 7): standing here reveals which goal is rewarding
+;;   # . #
+;;   # @ #   start (idx 13)
+(def grid [[:A    :empty :B]
+           [:wall :empty :wall]
+           [:wall :empty :wall]
+           [:wall :empty :wall]
+           [:wall :empty :wall]])
+(def signpost 7)
+(def goals [:A :B])
+(def alpha 8.0)            ; decisive (still soft) — the belief story, not alpha, is the point
+
+(defonce ds (r/atom {:true-world :A :idx 0 :frames [] :beliefs [] :timer nil}))
+
+(defn- regen!
+  "Build the POMDP agent + a fresh belief-filtered rollout for the current true
+   world; produce the grid Frames and the per-step beliefs (both from one roll)."
+  []
+  (let [e      (env/restaurant-gridworld {:grid grid :goals goals :signpost signpost
+                                          :true-world (:true-world @ds) :start [1 4]})
+        pa     (pomdp/make-pomdp-agent (assoc e :alpha alpha :gamma 1.0 :n-iters 40))
+        roll   (pomdp/simulate-pomdp pa e (:start-idx e) 20)
+        wa     ((:world-agents pa) (:true-world @ds))
+        frames (pres/env->trajectory (:mdp wa) roll (:V wa))]
+    (swap! ds assoc :frames frames :beliefs (:beliefs roll) :idx 0)))
+
+(defn- step! []
+  (swap! ds update :idx #(min (dec (count (:frames @ds))) (inc %))))
+
+(defn enter! []
+  (regen!)
+  (when-not (:timer @ds)
+    (swap! ds assoc :timer (js/setInterval step! 600))))
+
+(defn leave! []
+  (when-let [t (:timer @ds)] (js/clearInterval t) (swap! ds assoc :timer nil)))
+
+(defn on-key [k]
+  (case k
+    :space  (step!)
+    :replay (regen!)
+    :toggle (do (swap! ds update :true-world {:A :B :B :A}) (regen!))
+    nil))
+
+(defn view []
+  (let [{:keys [true-world idx frames beliefs]} @ds
+        n (max 1 (count frames))
+        i (min idx (dec n))
+        f (when (seq frames) (nth frames i))
+        b (when (seq beliefs) (nth beliefs (min i (dec (count beliefs)))))]
+    [:> Box {:flexDirection "column" :padding 1}
+     [views/status-bar {:title "Ch 3c: POMDP belief filtering"
+                        :status (str "true world = " (name true-world) "    step " i "/" (dec n))}]
+     [:> Box {:flexDirection "row"}
+      (when f [:> Box {:marginRight 4} [views/grid-view f]])
+      (when b [:> Box {} [views/bars-view (pres/dist->bars "P(world)" b true-world) 16]])]
+     [:> Text {:dimColor true}
+      " [space] step   [r] resample   [t] toggle true world   [q/esc] menu"]
+     [:> Text {:color "gray"}
+      " belief stays flat until the agent reaches the centre signpost, then snaps to the truth"]]))

--- a/examples/agentmodels-tui/ch3d_demo.cljs
+++ b/examples/agentmodels-tui/ch3d_demo.cljs
@@ -8,8 +8,8 @@
    and cumulative regret flattens. `t` toggles Thompson <-> softmax-greedy.
 
    Pure data crosses the seam (bandit-bars -> bars-view); this file only wires +
-   renders. NB: Thompson here uses a Gaussian-approx draw (the exact beta sampler
-   crashes at high concentration — bean genmlx-gcw4)."
+   renders. (Thompson draws are EXACT Beta via the gamma ratio, sidestepping the
+   broken scalar beta sampler — bean genmlx-gcw4.)"
   (:require ["ink" :refer [Text Box]]
             [reagent.core :as r]
             [agentmodels.pomdp :as pomdp]

--- a/examples/agentmodels-tui/ch3d_demo.cljs
+++ b/examples/agentmodels-tui/ch3d_demo.cljs
@@ -1,0 +1,71 @@
+(ns ch3d-demo
+  "Ch 3d Bandits — belief filtering with no spatial state.
+
+   Three one-armed bandits with unknown payoff probabilities; the agent keeps a
+   Beta posterior per arm, pulls an arm (Thompson posterior sampling), sees the
+   reward, and conjugately updates that arm's belief. The per-arm posterior-mean
+   bars (true-best arm highlighted) sharpen as pulls concentrate on the best arm
+   and cumulative regret flattens. `t` toggles Thompson <-> softmax-greedy.
+
+   Pure data crosses the seam (bandit-bars -> bars-view); this file only wires +
+   renders. NB: Thompson here uses a Gaussian-approx draw (the exact beta sampler
+   crashes at high concentration — bean genmlx-gcw4)."
+  (:require ["ink" :refer [Text Box]]
+            [reagent.core :as r]
+            [agentmodels.pomdp :as pomdp]
+            [agentmodels.pomdp-env :as env]
+            [agentmodels.presentation :as pres]
+            [views]))
+
+(def thetas [0.25 0.50 0.80])         ; true arm payoff probs; arm 2 is best
+(def horizon 30)
+
+(defonce ds (r/atom {:strategy :thompson :idx 0 :roll nil :env nil :ag nil :timer nil}))
+
+(defn- regen!
+  "A fresh bandit + a full Thompson/softmax rollout at the current strategy."
+  []
+  (let [e    (env/bandit-pomdp {:thetas thetas :horizon horizon})
+        ag   (pomdp/make-bandit-agent {:strategy (:strategy @ds)})
+        roll (pomdp/simulate-bandit ag e)]   ; fresh key each regen -> a new run on `r`
+    (swap! ds assoc :roll roll :idx 0 :env e :ag ag)))
+
+(defn- step! []
+  (swap! ds update :idx #(min (dec (count (:beliefs (:roll @ds)))) (inc %))))
+
+(defn enter! []
+  (regen!)
+  (when-not (:timer @ds)
+    (swap! ds assoc :timer (js/setInterval step! 450))))
+
+(defn leave! []
+  (when-let [t (:timer @ds)] (js/clearInterval t) (swap! ds assoc :timer nil)))
+
+(defn on-key [k]
+  (case k
+    :space  (step!)
+    :replay (regen!)
+    :toggle (do (swap! ds update :strategy {:thompson :softmax :softmax :thompson}) (regen!))
+    nil))
+
+(defn view []
+  (let [{:keys [strategy idx roll env]} @ds
+        bs   (:beliefs roll)
+        n    (max 1 (count bs))
+        i    (min idx (dec n))
+        b    (nth bs i)
+        cum  (nth (:cum-reward roll) (max 0 (dec i)) 0)
+        reg  (nth (:regret roll) (max 0 (dec i)) 0)
+        pull (when (pos? i) (nth (:arms roll) (dec i)))]
+    [:> Box {:flexDirection "column" :padding 1}
+     [views/status-bar {:title "Ch 3d: Bandits (posterior sampling)"
+                        :status (str "strategy=" (name strategy) "    step " i "/" (dec n)
+                                     "    reward " cum "    regret " (.toFixed reg 2))}]
+     (when b [views/bars-view (pres/bandit-bars b (:true-best env)) 20])
+     [:> Text {:dimColor true}
+      (str " pulled arm " (if (some? pull) pull "-")
+           "    counts " (into (sorted-map) (frequencies (take i (:arms roll)))))]
+     [:> Text {:dimColor true}
+      " [space] step   [r] resample   [t] thompson<->softmax   [q/esc] menu"]
+     [:> Text {:color "gray"}
+      " bars = per-arm posterior means; green ◄true is arm 2 (theta=0.8) — pulls concentrate as belief sharpens"]]))

--- a/examples/agentmodels-tui/ch3d_demo.cljs
+++ b/examples/agentmodels-tui/ch3d_demo.cljs
@@ -8,8 +8,8 @@
    and cumulative regret flattens. `t` toggles Thompson <-> softmax-greedy.
 
    Pure data crosses the seam (bandit-bars -> bars-view); this file only wires +
-   renders. (Thompson draws are EXACT Beta via the gamma ratio, sidestepping the
-   broken scalar beta sampler — bean genmlx-gcw4.)"
+   renders. (Thompson draws are exact Beta via dist/beta-dist, now backed by the
+   stable gamma-ratio sampler — genmlx-gcw4.)"
   (:require ["ink" :refer [Text Box]]
             [reagent.core :as r]
             [agentmodels.pomdp :as pomdp]

--- a/examples/agentmodels-tui/ch5_demo.cljs
+++ b/examples/agentmodels-tui/ch5_demo.cljs
@@ -75,7 +75,7 @@
                                      "    observed " i "/" (dec n) " actions")}]
      [:> Box {:flexDirection "row"}
       (when f [:> Box {:marginRight 4} [views/grid-view f]])
-      (when post [:> Box {} [views/bars-view (pres/dist->bars "P(goal)" post) 18]])]
+      (when post [:> Box {} [views/bars-view (pres/dist->bars "P(goal)" post true-goal) 18]])]
      [:> Text {:dimColor true}
       " [space] step   [r] resample walk   [t] toggle true goal   [q/esc] menu"]
      [:> Text {:color "gray"}

--- a/examples/agentmodels-tui/ch5_demo.cljs
+++ b/examples/agentmodels-tui/ch5_demo.cljs
@@ -1,0 +1,82 @@
+(ns ch5-demo
+  "Ch 5 inverse goal inference — the live posterior viewer.
+
+   Watch GenMLX infer what an agent WANTS from how it moves. A 'true' agent
+   (valuing A or B) walks the grid; the observer maintains a posterior over the
+   agent's goal and updates it after every observed action by inverting the
+   forward model through the GFI (agentmodels.inverse uses p/assess as the
+   likelihood). As the walk plays, the grid (left) and the P(goal) bars (right)
+   advance in lockstep — the bars are uninformative while the agent heads down
+   the symmetry axis, then snap to the true goal the moment it commits.
+
+   space steps, r resamples a fresh walk, t toggles the true goal."
+  (:require ["ink" :refer [Text Box]]
+            [reagent.core :as r]
+            [agentmodels.gridworld :as gw]
+            [agentmodels.agent :as agent]
+            [agentmodels.inverse :as inv]
+            [agentmodels.presentation :as pres]
+            [views]))
+
+;; Open grid, A and B mirror-symmetric about the centre column; start top-centre.
+;;   . . . . .
+;;   . . . . .
+;;   A . . . B
+(def grid [[:empty :empty :empty :empty :empty]
+           [:empty :empty :empty :empty :empty]
+           [:A     :empty :empty :empty :B]])
+(def goals [:A :B])
+(def start [2 0])            ; top-centre
+(def alpha 2.0)             ; soft rationality (shared by the true agent + observer)
+(def prior {:A 0.5 :B 0.5})
+
+(defonce ds (r/atom {:true-goal :B :idx 0 :frames [] :posts [] :timer nil}))
+
+(defn- regen!
+  "Build per-goal agents, roll out the TRUE goal's agent, and compute the
+   incremental posterior over goals from the observed actions."
+  []
+  (let [agents (inv/goal-agents {:grid grid :goals goals :alpha alpha})
+        truth  (:true-goal @ds)
+        mdp    (:mdp (agents truth))
+        roll   (agent/simulate-mdp (agents truth) (+ (first start) (* (:W mdp) (second start))) 20)
+        obs    (inv/observe-rollout roll)
+        posts  (inv/posterior-sequence agents prior obs)
+        frames (pres/env->trajectory mdp roll (:V (agents truth)))]
+    (swap! ds assoc :frames frames :posts posts :idx 0)))
+
+(defn- step! []
+  (swap! ds update :idx #(min (dec (count (:frames @ds))) (inc %))))
+
+(defn enter! []
+  (regen!)
+  (when-not (:timer @ds)
+    (swap! ds assoc :timer (js/setInterval step! 650))))
+
+(defn leave! []
+  (when-let [t (:timer @ds)] (js/clearInterval t) (swap! ds assoc :timer nil)))
+
+(defn on-key [k]
+  (case k
+    :space  (step!)
+    :replay (regen!)
+    :toggle (do (swap! ds update :true-goal {:A :B :B :A}) (regen!))
+    nil))
+
+(defn view []
+  (let [{:keys [true-goal idx frames posts]} @ds
+        n (max 1 (count frames))
+        i (min idx (dec n))
+        f (when (seq frames) (nth frames i))
+        post (when (seq posts) (nth posts (min i (dec (count posts)))))]
+    [:> Box {:flexDirection "column" :padding 1}
+     [views/status-bar {:title "Ch 5: Inverse goal inference"
+                        :status (str "true goal = " (name true-goal)
+                                     "    observed " i "/" (dec n) " actions")}]
+     [:> Box {:flexDirection "row"}
+      (when f [:> Box {:marginRight 4} [views/grid-view f]])
+      (when post [:> Box {} [views/bars-view (pres/dist->bars "P(goal)" post) 18]])]
+     [:> Text {:dimColor true}
+      " [space] step   [r] resample walk   [t] toggle true goal   [q/esc] menu"]
+     [:> Text {:color "gray"}
+      " the observer sees only moves — P(goal) sharpens as the agent commits"]]))

--- a/examples/agentmodels-tui/gallery.cljs
+++ b/examples/agentmodels-tui/gallery.cljs
@@ -11,12 +11,15 @@
   (:require ["ink" :refer [render Text Box Newline]]
             [reagent.core :as r]
             [ch3-demo :as ch3]
+            [ch3c-demo :as ch3c]
             [ch5-demo :as ch5]))
 
 ;; -- Demo registry ----------------------------------------------------------
 (def demos
   [{:id :ch3 :title "Ch 3: Gridworld MDP"
     :view ch3/view :on-key ch3/on-key :enter ch3/enter! :leave ch3/leave!}
+   {:id :ch3c :title "Ch 3c: POMDP belief filtering"
+    :view ch3c/view :on-key ch3c/on-key :enter ch3c/enter! :leave ch3c/leave!}
    {:id :ch5 :title "Ch 5: Inverse goal inference"
     :view ch5/view :on-key ch5/on-key :enter ch5/enter! :leave ch5/leave!}])
 

--- a/examples/agentmodels-tui/gallery.cljs
+++ b/examples/agentmodels-tui/gallery.cljs
@@ -10,12 +10,15 @@
    new demo is one entry, no nav code to touch. View primitives live in views.cljs."
   (:require ["ink" :refer [render Text Box Newline]]
             [reagent.core :as r]
-            [ch3-demo :as ch3]))
+            [ch3-demo :as ch3]
+            [ch5-demo :as ch5]))
 
 ;; -- Demo registry ----------------------------------------------------------
 (def demos
   [{:id :ch3 :title "Ch 3: Gridworld MDP"
-    :view ch3/view :on-key ch3/on-key :enter ch3/enter! :leave ch3/leave!}])
+    :view ch3/view :on-key ch3/on-key :enter ch3/enter! :leave ch3/leave!}
+   {:id :ch5 :title "Ch 5: Inverse goal inference"
+    :view ch5/view :on-key ch5/on-key :enter ch5/enter! :leave ch5/leave!}])
 
 (defonce app-state (r/atom {:screen :menu :sel 0}))
 
@@ -39,6 +42,7 @@
     "q"  :quit    "Q"  :quit
     "r"  :replay  "R"  :replay
     "n"  :noise   "N"  :noise
+    "t"  :toggle  "T"  :toggle
     "+"  :plus    "="  :plus
     "-"  :minus   "_"  :minus
     :other))

--- a/examples/agentmodels-tui/gallery.cljs
+++ b/examples/agentmodels-tui/gallery.cljs
@@ -38,6 +38,7 @@
     "\r" :enter   "\n" :enter   " " :space
     "q"  :quit    "Q"  :quit
     "r"  :replay  "R"  :replay
+    "n"  :noise   "N"  :noise
     "+"  :plus    "="  :plus
     "-"  :minus   "_"  :minus
     :other))

--- a/examples/agentmodels-tui/gallery.cljs
+++ b/examples/agentmodels-tui/gallery.cljs
@@ -12,6 +12,7 @@
             [reagent.core :as r]
             [ch3-demo :as ch3]
             [ch3c-demo :as ch3c]
+            [ch3d-demo :as ch3d]
             [ch5-demo :as ch5]))
 
 ;; -- Demo registry ----------------------------------------------------------
@@ -20,6 +21,8 @@
     :view ch3/view :on-key ch3/on-key :enter ch3/enter! :leave ch3/leave!}
    {:id :ch3c :title "Ch 3c: POMDP belief filtering"
     :view ch3c/view :on-key ch3c/on-key :enter ch3c/enter! :leave ch3c/leave!}
+   {:id :ch3d :title "Ch 3d: Bandits (posterior sampling)"
+    :view ch3d/view :on-key ch3d/on-key :enter ch3d/enter! :leave ch3d/leave!}
    {:id :ch5 :title "Ch 5: Inverse goal inference"
     :view ch5/view :on-key ch5/on-key :enter ch5/enter! :leave ch5/leave!}])
 

--- a/examples/agentmodels-tui/gallery.cljs
+++ b/examples/agentmodels-tui/gallery.cljs
@@ -1,0 +1,93 @@
+(ns gallery
+  "agentmodels TUI gallery — a launcher menu over self-registering demos.
+
+   Mirrors the proven examples/genmlx-tui idiom: state in one r/atom, plain
+   reagent components, a single (render (r/as-element [app])) mount. Keyboard is
+   handled by a small Node stdin listener (an async event that swap!s state) so
+   we lean only on primitives this repo has already proven, not React hooks.
+
+   A demo registers an entry {:id :title :view :on-key :enter :leave}; adding a
+   new demo is one entry, no nav code to touch. View primitives live in views.cljs."
+  (:require ["ink" :refer [render Text Box Newline]]
+            [reagent.core :as r]
+            [ch3-demo :as ch3]))
+
+;; -- Demo registry ----------------------------------------------------------
+(def demos
+  [{:id :ch3 :title "Ch 3: Gridworld MDP"
+    :view ch3/view :on-key ch3/on-key :enter ch3/enter! :leave ch3/leave!}])
+
+(defonce app-state (r/atom {:screen :menu :sel 0}))
+
+(defn- demo-by-id [id] (first (filter #(= (:id %) id) demos)))
+
+;; -- Keyboard ---------------------------------------------------------------
+;; stdin delivers raw escape sequences; build the control strings from char
+;; codes so this source stays pure ASCII. ESC=27, Ctrl-C=3.
+(def ^:private esc (js/String.fromCharCode 27))
+(def ^:private ctrl-c (js/String.fromCharCode 3))
+
+(defn- normalize [s]
+  (condp = s
+    (str esc "[A") :up
+    (str esc "[B") :down
+    (str esc "[C") :right
+    (str esc "[D") :left
+    esc            :escape
+    ctrl-c         :ctrl-c
+    "\r" :enter   "\n" :enter   " " :space
+    "q"  :quit    "Q"  :quit
+    "r"  :replay  "R"  :replay
+    "+"  :plus    "="  :plus
+    "-"  :minus   "_"  :minus
+    :other))
+
+(defn- exit! [] (js/process.exit 0))
+
+(defn- handle-key [k]
+  (let [{:keys [screen sel]} @app-state]
+    (cond
+      (= k :ctrl-c) (exit!)
+      (= screen :menu)
+      (case k
+        :up    (swap! app-state update :sel #(mod (dec %) (count demos)))
+        :down  (swap! app-state update :sel #(mod (inc %) (count demos)))
+        :enter (let [d (nth demos sel)]
+                 (when (:enter d) ((:enter d)))
+                 (swap! app-state assoc :screen (:id d)))
+        :quit  (exit!)
+        nil)
+      :else
+      (let [d (demo-by-id screen)]
+        (if (#{:escape :quit} k)
+          (do (when (:leave d) ((:leave d))) (swap! app-state assoc :screen :menu))
+          (when (:on-key d) ((:on-key d) k)))))))
+
+(defn- setup-keys! []
+  (let [stdin js/process.stdin]
+    (when (.-setRawMode stdin) (.setRawMode stdin true))
+    (.resume stdin)
+    (.setEncoding stdin "utf8")
+    (.on stdin "data" (fn [d] (handle-key (normalize d))))))
+
+;; -- Components -------------------------------------------------------------
+(defn- menu []
+  (let [sel (:sel @app-state)]
+    [:> Box {:flexDirection "column" :padding 1}
+     [:> Text {:bold true :color "cyan"} " GenMLX · agentmodels gallery "]
+     [:> Newline]
+     (for [[i d] (map-indexed vector demos)]
+       ^{:key (:id d)}
+       [:> Text {:color (if (= i sel) "greenBright" "white")}
+        (str (if (= i sel) " > " "   ") (:title d))])
+     [:> Newline]
+     [:> Text {:dimColor true} " up/down select   enter open   q quit"]]))
+
+(defn- app []
+  (if (= :menu (:screen @app-state))
+    [menu]
+    [(:view (demo-by-id (:screen @app-state)))]))
+
+;; -- Main -------------------------------------------------------------------
+(render (r/as-element [app]))
+(setup-keys!)

--- a/examples/agentmodels-tui/package-lock.json
+++ b/examples/agentmodels-tui/package-lock.json
@@ -1,0 +1,559 @@
+{
+  "name": "agentmodels-tui",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agentmodels-tui",
+      "dependencies": {
+        "ink": "^4.4.1",
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
+      "integrity": "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.1"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
+      "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-4.4.1.tgz",
+      "integrity": "sha512-rXckvqPBB0Krifk5rn/5LvQGmyXwCUpBfmTwbkQNBY9JY8RSl3b8OftBNEYxg4+SWUhEKcPifgope28uL9inlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.1.3",
+        "ansi-escapes": "^6.0.0",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.2.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^3.1.0",
+        "code-excerpt": "^4.0.0",
+        "indent-string": "^5.0.0",
+        "is-ci": "^3.0.1",
+        "is-lower-case": "^2.0.2",
+        "is-upper-case": "^2.0.2",
+        "lodash": "^4.17.21",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.29.0",
+        "scheduler": "^0.23.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^6.0.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^5.1.2",
+        "type-fest": "^0.12.0",
+        "widest-line": "^4.0.1",
+        "wrap-ansi": "^8.1.0",
+        "ws": "^8.12.0",
+        "yoga-wasm-web": "~0.3.3"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0",
+        "react-devtools-core": "^4.19.1"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-2.0.2.tgz",
+      "integrity": "sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/is-upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-2.0.2.tgz",
+      "integrity": "sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/slice-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-6.0.0.tgz",
+      "integrity": "sha512-6bn4hRfkTvDfUoEQYkERg0BVF1D0vrX9HEkMl08uDiNWvVvjylLHvZFZWkDo6wjT8tUctbYl1nCOuE66ZTaUtA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
+      "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yoga-wasm-web": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/yoga-wasm-web/-/yoga-wasm-web-0.3.3.tgz",
+      "integrity": "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==",
+      "license": "MIT"
+    }
+  }
+}

--- a/examples/agentmodels-tui/package.json
+++ b/examples/agentmodels-tui/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "agentmodels-tui",
+  "private": true,
+  "description": "Terminal gallery for the GenMLX agentmodels.org port — gridworld MDP demos rendered with Ink",
+  "dependencies": {
+    "ink": "^4.4.1",
+    "react": "^18.3.1"
+  }
+}

--- a/examples/agentmodels-tui/run.sh
+++ b/examples/agentmodels-tui/run.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Run the agentmodels TUI gallery.
+#   ./run.sh          interactive gallery (menu -> demos; needs a real terminal)
+#   ./run.sh views    static views_demo smoke (renders sample data, then exits)
+#
+# Mirrors examples/genmlx-tui/run.sh: ink resolves from the local node_modules,
+# reagent / nbb / @mlx-node from the repo-root node_modules (NODE_PATH). The
+# explicit --classpath adds the repo source roots plus this sub-app dir so the
+# local gallery/views/ch3_demo requires and the agentmodels.* library resolve.
+set -e
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HERE="$ROOT/examples/agentmodels-tui"
+TARGET="gallery.cljs"
+[ "$1" = "views" ] && TARGET="views_demo.cljs"
+cd "$ROOT"
+NODE_PATH="$HERE/node_modules:$ROOT/node_modules" \
+  npx nbb --classpath "src:examples:test:malli/src:instaparse/src:examples/agentmodels-tui" \
+    "examples/agentmodels-tui/$TARGET"

--- a/examples/agentmodels-tui/views.cljs
+++ b/examples/agentmodels-tui/views.cljs
@@ -1,0 +1,72 @@
+(ns views
+  "Reusable Ink view primitives for the agentmodels gallery. ABOVE THE SEAM:
+   every component is a pure function of the render-agnostic data shapes defined
+   in agentmodels.presentation (Frame, PosteriorBars) plus reagent atoms. They
+   know nothing about MDPs, MLX, or inference — only how to turn data into
+   colored cells. Re-rendering is the proven genmlx-tui model: an r/atom changes,
+   reagent re-renders these plain components.
+
+   grid-view        Frame        -> column of colored rows
+   bars-view        PosteriorBars-> labeled horizontal bars
+   frames-view      [Frame] + idx-atom -> grid-view of the current frame
+   status-bar       map          -> a one-line title/status strip"
+  (:require ["ink" :refer [Text Box]]
+            [reagent.core :as r]))
+
+(def role->color {:agent "greenBright" :wall "gray" :goal "yellowBright"
+                  :path "cyan" :empty "white"})
+
+(defn- hex2 [n] (let [s (.toString (max 0 (min 255 (int n))) 16)]
+                  (if (= 1 (count s)) (str "0" s) s)))
+
+(defn- value->bg
+  "Subtle value-function shading for empty cells: brighter green = higher value."
+  [v]
+  (when v (str "#00" (hex2 (+ 24 (* 150 v))) "00")))
+
+(defn grid-view
+  "Frame -> a column of rows of colored cells. role -> foreground color;
+   optional :value -> background shade on empty cells."
+  [{:keys [W H cells]}]
+  [:> Box {:flexDirection "column"}
+   (for [y (range H)]
+     ^{:key y}
+     [:> Box {}
+      (for [x (range W)
+            :let [{:keys [glyph role value]} (nth cells (+ x (* W y)))]]
+        ^{:key x}
+        [:> Text (cond-> {:color (role->color role) :bold (= role :agent)}
+                   (and value (= role :empty)) (assoc :backgroundColor (value->bg value)))
+         (str " " glyph " ")])])])
+
+(defn frames-view
+  "[Frame] + an index r/atom -> the current frame + a step line. Derefing the
+   atom makes this re-render as the index advances (proven reagent reactivity)."
+  [frames idx]
+  (let [i (min @idx (dec (count frames)))
+        f (nth frames i)]
+    [:> Box {:flexDirection "column"}
+     [grid-view f]
+     [:> Text {:dimColor true}
+      (str "step " i "/" (dec (count frames))
+           (when-let [a (:action (:meta f))] (str "   →" (name a))))]]))
+
+(defn bars-view
+  "PosteriorBars -> labeled horizontal bars; widths normalized to `width` cells."
+  [{:keys [title bars]} & [width]]
+  (let [w (or width 20)]
+    [:> Box {:flexDirection "column"}
+     [:> Text {:bold true} title]
+     (for [{:keys [label weight]} bars]
+       ^{:key label}
+       [:> Box {}
+        [:> Text {:color "gray"} (str label " ")]
+        [:> Text {:color "cyanBright"} (apply str (repeat (Math/round (* weight w)) "█"))]
+        [:> Text {:dimColor true} (str " " (.toFixed weight 3))]])]))
+
+(defn status-bar
+  "A bordered one-line status strip: a title plus arbitrary right-hand status."
+  [{:keys [title status]}]
+  [:> Box {:borderStyle "round" :borderColor "cyan" :paddingX 1}
+   [:> Text {:bold true :color "cyan"} (str " " title " ")]
+   (when status [:> Text {:color "gray"} (str "  " status)])])

--- a/examples/agentmodels-tui/views.cljs
+++ b/examples/agentmodels-tui/views.cljs
@@ -52,17 +52,22 @@
            (when-let [a (:action (:meta f))] (str "   →" (name a))))]]))
 
 (defn bars-view
-  "PosteriorBars -> labeled horizontal bars; widths normalized to `width` cells."
+  "PosteriorBars -> labeled horizontal bars; widths normalized to `width` cells.
+   A bar carrying :highlight true (e.g. the known true goal) is drawn in green,
+   bold, with a trailing marker — so the eye can check the posterior against truth."
   [{:keys [title bars]} & [width]]
   (let [w (or width 20)]
     [:> Box {:flexDirection "column"}
      [:> Text {:bold true} title]
-     (for [{:keys [label weight]} bars]
+     (for [{:keys [label weight highlight]} bars]
        ^{:key label}
        [:> Box {}
-        [:> Text {:color "gray"} (str label " ")]
-        [:> Text {:color "cyanBright"} (apply str (repeat (Math/round (* weight w)) "█"))]
-        [:> Text {:dimColor true} (str " " (.toFixed weight 3))]])]))
+        [:> Text {:color (if highlight "greenBright" "gray") :bold (boolean highlight)}
+         (str label " ")]
+        [:> Text {:color (if highlight "greenBright" "cyanBright")}
+         (apply str (repeat (Math/round (* weight w)) "█"))]
+        [:> Text (if highlight {:color "green" :bold true} {:dimColor true})
+         (str " " (.toFixed weight 3) (when highlight "  ◄ true"))]])]))
 
 (defn status-bar
   "A bordered one-line status strip: a title plus arbitrary right-hand status."

--- a/examples/agentmodels-tui/views_demo.cljs
+++ b/examples/agentmodels-tui/views_demo.cljs
@@ -18,7 +18,8 @@
            {:glyph "·" :role :empty :value 0.1}     {:glyph "·" :role :empty :value 0.4} {:glyph "B" :role :goal}]})
 
 (def sample-bars
-  {:title "P(goal)" :bars [{:label "A" :weight 0.27} {:label "B" :weight 0.73}]})
+  {:title "P(goal)" :bars [{:label "A" :weight 0.27}
+                           {:label "B" :weight 0.73 :highlight true}]})
 
 (defn app []
   [:> Box {:flexDirection "column" :padding 1}

--- a/examples/agentmodels-tui/views_demo.cljs
+++ b/examples/agentmodels-tui/views_demo.cljs
@@ -1,0 +1,33 @@
+(ns views-demo
+  "Headless-ish smoke for the view primitives: renders grid-view, status-bar and
+   bars-view against HAND-WRITTEN sample data (no inference, no keyboard), then
+   unmounts and exits. Proves the view layer is a pure function of seam data and
+   that the reagent -> Ink mount works, independently of the models.
+
+   Run: bun run --bun nbb examples/agentmodels-tui/views_demo.cljs (from repo root
+   via run.sh's classpath), or ./run.sh views (see README)."
+  (:require ["ink" :refer [render Box Newline]]
+            [reagent.core :as r]
+            [views]))
+
+;; A hand-written Frame (no MDP involved): 3x3, agent + wall + two goals + a path.
+(def sample-frame
+  {:W 3 :H 3 :meta {:step 2 :action :right}
+   :cells [{:glyph "A" :role :goal}                 {:glyph "∘" :role :path}  {:glyph "·" :role :empty :value 0.6}
+           {:glyph "·" :role :empty :value 0.2}     {:glyph "█" :role :wall}  {:glyph "@" :role :agent}
+           {:glyph "·" :role :empty :value 0.1}     {:glyph "·" :role :empty :value 0.4} {:glyph "B" :role :goal}]})
+
+(def sample-bars
+  {:title "P(goal)" :bars [{:label "A" :weight 0.27} {:label "B" :weight 0.73}]})
+
+(defn app []
+  [:> Box {:flexDirection "column" :padding 1}
+   [views/status-bar {:title "views_demo" :status "hand-written sample data"}]
+   [:> Newline]
+   [views/grid-view sample-frame]
+   [:> Newline]
+   [views/bars-view sample-bars 20]])
+
+(render (r/as-element [app]))
+;; render one frame, then exit cleanly in a non-TTY shell
+(js/setTimeout (fn [] (js/process.exit 0)) 300)

--- a/examples/agentmodels-tui/views_demo.cljs
+++ b/examples/agentmodels-tui/views_demo.cljs
@@ -24,9 +24,10 @@
   [:> Box {:flexDirection "column" :padding 1}
    [views/status-bar {:title "views_demo" :status "hand-written sample data"}]
    [:> Newline]
-   [views/grid-view sample-frame]
-   [:> Newline]
-   [views/bars-view sample-bars 20]])
+   ;; the Ch 5 side-by-side layout: grid left, posterior bars right
+   [:> Box {:flexDirection "row"}
+    [:> Box {:marginRight 4} [views/grid-view sample-frame]]
+    [:> Box {} [views/bars-view sample-bars 18]]]])
 
 (render (r/as-element [app]))
 ;; render one frame, then exit cleanly in a non-TTY shell

--- a/examples/agentmodels/agent.cljs
+++ b/examples/agentmodels/agent.cljs
@@ -1,0 +1,78 @@
+(ns agentmodels.agent
+  "MDP agent for the agentmodels port — GenMLX-native.
+
+   agentmodels.org defines an agent by the mutual recursion `act` / `expectedUtility`
+   under a softmax (Boltzmann) action choice with rationality `alpha`. Here that
+   becomes two things that compose cleanly with the GFI:
+
+   1. VALUE ITERATION as a pure MLX graph — the Bellman backup
+        Q = R + gamma*(1-term) * (T . V),   V = max_a Q
+      run for a fixed number of sweeps. This is the GPU-native realisation of
+      `expectedUtility` (the hard/argmax limit; soft backup swaps max for
+      logsumexp — a follow-up for the faithful equivalence test, bean genmlx-m4pr).
+
+   2. THE POLICY AS A GENERATIVE FUNCTION — `act` is literally
+        (gen [s] (trace :action (softmax-action alpha Q[s])))
+      so the agent's action is a GFI random choice. `softmax-action` (helpers.cljs)
+      is Categorical(softmax(alpha*Q[s])); at alpha = ##Inf it is the deterministic
+      argmax. This IS agentmodels' factor(alpha*EU), expressed in one line and
+      fully composable with simulate / generate / assess.
+
+   Vertical-slice scope: the tensor-Bellman path + rollout. The faithful
+   exact/with-cache recursive path and the recursive≡tensor equivalence test are
+   the next increment (bean genmlx-m4pr)."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.protocols :as p]
+            [genmlx.dynamic :as dyn]
+            [agentmodels.helpers :as h])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(defn bellman-step
+  "One synchronous Bellman backup (pure MLX graph). V:[S] -> [Q:[S,A], V':[S]].
+   next-V[s,a] = sum_s' T[s,a,s'] * V[s']  via a flat matrix-vector product."
+  [{:keys [S A T R term]} gamma V]
+  (let [V-col  (mx/reshape V #js [S 1])
+        T-flat (mx/reshape T #js [(* S A) S])
+        next-V (mx/reshape (mx/matmul T-flat V-col) #js [S A])           ; [S,A]
+        cont   (mx/reshape (mx/subtract (mx/scalar 1.0) term) #js [S 1]) ; [S,1] -> bcast over A
+        Q      (mx/add R (mx/multiply (mx/scalar gamma)
+                                      (mx/multiply cont next-V)))]
+    [Q (mx/amax Q [1])]))
+
+(defn value-iteration
+  "Run `n` Bellman sweeps from V = 0. Returns {:Q [S,A] :V [S]}. Materializes V
+   each sweep to break lazy-graph accumulation (the Layer C eval boundary)."
+  [{:keys [S gamma] :as mdp} n]
+  (loop [V (mx/zeros #js [S]), i 0, Q nil]
+    (if (>= i n)
+      {:Q Q :V V}
+      (let [[Q' V'] (bellman-step mdp gamma V)]
+        (mx/materialize! V')
+        (recur V' (inc i) Q')))))
+
+(defn make-mdp-agent
+  "Build an MDP agent over `mdp`. Returns
+     {:mdp :Q [S,A] :V [S] :policy gen-fn :act (fn [s] -> action-int) :params}.
+   `:policy` is the softmax-action generative function; `:act` samples one action
+   for a state by running it through the GFI (p/simulate)."
+  [{:keys [mdp alpha gamma n-iters]
+    :or   {alpha 100.0 gamma 1.0 n-iters 24}}]
+  (let [mdp        (assoc mdp :gamma gamma)
+        {:keys [Q V]} (value-iteration mdp n-iters)
+        policy     (gen [s] (trace :action (h/softmax-action alpha (mx/idx Q s))))]
+    {:mdp mdp :Q Q :V V :policy policy
+     :act (fn [s] (int (mx/item (:retval (p/simulate (dyn/auto-key policy) [s])))))
+     :params {:alpha alpha :gamma gamma}}))
+
+(defn simulate-mdp
+  "Roll the agent's policy out from `start` for at most `horizon` steps, stopping
+   at a terminal. Returns {:states [s0 s1 ...] :actions [a0 a1 ...]} (JS ints).
+   One action per transition, so (count actions) == (dec (count states))."
+  [{:keys [mdp act]} start horizon]
+  (let [{:keys [ns-fn terminals]} mdp]
+    (loop [s start, step 0, states [start], actions []]
+      (if (or (>= step horizon) (contains? terminals s))
+        {:states states :actions actions}
+        (let [a  (act s)
+              s' (ns-fn s a)]
+          (recur s' (inc step) (conj states s') (conj actions a)))))))

--- a/examples/agentmodels/agent.cljs
+++ b/examples/agentmodels/agent.cljs
@@ -22,6 +22,7 @@
    exact/with-cache recursive path and the recursive≡tensor equivalence test are
    the next increment (bean genmlx-m4pr)."
   (:require [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
             [genmlx.protocols :as p]
             [genmlx.dynamic :as dyn]
             [agentmodels.helpers :as h])
@@ -64,15 +65,26 @@
      :act (fn [s] (int (mx/item (:retval (p/simulate (dyn/auto-key policy) [s])))))
      :params {:alpha alpha :gamma gamma}}))
 
+;; The environment transition is itself a generative function: given the T-row
+;; probabilities for (s,a), sample the next state. With a deterministic (noise=0)
+;; MDP the row is one-hot, so this reduces to the obvious deterministic step.
+(def ^:private env-step
+  (gen [probs] (trace :s (dist/weighted probs))))
+
+(defn- sample-next [T s a]
+  (let [probs (vec (mx/->clj (mx/idx (mx/idx T s) a)))]      ; T[s,a,:] -> [S'] probs
+    (int (mx/item (:retval (p/simulate (dyn/auto-key env-step) [probs]))))))
+
 (defn simulate-mdp
   "Roll the agent's policy out from `start` for at most `horizon` steps, stopping
-   at a terminal. Returns {:states [s0 s1 ...] :actions [a0 a1 ...]} (JS ints).
-   One action per transition, so (count actions) == (dec (count states))."
+   at a terminal. The action comes from the softmax policy (decision noise) and
+   the next state is sampled from T (environment / transition noise). Returns
+   {:states [s0 s1 ...] :actions [a0 a1 ...]} (JS ints); one action per transition."
   [{:keys [mdp act]} start horizon]
-  (let [{:keys [ns-fn terminals]} mdp]
+  (let [{:keys [T terminals]} mdp]
     (loop [s start, step 0, states [start], actions []]
       (if (or (>= step horizon) (contains? terminals s))
         {:states states :actions actions}
         (let [a  (act s)
-              s' (ns-fn s a)]
+              s' (sample-next T s a)]
           (recur s' (inc step) (conj states s') (conj actions a)))))))

--- a/examples/agentmodels/agent.cljs
+++ b/examples/agentmodels/agent.cljs
@@ -1,69 +1,166 @@
 (ns agentmodels.agent
-  "MDP agent for the agentmodels port — GenMLX-native.
+  "MDP agent for the agentmodels port — GenMLX-native, with TWO paths that agree.
 
-   agentmodels.org defines an agent by the mutual recursion `act` / `expectedUtility`
-   under a softmax (Boltzmann) action choice with rationality `alpha`. Here that
-   becomes two things that compose cleanly with the GFI:
+   agentmodels.org defines an agent by the mutual recursion act / expectedUtility
+   under a softmax (Boltzmann) action choice with rationality `alpha`. That agent
+   is SOFT-rational: the value of a state is the expectation of expectedUtility
+   under the agent's OWN softmax policy (not a hard max). GenMLX realises this two
+   ways that compute the identical value function and Q:
 
-   1. VALUE ITERATION as a pure MLX graph — the Bellman backup
-        Q = R + gamma*(1-term) * (T . V),   V = max_a Q
-      run for a fixed number of sweeps. This is the GPU-native realisation of
-      `expectedUtility` (the hard/argmax limit; soft backup swaps max for
-      logsumexp — a follow-up for the faithful equivalence test, bean genmlx-m4pr).
+   1. TENSOR VALUE ITERATION (Layer B, GPU-native) — the Bellman backup
+        Q = R + gamma*(1-term) * (T . V),    V = backup(Q)
+      where backup is the soft policy-expectation  V(s) = Σ_a softmax(alpha*Q[s])[a]*Q[s,a]
+      for finite alpha, and the hard max_a Q in the optimal limit alpha = ##Inf.
 
-   2. THE POLICY AS A GENERATIVE FUNCTION — `act` is literally
+   2. RECURSIVE expectedUtility (faithful agentmodels) — memoized with
+      exact/with-cache (the dp.cache analog), mutually recursive with the soft
+      policy, exactly mirroring act/expectedUtility over a finite horizon.
+
+   Both produce the same first action / Q-values (certified by the equivalence
+   test). The policy is itself a generative function: act = a GFI random choice,
         (gen [s] (trace :action (softmax-action alpha Q[s])))
-      so the agent's action is a GFI random choice. `softmax-action` (helpers.cljs)
-      is Categorical(softmax(alpha*Q[s])); at alpha = ##Inf it is the deterministic
-      argmax. This IS agentmodels' factor(alpha*EU), expressed in one line and
-      fully composable with simulate / generate / assess.
+   which is agentmodels' factor(alpha*EU) in one composable line.
 
-   Vertical-slice scope: the tensor-Bellman path + rollout. The faithful
-   exact/with-cache recursive path and the recursive≡tensor equivalence test are
-   the next increment (bean genmlx-m4pr)."
+   Scope: MDP planning + rollout + the recursive≡tensor equivalence. POMDP
+   (make-pomdp-agent, belief filtering, :update-belief, simulate-pomdp) remains."
   (:require [genmlx.mlx :as mx]
             [genmlx.dist :as dist]
             [genmlx.protocols :as p]
             [genmlx.dynamic :as dyn]
+            [genmlx.inference.exact :as exact]
             [agentmodels.helpers :as h])
   (:require-macros [genmlx.gen :refer [gen]]))
 
+;; ---------------------------------------------------------------------------
+;; Backups: hard max (optimal limit) vs soft policy-expectation (faithful)
+;; ---------------------------------------------------------------------------
+
+(defn- hard-value [_alpha Q] (mx/amax Q [1]))            ; V = max_a Q
+
+(defn- soft-value
+  "agentmodels' state value: the expectation of Q under the agent's softmax
+   policy, V(s) = Σ_a softmax(alpha*Q[s])[a] * Q[s,a]. (Expectation over the
+   policy — NOT logsumexp/mellowmax.)"
+  [alpha Q]
+  (let [pi (mx/softmax (mx/multiply (mx/scalar alpha) Q) 1)]   ; [S,A] over actions
+    (mx/sum (mx/multiply pi Q) [1])))                          ; [S]
+
+(defn- value-fn-for [alpha] (if (= alpha ##Inf) hard-value soft-value))
+
+;; ---------------------------------------------------------------------------
+;; Path 1: tensor value iteration
+;; ---------------------------------------------------------------------------
+
 (defn bellman-step
   "One synchronous Bellman backup (pure MLX graph). V:[S] -> [Q:[S,A], V':[S]].
-   next-V[s,a] = sum_s' T[s,a,s'] * V[s']  via a flat matrix-vector product."
-  [{:keys [S A T R term]} gamma V]
+   next-V[s,a] = Σ_s' T[s,a,s'] * V[s']  via a flat matrix-vector product."
+  [{:keys [S A T R term]} gamma alpha value-of V]
   (let [V-col  (mx/reshape V #js [S 1])
         T-flat (mx/reshape T #js [(* S A) S])
         next-V (mx/reshape (mx/matmul T-flat V-col) #js [S A])           ; [S,A]
         cont   (mx/reshape (mx/subtract (mx/scalar 1.0) term) #js [S 1]) ; [S,1] -> bcast over A
         Q      (mx/add R (mx/multiply (mx/scalar gamma)
                                       (mx/multiply cont next-V)))]
-    [Q (mx/amax Q [1])]))
+    [Q (value-of alpha Q)]))
 
 (defn value-iteration
-  "Run `n` Bellman sweeps from V = 0. Returns {:Q [S,A] :V [S]}. Materializes V
-   each sweep to break lazy-graph accumulation (the Layer C eval boundary)."
-  [{:keys [S gamma] :as mdp} n]
-  (loop [V (mx/zeros #js [S]), i 0, Q nil]
-    (if (>= i n)
-      {:Q Q :V V}
-      (let [[Q' V'] (bellman-step mdp gamma V)]
-        (mx/materialize! V')
-        (recur V' (inc i) Q')))))
+  "Run `n` Bellman sweeps from V = 0. Backup is the soft policy-expectation for
+   finite alpha and hard max at alpha = ##Inf. Returns {:Q [S,A] :V [S]}.
+   Materializes V each sweep to break lazy-graph accumulation."
+  [{:keys [S gamma] :as mdp} alpha n]
+  (let [value-of (value-fn-for alpha)]
+    (loop [V (mx/zeros #js [S]), i 0, Q nil]
+      (if (>= i n)
+        {:Q Q :V V}
+        (let [[Q' V'] (bellman-step mdp gamma alpha value-of V)]
+          (mx/materialize! V')
+          (recur V' (inc i) Q'))))))
+
+;; ---------------------------------------------------------------------------
+;; Path 2: faithful recursive expectedUtility (exact/with-cache + soft policy)
+;; ---------------------------------------------------------------------------
+
+(defn- softmax-vec [xs]
+  (let [m  (apply max xs)
+        es (mapv #(Math/exp (- % m)) xs)
+        z  (reduce + es)]
+    (mapv #(/ % z) es)))
+
+(defn recursive-eu
+  "agentmodels' expectedUtility / act, memoized with exact/with-cache (the
+   dp.cache analog). SOFT-rational and mutually recursive: the future value is
+   the expectation of EU under the agent's own softmax(alpha*EU) policy. Operates
+   on host-side scalars (state, action, timeLeft) — with-cache keys on JS args.
+
+       EU(s,a,t) = u(s,a) + gamma*[ terminal(s) or t<=1 ? 0
+                                    : Σ_s' T(s,a,s') * V(s', t-1) ]
+       V(s,t)    = Σ_a  softmax(alpha*EU(s,·,t))[a] * EU(s,a,t)
+
+   Returns {:eu (fn [s a t]) :soft-v (fn [s t])}; EU(s,a,horizon) is the t-step Q
+   that `value-iteration` computes with `n = horizon` sweeps."
+  [{:keys [A gamma terminals] :as mdp}]
+  (let [Rh      (mx/->clj (:R mdp))       ; [S][A] JS numbers
+        Th      (mx/->clj (:T mdp))       ; [S][A][S'] JS numbers
+        terms   (set (keys terminals))
+        eu-atom (atom nil)
+        soft-v  (fn [s t]
+                  (let [qs (mapv (fn [a] (@eu-atom s a t)) (range A))]
+                    (reduce + (map * (softmax-vec (mapv #(* (:alpha mdp) %) qs)) qs))))
+        eu      (exact/with-cache
+                  (fn [s a t]
+                    (let [u (get-in Rh [s a])]
+                      (if (or (terms s) (<= t 1))
+                        u
+                        (+ u (* gamma
+                                (reduce-kv
+                                  (fn [acc s' pr]
+                                    (if (pos? pr) (+ acc (* pr (soft-v s' (dec t)))) acc))
+                                  0.0 (get-in Th [s a]))))))))]
+    (reset! eu-atom eu)
+    {:eu eu :soft-v soft-v}))
+
+(defn- recursive-eu-inf
+  "alpha = ##Inf limit of recursive-eu: the soft policy expectation collapses to
+   the hard max, so V(s,t) = max_a EU(s,a,t). Kept separate to avoid Inf*Q NaNs."
+  [{:keys [A gamma terminals] :as mdp}]
+  (let [Rh (mx/->clj (:R mdp))
+        Th (mx/->clj (:T mdp))
+        terms (set (keys terminals))
+        eu-atom (atom nil)
+        max-v (fn [s t] (apply max (mapv (fn [a] (@eu-atom s a t)) (range A))))
+        eu (exact/with-cache
+             (fn [s a t]
+               (let [u (get-in Rh [s a])]
+                 (if (or (terms s) (<= t 1))
+                   u
+                   (+ u (* gamma (reduce-kv
+                                   (fn [acc s' pr]
+                                     (if (pos? pr) (+ acc (* pr (max-v s' (dec t)))) acc))
+                                   0.0 (get-in Th [s a]))))))))]
+    (reset! eu-atom eu)
+    {:eu eu :soft-v max-v}))
+
+;; ---------------------------------------------------------------------------
+;; Agent constructor + rollout
+;; ---------------------------------------------------------------------------
 
 (defn make-mdp-agent
   "Build an MDP agent over `mdp`. Returns
-     {:mdp :Q [S,A] :V [S] :policy gen-fn :act (fn [s] -> action-int) :params}.
-   `:policy` is the softmax-action generative function; `:act` samples one action
-   for a state by running it through the GFI (p/simulate)."
+     {:mdp :Q [S,A] :V [S] :policy gen-fn :act (fn [s]->action)
+      :expected-utility (fn [s a]) :params}.
+   :Q comes from tensor value iteration; :expected-utility is the faithful
+   recursive path at the same horizon (lazy — only computed if called, so demos
+   pay nothing). Both agree (see the equivalence test)."
   [{:keys [mdp alpha gamma n-iters]
     :or   {alpha 100.0 gamma 1.0 n-iters 24}}]
-  (let [mdp        (assoc mdp :gamma gamma)
-        {:keys [Q V]} (value-iteration mdp n-iters)
-        policy     (gen [s] (trace :action (h/softmax-action alpha (mx/idx Q s))))]
+  (let [mdp        (assoc mdp :gamma gamma :alpha alpha)
+        {:keys [Q V]} (value-iteration mdp alpha n-iters)
+        policy     (gen [s] (trace :action (h/softmax-action alpha (mx/idx Q s))))
+        rec        (delay (if (= alpha ##Inf) (recursive-eu-inf mdp) (recursive-eu mdp)))]
     {:mdp mdp :Q Q :V V :policy policy
      :act (fn [s] (int (mx/item (:retval (p/simulate (dyn/auto-key policy) [s])))))
-     :params {:alpha alpha :gamma gamma}}))
+     :expected-utility (fn [s a] ((:eu @rec) s a n-iters))   ; recursive EU(s,a,horizon)
+     :params {:alpha alpha :gamma gamma :horizon n-iters}}))
 
 ;; The environment transition is itself a generative function: given the T-row
 ;; probabilities for (s,a), sample the next state. With a deterministic (noise=0)

--- a/examples/agentmodels/agent.cljs
+++ b/examples/agentmodels/agent.cljs
@@ -168,7 +168,11 @@
 (def ^:private env-step
   (gen [probs] (trace :s (dist/weighted probs))))
 
-(defn- sample-next [T s a]
+(defn sample-next
+  "Sample the next state from T[s,a,:] (the env-step generative function).
+   Deterministic when the row is one-hot (noise = 0). Public so the POMDP rollout
+   (agentmodels.pomdp/simulate-pomdp) threads the world transition the same way."
+  [T s a]
   (let [probs (vec (mx/->clj (mx/idx (mx/idx T s) a)))]      ; T[s,a,:] -> [S'] probs
     (int (mx/item (:retval (p/simulate (dyn/auto-key env-step) [probs]))))))
 

--- a/examples/agentmodels/gridworld.cljs
+++ b/examples/agentmodels/gridworld.cljs
@@ -1,0 +1,91 @@
+(ns agentmodels.gridworld
+  "Gridworld MDP environment — a human-readable grid literal compiled to the MLX
+   tensors an MDP planner needs: the transition tensor T:[S,A,S'], the reward
+   tensor R:[S,A], and the terminal mask term:[S].
+
+   GenMLX-native by design. The discrete *geometry* (which cell is a wall, where
+   each action lands) is tiny and is computed in plain, obvious host-side CLJS —
+   no `mx/clip` int-bounds dance (that path regressed; see bean genmlx-aonv).
+   The heavy *numeric* work (value iteration) is pure MLX and lives in agent.cljs.
+   That is the right purity split: host-side combinatorics, GPU-side linear
+   algebra. (examples/memo/mdp.cljs is a memo→genmlx conversion consulted only to
+   confirm which mx ops exist — not an idiomatic template.)
+
+   Coordinate convention (screen coordinates, fixed once here so renderers never
+   need to know it): a grid literal is a vector of rows, TOP row first. For cell
+   (x, y) — x = column, y = row from the top — the dense state index is
+
+       s = x + W*y
+
+   and actions move :left -x, :right +x, :up -y (toward the top), :down +y.
+
+   Cell literal vocabulary: `:empty`, `:wall`, or any other keyword names a
+   terminal cell (e.g. :A, :B), whose utility is looked up in the :utilities map."
+  (:require [genmlx.mlx :as mx]))
+
+;; Action 0..3. y increases DOWNWARD (screen coords), so :up is -y.
+(def action-deltas [[-1 0] [1 0] [0 -1] [0 1]])
+(def action-kw     [:left :right :up :down])
+
+(defn next-state
+  "Deterministic next state from state `idx` under action `a` (0..3). Clamps to
+   grid bounds with plain integer min/max, and stays put if the target is a wall."
+  [W H walls idx a]
+  (let [x (mod idx W), y (quot idx W)
+        [dx dy] (action-deltas a)
+        nx (max 0 (min (dec W) (+ x dx)))
+        ny (max 0 (min (dec H) (+ y dy)))
+        n  (+ nx (* W ny))]
+    (if (contains? walls n) idx n)))
+
+(defn parse-grid
+  "Parse a grid literal into geometry:
+   {:W :H :S :walls #{idx} :terminals {idx -> kw}}."
+  [grid]
+  (let [H (count grid)
+        W (count (first grid))
+        cells (for [y (range H) x (range W)]
+                [(+ x (* W y)) (nth (nth grid y) x)])]
+    {:W W :H H :S (* W H)
+     :walls     (into #{} (for [[idx c] cells :when (= c :wall)] idx))
+     :terminals (into {}  (for [[idx c] cells
+                                :when (and (keyword? c) (not (#{:empty :wall} c)))]
+                            [idx c]))}))
+
+(defn build-mdp
+  "Compile {:grid :utilities :start :gamma} into the MDP tensors.
+
+   `utilities` maps each terminal keyword to its reward and may carry a
+   `:timeCost` applied on every (s,a) (agentmodels' time cost). Returns
+
+     {:W :H :S :A
+      :T  [S,A,S'] float32 (deterministic one-hot rows)
+      :R  [S,A]    float32 (utility(s) + timeCost)
+      :term [S]    float32 (1.0 at terminal cells)
+      :terminals {idx->kw} :walls #{idx} :start-idx int
+      :ns-fn (fn [s a] -> s') :action-kw [...] :gamma}"
+  [{:keys [grid utilities start gamma] :or {utilities {} gamma 1.0}}]
+  (let [{:keys [W H S walls terminals]} (parse-grid grid)
+        A          (count action-deltas)
+        time-cost  (get utilities :timeCost 0.0)
+        ns-fn      (fn [s a] (next-state W H walls s a))
+        ;; geometry (host-side, pure CLJS) -> [S,A] table of next-state indices
+        ns-rows    (vec (for [s (range S)] (vec (for [a (range A)] (ns-fn s a)))))
+        ns-table   (mx/array (clj->js ns-rows) mx/int32)               ; [S,A]
+        ;; T[s,a,s'] = 1 iff s' == ns-table[s,a]  (one-hot via broadcasting)
+        sp         (mx/reshape (mx/astype (mx/arange S) mx/int32) #js [1 1 S])
+        nsx        (mx/reshape ns-table #js [S A 1])
+        T          (mx/astype (mx/eq? sp nsx) mx/float32)              ; [S,A,S']
+        util       (fn [s] (+ (get utilities (get terminals s) 0.0) time-cost))
+        R          (mx/array (clj->js (vec (for [s (range S)] (vec (repeat A (util s))))))
+                             mx/float32)                              ; [S,A]
+        term       (mx/array (clj->js (vec (for [s (range S)]
+                                             (if (contains? terminals s) 1.0 0.0))))
+                             mx/float32)                              ; [S]
+        [sx sy]    (or start [0 0])
+        start-idx  (+ sx (* W sy))]
+    (mx/eval! T R term)
+    {:W W :H H :S S :A A
+     :T T :R R :term term
+     :terminals terminals :walls walls :start-idx start-idx
+     :ns-fn ns-fn :action-kw action-kw :gamma gamma}))

--- a/examples/agentmodels/gridworld.cljs
+++ b/examples/agentmodels/gridworld.cljs
@@ -38,6 +38,30 @@
         n  (+ nx (* W ny))]
     (if (contains? walls n) idx n)))
 
+;; Orthogonal slip: a horizontal action (left/right) slips to a vertical one
+;; (up/down), and vice-versa — agentmodels' transitionNoiseProbability. NOT a
+;; uniform random action; the reverse direction is never part of the slip.
+(def ^:private perpendicular {0 [2 3] 1 [2 3] 2 [0 1] 3 [0 1]})
+
+(defn transition-tensor
+  "Build the [S,A,S'] float32 transition tensor from the host-side next-state
+   table `ns-rows`. With probability `noise` the intended action slips to one of
+   its two perpendicular actions (half each); slipping into a wall or edge keeps
+   the agent put, since ns-rows already encodes stay-on-block. Every row is a
+   proper distribution (sums to 1) by construction."
+  [S A ns-rows noise]
+  (mx/array
+    (clj->js
+      (vec (for [s (range S)]
+             (vec (for [a (range A)]
+                    (let [[p q] (perpendicular a)
+                          mass  (merge-with +
+                                  {(get-in ns-rows [s a]) (- 1.0 noise)}
+                                  {(get-in ns-rows [s p]) (* 0.5 noise)}
+                                  {(get-in ns-rows [s q]) (* 0.5 noise)})]
+                      (mapv #(get mass % 0.0) (range S))))))))
+    mx/float32))
+
 (defn parse-grid
   "Parse a grid literal into geometry:
    {:W :H :S :walls #{idx} :terminals {idx -> kw}}."
@@ -64,18 +88,15 @@
       :term [S]    float32 (1.0 at terminal cells)
       :terminals {idx->kw} :walls #{idx} :start-idx int
       :ns-fn (fn [s a] -> s') :action-kw [...] :gamma}"
-  [{:keys [grid utilities start gamma] :or {utilities {} gamma 1.0}}]
+  [{:keys [grid utilities start gamma noise] :or {utilities {} gamma 1.0 noise 0.0}}]
   (let [{:keys [W H S walls terminals]} (parse-grid grid)
         A          (count action-deltas)
         time-cost  (get utilities :timeCost 0.0)
         ns-fn      (fn [s a] (next-state W H walls s a))
         ;; geometry (host-side, pure CLJS) -> [S,A] table of next-state indices
         ns-rows    (vec (for [s (range S)] (vec (for [a (range A)] (ns-fn s a)))))
-        ns-table   (mx/array (clj->js ns-rows) mx/int32)               ; [S,A]
-        ;; T[s,a,s'] = 1 iff s' == ns-table[s,a]  (one-hot via broadcasting)
-        sp         (mx/reshape (mx/astype (mx/arange S) mx/int32) #js [1 1 S])
-        nsx        (mx/reshape ns-table #js [S A 1])
-        T          (mx/astype (mx/eq? sp nsx) mx/float32)              ; [S,A,S']
+        ;; transition tensor: deterministic when noise = 0, orthogonal slip otherwise
+        T          (transition-tensor S A ns-rows noise)              ; [S,A,S']
         util       (fn [s] (+ (get utilities (get terminals s) 0.0) time-cost))
         R          (mx/array (clj->js (vec (for [s (range S)] (vec (repeat A (util s))))))
                              mx/float32)                              ; [S,A]
@@ -88,4 +109,4 @@
     {:W W :H H :S S :A A
      :T T :R R :term term
      :terminals terminals :walls walls :start-idx start-idx
-     :ns-fn ns-fn :action-kw action-kw :gamma gamma}))
+     :ns-fn ns-fn :action-kw action-kw :gamma gamma :noise noise}))

--- a/examples/agentmodels/inverse.cljs
+++ b/examples/agentmodels/inverse.cljs
@@ -1,0 +1,71 @@
+(ns agentmodels.inverse
+  "Inverse goal inference (agentmodels Ch 4/5): observe an agent's actions and
+   infer which goal it values — by INVERTING the forward agent model through the
+   GFI.
+
+   The likelihood of an observed action under a hypothesized goal is *exactly*
+   `p/assess` on that goal's softmax policy: no bespoke likelihood function, just
+   the same generative policy the agent acts with, scored against the observed
+   action. Bayesian updating is incremental, so the posterior can be revealed one
+   observation at a time — which is what the live TUI viewer animates.
+
+       P(goal | a_1..a_t) ∝ P(goal) · Π_i  exp( assess(policy_goal, s_i){:action a_i} )
+
+   Soft rationality matters here: the policy must be a Boltzmann softmax (finite
+   alpha), not a hard argmax, or an observed sub-optimal action would have zero
+   likelihood and collapse the posterior (agentmodels' softmax assumption)."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.dynamic :as dyn]
+            [agentmodels.gridworld :as gw]
+            [agentmodels.agent :as agent]))
+
+(defn goal-agents
+  "Build one agent per candidate goal: the agent that VALUES that goal gives it
+   `high` utility and every other goal `low`. Same grid/noise for all. Returns an
+   ordered map {goal -> agent} (agents carry :policy and :Q)."
+  [{:keys [grid goals high low time-cost alpha noise gamma]
+    :or   {high 5.0 low 0.0 time-cost -0.1 alpha 2.0 noise 0.0 gamma 1.0}}]
+  (reduce
+    (fn [m g]
+      (let [utils (assoc (zipmap goals (repeat low)) g high :timeCost time-cost)
+            mdp   (gw/build-mdp {:grid grid :utilities utils :start [0 0]
+                                 :gamma gamma :noise noise})]
+        (assoc m g (agent/make-mdp-agent {:mdp mdp :alpha alpha :gamma gamma :n-iters 40}))))
+    {} goals))
+
+(defn action-loglik
+  "log P(action = a | state = s) under `agent`'s policy — the GFI assess weight.
+   assess fully constrains :action, so no sampling happens; the auto-key is just
+   to satisfy the handler and does not affect the (deterministic) score."
+  [agent s a]
+  (mx/item (:weight (p/assess (dyn/auto-key (:policy agent)) [s] (cm/choicemap :action a)))))
+
+(defn- normalize-logs
+  "{goal -> log-weight} -> {goal -> probability} (stable softmax)."
+  [logm]
+  (let [hi (apply max (vals logm))
+        ex (into {} (map (fn [[g l]] [g (Math/exp (- l hi))]) logm))
+        z  (reduce + (vals ex))]
+    (into {} (map (fn [[g e]] [g (/ e z)]) ex))))
+
+(defn posterior-sequence
+  "Incremental Bayesian update. `observations` is a seq of [state action] pairs.
+   Returns a vector of posterior maps {goal -> prob}, one per prefix length:
+   index 0 is the prior, index k is the posterior after k observed actions."
+  [goal-agents prior observations]
+  (let [goals (keys goal-agents)]
+    (loop [obs  observations
+           logp (into {} (map (fn [g] [g (Math/log (prior g))]) goals))
+           acc  [(normalize-logs logp)]]
+      (if (empty? obs)
+        acc
+        (let [[s a] (first obs)
+              logp' (into {} (map (fn [g] [g (+ (logp g) (action-loglik (goal-agents g) s a))]) goals))]
+          (recur (rest obs) logp' (conj acc (normalize-logs logp'))))))))
+
+(defn observe-rollout
+  "Turn an agent rollout {:states :actions} into [state action] observation pairs."
+  [{:keys [states actions]}]
+  (mapv vector states actions))

--- a/examples/agentmodels/inverse.cljs
+++ b/examples/agentmodels/inverse.cljs
@@ -42,8 +42,9 @@
   [agent s a]
   (mx/item (:weight (p/assess (dyn/auto-key (:policy agent)) [s] (cm/choicemap :action a)))))
 
-(defn- normalize-logs
-  "{goal -> log-weight} -> {goal -> probability} (stable softmax)."
+(defn normalize-logs
+  "{goal -> log-weight} -> {goal -> probability} (stable softmax). Public so the
+   POMDP belief filter (agentmodels.pomdp) reuses the same normalization."
   [logm]
   (let [hi (apply max (vals logm))
         ex (into {} (map (fn [[g l]] [g (Math/exp (- l hi))]) logm))

--- a/examples/agentmodels/pomdp.cljs
+++ b/examples/agentmodels/pomdp.cljs
@@ -130,6 +130,18 @@
   (update-in belief [:arms i]
              (fn [[a b]] (if (== reward 1) [(inc a) b] [a (inc b)]))))
 
+(defn- beta-sample
+  "Exact Beta(a,b) draw via the gamma ratio G_a/(G_a+G_b), with G ~ Gamma(shape,1)
+   from the STABLE Marsaglia-Tsang sampler (dist/gamma-dist). We route through
+   gamma rather than dist/beta-dist because the latter's Johnk's-algorithm sampler
+   SIGTRAPs at moderate+ concentration (bean genmlx-gcw4) — exactly where a
+   converging bandit lives. This is EXACT (not an approximation) and O(1)."
+  [a b key]
+  (let [[k1 k2] (rng/split key)
+        ga (mx/item (dist/sample (dist/gamma-dist a 1.0) k1))
+        gb (mx/item (dist/sample (dist/gamma-dist b 1.0) k2))]
+    (/ ga (+ ga gb))))
+
 (defn make-bandit-agent
   "Bandit POMDP agent. Belief = {:arms [[alpha beta] ...]} (per-arm Beta).
      :strategy :thompson (default) | :softmax ;  :alpha inverse-temp for :softmax.
@@ -150,22 +162,11 @@
               :thompson
               ;; posterior sampling: draw theta_i ~ Beta(alpha_i,beta_i) per arm and
               ;; pull the argmax. The action is the argmax of K draws (not one random
-              ;; choice), so we sample directly rather than as a GFI trace.
-              ;; NOTE: dist/beta-dist's sampler SIGTRAPs at moderate+ concentration
-              ;; (bean genmlx-gcw4) — which a converging bandit always reaches — so
-              ;; until that's fixed we draw from a GAUSSIAN MOMENT-MATCHED
-              ;; approximation N(mu,var) clamped to [0,1] (mu=a/(a+b),
-              ;; var=ab/((a+b)^2 (a+b+1))) via the stable dist/gaussian sampler.
-              ;; Standard "Gaussian Thompson": exact in the high-count limit, a touch
-              ;; wide early; the explore->exploit behaviour is preserved.
+              ;; choice), so we sample directly rather than as a GFI trace. beta-sample
+              ;; does an EXACT gamma-ratio Beta draw (stable at all concentrations),
+              ;; sidestepping dist/beta-dist's broken Johnk's sampler (bean genmlx-gcw4).
               (let [ks (rng/split-n key (count arms))
-                    ss (mapv (fn [k [a b]]
-                               (let [s   (+ a b)
-                                     mu  (/ a s)
-                                     sd  (Math/sqrt (/ (* a b) (* s s (+ s 1.0))))
-                                     x   (mx/item (dist/sample (dist/gaussian mu sd) k))]
-                                 (min (max x 0.0) 1.0)))
-                             ks arms)]
+                    ss (mapv (fn [k [a b]] (beta-sample a b k)) ks arms)]
                 (int (apply max-key #(nth ss %) (range (count ss)))))
               :softmax
               (let [eu  (mx/array (clj->js (arm-values {:arms arms})))

--- a/examples/agentmodels/pomdp.cljs
+++ b/examples/agentmodels/pomdp.cljs
@@ -1,0 +1,105 @@
+(ns agentmodels.pomdp
+  "POMDP agent (agentmodels Ch 3c) — belief filtering + belief-space action,
+   GenMLX-native by reuse.
+
+   The agent is uncertain about a discrete latent WORLD (e.g. which goal is the
+   rewarding one). It keeps a belief over worlds, acts on that belief, observes,
+   and Bayesian-updates the belief (filtering). The pieces all compose on what is
+   already built:
+
+   - one MDP planner PER world via agentmodels.inverse/goal-agents (each carries
+     its solved :Q [S,A]);
+   - the belief-space value is QMDP: Q_QMDP(b,s) = Σ_w b(w) · Q_w[s] — a plain MLX
+     reduction over the per-world :Q rows;
+   - act = softmax-action over that mixed Q-row, scored through the GFI exactly
+     like the MDP policy;
+   - the belief filter reuses inverse/normalize-logs with an observation
+     likelihood (here a deterministic location-gated reveal).
+
+   FAITHFULNESS / SCOPE: this is the QMDP approximation, NOT agentmodels' full
+   belief-space lookahead. QMDP assumes uncertainty resolves after one step, so it
+   does not value information-gathering. That is acceptable here because the
+   slice's observation is gated by GEOMETRY, not chosen as an action — there is no
+   explore-to-learn decision whose value QMDP would miss, so QMDP and full
+   lookahead pick the same path. Full finite-horizon belief-space planning is a
+   future increment. No exact/expectation in any recursion (project ethos)."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.protocols :as p]
+            [genmlx.dynamic :as dyn]
+            [agentmodels.inverse :as inv]
+            [agentmodels.agent :as agent]
+            [agentmodels.helpers :as h])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(defn make-pomdp-agent
+  "Build a POMDP agent over a discrete latent world. Options:
+     :grid :goals :alpha :noise :gamma :n-iters — passed through to the per-world
+       MDP planners (inverse/goal-agents);
+     :prior   {world -> prob}  (defaults to uniform over :goals);
+     :observe (fn [world loc] -> obs|nil)  the observation model.
+   Returns
+     {:worlds :world-agents {world->agent} :prior :observe
+      :belief-Q (fn [belief s] -> [A] MLX)         ; QMDP belief-space Q row
+      :update-belief (fn [belief loc obs] -> belief') ; one Bayes filtering step
+      :act (fn [belief s] -> action-int)            ; softmax over belief-Q
+      :expected-utility (fn [belief s a] -> float)  ; belief-weighted EU
+      :params {...}}."
+  [{:keys [grid goals alpha noise gamma prior observe n-iters]
+    :or   {alpha 2.0 noise 0.0 gamma 1.0 n-iters 40}}]
+  (let [world-agents (inv/goal-agents {:grid grid :goals goals :alpha alpha
+                                       :noise noise :gamma gamma})
+        A         (:A (:mdp (val (first world-agents))))
+        prior     (or prior (zipmap goals (repeat (/ 1.0 (count goals)))))
+        ;; QMDP belief-space Q at state s: Σ_w b(w) · Q_w[s]  (plain mx reduction)
+        belief-Q  (fn [belief s]
+                    (reduce (fn [acc [w b]]
+                              (mx/add acc (mx/multiply (mx/scalar b)
+                                                       (mx/idx (:Q (world-agents w)) s))))
+                            (mx/zeros #js [A]) belief))
+        ;; one Bayes filtering step: b'(w) ∝ b(w) · P(obs | w, loc).
+        ;; obs = nil (uninformative location) => belief unchanged (flat-then-snap).
+        update-belief (fn [belief loc obs]
+                        (if (nil? obs)
+                          belief
+                          (inv/normalize-logs
+                            (into {} (map (fn [[w b]]
+                                            [w (+ (Math/log b)
+                                                  (if (= (observe w loc) obs) 0.0 ##-Inf))])
+                                          belief)))))
+        ;; act = softmax-action over the belief-mixed Q row, as a real GFI choice
+        act (fn [belief s]
+              (let [q      (belief-Q belief s)
+                    policy (gen [] (trace :action (h/softmax-action alpha q)))]
+                (int (mx/item (:retval (p/simulate (dyn/auto-key policy) []))))))]
+    {:worlds (vec goals) :world-agents world-agents :prior prior :observe observe
+     :belief-Q belief-Q :update-belief update-belief :act act
+     :expected-utility (fn [belief s a]
+                         (reduce + (map (fn [[w b]]
+                                          (* b ((:expected-utility (world-agents w)) s a)))
+                                        belief)))
+     :params {:alpha alpha :gamma gamma :noise noise :horizon n-iters}}))
+
+(defn simulate-pomdp
+  "Roll the POMDP agent out from `start` over a finite horizon, threading
+   (state, belief, action, observation). Each step: (1) the agent ACTS from its
+   current belief; (2) the world transitions via the TRUE world's T; (3) the agent
+   OBSERVES at the new location; (4) it FILTERS its belief. Returns
+     {:states [...] :actions [...] :observations [...] :beliefs [b0 b1 ...]}
+   where :beliefs index k is the belief held at state k (when choosing action k) —
+   so :states and :beliefs align and both feed the seam (env->trajectory / dist->bars)."
+  [{:keys [act update-belief observe world-agents prior]} env start horizon]
+  (let [true-world (:true-world env)
+        true-mdp   (:mdp (world-agents true-world))
+        T          (:T true-mdp)
+        terminals  (:terminals true-mdp)]
+    (loop [s start, b prior, step 0
+           states [start], actions [], obss [], beliefs [prior]]
+      (if (or (>= step horizon) (contains? terminals s))
+        {:states states :actions actions :observations obss :beliefs beliefs}
+        (let [a  (act b s)
+              s' (agent/sample-next T s a)
+              o  (observe true-world s')
+              b' (update-belief b s' o)]
+          (recur s' b' (inc step)
+                 (conj states s') (conj actions a)
+                 (conj obss o) (conj beliefs b')))))))

--- a/examples/agentmodels/pomdp.cljs
+++ b/examples/agentmodels/pomdp.cljs
@@ -130,17 +130,6 @@
   (update-in belief [:arms i]
              (fn [[a b]] (if (== reward 1) [(inc a) b] [a (inc b)]))))
 
-(defn- beta-sample
-  "Exact Beta(a,b) draw via the gamma ratio G_a/(G_a+G_b), with G ~ Gamma(shape,1)
-   from the STABLE Marsaglia-Tsang sampler (dist/gamma-dist). We route through
-   gamma rather than dist/beta-dist because the latter's Johnk's-algorithm sampler
-   SIGTRAPs at moderate+ concentration (bean genmlx-gcw4) — exactly where a
-   converging bandit lives. This is EXACT (not an approximation) and O(1)."
-  [a b key]
-  (let [[k1 k2] (rng/split key)
-        ga (mx/item (dist/sample (dist/gamma-dist a 1.0) k1))
-        gb (mx/item (dist/sample (dist/gamma-dist b 1.0) k2))]
-    (/ ga (+ ga gb))))
 
 (defn make-bandit-agent
   "Bandit POMDP agent. Belief = {:arms [[alpha beta] ...]} (per-arm Beta).
@@ -162,11 +151,11 @@
               :thompson
               ;; posterior sampling: draw theta_i ~ Beta(alpha_i,beta_i) per arm and
               ;; pull the argmax. The action is the argmax of K draws (not one random
-              ;; choice), so we sample directly rather than as a GFI trace. beta-sample
-              ;; does an EXACT gamma-ratio Beta draw (stable at all concentrations),
-              ;; sidestepping dist/beta-dist's broken Johnk's sampler (bean genmlx-gcw4).
+              ;; choice), so we sample directly. dist/beta-dist now uses the stable
+              ;; gamma-ratio sampler (genmlx-gcw4 fixed), so this is exact + crash-free
+              ;; at the high concentration a converging bandit reaches.
               (let [ks (rng/split-n key (count arms))
-                    ss (mapv (fn [k [a b]] (beta-sample a b k)) ks arms)]
+                    ss (mapv (fn [k [a b]] (mx/item (dist/sample (dist/beta-dist a b) k))) ks arms)]
                 (int (apply max-key #(nth ss %) (range (count ss)))))
               :softmax
               (let [eu  (mx/array (clj->js (arm-values {:arms arms})))

--- a/examples/agentmodels/pomdp.cljs
+++ b/examples/agentmodels/pomdp.cljs
@@ -24,6 +24,8 @@
    lookahead pick the same path. Full finite-horizon belief-space planning is a
    future increment. No exact/expectation in any recursion (project ethos)."
   (:require [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.dist :as dist]
             [genmlx.protocols :as p]
             [genmlx.dynamic :as dyn]
             [agentmodels.inverse :as inv]
@@ -103,3 +105,92 @@
           (recur s' b' (inc step)
                  (conj states s') (conj actions a)
                  (conj obss o) (conj beliefs b')))))))
+
+;; ---------------------------------------------------------------------------
+;; Multi-armed bandit POMDP (agentmodels Ch 3c/3d)
+;; ---------------------------------------------------------------------------
+;;
+;; A bandit is a POMDP whose latent never changes: the hidden state is the
+;; per-arm payoff parameter (fixed for the episode); pulling an arm is both the
+;; action and the only observation of that arm; the reward is the observation;
+;; belief factorizes into one independent Beta(alpha,beta) per arm.
+;;
+;; The Beta-Bernoulli update is the trivial conjugate increment kept HOST-SIDE on
+;; a plain per-arm map. This is the same identity as
+;; genmlx.inference.conjugate/bb-update, but that namespace is analytical-inference
+;; *marginalization* middleware (array in/out, co-computes a marginal LL a filter
+;; discards) — not an acting agent's online belief store. Keeping it host-side
+;; matches how the gridworld POMDP filter above stays host-side via
+;; inverse/normalize-logs rather than forcing the inference engine.
+
+(defn update-arm
+  "Conjugate Beta-Bernoulli posterior update on arm `i`: a success (reward 1)
+   bumps alpha, a failure bumps beta; every other arm is untouched (independence)."
+  [belief i reward]
+  (update-in belief [:arms i]
+             (fn [[a b]] (if (== reward 1) [(inc a) b] [a (inc b)]))))
+
+(defn make-bandit-agent
+  "Bandit POMDP agent. Belief = {:arms [[alpha beta] ...]} (per-arm Beta).
+     :strategy :thompson (default) | :softmax ;  :alpha inverse-temp for :softmax.
+   Returns {:act (fn [belief key] -> arm-int) :update-belief (fn [belief arm reward])
+            :arm-values (fn [belief] -> [mean ...]) :params}.
+
+   Thompson sampling is POSTERIOR SAMPLING: each step draws one theta_i ~
+   Beta(alpha_i,beta_i) per arm and pulls the argmax. The explore->exploit
+   behaviour is emergent — the posterior draw is wide while the belief is
+   uncertain and collapses as the Beta sharpens — NOT the optimal Bayes-adaptive
+   (information-valuing) policy."
+  [{:keys [strategy alpha] :or {strategy :thompson alpha 4.0}}]
+  (let [arm-values (fn [{:keys [arms]}] (mapv (fn [[a b]] (/ a (+ a b))) arms))]
+    {:arm-values    arm-values
+     :update-belief update-arm
+     :act (fn [{:keys [arms]} key]
+            (case strategy
+              :thompson
+              ;; posterior sampling: draw theta_i ~ Beta(alpha_i,beta_i) per arm and
+              ;; pull the argmax. The action is the argmax of K draws (not one random
+              ;; choice), so we sample directly rather than as a GFI trace.
+              ;; NOTE: dist/beta-dist's sampler SIGTRAPs at moderate+ concentration
+              ;; (bean genmlx-gcw4) — which a converging bandit always reaches — so
+              ;; until that's fixed we draw from a GAUSSIAN MOMENT-MATCHED
+              ;; approximation N(mu,var) clamped to [0,1] (mu=a/(a+b),
+              ;; var=ab/((a+b)^2 (a+b+1))) via the stable dist/gaussian sampler.
+              ;; Standard "Gaussian Thompson": exact in the high-count limit, a touch
+              ;; wide early; the explore->exploit behaviour is preserved.
+              (let [ks (rng/split-n key (count arms))
+                    ss (mapv (fn [k [a b]]
+                               (let [s   (+ a b)
+                                     mu  (/ a s)
+                                     sd  (Math/sqrt (/ (* a b) (* s s (+ s 1.0))))
+                                     x   (mx/item (dist/sample (dist/gaussian mu sd) k))]
+                                 (min (max x 0.0) 1.0)))
+                             ks arms)]
+                (int (apply max-key #(nth ss %) (range (count ss)))))
+              :softmax
+              (let [eu  (mx/array (clj->js (arm-values {:arms arms})))
+                    pol (gen [] (trace :action (h/softmax-action alpha eu)))]
+                (int (mx/item (:retval (p/simulate (dyn/with-key pol key) [])))))))
+     :params {:strategy strategy :alpha alpha}}))
+
+(defn simulate-bandit
+  "Roll the bandit agent over the horizon, threading (belief, arm, reward). Each
+   step: ACT from belief -> arm; PULL -> reward (the observation); FILTER ->
+   belief'. Returns {:arms [...] :rewards [...] :beliefs [b0 b1 ...] :cum-reward
+   [...] :regret [...]}; :beliefs index k is the belief held when choosing pull k.
+   Pass `key0` (e.g. (rng/fresh-key 42)) for a reproducible rollout."
+  [{:keys [act update-belief]} {:keys [pull prior theta* thetas horizon]} & [key0]]
+  (loop [b prior, step 0, key (or key0 (rng/fresh-key))
+         arms [], rewards [], beliefs [prior], cum 0.0, reg 0.0, cum-reward [], regret []]
+    (if (>= step horizon)
+      {:arms arms :rewards rewards :beliefs beliefs :cum-reward cum-reward :regret regret}
+      (let [[k1 krest] (rng/split key)
+            [k2 k3]    (rng/split krest)
+            i  (act b k1)
+            r  (pull i k2)
+            b' (update-belief b i r)
+            cum' (+ cum r)
+            reg' (+ reg (- theta* (nth thetas i)))]   ; instantaneous regret theta* - theta_i
+        (recur b' (inc step) k3
+               (conj arms i) (conj rewards r) (conj beliefs b')
+               cum' reg' (conj cum-reward cum') (conj regret reg'))))))

--- a/examples/agentmodels/pomdp_env.cljs
+++ b/examples/agentmodels/pomdp_env.cljs
@@ -4,11 +4,10 @@
    themselves are produced inside make-pomdp-agent via inverse/goal-agents ->
    gridworld/build-mdp, so the env stays pure geometry/config.
 
-   Shipped here: the hidden-goal RESTAURANT GRIDWORLD (the slice). The multi-armed
-   BANDIT (conjugate Beta/Normal belief filtering) is the planned second env and
-   a follow-up — noted at the bottom — kept out of the slice to avoid coupling it
-   to the conjugate-update API before that demo is built."
-  (:require [genmlx.mlx :as mx]))
+   Shipped here: the hidden-goal RESTAURANT GRIDWORLD (latent = which goal pays)
+   and the multi-armed BANDIT (latent = per-arm payoff parameters)."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]))
 
 (defn restaurant-gridworld
   "Hidden-goal POMDP: a grid with candidate goals, exactly one of which is the
@@ -34,10 +33,29 @@
      ;; world identity; everywhere else there is no information (obs = nil).
      :observe    (fn [world loc] (when (= loc signpost) world))}))
 
-;; ---------------------------------------------------------------------------
-;; FOLLOW-UP (genmlx-m9m9): multi-armed bandit POMDP — latent = each arm's payoff
-;; parameter; belief = independent conjugate posteriors per arm (Beta-Bernoulli /
-;; Normal-Normal via genmlx.inference.conjugate). Pulling an arm reveals its prize
-;; and updates only that arm's posterior. A separate visual idiom (arm bars rather
-;; than a grid), so it ships after the gridworld slice rather than gating it.
-;; ---------------------------------------------------------------------------
+(defn bandit-pomdp
+  "Multi-armed bandit POMDP (agentmodels Ch 3c/3d). The hidden state is the
+   per-arm payoff parameter theta_i (FIXED for the episode); pulling arm i is the
+   action AND the only observation channel for theta_i; the reward r ~
+   Bernoulli(theta_i) IS the observation; belief factorizes into one independent
+   Beta(alpha_i, beta_i) per arm (Beta-Bernoulli conjugacy, filtered host-side in
+   agentmodels.pomdp). Returns the bundle make-bandit-agent / simulate-bandit
+   consume — pure config plus a reward sampler; no MDP tensors (no spatial latent).
+
+   Options: :thetas [p ...] true Bernoulli params (latent, fixed);
+            :prior [[a b] ...] per-arm Beta priors (default Beta(1,1) each);
+            :horizon H."
+  [{:keys [thetas prior horizon] :or {horizon 30}}]
+  (let [k     (count thetas)
+        thv   (vec thetas)
+        prior (or prior (vec (repeat k [1.0 1.0])))]
+    {:kind      :bandit
+     :arms      k
+     :thetas    thv
+     :true-best (apply max-key thv (range k))      ; index of the highest-theta arm
+     :theta*    (apply max thetas)
+     :prior     {:arms prior}
+     :horizon   horizon
+     ;; reward = observation: pulling arm i samples r ~ Bernoulli(theta_i).
+     :pull      (fn [i key]
+                  (int (mx/item (dist/sample (dist/bernoulli (nth thv i)) key))))}))

--- a/examples/agentmodels/pomdp_env.cljs
+++ b/examples/agentmodels/pomdp_env.cljs
@@ -1,0 +1,43 @@
+(ns agentmodels.pomdp-env
+  "POMDP environments (bean genmlx-m9m9). Each constructor returns the data
+   bundle make-pomdp-agent / simulate-pomdp consume. The per-world MDP tensors
+   themselves are produced inside make-pomdp-agent via inverse/goal-agents ->
+   gridworld/build-mdp, so the env stays pure geometry/config.
+
+   Shipped here: the hidden-goal RESTAURANT GRIDWORLD (the slice). The multi-armed
+   BANDIT (conjugate Beta/Normal belief filtering) is the planned second env and
+   a follow-up — noted at the bottom — kept out of the slice to avoid coupling it
+   to the conjugate-update API before that demo is built."
+  (:require [genmlx.mlx :as mx]))
+
+(defn restaurant-gridworld
+  "Hidden-goal POMDP: a grid with candidate goals, exactly one of which is the
+   true rewarding restaurant (the latent world). The agent learns which only by
+   STANDING ON the signpost cell — elsewhere observe -> nil, so belief stays at
+   the prior (flat-then-snap). Pure geometry; the per-world MDP tensors come from
+   gridworld/build-mdp via inverse/goal-agents inside make-pomdp-agent.
+
+   Options: :grid :goals :signpost (state idx) :true-world (a goal keyword)
+            :start [x y]. Returns the env bundle + an :observe model."
+  [{:keys [grid goals signpost true-world start] :or {goals [:A :B] start [0 0]}}]
+  (let [W (count (first grid))
+        [sx sy] start]
+    {:kind       :gridworld
+     :grid       grid
+     :goals      goals
+     :worlds     goals                 ; latent = which goal is rewarding
+     :true-world true-world
+     :signpost   signpost
+     :start-idx  (+ sx (* W sy))
+     :prior      (zipmap goals (repeat (/ 1.0 (count goals))))
+     ;; deterministic location-gated reveal: standing on the signpost reveals the
+     ;; world identity; everywhere else there is no information (obs = nil).
+     :observe    (fn [world loc] (when (= loc signpost) world))}))
+
+;; ---------------------------------------------------------------------------
+;; FOLLOW-UP (genmlx-m9m9): multi-armed bandit POMDP — latent = each arm's payoff
+;; parameter; belief = independent conjugate posteriors per arm (Beta-Bernoulli /
+;; Normal-Normal via genmlx.inference.conjugate). Pulling an arm reveals its prize
+;; and updates only that arm's posterior. A separate visual idiom (arm bars rather
+;; than a grid), so it ships after the gridworld slice rather than gating it.
+;; ---------------------------------------------------------------------------

--- a/examples/agentmodels/presentation.cljs
+++ b/examples/agentmodels/presentation.cljs
@@ -80,6 +80,15 @@
                (sort-by :label)
                vec)})
 
+(defn dist->bars
+  "PosteriorBars from a plain {value -> probability} map (e.g. a goal posterior)."
+  [title m]
+  {:title title
+   :bars  (->> m
+               (map (fn [[v p]] {:label (if (keyword? v) (name v) (str v)) :weight p}))
+               (sort-by :label)
+               vec)})
+
 ;; ---------------------------------------------------------------------------
 ;; text renderers (consume the data shapes above)
 ;; ---------------------------------------------------------------------------

--- a/examples/agentmodels/presentation.cljs
+++ b/examples/agentmodels/presentation.cljs
@@ -16,7 +16,8 @@
                 ;; role ∈ #{:agent :wall :goal :path :empty}
       :meta  {:step int :action (kw|nil)}}
    Trajectory — [Frame], one per rollout step.
-   PosteriorBars — {:title str :bars [ {:label str :weight float} ... ]}  (weights sum to 1)."
+   PosteriorBars — {:title str :bars [ {:label str :weight float
+                                        :highlight (optional bool)} ... ]}  (weights sum to 1)."
   (:require [genmlx.mlx :as mx]
             [clojure.string :as str]))
 
@@ -81,11 +82,15 @@
                vec)})
 
 (defn dist->bars
-  "PosteriorBars from a plain {value -> probability} map (e.g. a goal posterior)."
-  [title m]
+  "PosteriorBars from a plain {value -> probability} map (e.g. a goal posterior).
+   Optional `highlight` marks the bar for that value with :highlight true (e.g.
+   the known true goal), which the view renders distinctly."
+  [title m & [highlight]]
   {:title title
    :bars  (->> m
-               (map (fn [[v p]] {:label (if (keyword? v) (name v) (str v)) :weight p}))
+               (map (fn [[v p]]
+                      (cond-> {:label (if (keyword? v) (name v) (str v)) :weight p}
+                        (= v highlight) (assoc :highlight true))))
                (sort-by :label)
                vec)})
 

--- a/examples/agentmodels/presentation.cljs
+++ b/examples/agentmodels/presentation.cljs
@@ -1,0 +1,108 @@
+(ns agentmodels.presentation
+  "THE RENDER-AGNOSTIC SEAM.
+
+   Pure CLJS data producers + plain-text renderers. NO Ink, NO React, NO reagent
+   — this namespace stays on the assert-test side of the line. Inference below it
+   produces these immutable data shapes; the ASCII renderers here and the Ink view
+   primitives in examples/agentmodels-tui/ consume the *identical* data. The same
+   bytes that an assert test renders to text drive the live terminal.
+
+   DATA CONTRACT
+   -------------
+   Frame  — one gridworld picture:
+     {:W int :H int
+      :cells [ {:glyph str :role kw :value (optional float 0..1)} ... ]
+                ;; row-major, count == W*H, index = x + W*y
+                ;; role ∈ #{:agent :wall :goal :path :empty}
+      :meta  {:step int :action (kw|nil)}}
+   Trajectory — [Frame], one per rollout step.
+   PosteriorBars — {:title str :bars [ {:label str :weight float} ... ]}  (weights sum to 1)."
+  (:require [genmlx.mlx :as mx]
+            [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; env + trajectory -> [Frame]   (pure producers; the ONE seam crossing is the
+;; single (mx/->clj V) below, turning the MLX value function into JS numbers)
+;; ---------------------------------------------------------------------------
+
+(defn- terminal-glyph [kw] (subs (str/upper-case (name kw)) 0 1)) ; :A -> "A"
+
+(defn- norm01 [v lo hi]
+  (when (and v lo hi (not= hi lo))
+    (max 0.0 (min 1.0 (/ (- v lo) (- hi lo))))))
+
+(defn state->frame
+  "Pure: one Frame picturing the agent at `agent-idx`. `path` (set of visited
+   indices) renders as :path; `vs`/`vlo`/`vhi` (pre-extracted JS value function)
+   shade empty cells."
+  [{:keys [W H walls terminals]} agent-idx
+   {:keys [step action vs vlo vhi path] :or {path #{}}}]
+  {:W W :H H
+   :meta {:step step :action action}
+   :cells (vec (for [y (range H) x (range W)
+                     :let [idx (+ x (* W y))]]
+                 (cond
+                   (contains? walls idx)     {:glyph "█" :role :wall}
+                   (= idx agent-idx)         {:glyph "@" :role :agent}
+                   (contains? terminals idx) {:glyph (terminal-glyph (terminals idx)) :role :goal}
+                   (contains? path idx)      {:glyph "∘" :role :path}
+                   :else                     {:glyph "·" :role :empty
+                                              :value (when vs (norm01 (nth vs idx) vlo vhi))})))})
+
+(defn env->trajectory
+  "Pure: a Trajectory ([Frame]) from a rollout {:states :actions}. Frame i shows
+   the agent at states[i] with earlier states drawn as :path. Optional value
+   array `V` ([S] MLX) shades empties; (mx/->clj V) is the lone seam crossing."
+  [{:keys [action-kw] :as mdp} {:keys [states actions]} & [V]]
+  (let [vs  (when V (vec (mx/->clj V)))
+        vlo (when vs (reduce min vs))
+        vhi (when vs (reduce max vs))]
+    (vec (map-indexed
+           (fn [i s]
+             (state->frame mdp s
+                           {:step i
+                            :action (when (< i (count actions)) (nth action-kw (nth actions i)))
+                            :vs vs :vlo vlo :vhi vhi
+                            :path (set (take i states))}))
+           states))))
+
+;; ---------------------------------------------------------------------------
+;; marginals -> PosteriorBars   (consumes exact/exact-posterior :marginals shape)
+;; ---------------------------------------------------------------------------
+
+(defn marginals->bars
+  "PosteriorBars from an exact/exact-posterior {:marginals {addr {value prob}}}
+   map: pick address `addr`, one bar per value."
+  [marginals addr title]
+  {:title title
+   :bars  (->> (get marginals addr)
+               (map (fn [[v p]] {:label (str v) :weight p}))
+               (sort-by :label)
+               vec)})
+
+;; ---------------------------------------------------------------------------
+;; text renderers (consume the data shapes above)
+;; ---------------------------------------------------------------------------
+
+(defn render-frame-text
+  "ASCII render of a Frame: a header line + rows of glyphs, top row first."
+  [{:keys [W H cells meta]}]
+  (str/join
+    "\n"
+    (cons (str "step " (:step meta) (when (:action meta) (str "  →" (name (:action meta)))))
+          (for [y (range H)]
+            (str/join " " (for [x (range W)] (:glyph (nth cells (+ x (* W y))))))))))
+
+(defn- bar-glyphs [weight width] (apply str (repeat (Math/round (* weight width)) "█")))
+
+(defn render-bars-text
+  "ASCII bar chart of a PosteriorBars."
+  [{:keys [title bars]} & [width]]
+  (let [w   (or width 24)
+        lab (apply max 1 (map (comp count :label) bars))]
+    (str/join
+      "\n"
+      (cons title
+            (for [{:keys [label weight]} bars]
+              (str (str/join (repeat (- lab (count label)) " ")) label " │"
+                   (bar-glyphs weight w) " " (.toFixed weight 3)))))))

--- a/examples/agentmodels/presentation.cljs
+++ b/examples/agentmodels/presentation.cljs
@@ -81,6 +81,19 @@
                (sort-by :label)
                vec)})
 
+(defn bandit-bars
+  "PosteriorBars from a bandit belief {:arms [[a b] ...]}: one bar per arm whose
+   weight is the posterior mean alpha/(alpha+beta) — an independent value in
+   [0,1], NOT a normalized category probability, so this builds PosteriorBars
+   directly rather than via dist->bars. The true-best arm gets :highlight."
+  [{:keys [arms]} true-best]
+  {:title "arm posterior means"
+   :bars  (vec (map-indexed
+                 (fn [i [a b]]
+                   (cond-> {:label (str "arm" i) :weight (/ a (+ a b))}
+                     (= i true-best) (assoc :highlight true)))
+                 arms))})
+
 (defn dist->bars
   "PosteriorBars from a plain {value -> probability} map (e.g. a goal posterior).
    Optional `highlight` marks the bar for that value with :highlight true (e.g.

--- a/src/genmlx/dist.cljs
+++ b/src/genmlx/dist.cljs
@@ -245,6 +245,37 @@
   (bernoulli prob))
 
 ;; ---------------------------------------------------------------------------
+;; Shared scalar Gamma sampler (used by both Beta and Gamma below)
+;; ---------------------------------------------------------------------------
+
+(defn- gamma-sample-scalar
+  "One Gamma(shape, rate) draw (JS number) via Marsaglia and Tsang's method, with
+   the Ahrens-Dieter boost for shape < 1. `shape-param`/`rate` are MLX scalars.
+   Stable at all shapes (~95% first-try acceptance) — the basis for the
+   gamma-ratio Beta sampler that replaces Johnk's algorithm (bean genmlx-gcw4)."
+  [shape-param rate key]
+  (let [a (mx/realize shape-param)
+        r (mx/realize rate)
+        alpha<1? (< a 1.0)
+        a' (if alpha<1? (inc a) a)
+        d (- a' (/ 1.0 3.0))
+        c (/ 1.0 (js/Math.sqrt (* 9.0 d)))
+        [key-sample key-boost] (rng/split key)
+        raw (loop [k key-sample]
+              (let [[k1 k2] (rng/split k)
+                    x (mx/realize (rng/normal k1 []))
+                    v (js/Math.pow (+ 1.0 (* c x)) 3)
+                    u (mx/realize (rng/uniform k2 []))]
+                (if (and (> v 0)
+                         (< (js/Math.log u) (+ (* 0.5 x x) (* d (+ 1 (- v) (js/Math.log v))))))
+                  (/ (* d v) r)
+                  (let [[k' _] (rng/split k2)]
+                    (recur k')))))]
+    (if alpha<1?
+      (* raw (js/Math.pow (mx/realize (rng/uniform key-boost [])) (/ 1.0 a)))
+      raw)))
+
+;; ---------------------------------------------------------------------------
 ;; Beta
 ;; ---------------------------------------------------------------------------
 
@@ -252,19 +283,16 @@
   "Beta distribution with parameters alpha and beta."
   [alpha beta-param]
   (sample [key]
-    ;; Johnk's algorithm for beta sampling
-          (let [a (mx/realize alpha)
-                b (mx/realize beta-param)]
-            (loop [k key]
-              (let [[k1 k2] (rng/split k)
-                    u1 (mx/realize (rng/uniform k1 []))
-                    u2 (mx/realize (rng/uniform k2 []))
-                    x (js/Math.pow u1 (/ 1.0 a))
-                    y (js/Math.pow u2 (/ 1.0 b))]
-                (if (<= (+ x y) 1.0)
-                  (mx/scalar (/ x (+ x y)))
-                  (let [[k' _] (rng/split k2)]
-                    (recur k')))))))
+    ;; Beta(a,b) = G_a / (G_a + G_b), with G ~ Gamma(shape, 1) from the stable
+    ;; Marsaglia-Tsang sampler. Replaces Johnk's algorithm, which diverges (and
+    ;; SIGTRAPs the native layer) at moderate+ concentration — genmlx-gcw4. This
+    ;; matches the batch path (dist-sample-n* :beta-dist), which already does it.
+          (let [[k1 k2] (rng/split key)
+                ga (gamma-sample-scalar alpha ONE k1)
+                gb (gamma-sample-scalar beta-param ONE k2)
+                v  (/ ga (+ ga gb))]
+            ;; clamp into the open support (0,1) — log-prob is +inf at the edges
+            (mx/scalar (min (- 1.0 1e-7) (max 1e-7 v)))))
   (log-prob [v]
             ;; Boundary: log(v) → -Inf at v=0, log(1-v) → -Inf at v=1.
             ;; Mathematically correct for the beta distribution — the density
@@ -293,30 +321,9 @@
   "Gamma distribution with shape and rate parameters."
   [shape-param rate]
   (sample [key]
-    ;; Marsaglia and Tsang's method (requires shape >= 1/3).
-    ;; For shape < 1: Ahrens-Dieter boost — sample Gamma(shape+1, rate),
-    ;; then scale by U^(1/shape). Matches gamma-sample-n logic.
-          (let [a (mx/realize shape-param)
-                r (mx/realize rate)
-                alpha<1? (< a 1.0)
-                a' (if alpha<1? (inc a) a)
-                d (- a' (/ 1.0 3.0))
-                c (/ 1.0 (js/Math.sqrt (* 9.0 d)))
-                [key-sample key-boost] (rng/split key)
-                raw (loop [k key-sample]
-                      (let [[k1 k2] (rng/split k)
-                            x (mx/realize (rng/normal k1 []))
-                            v (js/Math.pow (+ 1.0 (* c x)) 3)
-                            u (mx/realize (rng/uniform k2 []))]
-                        (if (and (> v 0)
-                                 (< (js/Math.log u) (+ (* 0.5 x x) (* d (+ 1 (- v) (js/Math.log v))))))
-                          (/ (* d v) r)
-                          (let [[k' _] (rng/split k2)]
-                            (recur k')))))]
-            (if alpha<1?
-              (let [u (mx/realize (rng/uniform key-boost []))]
-                (mx/scalar (* raw (js/Math.pow u (/ 1.0 a)))))
-              (mx/scalar raw))))
+    ;; Marsaglia and Tsang's method (Ahrens-Dieter boost for shape < 1),
+    ;; shared with the gamma-ratio Beta sampler above.
+          (mx/scalar (gamma-sample-scalar shape-param rate key)))
   (log-prob [v]
             (let [k shape-param]
               (-> (mx/add (mx/multiply (mx/subtract k ONE) (mx/log v))

--- a/test/genmlx/agentmodels_pomdp_test.cljs
+++ b/test/genmlx/agentmodels_pomdp_test.cljs
@@ -1,0 +1,109 @@
+;; Headless tests for the POMDP agent (agentmodels Ch 3c) — belief filtering +
+;; belief-space (QMDP) action on the hidden-goal restaurant gridworld. Pure data,
+;; no terminal. The belief filter and belief-Q are pure; the convergence rollout
+;; is made deterministic by using the alpha = Inf (argmax) agent on a noise-0 env.
+;;
+;; Run: bun run --bun nbb test/genmlx/agentmodels_pomdp_test.cljs
+
+(ns genmlx.agentmodels-pomdp-test
+  (:require [agentmodels.gridworld :as gw]
+            [agentmodels.agent :as agent]
+            [agentmodels.pomdp :as pomdp]
+            [agentmodels.pomdp-env :as env]
+            [agentmodels.presentation :as pres]
+            [genmlx.mlx :as mx]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-close [msg expected actual tol]
+  (if (<= (Math/abs (- expected actual)) tol)
+    (do (vswap! passed inc) (println " PASS" msg "  =" actual))
+    (do (vswap! failed inc) (println " FAIL" msg "  expected:" expected "  got:" actual))))
+(defn assert-equal [msg expected actual]
+  (if (= expected actual) (do (vswap! passed inc) (println " PASS" msg "  =" (pr-str actual)))
+      (do (vswap! failed inc) (println " FAIL" msg "  expected:" (pr-str expected) "  got:" (pr-str actual)))))
+
+;; A corridor world: the only path from the start (bottom-centre, idx 13) to the
+;; two goals (A top-left idx 0, B top-right idx 2) runs UP through the signpost
+;; (idx 7), so the agent must pass it and learn the latent before the fork.
+;;   A . B
+;;   # . #
+;;   # P #     P = signpost (idx 7)
+;;   # . #
+;;   # @ #     start (idx 13)
+(def grid [[:A    :empty :B]
+           [:wall :empty :wall]
+           [:wall :empty :wall]
+           [:wall :empty :wall]
+           [:wall :empty :wall]])
+(def signpost 7)
+(def goals [:A :B])
+(defn build [true-world alpha]
+  (let [e  (env/restaurant-gridworld {:grid grid :goals goals :signpost signpost
+                                      :true-world true-world :start [1 4]})
+        pa (pomdp/make-pomdp-agent (assoc e :alpha alpha :gamma 1.0 :n-iters 40))]
+    [e pa]))
+
+(println "\n== Section 1: Bayesian belief filter (pure) ==")
+(let [[_ pa] (build :A 2.0)
+      ub     (:update-belief pa)
+      prior  (:prior pa)]
+  (assert-close "obs=nil leaves belief unchanged (:A)" 0.5 (:A (ub prior 10 nil)) 1e-9)
+  (let [snap-a (ub prior signpost :A)]
+    (assert-close "reveal :A at signpost -> P(:A)=1" 1.0 (:A snap-a) 1e-9)
+    (assert-close "reveal :A at signpost -> P(:B)=0" 0.0 (:B snap-a) 1e-9))
+  (let [snap-b (ub prior signpost :B)]
+    (assert-close "reveal :B at signpost -> P(:B)=1" 1.0 (:B snap-b) 1e-9))
+  (assert-close "every filtered belief is normalized"
+                1.0 (reduce + (vals (ub prior signpost :A))) 1e-9))
+
+(println "\n== Section 2: belief converges + QMDP reaches the right goal ==")
+(doseq [[tw goal-idx] [[:A 0] [:B 2]]]
+  (let [[e pa] (build tw ##Inf)            ; alpha=Inf + noise 0 => deterministic rollout
+        roll   (pomdp/simulate-pomdp pa e (:start-idx e) 12)
+        {:keys [states beliefs]} roll]
+    (println (str "  true world " (name tw) " | path " states
+                  " | P(" (name tw) ") " (mapv #(.toFixed (get % tw) 2) beliefs)))
+    (assert-equal (str "true world " (name tw) ": reaches its goal idx") goal-idx (last states))
+    (assert-equal "#beliefs == #states" (count states) (count beliefs))
+    (assert-close "belief flat (prior) at the start"      0.5 (get (first beliefs) tw) 1e-9)
+    (assert-close "belief still flat one step before signpost" 0.5 (get (nth beliefs 1) tw) 1e-9)
+    (assert-close "belief snaps to truth at the signpost" 1.0 (get (nth beliefs 2) tw) 1e-9)
+    (assert-true  "belief is monotone toward the truth"
+                  (>= (get (last beliefs) tw) (get (first beliefs) tw)))))
+
+(println "\n== Section 3: belief-space Q is a genuine QMDP mixture (pure) ==")
+(let [[_ pa] (build :A 2.0)
+      wa     (:world-agents pa)
+      bq     (:belief-Q pa)
+      s      1                                  ; the fork
+      mixed  (vec (mx/->clj (bq {:A 0.5 :B 0.5} s)))
+      qa     (vec (mx/->clj (mx/idx (:Q (wa :A)) s)))
+      qb     (vec (mx/->clj (mx/idx (:Q (wa :B)) s)))]
+  (assert-true "belief-Q(0.5/0.5) == 0.5*Q_A + 0.5*Q_B elementwise"
+               (every? (fn [[m a b]] (< (Math/abs (- m (+ (* 0.5 a) (* 0.5 b)))) 1e-4))
+                       (map vector mixed qa qb))))
+
+(println "\n== Section 4: point-mass collapse to the underlying MDP (anchor) ==")
+(let [[_ pa] (build :A ##Inf)
+      wa     (:world-agents pa)
+      bq     (:belief-Q pa)
+      s      1
+      pm     (vec (mx/->clj (bq {:A 1.0 :B 0.0} s)))
+      qa     (vec (mx/->clj (mx/idx (:Q (wa :A)) s)))]
+  (assert-true "point-mass belief-Q == Q_A exactly"
+               (every? (fn [[m a]] (< (Math/abs (- m a)) 1e-6)) (map vector pm qa)))
+  (assert-equal "POMDP act under certain belief == the MDP agent's action"
+                ((:act (wa :A)) s) ((:act pa) {:A 1.0 :B 0.0} s)))
+
+(println "\n== Section 5: the seam — belief -> PosteriorBars ==")
+(let [bars (pres/dist->bars "P(world)" {:A 1.0 :B 0.0} :A)]
+  (assert-close "bars sum to 1" 1.0 (reduce + (map :weight (:bars bars))) 1e-9)
+  (assert-true  "true world bar is highlighted"
+                (:highlight (first (filter #(= "A" (:label %)) (:bars bars))))))
+
+(println (str "\n" @passed " passed, " @failed " failed"))
+(when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/agentmodels_slice_test.cljs
+++ b/test/genmlx/agentmodels_slice_test.cljs
@@ -165,5 +165,25 @@
   (assert-true "dist->bars highlights the true goal (B)"      (:highlight (bar "B")))
   (assert-true "dist->bars leaves the other goal (A) unmarked" (not (:highlight (bar "A")))))
 
+(println "\n== Section 7: recursive expectedUtility == tensor value iteration ==")
+;; A tiny grid; both paths must compute identical Q-values and first action, for
+;; a finite (soft) alpha AND the alpha = Inf (hard max) limit.
+(def eq-mdp (gw/build-mdp {:grid [[:empty :G]
+                                  [:empty :empty]]
+                           :utilities {:G 2.0 :timeCost -0.1} :start [0 1] :gamma 1.0}))
+(defn- argmax-idx [xs] (first (apply max-key second (map-indexed vector xs))))
+(doseq [[label alpha n] [["soft (alpha=1.0)" 1.0 4] ["hard (alpha=Inf)" ##Inf 6]]]
+  (let [ag   (agent/make-mdp-agent {:mdp eq-mdp :alpha alpha :gamma 1.0 :n-iters n})
+        Qh   (mx/->clj (:Q ag))               ; tensor Q [S][A]
+        eu   (:expected-utility ag)            ; recursive EU(s,a,horizon)
+        errs (for [s (range (:S eq-mdp)) a (range (:A eq-mdp))]
+               (Math/abs (- (get-in Qh [s a]) (eu s a))))
+        s0   (:start-idx eq-mdp)]
+    (assert-true (str "  " label ": recursive EU matches tensor Q (max err < 1e-4)")
+                 (< (apply max errs) 1e-4))
+    (assert-equal (str "  " label ": first action agrees at start")
+                  (argmax-idx (get Qh s0))
+                  (argmax-idx (mapv #(eu s0 %) (range (:A eq-mdp)))))))
+
 (println (str "\n" @passed " passed, " @failed " failed"))
 (when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/agentmodels_slice_test.cljs
+++ b/test/genmlx/agentmodels_slice_test.cljs
@@ -1,0 +1,87 @@
+;; Headless tests for the agentmodels TUI vertical slice — everything BELOW the
+;; render seam: gridworld geometry/tensors, tensor value iteration + the
+;; softmax-action policy rollout, and the pure Frame producer + ASCII renderer.
+;; No Ink, no terminal — pure data, proven by asserts. If this passes, the live
+;; TUI renders the same data correctly by construction.
+;;
+;; Run: bun run --bun nbb test/genmlx/agentmodels_slice_test.cljs
+
+(ns genmlx.agentmodels-slice-test
+  (:require [agentmodels.gridworld :as gw]
+            [agentmodels.agent :as agent]
+            [agentmodels.presentation :as pres]
+            [genmlx.mlx :as mx]
+            [clojure.string :as str]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-equal [msg expected actual]
+  (if (= expected actual) (do (vswap! passed inc) (println " PASS" msg "  =" (pr-str actual)))
+      (do (vswap! failed inc) (println " FAIL" msg "  expected:" (pr-str expected) "  got:" (pr-str actual)))))
+
+;; -- The demo world (top row first; screen coords, y down) --------------------
+;;   A . .        idx:  0 1 2
+;;   . # .              3 4 5
+;;   . . B              6 7 8
+;; A (util 1) top-left, B (util 5) bottom-right, wall in the centre (idx 4).
+(def grid [[:A     :empty :empty]
+           [:empty :wall  :empty]
+           [:empty :empty :B]])
+(def mdp (gw/build-mdp {:grid grid
+                        :utilities {:A 1.0 :B 5.0 :timeCost -0.1}
+                        :start [1 0]            ; top-middle, idx 1
+                        :gamma 1.0}))
+
+(println "\n== Section 1: gridworld geometry + tensors ==")
+(assert-equal "S = 9"            9 (:S mdp))
+(assert-equal "A = 4"            4 (:A mdp))
+(assert-equal "start-idx = 1"    1 (:start-idx mdp))
+(assert-equal "wall at idx 4"    {4 :wall} (select-keys (zipmap (:walls mdp) (repeat :wall)) [4]))
+(assert-equal "terminals {0:A 8:B}" {0 :A 8 :B} (:terminals mdp))
+(assert-equal "T shape [9 4 9]"  [9 4 9] (mx/shape (:T mdp)))
+(assert-equal "R shape [9 4]"    [9 4]   (mx/shape (:R mdp)))
+(assert-equal "term shape [9]"   [9]     (mx/shape (:term mdp)))
+;; every T[s,a,:] is a probability row that sums to 1  => total == S*A == 36
+(assert-true  "T rows each sum to 1 (total 36)" (< (Math/abs (- 36.0 (mx/item (mx/sum (:T mdp))))) 1e-4))
+;; known transitions: right from 1 -> 2; down from 1 hits the wall -> stays at 1; left from 0 clamps -> 0
+(assert-equal "right(1) -> 2"        2 ((:ns-fn mdp) 1 1))
+(assert-equal "down(1) into wall -> 1 (stays)" 1 ((:ns-fn mdp) 1 3))
+(assert-equal "left(0) clamps -> 0"  0 ((:ns-fn mdp) 0 0))
+
+(println "\n== Section 2: value iteration + optimal-policy rollout ==")
+(def opt (agent/make-mdp-agent {:mdp mdp :alpha ##Inf :gamma 1.0 :n-iters 24}))
+(assert-equal "Q shape [9 4]" [9 4] (mx/shape (:Q opt)))
+(assert-equal "V shape [9]"   [9]   (mx/shape (:V opt)))
+;; V(B) should be the largest value in the grid (highest-reward terminal)
+(let [vs (vec (mx/->clj (:V opt)))]
+  (assert-true "V is maximal at B (idx 8)" (= 8 (apply max-key #(nth vs %) (range 9)))))
+;; the deterministic optimal agent must reach B (idx 8), routing around the wall
+(let [{:keys [states]} (agent/simulate-mdp opt 1 8)]
+  (println "  optimal path (alpha=Inf):" states)
+  (assert-equal "optimal rollout ends at B (idx 8)" 8 (last states))
+  (assert-true  "optimal rollout does NOT end at A (idx 0)" (not= 0 (last states)))
+  (assert-true  "path stepped around the wall (never visits idx 4)" (not (some #{4} states))))
+
+(println "\n== Section 3: the pure Frame producer + ASCII seam ==")
+(def frame0 (pres/state->frame mdp 1 {:step 0 :vs (vec (mx/->clj (:V opt)))
+                                      :vlo 0.0 :vhi 1.0}))
+(assert-equal "frame :cells count == W*H == 9" 9 (count (:cells frame0)))
+(assert-equal "cell idx 1 is the agent" :agent (:role (nth (:cells frame0) 1)))
+(assert-equal "cell idx 4 is the wall"  :wall  (:role (nth (:cells frame0) 4)))
+(assert-equal "cell idx 0 is a goal (A)" :goal  (:role (nth (:cells frame0) 0)))
+(let [txt (pres/render-frame-text frame0)]
+  (println "\n" (str/replace txt "\n" "\n  "))
+  (assert-true "ASCII frame shows the agent @"  (str/includes? txt "@"))
+  (assert-true "ASCII frame shows terminal A"   (str/includes? txt "A"))
+  (assert-true "ASCII frame shows terminal B"   (str/includes? txt "B")))
+;; the trajectory is one Frame per state and crosses the seam via (mx/->clj V) once
+(let [roll   (agent/simulate-mdp opt 1 8)
+      frames (pres/env->trajectory mdp roll (:V opt))]
+  (assert-equal "trajectory length == #states" (count (:states roll)) (count frames))
+  (assert-true  "final frame's agent sits on B" (= :agent (:role (nth (:cells (last frames)) 8)))))
+
+(println (str "\n" @passed " passed, " @failed " failed"))
+(when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/agentmodels_slice_test.cljs
+++ b/test/genmlx/agentmodels_slice_test.cljs
@@ -159,6 +159,11 @@
 (assert-true  "evidence accumulates: P(B) after rights > after downs"
               (> (:B (nth posts 4)) (:B (nth posts 2))))
 (println "  P(goal=B) over time:" (mapv #(.toFixed (:B %) 3) posts))
+;; dist->bars marks only the highlighted (true) goal
+(let [pb   (pres/dist->bars "P(goal)" {:A 0.3 :B 0.7} :B)
+      bar  (fn [lbl] (first (filter #(= lbl (:label %)) (:bars pb))))]
+  (assert-true "dist->bars highlights the true goal (B)"      (:highlight (bar "B")))
+  (assert-true "dist->bars leaves the other goal (A) unmarked" (not (:highlight (bar "A")))))
 
 (println (str "\n" @passed " passed, " @failed " failed"))
 (when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/agentmodels_slice_test.cljs
+++ b/test/genmlx/agentmodels_slice_test.cljs
@@ -83,5 +83,57 @@
   (assert-equal "trajectory length == #states" (count (:states roll)) (count frames))
   (assert-true  "final frame's agent sits on B" (= :agent (:role (nth (:cells (last frames)) 8)))))
 
+(println "\n== Section 4: transition noise (orthogonal slip) ==")
+;; A wall-free 3x3 so the slip lands on three distinct cells. Center state 4 =
+;; (1,1); action right(1): intended -> 5, slips up -> 1, slips down -> 7.
+(def open-mdp (gw/build-mdp {:grid [[:empty :empty :empty]
+                                    [:empty :empty :empty]
+                                    [:empty :empty :B]]
+                             :utilities {:B 5.0 :timeCost -0.1}
+                             :start [0 0] :noise 0.2}))
+(let [row (vec (mx/->clj (mx/idx (mx/idx (:T open-mdp) 4) 1)))]   ; T[4, right, :]
+  (assert-true "row T[4,right,:] sums to 1"            (< (Math/abs (- 1.0 (reduce + row))) 1e-5))
+  (assert-true "intended (->5) gets 1-noise = 0.8"     (< (Math/abs (- 0.8 (nth row 5))) 1e-5))
+  (assert-true "slip up   (->1) gets noise/2 = 0.1"    (< (Math/abs (- 0.1 (nth row 1))) 1e-5))
+  (assert-true "slip down (->7) gets noise/2 = 0.1"    (< (Math/abs (- 0.1 (nth row 7))) 1e-5))
+  (assert-true "all mass is on intended + the two slips"
+               (< (Math/abs (- 1.0 (+ (nth row 5) (nth row 1) (nth row 7)))) 1e-5)))
+(assert-true "noisy T rows each still sum to 1 (total 36)"
+             (< (Math/abs (- 36.0 (mx/item (mx/sum (:T open-mdp))))) 1e-4))
+
+(println "\n== Section 5: richer maze grid (wall forces a detour) ==")
+;;   . . . . . .
+;;   . # # # # .
+;;   . . . . # .
+;;   # # # . # .
+;;   A . . . . B     start top-left; the only route to B hugs the right edge
+(def maze [[:empty :empty :empty :empty :empty :empty]
+           [:empty :wall  :wall  :wall  :wall  :empty]
+           [:empty :empty :empty :empty :wall  :empty]
+           [:wall  :wall  :wall  :empty :wall  :empty]
+           [:A     :empty :empty :empty :empty :B]])
+(def maze-mdp (gw/build-mdp {:grid maze :utilities {:A 1.0 :B 5.0 :timeCost -0.1}
+                             :start [0 0] :gamma 1.0}))   ; noise 0 -> deterministic assert
+(def maze-opt (agent/make-mdp-agent {:mdp maze-mdp :alpha ##Inf :gamma 1.0 :n-iters 40}))
+(assert-equal "maze S = 30"     30 (:S maze-mdp))
+(assert-equal "B at idx 29"     {29 :B} (select-keys (:terminals maze-mdp) [29]))
+(let [vs (vec (mx/->clj (:V maze-opt)))]
+  (assert-true "V maximal at B (idx 29)" (= 29 (apply max-key #(nth vs %) (range 30)))))
+(let [{:keys [states]} (agent/simulate-mdp maze-opt (:start-idx maze-mdp) 30)
+      frames (pres/env->trajectory maze-mdp {:states states :actions []} (:V maze-opt))]
+  (println "  optimal maze path:" states)
+  (println "\n " (str/replace (pres/render-frame-text (last frames)) "\n" "\n  "))
+  (assert-equal "optimal maze rollout ends at B (idx 29)" 29 (last states))
+  (assert-true  "optimal path avoids every wall" (not-any? (:walls maze-mdp) states)))
+
+;; a noisy rollout (the path the live demo walks) must still produce a valid
+;; trajectory: every visited cell is in-bounds and never a wall.
+(let [nm (gw/build-mdp {:grid maze :utilities {:A 1.0 :B 5.0 :timeCost -0.1}
+                        :start [0 0] :gamma 1.0 :noise 0.3})
+      ag (agent/make-mdp-agent {:mdp nm :alpha 5.0 :gamma 1.0 :n-iters 40})
+      {:keys [states]} (agent/simulate-mdp ag (:start-idx nm) 30)]
+  (assert-true "noisy rollout stays in-bounds and off walls"
+               (every? (fn [s] (and (<= 0 s) (< s 30) (not ((:walls nm) s)))) states)))
+
 (println (str "\n" @passed " passed, " @failed " failed"))
 (when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/agentmodels_slice_test.cljs
+++ b/test/genmlx/agentmodels_slice_test.cljs
@@ -10,6 +10,7 @@
   (:require [agentmodels.gridworld :as gw]
             [agentmodels.agent :as agent]
             [agentmodels.presentation :as pres]
+            [agentmodels.inverse :as inv]
             [genmlx.mlx :as mx]
             [clojure.string :as str]))
 
@@ -134,6 +135,30 @@
       {:keys [states]} (agent/simulate-mdp ag (:start-idx nm) 30)]
   (assert-true "noisy rollout stays in-bounds and off walls"
                (every? (fn [s] (and (<= 0 s) (< s 30) (not ((:walls nm) s)))) states)))
+
+(println "\n== Section 6: inverse goal inference (assess-based) ==")
+;;   . . . . .
+;;   . . . . .
+;;   A . . . B     start top-centre (idx 2); A/B are mirror-symmetric about col 2
+(def inv-grid [[:empty :empty :empty :empty :empty]
+               [:empty :empty :empty :empty :empty]
+               [:A     :empty :empty :empty :B]])
+(def goal-ags (inv/goal-agents {:grid inv-grid :goals [:A :B] :alpha 2.0}))
+;; hand-specified observations from idx 2: DOWN, DOWN (on the symmetry axis, so
+;; uninformative), then RIGHT, RIGHT toward B (idx 14). down = 3, right = 1.
+(def obs [[2 3] [7 3] [12 1] [13 1]])
+(def posts (inv/posterior-sequence goal-ags {:A 0.5 :B 0.5} obs))
+(assert-equal "one posterior per prefix (prior + 4 obs)" 5 (count posts))
+(assert-true  "every posterior sums to 1"
+              (every? (fn [m] (< (Math/abs (- 1.0 (reduce + (vals m)))) 1e-6)) posts))
+(assert-true  "prior is uniform"  (< (Math/abs (- 0.5 (:B (nth posts 0)))) 1e-6))
+(assert-true  "two DOWN moves are symmetric -> still ~0.5"
+              (< (Math/abs (- 0.5 (:B (nth posts 2)))) 0.02))
+(assert-true  "after turning RIGHT toward B, P(B) jumps above 0.8"
+              (> (:B (nth posts 4)) 0.8))
+(assert-true  "evidence accumulates: P(B) after rights > after downs"
+              (> (:B (nth posts 4)) (:B (nth posts 2))))
+(println "  P(goal=B) over time:" (mapv #(.toFixed (:B %) 3) posts))
 
 (println (str "\n" @passed " passed, " @failed " failed"))
 (when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/bandit_test.cljs
+++ b/test/genmlx/bandit_test.cljs
@@ -1,0 +1,74 @@
+;; Headless tests for the multi-armed bandit POMDP (agentmodels Ch 3c/3d):
+;; host-side Beta-Bernoulli belief filter + Thompson posterior sampling. The
+;; belief update and arm-values are pure; the rollout is made reproducible by
+;; passing a seeded key (rng/fresh-key 42) to simulate-bandit.
+;;
+;; Run: bun run --bun nbb test/genmlx/bandit_test.cljs
+
+(ns genmlx.bandit-test
+  (:require [agentmodels.pomdp :as pomdp]
+            [agentmodels.pomdp-env :as env]
+            [agentmodels.presentation :as pres]
+            [genmlx.mlx.random :as rng]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-close [msg expected actual tol]
+  (if (<= (Math/abs (- expected actual)) tol)
+    (do (vswap! passed inc) (println " PASS" msg "  =" actual))
+    (do (vswap! failed inc) (println " FAIL" msg "  expected:" expected "  got:" actual))))
+(defn assert-equal [msg expected actual]
+  (if (= expected actual) (do (vswap! passed inc) (println " PASS" msg "  =" (pr-str actual)))
+      (do (vswap! failed inc) (println " FAIL" msg "  expected:" (pr-str expected) "  got:" (pr-str actual)))))
+
+(def ag (pomdp/make-bandit-agent {:strategy :thompson}))
+
+(println "\n== Section 1: Beta-Bernoulli belief update (pure) ==")
+(let [ub (:update-belief ag)
+      b0 {:arms [[1.0 1.0] [1.0 1.0] [1.0 1.0]]}]
+  (assert-equal "success on arm 0 -> Beta(2,1)"     [2.0 1.0] (get-in (ub b0 0 1) [:arms 0]))
+  (assert-equal "unpulled arm 1 unchanged"          [1.0 1.0] (get-in (ub b0 0 1) [:arms 1]))
+  (assert-equal "unpulled arm 2 unchanged"          [1.0 1.0] (get-in (ub b0 0 1) [:arms 2]))
+  (assert-equal "failure on arm 2 -> Beta(1,2)"     [1.0 2.0] (get-in (ub b0 2 0) [:arms 2])))
+
+(println "\n== Section 2: arm-values = posterior mean alpha/(alpha+beta) (pure) ==")
+(let [av (:arm-values ag)]
+  (assert-close "mean Beta(8,2) = 0.8" 0.8 (nth (av {:arms [[8.0 2.0]]}) 0) 1e-9)
+  (assert-close "mean Beta(1,1) = 0.5" 0.5 (nth (av {:arms [[1.0 1.0]]}) 0) 1e-9))
+
+(println "\n== Section 3: belief converges + pulls concentrate on the best arm ==")
+;; 3 Bernoulli arms; arm 2 (theta=0.8) is best. Seeded rollout, horizon 60.
+(def bandit (env/bandit-pomdp {:thetas [0.25 0.50 0.80] :horizon 60}))
+(def roll   (pomdp/simulate-bandit ag bandit (rng/fresh-key 42)))
+(let [means  ((:arm-values ag) (last (:beliefs roll)))
+      counts (frequencies (:arms roll))]
+  (println "  pull counts:" (into (sorted-map) counts) " | final means:" (mapv #(.toFixed % 2) means))
+  (assert-equal "true-best arm is index 2" 2 (:true-best bandit))
+  (assert-close "best-arm posterior mean -> ~0.8" 0.80 (nth means 2) 0.15)
+  (assert-true  "best arm (2) is the modal pull" (= 2 (apply max-key #(get counts % 0) (range 3))))
+  (assert-true  "best arm pulled a majority of the time" (> (get counts 2 0) (/ 60 2))))
+
+(println "\n== Section 4: cumulative regret is sublinear ==")
+(let [reg (:regret roll)
+      early (/ (nth reg 9) 10.0)                         ; avg regret/step, first 10
+      late  (/ (- (last reg) (nth reg 49)) 10.0)]        ; avg regret/step, last 10
+  (println "  regret: early-slope" (.toFixed early 3) " late-slope" (.toFixed late 3)
+           " total" (.toFixed (last reg) 2))
+  (assert-true "regret accrues early"               (> early 0.0))
+  (assert-true "regret slope flattens (sublinear)"  (< late early))
+  (assert-true "total regret well below the worst-arm bound"
+               (< (last reg) (* 60 (- 0.80 0.25)))))
+
+(println "\n== Section 5: the seam — bandit belief -> PosteriorBars ==")
+(let [bars (pres/bandit-bars {:arms [[2.0 6.0] [3.0 3.0] [9.0 2.0]]} 2)]
+  (assert-equal "one bar per arm" 3 (count (:bars bars)))
+  (assert-equal "labels" ["arm0" "arm1" "arm2"] (mapv :label (:bars bars)))
+  (assert-close "arm2 weight = posterior mean 9/11" (/ 9.0 11.0) (:weight (nth (:bars bars) 2)) 1e-9)
+  (assert-true  "true-best arm highlighted"        (:highlight (nth (:bars bars) 2)))
+  (assert-true  "other arms not highlighted"       (not (:highlight (nth (:bars bars) 0)))))
+
+(println (str "\n" @passed " passed, " @failed " failed"))
+(when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/dist_test.cljs
+++ b/test/genmlx/dist_test.cljs
@@ -208,4 +208,18 @@
       (is (h/close? 5.0 mean 0.3) "Gaussian mean ~ 5")
       (is (h/close? 4.0 variance 1.0) "Gaussian variance ~ 4"))))
 
+(deftest beta-high-concentration-regression-test
+  ;; genmlx-gcw4: the old Johnk's beta sampler diverged and SIGTRAPped the native
+  ;; layer at moderate+ concentration. The gamma-ratio sampler is stable + correct
+  ;; at all concentrations (this is exactly where a converging bandit lives).
+  (testing "Beta sampling at high concentration is stable + correct (no SIGTRAP)"
+    (doseq [[a b] [[40 10] [100 20]]]
+      (let [d    (dist/beta-dist a b)
+            xs   (mapv (fn [_] (let [v (dist/sample d)] (mx/eval! v) (mx/item v))) (range 50))
+            mean (/ (reduce + xs) (count xs))]
+        (is (every? #(and (> % 0.0) (< % 1.0)) xs)
+            (str "Beta(" a "," b ") samples all in open (0,1)"))
+        (is (h/close? (/ a (+ a b)) mean 0.06)
+            (str "Beta(" a "," b ") sample mean ~ " (/ a (+ a b))))))))
+
 (cljs.test/run-tests)


### PR DESCRIPTION
## What

The first end-to-end vertical slice of the agentmodels.org TUI gallery
(milestone `genmlx-vui9`): a 3×3 gridworld where **real MLX value iteration**
computes Q, a **softmax-action policy (itself a generative function)** rolls out
a path, and the agent **walks it in the terminal** via Ink.

## The architecture — one render-agnostic data seam

Everything below `agentmodels.presentation`'s `Frame` / `Trajectory` /
`PosteriorBars` shapes is pure CLJS + MLX and is proven headlessly; everything
above is just reagent + Ink turning that *same data* into colored cells.

```
gridworld.cljs ─► agent.cljs ─► presentation.cljs ─►║ Frame ║─► views.cljs ─► gallery/ch3_demo
  (env tensors)    (VI + GFI      (pure producers +  ║ SEAM  ║   (Ink views)    (sub-app)
                    policy)        ASCII renderers)   ╚═══════╝
```

Two shapes that make it idiomatic GenMLX:

```clojure
;; agent.cljs — the policy IS a generative function (agentmodels' `act`)
(gen [s] (trace :action (h/softmax-action alpha (mx/idx Q s))))   ; alpha=##Inf → optimal
;; the Bellman backup is one pure MLX-graph step
Q = R + gamma*(1-term) * (T · V),   V = max_a Q
```

## Files (12; no `src/` changes, `node_modules` git-ignored)

**Foundation lib** (`examples/agentmodels/`, pure CLJS + MLX):
- `gridworld.cljs` — grid literal → `{T [S,A,S'], R [S,A], term [S], ns-fn}` via host-side
  integer geometry (avoids the `mx/clip` int32-bounds trap, `genmlx-aonv`) + MLX one-hot
- `agent.cljs` — tensor-Bellman value iteration; policy as a GFI gen-fn; rollout driver
- `presentation.cljs` — the render-agnostic seam: `env->trajectory` → `[Frame]`,
  `marginals->bars` → `PosteriorBars`, plus ASCII renderers (no Ink)

**TUI gallery** (`examples/agentmodels-tui/`, reagent + Ink, mirrors `examples/genmlx-tui`):
- `gallery.cljs` — one `r/atom` + demo-registry + `stdin` key router (proven reagent-atom
  reactivity, no React hooks)
- `views.cljs` — `grid-view` / `bars-view` / `frames-view` / `status-bar`
- `ch3_demo.cljs` — wires VI → rollout → frames → animated walk; `+/-` adjusts alpha
- `views_demo.cljs`, `run.sh`, `README.md`

## Verification

| check | result |
|---|---|
| `bun run --bun nbb test/genmlx/agentmodels_slice_test.cljs` | **27/27** — optimal agent path `[1 2 5 8]`, routes around the wall to **B** |
| `./run.sh views` | grid + status bar + posterior bars render; clean exit |
| `printf 'q' \| ./run.sh` | full module graph loads, menu renders, key handled |

## Run the live demo

```bash
cd examples/agentmodels-tui && npm install && ./run.sh
# ↑/↓ + enter → "Ch 3: Gridworld MDP"; the @ auto-walks to B around the wall;
# +/- changes alpha (→ INF = optimal), space steps, r resamples, q/esc back
```

## Scope / deferred (tracked in beans)

This is the *minimal* subset of each foundation/TUI bean (`genmlx-6nmg` scaffold is
complete). Deferred: orthogonal transition noise + Restaurant-Choice topology
(`genmlx-pe5l`), the faithful `exact/with-cache` recursive path + equivalence test
(`genmlx-m4pr`), Q-annotation / marginals-table renderers (`genmlx-rops`), a dedicated
`trajectory-player` component (`genmlx-bfwz`), and live-TTY confirmation (`genmlx-kdp6`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
