### PR TITLE
feat(agentmodels): 5d procrastination joint inference (Ch 5d)

### DIFF
--- a/examples/agentmodels/joint_5d_inference.cljs
+++ b/examples/agentmodels/joint_5d_inference.cljs
@@ -1,0 +1,207 @@
+(ns agentmodels.joint-5d-inference
+  "Procrastination JOINT inference (agentmodels Ch 5d) — joint inference of biases
+   AND preferences. Extends the z4si single-latent (:bias) pattern in
+   `biased_inverse.cljs` to MULTIPLE traced latents: :reward, :alpha, :discount,
+   inverted by exact host-side enumeration over finite priors. (:bias is FIXED to
+   :naive — agentmodels 5d's `sophisticatedOrNaive='naive'` — not jointly inferred.)
+
+   An agent procrastinates: it WAITS day after day, then maybe works near the
+   deadline. From an observed wait/work sequence we jointly infer the agent's
+   reward, softmax-noise alpha, and hyperbolic discount k — comparing two models:
+
+     - OPTIMAL            : discount fixed to {0} (no present bias). To explain the
+                            observed waiting it must infer a LOW reward and HIGH noise.
+     - POSSIBLY-DISCOUNTING: discount free over {0, .5, 1, 2, 4}. It can explain the
+                             waiting as time-inconsistency, keeping reward higher and
+                             noise lower.
+
+   The likelihood of an observed action is exactly the softmax policy probability of
+   the forward biased planner (`make-biased-mdp-agent`), scored with `p/assess` — no
+   bespoke likelihood. The procrastination horizon SHRINKS along the sequence: the
+   action at wait-state W_w is scored at the remaining horizon (deadline - w), the
+   faithful reading of agentmodels' `observe(act(state, 0), action)`.
+
+   Reuse (no duplicated recursion/enumeration): bp/make-biased-mdp-agent +
+   bp/procrastination-mdp (forward model), bi/action-cm (z4si choicemap),
+   inv/normalize-logs (stable softmax), h/uniform-draw|weighted-draw (finite priors).
+   Zero engine change.
+
+   Scope: 5d procrastination only (capability v1). Bandit reward-myopia across
+   horizons is split to a follow-up bean (research-thin; needs a bandit MDP)."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.dynamic :as dyn]
+            [agentmodels.biased-planners :as bp]
+            [agentmodels.helpers :as h]
+            [agentmodels.inverse :as inv]
+            [agentmodels.biased-inverse :as bi])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+;; agentmodels Ch 5d priors
+(def reward-vals  [0.5 2 3 4 5 6 7 8])
+(def alpha-vals   [0.1 1 10 100 1000])
+(def alpha-probs  [0.1 0.2 0.2 0.2 0.3])
+(def discount-vals-discounting [0 0.5 1 2 4])
+(def discount-vals-optimal     [0])
+
+;; ===========================================================================
+;; Forward agents over the joint finite prior
+;; ===========================================================================
+
+(defn build-agents
+  "Map {[reward-idx alpha-idx discount-idx] -> {:agent :alpha :reward :discount}}.
+   The procrastination MDP is rebuilt ONCE per reward value (reward is an MDP-build
+   arg), then shared across the alpha x discount grid."
+  [{:keys [reward-vals alpha-vals discount-vals work-cost wait-cost deadline n-iters bias]
+    :or   {work-cost -1.0 wait-cost -0.1 deadline 10 n-iters 12 bias :naive}}]
+  (let [mdps (mapv (fn [r] (bp/procrastination-mdp {:reward r :work-cost work-cost
+                                                    :wait-cost wait-cost :deadline deadline}))
+                   reward-vals)]
+    (into {}
+          (for [ri (range (count reward-vals))
+                ai (range (count alpha-vals))
+                di (range (count discount-vals))]
+            (let [a (nth alpha-vals ai) k (nth discount-vals di)]
+              [[ri ai di]
+               {:agent   (bp/make-biased-mdp-agent
+                           {:mdp (nth mdps ri) :alpha a :gamma 1.0 :n-iters n-iters}
+                           {:discount k :bias bias})
+                :alpha a :reward (nth reward-vals ri) :discount k}])))))
+
+(defn- eu-at
+  "EU vector over actions at wait-state s, horizon t (delay 0)."
+  [agent s t]
+  (mapv #((:eu agent) s % t 0) (range 2)))
+
+;; ===========================================================================
+;; The multi-latent joint generative function (extends z4si biased-agent-model)
+;; ===========================================================================
+
+(defn joint-procrastination-model
+  "Joint GF tracing :reward, :alpha, :discount (indices into finite prior boxes);
+   the sampled tuple selects a precomputed forward agent; one softmax-action site
+   :a0 :a1 ... per observed wait-state, scored at the remaining horizon
+   (horizon-fn s). All agents + EU-row arrays precomputed before `gen` (the body is
+   re-run per enumerated tuple, so it only indexes)."
+  [{:keys [states horizon-fn reward-vals alpha-vals discount-vals alpha-probs] :as cfg} agents]
+  (let [reward-box   (h/uniform-draw reward-vals)
+        alpha-box    (if alpha-probs (h/weighted-draw alpha-vals alpha-probs) (h/uniform-draw alpha-vals))
+        discount-box (h/uniform-draw discount-vals)
+        rows (into {} (for [[k {:keys [agent]}] agents]
+                        [k (mapv (fn [s] (mx/array (clj->js (eu-at agent s (horizon-fn s))) mx/float32))
+                                 states)]))]
+    (gen []
+      (let [ri (trace :reward   (:dist reward-box))
+            ai (trace :alpha    (:dist alpha-box))
+            di (trace :discount (:dist discount-box))
+            er (rows [ri ai di])
+            al (:alpha (agents [ri ai di]))]
+        (doseq [i (range (count states))]
+          (trace (keyword (str "a" i)) (h/softmax-action al (nth er i))))
+        [ri ai di]))))
+
+(defn- multi-full-cm
+  "Choicemap {:reward ri, :alpha ai, :discount di, :a0 a0, ...}."
+  [ri ai di actions]
+  (-> (bi/action-cm actions)
+      (cm/set-choice [:reward] ri)
+      (cm/set-choice [:alpha] ai)
+      (cm/set-choice [:discount] di)))
+
+;; ===========================================================================
+;; Exact enumeration over the joint finite prior
+;; ===========================================================================
+
+(defn- marginal [post vals axis]
+  (reduce (fn [m [tup pr]] (update m (nth vals (nth tup axis)) (fnil + 0.0) pr)) {} post))
+
+(defn expect
+  "Posterior expectation of a latent given its {value -> prob} marginal."
+  [marg]
+  (reduce (fn [s [v pr]] (+ s (* v pr))) 0.0 marg))
+
+(defn joint-posterior
+  "Exact P(reward,alpha,discount | actions). Enumerate the joint finite prior; for
+   each tuple assess the joint GF on the full choicemap; normalize. Returns
+   {:joint {[ri ai di] prob} :marginals {:reward {...} :alpha {...} :discount {...}}}."
+  [{:keys [states actions reward-vals alpha-vals discount-vals] :as cfg} agents]
+  (assert (= (count states) (count actions))
+          (str "5d joint: states/actions length mismatch " (count states) " vs " (count actions)))
+  (let [model (joint-procrastination-model cfg agents)
+        tuples (for [ri (range (count reward-vals))
+                     ai (range (count alpha-vals))
+                     di (range (count discount-vals))] [ri ai di])
+        logw (into {} (for [[ri ai di :as tup] tuples]
+                        [tup (mx/item (:weight (p/assess (dyn/auto-key model) []
+                                                         (multi-full-cm ri ai di actions))))]))
+        post (inv/normalize-logs logw)]
+    {:joint post
+     :marginals {:reward   (marginal post reward-vals 0)
+                 :alpha    (marginal post alpha-vals 1)
+                 :discount (marginal post discount-vals 2)}}))
+
+(defn predict-work
+  "Posterior-predictive P(work) at a wait-state (predict-state, predict-horizon):
+   sum over the joint posterior of each tuple's softmax P(work=1)."
+  [post agents predict-state predict-horizon]
+  (reduce (fn [acc [tup pr]]
+            (let [{:keys [agent alpha]} (agents tup)
+                  eus (eu-at agent predict-state predict-horizon)
+                  m   (apply max (mapv #(* alpha %) eus))
+                  es  (mapv #(Math/exp (- (* alpha %) m)) eus)
+                  pw  (/ (nth es 1) (reduce + es))]   ; action 1 = work
+              (+ acc (* pr pw))))
+          0.0 post))
+
+;; ===========================================================================
+;; Online (incremental) posterior time-series
+;; ===========================================================================
+
+(defn online-posteriors
+  "Posterior expectations + predict-work after each prefix of the observed
+   sequence (index 0 = prior). Reuses joint-posterior on truncated observations."
+  [{:keys [states actions] :as cfg} agents predict-state predict-horizon]
+  (mapv (fn [L]
+          (let [c (assoc cfg :states (vec (take L states)) :actions (vec (take L actions)))
+                {:keys [joint marginals]} (joint-posterior c agents)]
+            {:n L
+             :E-reward   (expect (:reward marginals))
+             :E-alpha    (expect (:alpha marginals))
+             :E-discount (expect (:discount marginals))
+             :predict-work (predict-work joint agents predict-state predict-horizon)}))
+        (range (inc (count states)))))
+
+;; ===========================================================================
+;; Demo configs (the canonical 8-waits procrastination observation)
+;; ===========================================================================
+
+(def DEADLINE 10)
+
+(defn demo-cfg
+  "cfg for a model. :optimal? true => discount fixed {0}; else Possibly-Discounting.
+   :extra-work? true => append a work action at W_8 (task completes)."
+  [{:keys [optimal? extra-work?]}]
+  (let [n-wait    8                              ; 8 observed waits at W_0..W_7
+        states    (vec (range n-wait))           ; W_0..W_7
+        actions   (vec (repeat n-wait 0))        ; all wait
+        states'   (if extra-work? (conj states n-wait) states)        ; + W_8
+        actions'  (if extra-work? (conj actions 1) actions)]           ; + work
+    {:states states' :actions actions'
+     :horizon-fn #(- DEADLINE %)                 ; remaining horizon at W_w
+     :reward-vals reward-vals :alpha-vals alpha-vals :alpha-probs alpha-probs
+     :discount-vals (if optimal? discount-vals-optimal discount-vals-discounting)
+     :deadline DEADLINE}))
+
+(defn analyze
+  "Run a model end-to-end: build agents, joint posterior, predict-work, marginal
+   expectations. predict at W_8 (horizon 2)."
+  [opts]
+  (let [cfg    (demo-cfg opts)
+        agents (build-agents cfg)
+        {:keys [joint marginals] :as pp} (joint-posterior cfg agents)]
+    {:cfg cfg :agents agents :posterior pp
+     :predict-work (predict-work joint agents 8 2)
+     :E-reward   (expect (:reward marginals))
+     :E-alpha    (expect (:alpha marginals))
+     :E-discount (expect (:discount marginals))}))

--- a/test/genmlx/agentmodels_5d_joint_test.cljs
+++ b/test/genmlx/agentmodels_5d_joint_test.cljs
@@ -1,0 +1,70 @@
+;; Headless tests for 5d procrastination JOINT inference (agentmodels Ch 5d).
+;; Run: bun run --bun nbb test/genmlx/agentmodels_5d_joint_test.cljs
+
+(ns genmlx.agentmodels-5d-joint-test
+  (:require [agentmodels.joint-5d-inference :as j5d]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-close [msg expected actual tol]
+  (if (<= (Math/abs (- expected actual)) tol)
+    (do (vswap! passed inc) (println " PASS" msg "  =" actual))
+    (do (vswap! failed inc) (println " FAIL" msg "  expected:" expected "  got:" actual))))
+
+(println "\n== 5d: Optimal vs Possibly-Discounting (8 observed waits) ==")
+(def opt  (j5d/analyze {:optimal? true}))
+(def disc (j5d/analyze {:optimal? false}))
+(println "  Optimal     : pwork" (:predict-work opt)  " E[reward]" (:E-reward opt)  " E[alpha]" (:E-alpha opt))
+(println "  Discounting : pwork" (:predict-work disc) " E[reward]" (:E-reward disc) " E[discount]" (:E-discount disc))
+
+(assert-close "Optimal predictWorkLastMinute ~= 0.0056"        0.0056 (:predict-work opt)  5e-4)
+(assert-close "Discounting predictWorkLastMinute ~= 0.216"     0.216  (:predict-work disc) 5e-3)
+(assert-true  "Discounting pwork > Optimal pwork"              (> (:predict-work disc) (:predict-work opt)))
+(assert-true  "ratio Disc/Opt > 10"                            (> (/ (:predict-work disc) (:predict-work opt)) 10))
+(assert-true  "both pwork < 0.3"                               (and (< (:predict-work opt) 0.3) (< (:predict-work disc) 0.3)))
+(assert-close "Optimal explains waiting by low reward ~0.530"  0.530  (:E-reward opt)  0.02)
+(assert-close "Optimal infers high noise E[alpha] ~457.5"      457.5  (:E-alpha opt)  2.0)
+(assert-close "Discounting keeps reward higher ~2.849"         2.849  (:E-reward disc) 0.05)
+(assert-close "Discounting E[discount] ~2.631"                 2.631  (:E-discount disc) 0.05)
+
+(println "\n== 5d: posterior revision when the task COMPLETES (append work@W_8) ==")
+(def opt2  (j5d/analyze {:optimal? true  :extra-work? true}))
+(def disc2 (j5d/analyze {:optimal? false :extra-work? true}))
+(println "  Optimal      reward" (:E-reward opt)  "->" (:E-reward opt2)  "  alpha" (:E-alpha opt)  "->" (:E-alpha opt2))
+(println "  Discounting  reward" (:E-reward disc) "->" (:E-reward disc2) "  alpha" (:E-alpha disc) "->" (:E-alpha disc2))
+
+(assert-true  "Optimal E[reward] rises by > 2.0 on completion"  (> (- (:E-reward opt2) (:E-reward opt)) 2.0))
+(assert-true  "Optimal E[alpha] collapses (> 100x drop)"        (> (/ (:E-alpha opt) (:E-alpha opt2)) 100))
+(assert-true  "Discounting alpha barely moves (< 3x change)"    (< (/ (max (:E-alpha disc) (:E-alpha disc2))
+                                                                      (min (:E-alpha disc) (:E-alpha disc2))) 3))
+(assert-true  "Discounting reward rises moderately (> 1.0)"     (> (- (:E-reward disc2) (:E-reward disc)) 1.0))
+(assert-true  "Optimal alpha-revision >> Discounting alpha-revision"
+              (> (Math/abs (- (:E-alpha opt) (:E-alpha opt2)))
+                 (Math/abs (- (:E-alpha disc) (:E-alpha disc2)))))
+
+(println "\n== 5d: online posterior sequence ==")
+(def series (j5d/online-posteriors (j5d/demo-cfg {:optimal? false}) (j5d/build-agents (j5d/demo-cfg {:optimal? false})) 8 2))
+(println "  prefix lengths:" (mapv :n series))
+(assert-true  "online series has prior + one-per-observation"   (= (count series) 9))
+(assert-true  "index 0 is the prior (E[discount] = prior mean 1.5)"
+              (< (Math/abs (- (:E-discount (first series)) 1.5)) 1e-6))
+(println "  predict-work :" (mapv #(.toFixed (:predict-work %) 3) series))
+(println "  E[discount]  :" (mapv #(.toFixed (:E-discount %) 3) series))
+;; Observing waiting => the model infers a procrastinator: P(work) FALLS, E[discount] RISES.
+(assert-true  "predict-work FALLS as waiting accumulates (looks like a procrastinator)"
+              (< (:predict-work (last series)) (:predict-work (first series))))
+(assert-true  "E[discount] RISES as waiting accumulates (prior 1.5 -> ~2.63)"
+              (> (:E-discount (last series)) (:E-discount (first series))))
+
+(println "\n== 5d: normalization & structure ==")
+(let [post (:joint (:posterior disc))]
+  (assert-true "joint posterior sums to 1" (< (Math/abs (- 1.0 (reduce + (vals post)))) 1e-6)))
+(let [m (:marginals (:posterior disc))]
+  (assert-true "reward marginal sums to 1"   (< (Math/abs (- 1.0 (reduce + (vals (:reward m))))) 1e-6))
+  (assert-true "discount marginal sums to 1" (< (Math/abs (- 1.0 (reduce + (vals (:discount m))))) 1e-6)))
+
+(println (str "\n" @passed " passed, " @failed " failed"))
+(when (pos? @failed) (js/process.exit 1))


### PR DESCRIPTION
## Summary

Multi-latent **joint inference of biases AND preferences** (agentmodels Ch 5d, capability v1, bean `genmlx-4zfy`). Extends the z4si single-latent (`:bias`) pattern in `biased_inverse.cljs` to **multiple traced latents** — `:reward`, `:alpha`, `:discount` — inverted by **exact host-side enumeration** over finite priors.

An agent procrastinates (waits, then maybe works near the deadline); from the observed sequence we jointly infer its reward, softmax-noise, and hyperbolic discount, comparing two models:
- **Optimal** (discount fixed `{0}`): explains waiting only via low reward + high noise.
- **Possibly-Discounting** (discount free): explains it as time-inconsistency.

## Contents
- `examples/agentmodels/joint_5d_inference.cljs` — the joint GF + enumeration + `predict-work` + online series.
- `test/genmlx/agentmodels_5d_joint_test.cljs` — 21/21.

## Verified targets (live, bit-deterministic)
- `predictWorkLastMinute`: Optimal **0.005645**, Possibly-Discounting **0.21580** (ratio >10, both <0.3)
- Optimal explains waiting via low reward `E≈0.530` + high noise `E[α]≈457.5`; Discounting `E[reward]≈2.85`, `E[discount]≈2.63`
- On task completion: Optimal **collapses** `E[α]` 457→0.68 & raises reward 0.53→4.77; Discounting `α` barely moves (496→573)
- Online series: `predict-work` falls 0.654→0.216, `E[discount]` rises 1.5→2.63 as waiting accumulates
- The procrastination horizon **shrinks** (action at `W_w` scored at remaining horizon `deadline-w`) — faithful `observe(act(state,0),action)`

## Process
spec → research workflow → user-approved tight v1 → implement → 4-dimension adversarial review (14 positive faithfulness/correctness confirmations; one test-strengthening applied; rest dismissed/deferred with cause). Composes existing primitives (`make-biased-mdp-agent`, `normalize-logs`, `action-cm`, draws) — **zero engine change**. Regression intact (z4si 42, biased_planners 41, helpers 22, slice 51, pomdp 22).

## Scope
5d only. **All of Ch 5e** is split to bean `genmlx-69s8` — faithful 5e identifiability + `[imm,del]` utility joint + summary-stat posteriors are geometry-bound (minimal MDPs give tie-break artifacts / non-graded inference; needs the full restaurant geometry).

## ⚠️ Running the tests
Use the pinned nbb: `bunx nbb@1.4.206 test/genmlx/agentmodels_5d_joint_test.cljs`. nbb **1.4.207** (current global homebrew) breaks on `cm/Node` resolution in `handler.cljs` — a version-drift issue, not a code issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)