### PR TITLE
feat(agentmodels): multi-agent models (Ch 7) — Schelling, RSA, tic-tac-toe game tree

### DIFF
--- a/examples/agentmodels/multi_agent.cljs
+++ b/examples/agentmodels/multi_agent.cljs
@@ -1,0 +1,358 @@
+(ns agentmodels.multi-agent
+  "Chapter 7 — Multi-agent models, as native genmlx.agents.
+
+   An *agent is a generative function*; the inference backend used to reason about
+   it — exact enumeration, importance/Monte-Carlo, or a MIX — is a pluggable seam,
+   orthogonal to the model. That separation is the point: every model here takes an
+   `infer` argument and defaults it, and the test demonstrates exact ≈ sampled on
+   the very same agent GF.
+
+   Three agents built from one small set of primitives:
+
+   - Schelling coordination : two nested-reasoning GFs that condition on meeting
+                              (native bernoulli-observe), memoized over a depth
+                              ladder with exact/with-cache. Focal-point amplification.
+   - RSA (sprouted seeds)   : the speaker is a softmax-action agent — factor(α·EU),
+                              EU = the literal listener's log-score; the literal
+                              listener is a GF run through the (pluggable) inference
+                              seam. A mixed pipeline: inferred L0 → softmax S1 → Bayes L1.
+   - Tic-tac-toe game tree  : a softmax-action agent over a with-cache game-tree
+                              expected utility = expectation over the opponent's own
+                              softmax policy (soft minimax; hard minimax at α=##Inf).
+
+   Source: agentmodels.org Chapter 7 (canonical). Ground truth is ANALYTIC (derived
+   from the model math), not copied from examples/memo (a separate memo-conversion
+   corpus). No engine change — composes genmlx.inference.exact, agentmodels.helpers,
+   and exact/with-cache only."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.protocols :as p]
+            [genmlx.dynamic :as dyn]
+            [genmlx.choicemap :as cm]
+            [genmlx.inference.exact :as exact]
+            [agentmodels.helpers :as h])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+;; ===========================================================================
+;; Inference seam — an agent is a GF; HOW we reason about it is pluggable.
+;;
+;; A "marginal inferer" reasons about a discrete gen model GF and returns the [k]
+;; posterior marginal of one address under observations `obs`. `exact-marginal`
+;; is the default (exact enumeration); `importance-marginal` is a sampling backend
+;; that reasons about the SAME model GF. Swapping one for the other changes nothing
+;; about the agent definition — that orthogonality is the whole idea.
+;; ===========================================================================
+
+(defn exact-marginal
+  "Default reasoning backend: exact enumeration. Returns the [k] posterior marginal
+   of `addr` in `model` under observation choicemap `obs`, as an MLX vector."
+  [model obs addr k]
+  (let [r (exact/exact-posterior model [] obs)]
+    (mx/array (clj->js (mapv #(get-in (:marginals r) [addr %]) (range k))))))
+
+(defn importance-marginal
+  "A SAMPLING reasoning backend: importance sampling with the model's own priors as
+   the proposal. `p/generate` constrains `obs` and returns weight = log p(obs | sampled
+   latents) — exactly the importance log-weight — so weighting samples by exp(weight)
+   yields the posterior. Reasons about the SAME agent GF as `exact-marginal`,
+   demonstrating that the inference backend is orthogonal to the model. Returns a
+   [k] probability vector for `addr`. (n samples; uses live entropy, so callers
+   should assert with a tolerance, not for bit-equality.)"
+  [n]
+  (fn [model obs addr k]
+    (let [tally (reduce
+                  (fn [acc _]
+                    (let [{:keys [trace weight]} (p/generate (dyn/auto-key model) [] obs)
+                          w (Math/exp (mx/item weight))
+                          v (int (mx/item (cm/get-value (cm/get-submap (:choices trace) addr))))]
+                      (update acc v + w)))
+                  (vec (repeat k 0.0))
+                  (range n))
+          z (reduce + tally)]
+      (mx/array (clj->js (mapv #(/ % (max z 1e-300)) tally))))))
+
+;; ===========================================================================
+;; Model 1 — Schelling coordination (focal-point amplification)
+;;
+;; agentmodels.org Ch 7: alice(d) samples a location ~ prior, samples bob(d-1)'s
+;; location, and conditions on meeting; bob(d) coordinates with alice(d); base case
+;; bob(0) = prior (the non-strategic agent). There is NO utility/softmax here — pure
+;; coordination by conditioning. The repeated multiplication by the prior at each
+;; rung amplifies the 0.55 focal point toward ~1.0.
+;; ===========================================================================
+
+(def location-prior
+  "P(popular-bar)=0.55, P(unpopular-bar)=0.45. Index 0 = popular (the focal point)."
+  (mx/array #js [0.55 0.45]))
+
+(defn coordination-model
+  "One agent reasoning about the other: sample my location ~ prior and the other's
+   ~ `other-probs`, then CONDITION on meeting. Conditioning is the native GenMLX
+   bernoulli-observe idiom (cf. exact/observe-constraint): a Bernoulli whose success
+   probability is 1 iff we picked the same bar, observed to be 1. Works identically
+   under exact enumeration and importance sampling — the inference is pluggable."
+  [other-probs]
+  (gen []
+    (let [other (trace :other (dist/categorical (mx/log other-probs)))
+          me    (trace :me    (dist/categorical (mx/log location-prior)))
+          match (.astype (mx/equal me other) mx/float32)]
+      (trace :meet (dist/bernoulli match))           ; observed = 1  ⇒  condition(me == other)
+      me)))
+
+(def ^:private MEET (cm/choicemap :meet (mx/scalar 1)))
+
+(defn coordinate
+  "The coordination posterior over my location (the [2] marginal of :me), given the
+   other agent's location distribution. `infer` is the pluggable reasoning backend."
+  [other-probs infer]
+  (infer (coordination-model other-probs) MEET :me 2))
+
+(defn schelling-agents
+  "Build the mutually-recursive alice/bob coordination agents over a depth ladder.
+   Returns {:alice :bob}, each a memoized (fn [depth] -> [2] location probs):
+     alice(d) coordinates with bob(d-1);  bob(d>0) coordinates with alice(d);
+     bob(0) = prior (base case). `infer` defaults to exact enumeration; pass
+     (importance-marginal n) to reason by sampling instead — same agents, same
+     numbers (within MC error). Call alice for d>=1, bob for d>=0."
+  ([] (schelling-agents exact-marginal))
+  ([infer]
+   (let [alice (atom nil)
+         bob   (atom nil)]
+     (reset! alice (exact/with-cache (fn [d] (coordinate (@bob (dec d)) infer))))
+     (reset! bob   (exact/with-cache (fn [d] (if (zero? d)
+                                               location-prior
+                                               (coordinate (@alice d) infer)))))
+     {:alice @alice :bob @bob})))
+
+(defn p-popular
+  "P(popular-bar) from a [2] location-probability vector, as a JS number."
+  [probs]
+  (mx/item (mx/slice probs 0 1)))
+
+;; ===========================================================================
+;; Model 2 — RSA: the speaker is a softmax-action agent (sprouted-seeds + reference)
+;;
+;; A denotation is a [n-utts × n-states] truth matrix (rows = utterance). The tower:
+;;   L0(s|u) ∝ prior(s)·denotation(u,s)              literal listener (a GF, via `infer`)
+;;   S1(u|s) ∝ exp(α · log L0(s|u))                  pragmatic speaker = softmax-action
+;;   L1(s|u) ∝ prior(s)·S1(u|s)                      pragmatic listener = Bayes(S1)
+;; This is a MIXED-inference pipeline: L0 goes through the pluggable inference seam
+;; (swap exact↔importance freely); S1/S2/L1 are the speaker's softmax policy and its
+;; Bayesian inversion — pure tensor transforms of the L0 table. The "sprouted-seeds
+;; variant = re-parameterized denotation matrix": same code, different denotation.
+;; ===========================================================================
+
+(defn literal-listener-model
+  "L0 as a GF: a state ~ prior, observe that the utterance's denotation (`truth-row`,
+   a [n-states] 0/1 vector gathered at the sampled state) holds — native bernoulli-
+   observe = condition(meaning(state)). Runs under exact OR importance unchanged."
+  [state-prior truth-row]
+  (gen []
+    (let [s (trace :s (dist/categorical (mx/log state-prior)))]
+      (trace :holds (dist/bernoulli (mx/take-idx truth-row s)))   ; observed = 1 ⇒ condition(denotes)
+      s)))
+
+(def ^:private HOLDS (cm/choicemap :holds (mx/scalar 1)))
+
+(defn literal-listener
+  "The literal-listener table L0: [n-utts × n-states], row u = P_L0(state | utterance u).
+   Each row is produced by the pluggable inference seam over the listener GF."
+  [{:keys [denotation state-prior infer] :or {infer exact-marginal}}]
+  (let [[nu ns] (vec (mx/shape denotation))
+        rows (mapv (fn [u] (infer (literal-listener-model state-prior (mx/idx denotation u))
+                                  HOLDS :s ns))
+                   (range nu))]
+    (mx/stack rows)))
+
+(defn speaker-table
+  "The pragmatic speaker S1: [n-states × n-utts], row s = P_S1(utterance | state s).
+   S1(u|s) = softmax_u(α · log L0(s|u)) — Boltzmann/softmax-action over utterances
+   with utility = the literal listener's log-score. (This is agentmodels' factor(α·EU)
+   realized as a policy; see agentmodels.helpers/softmax-action.)"
+  [L0 alpha]
+  (mx/softmax (mx/multiply (mx/scalar alpha) (mx/log (mx/transpose L0))) 1))
+
+(defn pragmatic-listener-table
+  "The pragmatic listener L1: [n-utts × n-states], row u = P_L1(state | utterance u).
+   Bayesian inversion of the speaker: L1(s|u) ∝ prior(s)·S1(u|s)."
+  [L0 state-prior alpha]
+  (let [S1    (speaker-table L0 alpha)                          ; [ns × nu]
+        ns    (first (vec (mx/shape S1)))
+        joint (mx/multiply S1 (mx/reshape state-prior #js [ns 1]))  ; [ns × nu]
+        col-z (mx/sum joint [0] true)                           ; [1 × nu] = P(u)
+        L1-su (mx/divide joint col-z)]                          ; [ns × nu] = P(s | u)
+    (mx/transpose L1-su)))                                      ; [nu × ns]
+
+(defn make-rsa
+  "Build an RSA tower over a denotation matrix. Returns {:L0 :S1 :L1}, the literal
+   listener, speaker, and pragmatic listener tables. `infer` (default exact) is the
+   pluggable backend for the literal listener — pass (importance-marginal n) to make
+   L0 sampled while S1/L1 stay exact (a genuine mixed-inference pipeline).
+
+   `alpha` is the speaker rationality / optimality parameter (factor(alpha·EU)); it is
+   domain-specific. The canonical Ch 7 sprouted-seeds tower uses 2 (the default here);
+   classic reference games often use 1 (pass :alpha 1.0)."
+  [{:keys [denotation state-prior alpha infer]
+    :or   {alpha 2.0 infer exact-marginal}}]
+  (let [L0 (literal-listener {:denotation denotation :state-prior state-prior :infer infer})]
+    {:L0 L0
+     :S1 (speaker-table L0 alpha)
+     :L1 (pragmatic-listener-table L0 state-prior alpha)}))
+
+(defn table-row
+  "Row `i` of a probability table as a vector of JS numbers."
+  [table i]
+  (let [row (mx/idx table i)
+        n   (first (vec (mx/shape row)))]
+    (mapv #(mx/item (mx/slice row % (inc %))) (range n))))
+
+;; -- Two denotations, same tower (the re-parameterized-denotation point) --
+
+(def sprouted-denotation
+  "Sprouted-seeds scalar implicature (agentmodels.org Ch 7). Utterances [all some none],
+   states [0 1 2 3] = number of sprouted seeds. all=(s==3), some=(s>0), none=(s==0)."
+  (.astype (mx/array #js [#js [0 0 0 1]      ; all  : s == 3
+                          #js [0 1 1 1]      ; some : s  > 0
+                          #js [1 0 0 0]])    ; none : s == 0
+           mx/float32))
+
+(def sprouted-prior (mx/array #js [0.25 0.25 0.25 0.25]))
+
+(def reference-denotation
+  "A minimal referential-implicature game. Utterances [u0 uboth], referents [r0 r1].
+   u0 is true of r0 only; uboth is true of both. Different denotation, same tower —
+   the pragmatic listener resolves the ambiguous 'uboth' toward r1."
+  (.astype (mx/array #js [#js [1 0]          ; u0    : r0 only
+                          #js [1 1]])        ; uboth : both
+           mx/float32))
+
+(def reference-prior (mx/array #js [0.5 0.5]))
+
+;; ===========================================================================
+;; Model 3 — Tic-tac-toe game tree (a softmax-action agent over a with-cache EU)
+;;
+;; Board = a flat 9-vector of #{:x :o :_} (index = 3*row + col). Everything about the
+;; game is pure host data/combinatorics (the host-geometry side of the split); MLX
+;; appears only in the final softmax-action policy distribution. The agent's value is
+;;   val(board, mover, scorer) = utility(board, scorer)                   if terminal
+;;                             = Σ_m π_mover(m) · val(child_m, other(mover), scorer)
+;;   π_mover = softmax(α · [val(child_m, other(mover), mover)])    (argmax at α=##Inf)
+;; i.e. the expectation of the scorer's value under the mover's own softmax policy —
+;; soft minimax, collapsing to exact (adversarial) minimax in the α=##Inf limit.
+;; ===========================================================================
+
+(def ^:private lines
+  [[0 1 2] [3 4 5] [6 7 8]    ; rows
+   [0 3 6] [1 4 7] [2 5 8]    ; cols
+   [0 4 8] [2 4 6]])          ; diagonals
+
+(defn other-player [p] (if (= p :x) :o :x))
+
+(defn won? [board p]
+  (boolean (some (fn [[a b c]] (and (= p (board a)) (= p (board b)) (= p (board c)))) lines)))
+
+(defn board-full? [board] (not-any? #{:_} board))
+
+(defn terminal? [board] (or (won? board :x) (won? board :o) (board-full? board)))
+
+(defn utility
+  "Utility of a board to `player`: win 10, loss -10, draw / non-terminal 0
+   (per the chapter: isDraw = neither has three-in-a-row)."
+  [board player]
+  (cond (won? board player)               10.0
+        (won? board (other-player player)) -10.0
+        :else                              0.0))
+
+(defn legal-moves [board] (filterv #(= :_ (board %)) (range 9)))
+
+(defn place [board i player] (assoc board i player))
+
+(defn- softmax-weights [alpha qs]
+  (let [m  (apply max qs)
+        es (mapv #(Math/exp (* alpha (- % m))) qs)
+        z  (reduce + es)]
+    (mapv #(/ % z) es)))
+
+(defn- argmax-weights [qs]                ; α=##Inf: uniform over argmax ties
+  (let [m  (apply max qs)
+        is (mapv #(if (== % m) 1.0 0.0) qs)
+        z  (reduce + is)]
+    (mapv #(/ % z) is)))
+
+(defn- policy-weights [alpha qs]
+  (if (= alpha ##Inf) (argmax-weights qs) (softmax-weights alpha qs)))
+
+(defn make-game-agent
+  "Build the planning tic-tac-toe agent. Returns {:alpha :val :move-q :policy :act}.
+   :policy is the softmax-action GF (retval = index into legal moves); :act simulates
+   it host-side and returns the chosen cell. :move-q gives the per-move EU table.
+   :val is the memoized (with-cache) host recursion val(board, mover, scorer).
+   α defaults to ##Inf (exact/adversarial minimax — deterministic); finite α gives a
+   soft-rational opponent. The full game tree from a near-terminal board is tiny;
+   with-cache (the transposition table) keeps deeper boards tractable."
+  [{:keys [alpha] :or {alpha ##Inf}}]
+  (let [val (atom nil)]
+    (reset! val
+      (exact/with-cache
+        (fn [board mover scorer]
+          (if (terminal? board)
+            (utility board scorer)
+            (let [ms  (legal-moves board)
+                  ;; the mover picks per a softmax over ITS OWN continuation value:
+                  qs  (mapv (fn [m] (@val (place board m mover) (other-player mover) mover)) ms)
+                  pol (policy-weights alpha qs)
+                  ;; the scorer's value = expectation, under the mover's policy, of the
+                  ;; scorer's own continuation value:
+                  vs  (mapv (fn [m] (@val (place board m mover) (other-player mover) scorer)) ms)]
+              (reduce + (map * pol vs)))))))
+    (let [policy (fn [player]                    ; factor(α·EU) as a softmax-action GF; retval = INDEX into legal moves
+                   (gen [board]
+                     (let [eus (mapv (fn [m] (@val (place board m player) (other-player player) player))
+                                     (legal-moves board))]
+                       ;; raw traced index (NO in-body mx/item) — stays vectorization-safe,
+                       ;; matching agent.cljs / biased_planners.cljs. The legal cell is
+                       ;; resolved host-side in :act below.
+                       (trace :move (h/softmax-action alpha (mx/array (clj->js (mapv double eus))))))))]
+      {:alpha alpha
+       :val @val
+       :move-q (fn [board player]               ; [[move eu]...] EU to `player` of each legal move
+                 (mapv (fn [m] [m (@val (place board m player) (other-player player) player)])
+                       (legal-moves board)))
+       :policy policy
+       :act (fn [board player]                  ; host-side: simulate the policy, resolve the chosen legal cell
+              (let [ms (legal-moves board)
+                    i  (int (mx/item (:retval (p/simulate (dyn/auto-key (policy player)) [board]))))]
+                (nth ms i)))})))
+
+(defn best-move
+  "The agent's argmax legal move for `player` at `board` (min cell index breaks ties —
+   deterministic). Exact minimax at α=##Inf."
+  [agent board player]
+  (let [qs   ((:move-q agent) board player)
+        best (apply max (map second qs))]
+    (->> qs (filter #(>= (second %) (- best 1e-9))) (map first) (apply min))))
+
+(defn non-planning-move-q
+  "The one-step (no-lookahead) agent of the chapter: EU(move) = utility of the board
+   immediately after the move, for `player`. Used to contrast with planning."
+  [board player]
+  (mapv (fn [m] [m (utility (place board m player) player)]) (legal-moves board)))
+
+;; -- Reference boards used by the headless test (x to move; '_' = empty) --
+
+(def forced-win-board
+  "x has two-in-a-row on the top row; (0,2)=cell 2 completes it for an immediate win."
+  [:x :x :_
+   :o :o :_
+   :_ :_ :_])
+
+(def forced-block-board
+  "Near-endgame, x to move (3 empty cells). o threatens to complete the middle row at
+   cell 5. Blocking at cell 5 forces a DRAW (value 0); any other move lets o win
+   (value -10). So PLANNING (lookahead) blocks at cell 5, while the one-step agent is
+   indifferent (every immediate move is non-terminal → scores 0). The clean
+   planning-vs-non-planning discriminator: undiscounted minimax can only tell block
+   from non-block when the block actually salvages the game."
+  [:x :x :o
+   :o :o :_
+   :x :_ :_])

--- a/test/genmlx/agentmodels_multi_agent_test.cljs
+++ b/test/genmlx/agentmodels_multi_agent_test.cljs
@@ -1,0 +1,154 @@
+;; Headless tests for agentmodels Chapter 7 — Multi-agent models (native genmlx.agents).
+;; Run: bun run --bun nbb test/genmlx/agentmodels_multi_agent_test.cljs
+;;
+;; Ground truth is ANALYTIC (derived from the model math), not from examples/memo.
+;; Sections also demonstrate the core genmlx.agents principle: the SAME agent GF runs
+;; under exact OR sampled OR mixed inference — the backend is a pluggable seam.
+
+(ns genmlx.agentmodels-multi-agent-test
+  (:require [agentmodels.multi-agent :as ma]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-equal [msg expected actual]
+  (if (= expected actual) (do (vswap! passed inc) (println " PASS" msg "  =" (pr-str actual)))
+      (do (vswap! failed inc) (println " FAIL" msg "  expected:" (pr-str expected) "  got:" (pr-str actual)))))
+(defn assert-close [msg expected actual tol]
+  (if (<= (Math/abs (- expected actual)) tol) (do (vswap! passed inc) (println " PASS" msg "  =" actual))
+      (do (vswap! failed inc) (println " FAIL" msg "  expected:" expected "  got:" actual))))
+
+(defn- argmax-idx [xs] (first (apply max-key second (map-indexed vector xs))))
+
+;; ===========================================================================
+(println "\n== Section 1: Schelling — focal-point amplification (exact) ==")
+(let [{:keys [alice bob]} (ma/schelling-agents)
+      p (fn [probs] (ma/p-popular probs))]
+  (println "  depth :  bob P(popular)   alice P(popular)")
+  (doseq [d (range 5)]
+    (println (str "    " d "   :    "
+                  (.toFixed (p (bob d)) 4) "        "
+                  (if (>= d 1) (.toFixed (p (alice d)) 4) "   -"))))
+  (assert-close "bob(0) = prior 0.55"        0.55   (p (bob 0))   1e-6)
+  (assert-close "alice(1) = 0.5990"          0.5990 (p (alice 1)) 1e-3)
+  (assert-close "bob(1) = 0.6461"            0.6461 (p (bob 1))   1e-3)
+  (assert-close "alice(2) = 0.6905"          0.6905 (p (alice 2)) 1e-3)
+  (assert-close "bob(2) = 0.7317"            0.7317 (p (bob 2))   1e-3)
+  (assert-true  "alice P(popular) strictly increasing in depth"
+                (apply < (mapv #(p (alice %)) (range 1 5))))
+  (assert-true  "alice(4) P(popular) >= 0.83 (focal-point convergence)"
+                (>= (p (alice 4)) 0.83)))
+
+;; ===========================================================================
+(println "\n== Section 2: Schelling — inference is pluggable (exact ≈ importance, same GF) ==")
+(let [exact-a1 (ma/p-popular ((:alice (ma/schelling-agents)) 1))
+      ;; reason about the SAME coordination GF by importance sampling instead:
+      samp-a1  (ma/p-popular ((:alice (ma/schelling-agents (ma/importance-marginal 4000))) 1))]
+  (println "  alice(1) P(popular):  exact =" (.toFixed exact-a1 4) "   importance =" (.toFixed samp-a1 4))
+  (assert-close "importance sampling reproduces exact alice(1) (same agent, swapped backend)"
+                exact-a1 samp-a1 0.05))
+
+;; ===========================================================================
+(println "\n== Section 3: RSA sprouted-seeds — scalar implicature (exact) ==")
+;; utterances [all=0 some=1 none=2], states [0 1 2 3]
+(let [{:keys [L0 S1 L1]} (ma/make-rsa {:denotation ma/sprouted-denotation
+                                       :state-prior ma/sprouted-prior
+                                       :alpha 2.0})
+      l0-some (ma/table-row L0 1)
+      s1-s3   (ma/table-row S1 3)         ; speaker policy for state 3 = [all some none]
+      l1-some (ma/table-row L1 1)
+      l1-all  (ma/table-row L1 0)
+      l1-none (ma/table-row L1 2)]
+  (println "  L0(some)  =" (mapv #(.toFixed % 4) l0-some))
+  (println "  S1(.|s=3) =" (mapv #(.toFixed % 4) s1-s3) " [all some none]")
+  (println "  L1(some)  =" (mapv #(.toFixed % 4) l1-some))
+  ;; L0: literal listener for "some" is uniform over {1,2,3}, zero on 0
+  (assert-close "L0(some)->0 = 0"     0.0       (nth l0-some 0) 1e-6)
+  (assert-close "L0(some)->1 = 1/3"   (/ 1 3.0) (nth l0-some 1) 1e-4)
+  (assert-close "L0(some)->3 = 1/3"   (/ 1 3.0) (nth l0-some 3) 1e-4)
+  ;; S1: a speaker who knows state=3 mostly says "all" (0.9), rarely "some" (0.1)
+  (assert-close "S1(all | s=3) = 0.9"  0.9 (nth s1-s3 0) 1e-4)
+  (assert-close "S1(some| s=3) = 0.1"  0.1 (nth s1-s3 1) 1e-4)
+  ;; L1: the scalar implicature — "some" ⇒ not none (P0=0) AND not all (P3 ≪ P1=P2)
+  (assert-close "L1(some)->0 = 0   (not none)"        0.0           (nth l1-some 0) 1e-6)
+  (assert-close "L1(some)->1 = 10/21"                 (/ 10.0 21.0) (nth l1-some 1) 1e-4)
+  (assert-close "L1(some)->2 = 10/21"                 (/ 10.0 21.0) (nth l1-some 2) 1e-4)
+  (assert-close "L1(some)->3 = 1/21 (not all)"        (/ 1.0 21.0)  (nth l1-some 3) 1e-4)
+  (assert-true  "implicature: P(3|some) ≪ P(1|some)" (< (nth l1-some 3) (* 0.2 (nth l1-some 1))))
+  (assert-close "L1(all)->3  = 1"  1.0 (nth l1-all 3)  1e-6)
+  (assert-close "L1(none)->0 = 1"  1.0 (nth l1-none 0) 1e-6))
+
+;; ===========================================================================
+(println "\n== Section 4: RSA re-parameterized denotation — referential implicature ==")
+;; Same tower, different matrix. Utterances [u0=0 uboth=1], referents [r0 r1].
+(let [{:keys [L1]} (ma/make-rsa {:denotation ma/reference-denotation
+                                 :state-prior ma/reference-prior
+                                 :alpha 1.0})
+      l1-uboth (ma/table-row L1 1)
+      l1-u0    (ma/table-row L1 0)]
+  (println "  L1(uboth) =" (mapv #(.toFixed % 4) l1-uboth) " [r0 r1]")
+  (assert-close "L1(uboth)->r0 = 0.25"  0.25 (nth l1-uboth 0) 1e-4)
+  (assert-close "L1(uboth)->r1 = 0.75"  0.75 (nth l1-uboth 1) 1e-4)
+  (assert-true  "implicature: ambiguous 'uboth' resolves toward r1"
+                (> (nth l1-uboth 1) (nth l1-uboth 0)))
+  (assert-close "L1(u0)->r0 = 1.0"      1.0  (nth l1-u0 0)    1e-6))
+
+;; ===========================================================================
+(println "\n== Section 5: RSA mixed inference — sampled L0 → exact S1/L1, implicature survives ==")
+(let [{:keys [L1]} (ma/make-rsa {:denotation ma/sprouted-denotation
+                                 :state-prior ma/sprouted-prior
+                                 :alpha 2.0
+                                 :infer (ma/importance-marginal 3000)})
+      l1-some (ma/table-row L1 1)]
+  (println "  L1(some) [sampled-L0 pipeline] =" (mapv #(.toFixed % 4) l1-some))
+  (assert-close "P(0|some) = 0 exactly (rejection never keeps state 0)" 0.0 (nth l1-some 0) 1e-9)
+  (assert-true  "P(3|some) ≪ P(1|some) survives mixed inference"
+                (< (nth l1-some 3) (* 0.3 (nth l1-some 1))))
+  (assert-true  "P(1|some) ≈ P(2|some) ≈ 0.476 (within MC error)"
+                (and (< 0.40 (nth l1-some 1) 0.56) (< 0.40 (nth l1-some 2) 0.56))))
+
+;; ===========================================================================
+(println "\n== Section 6: Tic-tac-toe — forced win (planning and non-planning) ==")
+(let [agent (ma/make-game-agent {:alpha ##Inf})]
+  (assert-equal "planning best move completes the row (cell 2)"
+                2 (ma/best-move agent ma/forced-win-board :x))
+  ;; the one-step agent also finds an IMMEDIATE win (its argmax cell, not list position)
+  (assert-equal "one-step agent also takes the immediate win (cell 2)"
+                2 (first (apply max-key second (ma/non-planning-move-q ma/forced-win-board :x)))))
+
+;; ===========================================================================
+(println "\n== Section 7: Tic-tac-toe — forced block (planning vs non-planning) ==")
+(let [agent (ma/make-game-agent {:alpha ##Inf})
+      pq    ((:move-q agent) ma/forced-block-board :x)
+      npq   (ma/non-planning-move-q ma/forced-block-board :x)
+      block-q (second (first (filter #(= 5 (first %)) pq)))
+      other-q (apply max (map second (remove #(= 5 (first %)) pq)))]
+  (println "  planning move-q     :" (mapv (fn [[m q]] [m (.toFixed q 1)]) pq))
+  (println "  non-planning move-q :" (mapv (fn [[m q]] [m (.toFixed q 1)]) npq))
+  (assert-equal "PLANNING blocks at cell 5 (forces a draw instead of a loss)"
+                5 (ma/best-move agent ma/forced-block-board :x))
+  (assert-true  "planning: block value (draw=0) strictly beats every non-block move (loss=-10)"
+                (> block-q other-q))
+  (assert-true  "one-step agent is INDIFFERENT (every immediate move scores 0)"
+                (every? #(< (Math/abs (second %)) 1e-9) npq)))
+
+;; ===========================================================================
+(println "\n== Section 8: Tic-tac-toe — factor(α·EU) as a softmax-action GF ==")
+(let [agent (ma/make-game-agent {:alpha ##Inf})
+      moves (mapv (fn [_] ((:act agent) ma/forced-win-board :x)) (range 5))]
+  (println "  softmax-action (α=##Inf) :act moves:" moves)
+  (assert-true  "softmax-action policy deterministically takes the winning move (cell 2)"
+                (every? #(= 2 %) moves)))
+
+;; ===========================================================================
+(println "\n== Section 9: determinism ==")
+(let [agent (ma/make-game-agent {:alpha ##Inf})]
+  (assert-equal "best-move is repeatable"
+                (ma/best-move agent ma/forced-block-board :x)
+                (ma/best-move agent ma/forced-block-board :x)))
+
+;; ===========================================================================
+(println (str "\n==== " @passed " passed, " @failed " failed ===="))
+(when (pos? @failed) (js/process.exit 1))


### PR DESCRIPTION
## Summary

Chapter 7 of the agentmodels.org port — **multi-agent models** — built as the native **`genmlx.agents`** vertical: an agent is a generative function, and the inference backend (exact / importance / mixed) is a **pluggable seam**, orthogonal to the model. Re-derived from the canonical chapter and validated against **analytic ground truth** (not the `examples/memo` corpus).

## What's here (`examples/agentmodels/multi_agent.cljs`)

- **Schelling coordination** — nested-reasoning GFs + native bernoulli-observe `condition(me==other)`, memoized over a depth ladder with `exact/with-cache` (`bob(0)=prior`). Focal-point amplification to `alice(4)=0.8328`.
- **RSA** — a generic α-tower whose **speaker is a `softmax-action` agent** (`factor(α·EU)`); the literal listener runs through the pluggable `infer` seam. Sprouted-seeds scalar implicature (α=2) `L1(some)=[0,10/21,10/21,1/21]`, plus a reference game demonstrating the **re-parameterized denotation matrix**.
- **Tic-tac-toe game tree** — a `softmax-action` agent over a `with-cache` `val(board,mover,scorer)` recursion (soft minimax; hard/adversarial minimax at α=`##Inf`); masked categorical `movePrior` over legal moves. Forced-win / forced-block boards.

**Pluggable inference, demonstrated end-to-end:** Schelling runs under exact **and** importance (same GF, swapped backend → agree); RSA runs as a **mixed** sampled-L0 / exact-S1-L1 pipeline and the implicature survives.

## Validation

- Headless test `test/genmlx/agentmodels_multi_agent_test.cljs`: **34/34**.
- **Zero engine change** (2 new files; nothing in `src/`); no regressions (`exact` 120/120, `helpers` 22/22, `biased_planners` 41/41).

## Process

spec → your approval → research workflow → implement → **4-dimension adversarial review** (faithfulness / correctness / purity / spec, each finding independently verified). Surfaced 2 real nits, both fixed: `make-rsa` default α `1.0→2.0` (canonical Ch7), and the policy GF now returns the raw traced index with a host-side `:act` (vectorization-safe, matching `agent.cljs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)