### PR TITLE
feat(agentmodels): bias as a traced latent — inverse inference over agent bias (Ch 5d/5e)

### DIFF
--- a/examples/agentmodels/biased_inverse.cljs
+++ b/examples/agentmodels/biased_inverse.cljs
@@ -1,0 +1,252 @@
+(ns agentmodels.biased-inverse
+  "Inverse inference over an agent's BIAS (agentmodels Ch 5d/5e — joint inference of
+   biases and preferences), capability-only slice: the bias as a FIRST-CLASS TRACED
+   LATENT in a single joint generative function, inverted through the GFI.
+
+   The whole point of `genmlx.agents`: an agent is a generative function; the
+   inference method used to reason about it (exact enumeration, importance sampling,
+   …) is pluggable and orthogonal to the agent definition. Here we trace the agent's
+   bias (:naive vs :sophisticated) as the one latent random choice, wire it into the
+   forward biased EU recursion from `biased-planners.cljs` (no duplicated recursion —
+   we reuse `make-biased-mdp-agent` verbatim; `eu-row` is a thin accessor over the
+   agent's public `:eu`), and recover P(:bias | observed actions) two ways on the
+   SAME generative function:
+
+     1. EXACT — enumerate the finite bias prior, score the full trajectory
+        {:bias, :a0, …} with `p/assess`, normalize. This is the closed-form
+        posterior (the bias set is finite, assess only scores).
+     2. IMPORTANCE SAMPLING — sample :bias, constrain the actions, group the
+        normalized particle weight by sampled bias. A sampling cross-check that
+        agrees with the exact posterior (run at finite α; argmax likelihoods make
+        IS degenerate at α=##Inf).
+
+   The likelihood of an observed action under a hypothesized bias is exactly the
+   softmax policy probability of the forward biased planner — no bespoke likelihood,
+   just the same generative policy the agent acts with, scored against the action.
+   This mirrors `inverse.cljs`'s goal-inference idiom, but indexes hypotheses by
+   bias value rather than goal; `bias-posterior-via-policy` reuses that idiom as an
+   independent consistency check.
+
+   Scope: ONE latent (:bias). The full Ch 5d/5e joint over preferences/discount/α
+   (procrastination time-series, restaurant utility table) is bean genmlx-4zfy."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.dynamic :as dyn]
+            [genmlx.inference.importance :as is]
+            [genmlx.inference.util :as iu]
+            [agentmodels.biased-planners :as bp]
+            [agentmodels.helpers :as h]
+            [agentmodels.inverse :as inv])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(def bias-values
+  "The finite bias prior support, in index order (the categorical samples an index)."
+  [:naive :sophisticated])
+
+(defn- check-aligned
+  "Guard: :states and :actions must be the same length (one observed action per
+   visited state). A mismatch would silently drop/mis-bind action sites."
+  [{:keys [states actions]}]
+  (when-not (= (count states) (count actions))
+    (throw (ex-info (str "biased-inverse: :states and :actions must be the same length — got "
+                         (count states) " states and " (count actions) " actions")
+                    {:n-states (count states) :n-actions (count actions)}))))
+
+;; ===========================================================================
+;; The tiny temptation MDP (hand-built)
+;; ===========================================================================
+;;
+;; gw/build-mdp only produces 4-action gridworlds, so the minimal 5-state /
+;; 2-action world that yields clean closed-form posteriors is built as a literal
+;; MDP map fed straight to make-biased-mdp-agent (which destructures :A :terminals
+;; :R :T and assoc's :gamma/:alpha itself).
+;;
+;;   states  0=start  1=tempt(gate)  2=safe1  3=donut(term)  4=veg(term)
+;;   actions 0, 1
+;;   start  : a0 → tempt(1)   a1 → safe1(2)       ; a0 heads for the temptation gate
+;;   tempt  : a0 → donut(3)   a1 → veg(4)         ; a0 = succumb (eat), a1 = continue
+;;   safe1  : a0,a1 → veg(4)                       ; the safe route to veg
+;;   donut,veg : absorbing
+;;   R: tempt[a0]=Rd=5 (donut), veg[*]=Rv=8 ; everything else 0
+;;
+;; With k=1, γ=1: both routes reach veg in 2 steps → value 8·δ(2)=8/3 for a future
+;; self that resists. The crossover Rd>Rv/2 (5>4) makes the *delay-0* self at the
+;; gate succumb (donut value δ(1)·5=2.5), while Rd<2Rv/3 (5<5.33) makes the
+;; *delay-1* self resist. So:
+;;   naive  EU(start) = [8/3, 8/3]  (TIE — believes its future self resists, both
+;;                                   routes look like they reach veg)  → π=[0.5,0.5]
+;;   soph   EU(start) = [2.5, 8/3]  (foresees succumbing on the tempting route)
+;;                                   → π=[0,1] (NEVER heads for temptation)
+;; Hence: heading for temptation (a0) is diagnostic of naive; repeatedly taking the
+;; safe route (a1) is evidence for sophisticated.
+
+(defn temptation-mdp
+  "Build the minimal 5-state / 2-action temptation MDP (see namespace notes).
+   Returns an MDP map {:S :A :T :R :terminals} feeding make-biased-mdp-agent."
+  []
+  (let [S 5
+        A 2
+        ;; T[s][a][s'] one-hot transitions
+        T-rows [[[0 1 0 0 0] [0 0 1 0 0]]    ; start : a0→tempt, a1→safe1
+                [[0 0 0 1 0] [0 0 0 0 1]]    ; tempt : a0→donut(eat), a1→veg(continue)
+                [[0 0 0 0 1] [0 0 0 0 1]]    ; safe1 : both → veg
+                [[0 0 0 1 0] [0 0 0 1 0]]    ; donut : absorbing
+                [[0 0 0 0 1] [0 0 0 0 1]]]   ; veg   : absorbing
+        R-rows [[0 0]                         ; start
+                [5 0]                         ; tempt : a0 eat donut (Rd=5), a1 continue
+                [0 0]                         ; safe1
+                [0 0]                         ; donut
+                [8 8]]                        ; veg   : Rv=8
+        T (mx/array (clj->js T-rows) mx/float32)
+        R (mx/array (clj->js R-rows) mx/float32)]
+    ;; No eager mx/eval! — T/R are constant arrays consumed once via mx/->clj in
+    ;; build-biased-eu, which materializes them there (the proper boundary).
+    {:S S :A A :T T :R R :terminals {3 :donut 4 :veg}}))
+
+;; ===========================================================================
+;; Forward agents per bias + EU rows
+;; ===========================================================================
+
+(defn bias-agents
+  "One forward biased MDP agent per bias value, sharing the same mdp/α/k/C_g.
+   Returns {:naive agent :sophisticated agent}. Built once and reused (each agent
+   carries its own memoized EU cache), so importance sampling does not rebuild."
+  [{:keys [mdp alpha discount reward-myopic-bound n-iters]
+    :or   {alpha ##Inf discount 1.0 reward-myopic-bound ##Inf n-iters 10}}]
+  (into {}
+        (for [b bias-values]
+          [b (bp/make-biased-mdp-agent
+               {:mdp mdp :alpha alpha :gamma 1.0 :n-iters n-iters}
+               {:discount discount :bias b :reward-myopic-bound reward-myopic-bound})])))
+
+(defn eu-row
+  "Expected-utility vector over actions at state `s` (delay 0, the agent's horizon)
+   for a forward biased agent — exactly the row its softmax policy acts on."
+  [agent s]
+  (let [eu (:eu agent)
+        H  (:horizon (:params agent))
+        A  (:A (:mdp agent))]
+    (mapv #(eu s % H 0) (range A))))
+
+;; ===========================================================================
+;; The joint generative function — :bias is a first-class traced latent
+;; ===========================================================================
+
+(defn biased-agent-model
+  "The joint generative function. ONE traced latent — :bias — drawn from the prior
+   (uniform, or weighted by `:prior`, a weight vector aligned to `bias-values`).
+   The sampled bias selects a precomputed forward agent; one action site :a0 :a1 …
+   per state in `:states` is then a softmax-action over that agent's EU row.
+
+   Inverting:
+     • EXACT     — assess on a full choicemap {:bias i, :a0 a0, …}
+     • SAMPLING  — generate constraining only the actions (IS over the latent :bias)
+
+   cfg keys: :mdp :alpha :discount :reward-myopic-bound :n-iters :states [:prior].
+   Returns a DynamicGF of zero user args."
+  [{:keys [states alpha prior] :or {alpha ##Inf} :as cfg}]
+  (let [agents (bias-agents cfg)
+        box    (if prior
+                 (h/weighted-draw bias-values prior)
+                 (h/uniform-draw bias-values))
+        ;; Precompute the policy logit array per (bias, state) ONCE — the gen body
+        ;; is re-run per IS particle, so it must only index, never rebuild arrays.
+        rows   (into {} (for [b bias-values]
+                          [b (mapv #(mx/array (clj->js (eu-row (agents b) %)) mx/float32)
+                                   states)]))]
+    (gen []
+      (let [bi   (trace :bias (:dist box))
+            bias (h/draw-value box bi)
+            er   (rows bias)]
+        (doseq [t (range (count states))]
+          (trace (keyword (str "a" t))
+                 (h/softmax-action alpha (nth er t))))
+        bi))))
+
+;; ===========================================================================
+;; Choicemap builders
+;; ===========================================================================
+
+(defn action-cm
+  "Choicemap constraining the action sites only: {:a0 a0, :a1 a1, …}."
+  [actions]
+  (cm/from-flat-map
+    (into {} (map-indexed (fn [t a] [(keyword (str "a" t)) a]) actions))))
+
+(defn full-cm
+  "Choicemap constraining the full trajectory: {:bias i, :a0 a0, …}."
+  [bias-idx actions]
+  (cm/set-choice (action-cm actions) [:bias] bias-idx))
+
+;; ===========================================================================
+;; Exact posterior — enumerate the finite bias prior via p/assess
+;; ===========================================================================
+
+(defn bias-posterior
+  "Exact P(:bias | actions). Enumerate the bias prior; for each value, assess the
+   joint GF on {:bias i, :a0 a0, …} (weight = log P0(bias) + Σ log π_bias(a_t));
+   normalize via inv/normalize-logs. Closed-form (finite bias set, assess only
+   scores — no sampling). Returns {:naive p :sophisticated q}.
+
+   With `:states []` (no actions) this returns the prior — assess on {:bias i}
+   scores only the prior log-prob."
+  [{:keys [actions] :as cfg}]
+  (check-aligned cfg)
+  (let [model (biased-agent-model cfg)
+        logw  (into {}
+                    (for [[i b] (map-indexed vector bias-values)]
+                      [b (mx/item (:weight (p/assess (dyn/auto-key model) []
+                                                     (full-cm i actions))))]))]
+    (inv/normalize-logs logw)))
+
+(defn- prior-prob
+  "Normalized prior probability per bias value from a weight vector (nil = uniform)."
+  [prior]
+  (let [ws (or prior (vec (repeat (count bias-values) 1.0)))
+        z  (reduce + ws)]
+    (into {} (map-indexed (fn [i b] [b (/ (nth ws i) z)]) bias-values))))
+
+(defn bias-posterior-via-policy
+  "The SAME exact posterior via the established inverse.cljs idiom: one forward
+   agent per bias, inv/action-loglik scoring each observed [state action] against
+   that agent's :policy, plus the log-prior, normalized. An independent
+   consistency check that the joint GF agrees with the goal-inference idiom
+   (compose, don't duplicate)."
+  [{:keys [states actions prior] :as cfg}]
+  (check-aligned cfg)
+  (let [agents (bias-agents cfg)
+        p0     (prior-prob prior)
+        obs    (map vector states actions)
+        logw   (into {}
+                     (for [b bias-values]
+                       [b (reduce + (Math/log (p0 b))
+                                  (map (fn [[s a]] (inv/action-loglik (agents b) s a)) obs))]))]
+    (inv/normalize-logs logw)))
+
+;; ===========================================================================
+;; Importance-sampling cross-check
+;; ===========================================================================
+
+(defn is-bias-posterior
+  "Importance-sampling estimate of P(:bias | actions) on the joint GF: sample
+   :bias from the prior, constrain the observed actions, group the normalized
+   particle weight by each particle's sampled bias. Returns
+   {:posterior {:naive p :sophisticated q} :ess ess}.
+
+   Run at FINITE α — at α=##Inf the argmax likelihoods are 0/1 indicators and IS
+   degenerates (zero-weight particles). Pass a fixed `key` (e.g. (rng/fresh-key 42))
+   for reproducibility; MLX RNG is bit-reproducible."
+  [{:keys [actions] :as cfg} n key]
+  (check-aligned cfg)
+  (let [model (biased-agent-model cfg)
+        obs   (action-cm actions)
+        {:keys [traces log-weights]} (is/importance-sampling {:samples n :key key} model [] obs)
+        {:keys [probs]} (iu/normalize-log-weights log-weights)
+        ess   (iu/compute-ess log-weights)
+        post  (reduce (fn [m [tr w]]
+                        (let [i (int (mx/item (cm/get-choice (:choices tr) [:bias])))]
+                          (update m (nth bias-values i) + w)))
+                      {:naive 0.0 :sophisticated 0.0}
+                      (map vector traces probs))]
+    {:posterior post :ess ess}))

--- a/test/genmlx/agentmodels_biased_inverse_test.cljs
+++ b/test/genmlx/agentmodels_biased_inverse_test.cljs
@@ -1,0 +1,181 @@
+;; Headless tests for inverse inference over agent BIAS (agentmodels Ch 5d/5e,
+;; capability-only slice — bean genmlx-z4si).
+;; Run: bun run --bun nbb test/genmlx/agentmodels_biased_inverse_test.cljs
+
+(ns genmlx.agentmodels-biased-inverse-test
+  (:require [agentmodels.biased-inverse :as bi]
+            [agentmodels.inverse :as inv]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.protocols :as p]
+            [genmlx.dynamic :as dyn]
+            [genmlx.choicemap :as cm]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-close [msg expected actual tol]
+  (if (<= (Math/abs (- expected actual)) tol)
+    (do (vswap! passed inc) (println " PASS" msg "  =" actual))
+    (do (vswap! failed inc) (println " FAIL" msg "  expected:" expected "  got:" actual))))
+
+(def mdp (bi/temptation-mdp))
+(def THIRD (/ 1.0 3.0))      ; 8/3 ÷ 8 → δ(2); the veg value 8·δ(2)=8/3
+(def EU-VEG (/ 8.0 3.0))     ; 2.6667
+
+;; cfg helpers (α=##Inf unless overridden)
+(defn cfg-inf [states actions]
+  {:mdp mdp :alpha ##Inf :discount 1.0 :n-iters 10 :states states :actions actions})
+;; action 0 = head toward temptation gate ; action 1 = take the safe route
+
+;; ===========================================================================
+(println "\n== Section 1: forward agents — EU rows & policy at the start ==")
+(def agents (bi/bias-agents {:mdp mdp :alpha ##Inf :discount 1.0 :n-iters 10}))
+(def naive-ag (:naive agents))
+(def soph-ag  (:sophisticated agents))
+(def eu-n (bi/eu-row naive-ag 0))
+(def eu-s (bi/eu-row soph-ag 0))
+(println "  naive EU(start) =" eu-n "   soph EU(start) =" eu-s)
+(assert-close "naive EU(a0)=8/3 (believes future self resists)" EU-VEG (nth eu-n 0) 1e-6)
+(assert-close "naive EU(a1)=8/3"                                 EU-VEG (nth eu-n 1) 1e-6)
+(assert-close "soph EU(a0)=2.5 (foresees succumbing to donut)"   2.5    (nth eu-s 0) 1e-6)
+(assert-close "soph EU(a1)=8/3"                                  EU-VEG (nth eu-s 1) 1e-6)
+
+(defn pi-prob [agent s a] (Math/exp (inv/action-loglik agent s a)))
+(assert-close "π_naive(a0)=0.5 (exact tie, load-bearing)" 0.5 (pi-prob naive-ag 0 0) 1e-6)
+(assert-close "π_naive(a1)=0.5"                           0.5 (pi-prob naive-ag 0 1) 1e-6)
+(assert-close "π_soph(a0)=0 (NEVER heads for temptation)" 0.0 (pi-prob soph-ag 0 0) 1e-9)
+(assert-close "π_soph(a1)=1"                              1.0 (pi-prob soph-ag 0 1) 1e-6)
+
+;; ===========================================================================
+(println "\n== Section 2: prior decomposition (assess on {:bias} alone) ==")
+(def model-prior (bi/biased-agent-model {:mdp mdp :alpha ##Inf :discount 1.0
+                                         :n-iters 10 :states []}))
+(assert-close "log-prior P0(:naive)=log 1/2"
+              (Math/log 0.5)
+              (mx/item (:weight (p/assess (dyn/auto-key model-prior) []
+                                          (cm/choicemap :bias 0))))
+              1e-6)
+(assert-close "log-prior P0(:sophisticated)=log 1/2"
+              (Math/log 0.5)
+              (mx/item (:weight (p/assess (dyn/auto-key model-prior) []
+                                          (cm/choicemap :bias 1))))
+              1e-6)
+
+;; ===========================================================================
+(println "\n== Section 3: exact posterior — the three closed-form cases ==")
+(def pA (bi/bias-posterior (cfg-inf [0]     [1])))        ; safe ×1
+(def pB (bi/bias-posterior (cfg-inf [0]     [0])))        ; tempt ×1
+(def pC (bi/bias-posterior (cfg-inf [0 0 0] [1 1 1])))    ; safe ×3
+(println "  P(safe×1) =" pA)
+(println "  P(tempt×1)=" pB)
+(println "  P(safe×3) =" pC)
+(assert-close "Case A  P(:naive | safe×1) = 1/3"   THIRD          (:naive pA)         1e-6)
+(assert-close "Case A  P(:soph  | safe×1) = 2/3"   (/ 2.0 3.0)    (:sophisticated pA) 1e-6)
+(assert-close "Case B  P(:naive | tempt×1) = 1.0"  1.0            (:naive pB)         1e-9)
+(assert-close "Case B  P(:soph  | tempt×1) = 0.0"  0.0            (:sophisticated pB) 1e-9)
+(assert-close "Case C  P(:naive | safe×3) = 1/9"   (/ 1.0 9.0)    (:naive pC)         1e-6)
+(assert-close "Case C  P(:soph  | safe×3) = 8/9"   (/ 8.0 9.0)    (:sophisticated pC) 1e-6)
+
+;; ===========================================================================
+(println "\n== Section 4: identifiability invariants ==")
+;; The likelihood ratio per "safe" observation is naive:soph = π_naive(a1):π_soph(a1)
+;; = 0.5:1.0 = 1:2 — i.e. each safe action is twice as likely under sophisticated.
+;; That ratio, driven by the perceivedDelay mechanism (naive is indifferent at the
+;; start, soph is decisive), is what produces the closed-form posteriors below.
+(assert-true  "heading for temptation ⇒ MAP bias is :naive"   (> (:naive pB) 0.5))
+(assert-true  "repeated safe route   ⇒ MAP bias is :sophisticated" (> (:sophisticated pC) 0.5))
+(assert-true  "evidence accumulates: P(:soph|×3) > P(:soph|×1)" (> (:sophisticated pC) (:sophisticated pA)))
+(def pC2 (bi/bias-posterior (cfg-inf [0 0] [1 1])))   ; safe ×2
+(assert-true  "monotone increase across n: P(:soph|×1) < P(:soph|×2) < P(:soph|×3)"
+              (< (:sophisticated pA) (:sophisticated pC2) (:sophisticated pC)))
+(assert-close "monotone law P(:soph | n safe) = 1/(1+(1/2)^n) at n=2"
+              (/ 1.0 (+ 1.0 (Math/pow 0.5 2)))
+              (:sophisticated pC2) 1e-6)
+(assert-close "monotone law P(:soph | n safe) = 1/(1+(1/2)^n) at n=3"
+              (/ 1.0 (+ 1.0 (Math/pow 0.5 3)))
+              (:sophisticated pC) 1e-6)
+
+;; ===========================================================================
+(println "\n== Section 5: normalization ==")
+(doseq [[lbl pp] [["A" pA] ["B" pB] ["C" pC]]]
+  (assert-true (str "posterior " lbl " sums to 1")
+               (< (Math/abs (- 1.0 (+ (:naive pp) (:sophisticated pp)))) 1e-9)))
+
+;; ===========================================================================
+(println "\n== Section 6: consistency — joint GF == inverse.cljs idiom ==")
+(def pA' (bi/bias-posterior-via-policy (cfg-inf [0]     [1])))
+(def pC' (bi/bias-posterior-via-policy (cfg-inf [0 0 0] [1 1 1])))
+(assert-close "joint-GF assess == policy-idiom posterior (safe×1)"
+              (:sophisticated pA) (:sophisticated pA') 1e-9)
+(assert-close "joint-GF assess == policy-idiom posterior (safe×3)"
+              (:sophisticated pC) (:sophisticated pC') 1e-9)
+
+;; ===========================================================================
+(println "\n== Section 7: edge cases ==")
+(def pEmpty (bi/bias-posterior (cfg-inf [] [])))
+(assert-close "empty obs ⇒ posterior == prior (:naive 0.5)" 0.5 (:naive pEmpty)         1e-9)
+(assert-close "empty obs ⇒ posterior == prior (:soph 0.5)"  0.5 (:sophisticated pEmpty) 1e-9)
+;; asymmetric prior [0.3 0.7] on safe×1: P(:soph)=0.7·1/(0.7·1+0.3·0.5)=0.7/0.85
+(def pAsym (bi/bias-posterior {:mdp mdp :alpha ##Inf :discount 1.0 :n-iters 10
+                               :states [0] :actions [1] :prior [0.3 0.7]}))
+(assert-close "asymmetric prior [0.3 0.7], safe×1 ⇒ P(:soph)=0.8235"
+              (/ 0.7 0.85) (:sophisticated pAsym) 1e-6)
+;; misaligned :states/:actions must be rejected, not silently mis-scored
+(assert-true "mismatched :states/:actions lengths throw"
+             (try (bi/bias-posterior (cfg-inf [0 0] [1])) false
+                  (catch :default _ true)))
+
+;; ===========================================================================
+(println "\n== Section 8: exact ≈ importance-sampling (finite α=2) ==")
+(defn cfg-2 [states actions]
+  {:mdp mdp :alpha 2.0 :discount 1.0 :n-iters 10 :states states :actions actions})
+(def N 5000)
+(def exact2-safe  (bi/bias-posterior  (cfg-2 [0 0 0] [1 1 1])))
+(def exact2-tempt (bi/bias-posterior  (cfg-2 [0 0 0] [0 0 0])))
+(def is2-safe     (bi/is-bias-posterior (cfg-2 [0 0 0] [1 1 1]) N (rng/fresh-key 42)))
+(def is2-tempt    (bi/is-bias-posterior (cfg-2 [0 0 0] [0 0 0]) N (rng/fresh-key 7)))
+(println "  exact P(:soph|safe×3) @α=2 =" (:sophisticated exact2-safe)
+         "   IS =" (:sophisticated (:posterior is2-safe)) "   ESS =" (:ess is2-safe))
+(println "  exact P(:naive|tempt×3) @α=2 =" (:naive exact2-tempt)
+         "   IS =" (:naive (:posterior is2-tempt)) "   ESS =" (:ess is2-tempt))
+(assert-true  "finite-α: exact P(:soph|safe×3) > 0.5 (still identifiable, softer)"
+              (> (:sophisticated exact2-safe) 0.5))
+(assert-true  "finite-α: exact P(:naive|tempt×3) > 0.5"
+              (> (:naive exact2-tempt) 0.5))
+;; the exact α=2 posterior is deterministic (assess only scores), so the fidelity
+;; check against the math-verifier's reference value is tight (1e-3 absorbs only the
+;; 4-sig-fig rounding of the reference constant).
+(assert-close "world fidelity: exact P(:soph|safe×3) @α=2 ≈ 0.5515"
+              0.5515 (:sophisticated exact2-safe) 1e-3)
+(assert-close "world fidelity: exact P(:naive|tempt×3) @α=2 ≈ 0.5638"
+              0.5638 (:naive exact2-tempt) 1e-3)
+(assert-close "exact ≈ IS  P(:soph|safe×3) @α=2 (N=5000)"
+              (:sophisticated exact2-safe) (:sophisticated (:posterior is2-safe)) 0.05)
+(assert-close "exact ≈ IS  P(:naive|tempt×3) @α=2 (N=5000)"
+              (:naive exact2-tempt) (:naive (:posterior is2-tempt)) 0.05)
+;; ESS here is a FIXED value (seeds 42/7 are hardcoded and MLX RNG is bit-reproducible),
+;; not a probabilistic claim. The ~4× margin over N/4 reflects soft α=2 likelihoods.
+(assert-true  "IS ESS > N/4 (safe×3)"  (> (:ess is2-safe)  (/ N 4)))
+(assert-true  "IS ESS > N/4 (tempt×3)" (> (:ess is2-tempt) (/ N 4)))
+
+;; ===========================================================================
+(println "\n== Section 9: agent/cache reuse across calls on one model instance ==")
+;; One model instance carries precomputed agents + memoized EU caches; scoring it
+;; for both bias hypotheses (and against bias-posterior, which builds its own model)
+;; must agree — exercising the 'built once and reused' claim.
+(def shared-model (bi/biased-agent-model (cfg-inf [0] [1])))
+(defn- assess-w [idx a]
+  (mx/item (:weight (p/assess (dyn/auto-key shared-model) [] (bi/full-cm idx [a])))))
+(let [wn (assess-w 0 1) ws (assess-w 1 1)              ; naive(safe), soph(safe)
+      z  (+ (Math/exp wn) (Math/exp ws))]
+  (assert-true  "reused model scores naive(safe) finite" (js/isFinite wn))
+  (assert-true  "reused model scores soph(safe)  finite" (js/isFinite ws))
+  (assert-close "reused-model posterior P(:soph|safe×1) = 2/3 (matches bias-posterior)"
+                (/ 2.0 3.0) (/ (Math/exp ws) z) 1e-6))
+
+;; ===========================================================================
+(println (str "\n" @passed " passed, " @failed " failed"))
+(when (pos? @failed) (js/process.exit 1))


### PR DESCRIPTION
## Summary

`genmlx.agents` capability (agentmodels Ch 5d/5e, capability-only slice, bean `genmlx-z4si`): the agent **bias** (`:naive` vs `:sophisticated`) as a **first-class traced latent** in one joint generative function, inverted through the GFI.

The point of `genmlx.agents` made concrete — an agent is a generative function, and the inference method used to reason about it is pluggable and orthogonal. The same agent-GF is inverted two ways and they agree:

- **Exact** — enumerate the finite bias prior, score the full trajectory `{:bias, :a0..}` with `p/assess`, normalize (closed-form; the bias set is finite).
- **Importance sampling** — sample `:bias`, constrain the actions, group particle weight by sampled bias (finite alpha; argmax likelihoods make IS degenerate at alpha=##Inf).

Composes the forward biased planner (`make-biased-mdp-agent`) verbatim — no engine change, no duplicated recursion.

## Contents

- `examples/agentmodels/biased_inverse.cljs` — joint GF + exact/IS inverse + a hand-built 5-state temptation MDP.
- `test/genmlx/agentmodels_biased_inverse_test.cljs` — 42/42.

## Validation (analytic ground truth)

- naive EU(start) = `[8/3, 8/3]` (tie, pi=[0.5,0.5]); soph = `[2.5, 8/3]` (pi=[0,1]) — driven by the perceivedDelay mechanism.
- Posteriors: safe x1 `P(:soph)=2/3`, tempt x1 `P(:naive)=1.0`, safe x3 `P(:soph)=8/9`; monotone law `1/(1+(1/2)^n)`.
- joint-GF `assess` == `inverse.cljs` idiom to 1e-9; exact ~= IS at alpha=2 (N=5000).
- agentmodels regression intact (biased_planners 41, helpers 22, slice 51).

## Process

spec -> research (a math-verifier derived AND live-verified the closed forms) -> implement -> 4-dimension adversarial review (faithfulness / correctness / purity / spec). 10 confirmed findings triaged: 8 fixes applied (removed a redundant `mx/eval!`, precompute per-(bias,state) logits, states/actions alignment guard, tightened a deterministic tolerance, monotone-n + model-reuse tests, precise no-duplication docstring); 2 dismissed with cause.

## Follow-up

`genmlx-4zfy` (full Ch 5d/5e joint over preferences/discount/alpha) is now correctly `blocked-by` this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)