### PR TITLE
refactor(agents): promote examples/agentmodels → src/genmlx/agents (stable Layer-9 API)

### DIFF
--- a/examples/agentmodels-tui/README.md
+++ b/examples/agentmodels-tui/README.md
@@ -6,7 +6,7 @@ This is the **demo gallery** (distinct from the Studio TUI, bean `genmlx-tw52`).
 
 ## The architecture in one line
 
-Everything below the **render-agnostic data seam** (`agentmodels.presentation`:
+Everything below the **render-agnostic data seam** (`genmlx.agents.presentation`:
 `Frame` / `Trajectory` / `PosteriorBars`) is pure CLJS + MLX and is proven by a
 headless test; everything here above the seam is just reagent + Ink turning that
 same data into colored cells.
@@ -93,4 +93,4 @@ test means the live TUI renders correct pictures by construction.
 Append one entry to `demos` in `gallery.cljs`:
 `{:id … :title … :view … :on-key … :enter … :leave …}`. No nav code to touch.
 View primitives (`grid-view`, `bars-view`, `frames-view`, `status-bar`) live in
-`views.cljs` and consume only `agentmodels.presentation` data shapes.
+`views.cljs` and consume only `genmlx.agents.presentation` data shapes.

--- a/examples/agentmodels-tui/ch3_demo.cljs
+++ b/examples/agentmodels-tui/ch3_demo.cljs
@@ -13,9 +13,9 @@
    keys here via on-key and starts/stops the autoplay timer via enter!/leave!."
   (:require ["ink" :refer [Text Box]]
             [reagent.core :as r]
-            [agentmodels.gridworld :as gw]
-            [agentmodels.agent :as agent]
-            [agentmodels.presentation :as pres]
+            [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.agent :as agent]
+            [genmlx.agents.presentation :as pres]
             [views]))
 
 ;; A maze where the wall belt forces a detour (top row first; screen coords).

--- a/examples/agentmodels-tui/ch3c_demo.cljs
+++ b/examples/agentmodels-tui/ch3c_demo.cljs
@@ -10,9 +10,9 @@
    Ch5 viewer. Pure data crosses the seam; this file only wires + renders."
   (:require ["ink" :refer [Text Box]]
             [reagent.core :as r]
-            [agentmodels.pomdp :as pomdp]
-            [agentmodels.pomdp-env :as env]
-            [agentmodels.presentation :as pres]
+            [genmlx.agents.pomdp :as pomdp]
+            [genmlx.agents.pomdp-env :as env]
+            [genmlx.agents.presentation :as pres]
             [views]))
 
 ;;   A . B

--- a/examples/agentmodels-tui/ch3d_demo.cljs
+++ b/examples/agentmodels-tui/ch3d_demo.cljs
@@ -12,9 +12,9 @@
    stable gamma-ratio sampler — genmlx-gcw4.)"
   (:require ["ink" :refer [Text Box]]
             [reagent.core :as r]
-            [agentmodels.pomdp :as pomdp]
-            [agentmodels.pomdp-env :as env]
-            [agentmodels.presentation :as pres]
+            [genmlx.agents.pomdp :as pomdp]
+            [genmlx.agents.pomdp-env :as env]
+            [genmlx.agents.presentation :as pres]
             [views]))
 
 (def thetas [0.25 0.50 0.80])         ; true arm payoff probs; arm 2 is best

--- a/examples/agentmodels-tui/ch5_demo.cljs
+++ b/examples/agentmodels-tui/ch5_demo.cljs
@@ -4,7 +4,7 @@
    Watch GenMLX infer what an agent WANTS from how it moves. A 'true' agent
    (valuing A or B) walks the grid; the observer maintains a posterior over the
    agent's goal and updates it after every observed action by inverting the
-   forward model through the GFI (agentmodels.inverse uses p/assess as the
+   forward model through the GFI (genmlx.agents.inverse uses p/assess as the
    likelihood). As the walk plays, the grid (left) and the P(goal) bars (right)
    advance in lockstep — the bars are uninformative while the agent heads down
    the symmetry axis, then snap to the true goal the moment it commits.
@@ -12,10 +12,10 @@
    space steps, r resamples a fresh walk, t toggles the true goal."
   (:require ["ink" :refer [Text Box]]
             [reagent.core :as r]
-            [agentmodels.gridworld :as gw]
-            [agentmodels.agent :as agent]
-            [agentmodels.inverse :as inv]
-            [agentmodels.presentation :as pres]
+            [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.agent :as agent]
+            [genmlx.agents.inverse :as inv]
+            [genmlx.agents.presentation :as pres]
             [views]))
 
 ;; Open grid, A and B mirror-symmetric about the centre column; start top-centre.

--- a/examples/agentmodels-tui/views.cljs
+++ b/examples/agentmodels-tui/views.cljs
@@ -1,7 +1,7 @@
 (ns views
   "Reusable Ink view primitives for the agentmodels gallery. ABOVE THE SEAM:
    every component is a pure function of the render-agnostic data shapes defined
-   in agentmodels.presentation (Frame, PosteriorBars) plus reagent atoms. They
+   in genmlx.agents.presentation (Frame, PosteriorBars) plus reagent atoms. They
    know nothing about MDPs, MLX, or inference — only how to turn data into
    colored cells. Re-rendering is the proven genmlx-tui model: an r/atom changes,
    reagent re-renders these plain components.

--- a/examples/agentmodels/biased_inverse.cljs
+++ b/examples/agentmodels/biased_inverse.cljs
@@ -35,9 +35,9 @@
             [genmlx.dynamic :as dyn]
             [genmlx.inference.importance :as is]
             [genmlx.inference.util :as iu]
-            [agentmodels.biased-planners :as bp]
-            [agentmodels.helpers :as h]
-            [agentmodels.inverse :as inv])
+            [genmlx.agents.biased-planners :as bp]
+            [genmlx.agents.helpers :as h]
+            [genmlx.agents.inverse :as inv])
   (:require-macros [genmlx.gen :refer [gen]]))
 
 (def bias-values

--- a/examples/agentmodels/joint_5d_inference.cljs
+++ b/examples/agentmodels/joint_5d_inference.cljs
@@ -32,9 +32,9 @@
             [genmlx.protocols :as p]
             [genmlx.choicemap :as cm]
             [genmlx.dynamic :as dyn]
-            [agentmodels.biased-planners :as bp]
-            [agentmodels.helpers :as h]
-            [agentmodels.inverse :as inv]
+            [genmlx.agents.biased-planners :as bp]
+            [genmlx.agents.helpers :as h]
+            [genmlx.agents.inverse :as inv]
             [agentmodels.biased-inverse :as bi])
   (:require-macros [genmlx.gen :refer [gen]]))
 

--- a/examples/agentmodels/multi_agent.cljs
+++ b/examples/agentmodels/multi_agent.cljs
@@ -22,7 +22,7 @@
 
    Source: agentmodels.org Chapter 7 (canonical). Ground truth is ANALYTIC (derived
    from the model math), not copied from examples/memo (a separate memo-conversion
-   corpus). No engine change — composes genmlx.inference.exact, agentmodels.helpers,
+   corpus). No engine change — composes genmlx.inference.exact, genmlx.agents.helpers,
    and exact/with-cache only."
   (:require [genmlx.mlx :as mx]
             [genmlx.dist :as dist]
@@ -30,7 +30,7 @@
             [genmlx.dynamic :as dyn]
             [genmlx.choicemap :as cm]
             [genmlx.inference.exact :as exact]
-            [agentmodels.helpers :as h])
+            [genmlx.agents.helpers :as h])
   (:require-macros [genmlx.gen :refer [gen]]))
 
 ;; ===========================================================================
@@ -168,7 +168,7 @@
   "The pragmatic speaker S1: [n-states × n-utts], row s = P_S1(utterance | state s).
    S1(u|s) = softmax_u(α · log L0(s|u)) — Boltzmann/softmax-action over utterances
    with utility = the literal listener's log-score. (This is agentmodels' factor(α·EU)
-   realized as a policy; see agentmodels.helpers/softmax-action.)"
+   realized as a policy; see genmlx.agents.helpers/softmax-action.)"
   [L0 alpha]
   (mx/softmax (mx/multiply (mx/scalar alpha) (mx/log (mx/transpose L0))) 1))
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "nbb": "bunx nbb@1.4.206"
+  },
   "dependencies": {
     "@mlx-node/core": "file:./mlx-node/packages/core",
     "@mlx-node/lm": "file:./mlx-node/packages/lm"

--- a/src/genmlx/agents/agent.cljs
+++ b/src/genmlx/agents/agent.cljs
@@ -1,4 +1,4 @@
-(ns agentmodels.agent
+(ns genmlx.agents.agent
   "MDP agent for the agentmodels port — GenMLX-native, with TWO paths that agree.
 
    agentmodels.org defines an agent by the mutual recursion act / expectedUtility
@@ -28,7 +28,7 @@
             [genmlx.protocols :as p]
             [genmlx.dynamic :as dyn]
             [genmlx.inference.exact :as exact]
-            [agentmodels.helpers :as h])
+            [genmlx.agents.helpers :as h])
   (:require-macros [genmlx.gen :refer [gen]]))
 
 ;; ---------------------------------------------------------------------------
@@ -171,7 +171,7 @@
 (defn sample-next
   "Sample the next state from T[s,a,:] (the env-step generative function).
    Deterministic when the row is one-hot (noise = 0). Public so the POMDP rollout
-   (agentmodels.pomdp/simulate-pomdp) threads the world transition the same way."
+   (genmlx.agents.pomdp/simulate-pomdp) threads the world transition the same way."
   [T s a]
   (let [probs (vec (mx/->clj (mx/idx (mx/idx T s) a)))]      ; T[s,a,:] -> [S'] probs
     (int (mx/item (:retval (p/simulate (dyn/auto-key env-step) [probs]))))))

--- a/src/genmlx/agents/biased_planners.cljs
+++ b/src/genmlx/agents/biased_planners.cljs
@@ -1,4 +1,4 @@
-(ns agentmodels.biased-planners
+(ns genmlx.agents.biased-planners
   "Biased / bounded planners (agentmodels Ch 5) — GenMLX-native, zero engine change.
 
    agentmodels Ch 5 turns the rational MDP/POMDP agent into a family of HUMANLY
@@ -53,9 +53,9 @@
             [genmlx.protocols :as p]
             [genmlx.dynamic :as dyn]
             [genmlx.inference.exact :as exact]
-            [agentmodels.gridworld :as gw]
-            [agentmodels.agent :as agent]
-            [agentmodels.helpers :as h])
+            [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.agent :as agent]
+            [genmlx.agents.helpers :as h])
   (:require-macros [genmlx.gen :refer [gen]]))
 
 ;; ===========================================================================

--- a/src/genmlx/agents/gridworld.cljs
+++ b/src/genmlx/agents/gridworld.cljs
@@ -1,4 +1,4 @@
-(ns agentmodels.gridworld
+(ns genmlx.agents.gridworld
   "Gridworld MDP environment — a human-readable grid literal compiled to the MLX
    tensors an MDP planner needs: the transition tensor T:[S,A,S'], the reward
    tensor R:[S,A], and the terminal mask term:[S].

--- a/src/genmlx/agents/helpers.cljs
+++ b/src/genmlx/agents/helpers.cljs
@@ -1,4 +1,4 @@
-(ns agentmodels.helpers
+(ns genmlx.agents.helpers
   "Ergonomic helpers for the agentmodels examples library.
 
    Closes the 'partial' PPL-ergonomics gaps with a tiny shared namespace —

--- a/src/genmlx/agents/inverse.cljs
+++ b/src/genmlx/agents/inverse.cljs
@@ -1,4 +1,4 @@
-(ns agentmodels.inverse
+(ns genmlx.agents.inverse
   "Inverse goal inference (agentmodels Ch 4/5): observe an agent's actions and
    infer which goal it values — by INVERTING the forward agent model through the
    GFI.
@@ -18,8 +18,8 @@
             [genmlx.protocols :as p]
             [genmlx.choicemap :as cm]
             [genmlx.dynamic :as dyn]
-            [agentmodels.gridworld :as gw]
-            [agentmodels.agent :as agent]))
+            [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.agent :as agent]))
 
 (defn goal-agents
   "Build one agent per candidate goal: the agent that VALUES that goal gives it
@@ -44,7 +44,7 @@
 
 (defn normalize-logs
   "{goal -> log-weight} -> {goal -> probability} (stable softmax). Public so the
-   POMDP belief filter (agentmodels.pomdp) reuses the same normalization."
+   POMDP belief filter (genmlx.agents.pomdp) reuses the same normalization."
   [logm]
   (let [hi (apply max (vals logm))
         ex (into {} (map (fn [[g l]] [g (Math/exp (- l hi))]) logm))

--- a/src/genmlx/agents/pomdp.cljs
+++ b/src/genmlx/agents/pomdp.cljs
@@ -1,4 +1,4 @@
-(ns agentmodels.pomdp
+(ns genmlx.agents.pomdp
   "POMDP agent (agentmodels Ch 3c) — belief filtering + belief-space action,
    GenMLX-native by reuse.
 
@@ -7,7 +7,7 @@
    and Bayesian-updates the belief (filtering). The pieces all compose on what is
    already built:
 
-   - one MDP planner PER world via agentmodels.inverse/goal-agents (each carries
+   - one MDP planner PER world via genmlx.agents.inverse/goal-agents (each carries
      its solved :Q [S,A]);
    - the belief-space value is QMDP: Q_QMDP(b,s) = Σ_w b(w) · Q_w[s] — a plain MLX
      reduction over the per-world :Q rows;
@@ -28,9 +28,9 @@
             [genmlx.dist :as dist]
             [genmlx.protocols :as p]
             [genmlx.dynamic :as dyn]
-            [agentmodels.inverse :as inv]
-            [agentmodels.agent :as agent]
-            [agentmodels.helpers :as h])
+            [genmlx.agents.inverse :as inv]
+            [genmlx.agents.agent :as agent]
+            [genmlx.agents.helpers :as h])
   (:require-macros [genmlx.gen :refer [gen]]))
 
 (defn make-pomdp-agent

--- a/src/genmlx/agents/pomdp_env.cljs
+++ b/src/genmlx/agents/pomdp_env.cljs
@@ -1,4 +1,4 @@
-(ns agentmodels.pomdp-env
+(ns genmlx.agents.pomdp-env
   "POMDP environments (bean genmlx-m9m9). Each constructor returns the data
    bundle make-pomdp-agent / simulate-pomdp consume. The per-world MDP tensors
    themselves are produced inside make-pomdp-agent via inverse/goal-agents ->
@@ -39,7 +39,7 @@
    action AND the only observation channel for theta_i; the reward r ~
    Bernoulli(theta_i) IS the observation; belief factorizes into one independent
    Beta(alpha_i, beta_i) per arm (Beta-Bernoulli conjugacy, filtered host-side in
-   agentmodels.pomdp). Returns the bundle make-bandit-agent / simulate-bandit
+   genmlx.agents.pomdp). Returns the bundle make-bandit-agent / simulate-bandit
    consume — pure config plus a reward sampler; no MDP tensors (no spatial latent).
 
    Options: :thetas [p ...] true Bernoulli params (latent, fixed);

--- a/src/genmlx/agents/presentation.cljs
+++ b/src/genmlx/agents/presentation.cljs
@@ -1,4 +1,4 @@
-(ns agentmodels.presentation
+(ns genmlx.agents.presentation
   "THE RENDER-AGNOSTIC SEAM.
 
    Pure CLJS data producers + plain-text renderers. NO Ink, NO React, NO reagent

--- a/test/genmlx/agentmodels_biased_inverse_test.cljs
+++ b/test/genmlx/agentmodels_biased_inverse_test.cljs
@@ -4,7 +4,7 @@
 
 (ns genmlx.agentmodels-biased-inverse-test
   (:require [agentmodels.biased-inverse :as bi]
-            [agentmodels.inverse :as inv]
+            [genmlx.agents.inverse :as inv]
             [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
             [genmlx.protocols :as p]

--- a/test/genmlx/agentmodels_biased_planners_test.cljs
+++ b/test/genmlx/agentmodels_biased_planners_test.cljs
@@ -2,9 +2,9 @@
 ;; Run: bun run --bun nbb test/genmlx/agentmodels_biased_planners_test.cljs
 
 (ns genmlx.agentmodels-biased-planners-test
-  (:require [agentmodels.gridworld :as gw]
-            [agentmodels.agent :as agent]
-            [agentmodels.biased-planners :as bp]
+  (:require [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.agent :as agent]
+            [genmlx.agents.biased-planners :as bp]
             [genmlx.mlx :as mx]
             [genmlx.protocols :as p]
             [genmlx.dynamic :as dyn]

--- a/test/genmlx/agentmodels_helpers_test.cljs
+++ b/test/genmlx/agentmodels_helpers_test.cljs
@@ -1,4 +1,4 @@
-;; Unit tests for agentmodels.helpers — the ergonomic PPL helpers used across
+;; Unit tests for genmlx.agents.helpers — the ergonomic PPL helpers used across
 ;; the agentmodels examples library (factor-dist, softmax-action, value-carrying
 ;; draws, boxed-choice). Self-contained; no test framework.
 ;;
@@ -8,7 +8,7 @@
 ;; Run: bun run --bun nbb test/genmlx/agentmodels_helpers_test.cljs
 
 (ns genmlx.agentmodels-helpers-test
-  (:require [agentmodels.helpers :as h]
+  (:require [genmlx.agents.helpers :as h]
             [genmlx.mlx :as mx]
             [genmlx.dist :as dist]
             [genmlx.dynamic :as dyn]

--- a/test/genmlx/agentmodels_pomdp_test.cljs
+++ b/test/genmlx/agentmodels_pomdp_test.cljs
@@ -6,11 +6,11 @@
 ;; Run: bun run --bun nbb test/genmlx/agentmodels_pomdp_test.cljs
 
 (ns genmlx.agentmodels-pomdp-test
-  (:require [agentmodels.gridworld :as gw]
-            [agentmodels.agent :as agent]
-            [agentmodels.pomdp :as pomdp]
-            [agentmodels.pomdp-env :as env]
-            [agentmodels.presentation :as pres]
+  (:require [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.agent :as agent]
+            [genmlx.agents.pomdp :as pomdp]
+            [genmlx.agents.pomdp-env :as env]
+            [genmlx.agents.presentation :as pres]
             [genmlx.mlx :as mx]))
 
 (def passed (volatile! 0))

--- a/test/genmlx/agentmodels_slice_test.cljs
+++ b/test/genmlx/agentmodels_slice_test.cljs
@@ -7,10 +7,10 @@
 ;; Run: bun run --bun nbb test/genmlx/agentmodels_slice_test.cljs
 
 (ns genmlx.agentmodels-slice-test
-  (:require [agentmodels.gridworld :as gw]
-            [agentmodels.agent :as agent]
-            [agentmodels.presentation :as pres]
-            [agentmodels.inverse :as inv]
+  (:require [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.agent :as agent]
+            [genmlx.agents.presentation :as pres]
+            [genmlx.agents.inverse :as inv]
             [genmlx.mlx :as mx]
             [clojure.string :as str]))
 

--- a/test/genmlx/agents_api_test.cljs
+++ b/test/genmlx/agents_api_test.cljs
@@ -1,0 +1,88 @@
+;; Contract test for the PROMOTED genmlx.agents Layer-9 API (Lever A, bean genmlx-ssui).
+;; Proves the 8 promoted namespaces load + are reachable AS A SRC LIBRARY, that an agent
+;; IS a generative function (GFI ops work), and that the flagship tensor-VI <-> recursive-EU
+;; equivalence holds at the new namespace. Deep behavior of each module is covered by the
+;; re-pointed suites (agentmodels_*_test, bandit_test); this is the library-level contract.
+;; Run: bunx nbb@1.4.206 test/genmlx/agents_api_test.cljs
+
+(ns genmlx.agents-api-test
+  (:require [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.agent :as agent]
+            [genmlx.agents.helpers :as h]
+            [genmlx.agents.inverse :as inv]
+            [genmlx.agents.biased-planners :as bp]
+            [genmlx.agents.pomdp :as pomdp]
+            [genmlx.agents.pomdp-env :as penv]
+            [genmlx.agents.presentation :as present]
+            [genmlx.mlx :as mx]
+            [genmlx.protocols :as p]
+            [genmlx.dynamic :as dyn]
+            [genmlx.choicemap :as cm]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-close [msg expected actual tol]
+  (if (<= (Math/abs (- expected actual)) tol)
+    (do (vswap! passed inc) (println " PASS" msg "  =" actual))
+    (do (vswap! failed inc) (println " FAIL" msg "  expected:" expected "  got:" actual))))
+
+(println "\n== genmlx.agents API contract (Layer-9 src library) ==")
+
+;; ---- all 8 promoted namespaces load + expose their public API ----
+;; (a failed require would abort the run; these confirm the public fns are resolvable)
+(assert-true "genmlx.agents.gridworld reachable"  (every? fn? [gw/build-mdp gw/parse-grid gw/transition-tensor]))
+(assert-true "genmlx.agents.agent reachable"      (every? fn? [agent/make-mdp-agent agent/value-iteration agent/recursive-eu agent/simulate-mdp]))
+(assert-true "genmlx.agents.helpers reachable"    (every? fn? [h/softmax-action h/uniform-draw h/weighted-draw h/draw-value]))
+(assert-true "genmlx.agents.inverse reachable"    (every? fn? [inv/goal-agents inv/action-loglik inv/normalize-logs inv/posterior-sequence]))
+(assert-true "genmlx.agents.biased-planners reachable" (every? fn? [bp/make-biased-mdp-agent bp/biased-eu bp/delta bp/simulate-biased-mdp]))
+(assert-true "genmlx.agents.pomdp reachable"      (every? fn? [pomdp/make-pomdp-agent pomdp/simulate-pomdp pomdp/make-bandit-agent pomdp/simulate-bandit]))
+(assert-true "genmlx.agents.pomdp-env reachable"  (every? fn? [penv/bandit-pomdp penv/restaurant-gridworld]))
+(assert-true "genmlx.agents.presentation reachable" (every? fn? [present/state->frame present/env->trajectory present/marginals->bars present/render-frame-text]))
+
+;; ---- environment + agent + GFI: an agent IS a generative function ----
+(def mdp (gw/build-mdp {:grid [[:empty :G] [:empty :empty]]
+                        :utilities {:G 2.0 :timeCost -0.1} :start [0 1] :gamma 1.0}))
+(assert-true "gridworld/build-mdp returns :T :R :term :terminals, S=4" (and (every? mdp [:T :R :term :terminals]) (= 4 (:S mdp))))
+
+(def ag (agent/make-mdp-agent {:mdp mdp :alpha 1.0 :gamma 1.0 :n-iters 6}))
+(assert-true "make-mdp-agent exposes :policy (GF), :Q, :expected-utility"
+             (and (some? (:policy ag)) (some? (:Q ag)) (fn? (:expected-utility ag))))
+;; p/simulate returns a Trace directly (not {:trace ...}); its :choices hold :action
+(let [tr (p/simulate (dyn/auto-key (:policy ag)) [(:start-idx mdp)])]
+  (assert-true "agent is a GF: p/simulate yields an :action choice + a score"
+               (and (some? (cm/get-choice (:choices tr) [:action])) (some? (:score tr)))))
+;; GFI inference works: p/assess gives a finite log-weight
+(let [w (mx/item (:weight (p/assess (dyn/auto-key (:policy ag)) [(:start-idx mdp)]
+                                    (cm/choicemap :action 0))))]
+  (assert-true "agent is a GF: p/assess yields a finite log-weight" (js/isFinite w)))
+;; flagship invariant — tensor value-iteration Q == recursive expected-utility
+(let [Qh (mx/->clj (:Q ag)) eu (:expected-utility ag) S (:S mdp) A (:A mdp)
+      err (apply max (for [s (range S) a (range A)] (Math/abs (- (get-in Qh [s a]) (eu s a)))))]
+  (assert-true "tensor-VI Q == recursive-EU (max err < 1e-4)" (< err 1e-4)))
+
+;; ---- helpers ----
+(assert-true "helpers/softmax-action returns a distribution"
+             (some? (h/softmax-action 1.0 (mx/array #js [1.0 2.0 0.5] mx/float32))))
+(let [box (h/uniform-draw [:a :b :c])]
+  (assert-true "helpers value-carrying draw: box + draw-value by index"
+               (and (:dist box) (= 3 (count (:values box))) (= :b (h/draw-value box 1)))))
+
+;; ---- biased-planners: k=0 limit recovery (biased == unbiased) ----
+(assert-close "biased-planners/delta(0,d)=1" 1.0 (bp/delta 0 3) 1e-12)
+(let [bi (bp/make-biased-mdp-agent {:mdp mdp :alpha 1.0 :gamma 1.0 :n-iters 6}
+                                   {:discount 0.0 :bias :sophisticated})
+      eub (:expected-utility bi) eus (:expected-utility ag) S (:S mdp) A (:A mdp)
+      err (apply max (for [s (range S) a (range A)] (Math/abs (- (eub s a) (eus s a)))))]
+  (assert-true "biased agent at k=0 recovers the unbiased agent (max err < 1e-4)" (< err 1e-4)))
+
+;; ---- inverse: goal-inference posterior normalizes ----
+(let [gas (inv/goal-agents {:grid [[:A :empty :B]] :goals [:A :B] :alpha 2.0})
+      seq (inv/posterior-sequence gas {:A 0.5 :B 0.5} [])]
+  (assert-true "inverse/goal-agents builds one agent per goal" (= #{:A :B} (set (keys gas))))
+  (assert-close "inverse/posterior-sequence prior sums to 1" 1.0 (reduce + (vals (first seq))) 1e-9))
+
+(println (str "\n" @passed " passed, " @failed " failed"))
+(when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/bandit_test.cljs
+++ b/test/genmlx/bandit_test.cljs
@@ -6,9 +6,9 @@
 ;; Run: bun run --bun nbb test/genmlx/bandit_test.cljs
 
 (ns genmlx.bandit-test
-  (:require [agentmodels.pomdp :as pomdp]
-            [agentmodels.pomdp-env :as env]
-            [agentmodels.presentation :as pres]
+  (:require [genmlx.agents.pomdp :as pomdp]
+            [genmlx.agents.pomdp-env :as env]
+            [genmlx.agents.presentation :as pres]
             [genmlx.mlx.random :as rng]))
 
 (def passed (volatile! 0))


### PR DESCRIPTION
## Summary

**Lever A** — the proven agentmodels modeling surface graduates from `examples/` to a **stable Layer-9 domain-as-GF library** `src/genmlx/agents/`, beside `genmlx.llm`. After this, **`genmlx.agents` formally exists as a namespace** — the packaging milestone that unlocks the agents book/app and gives the future `genmlx.control` axis a clean API to depend on.

Atomic, **behavior-preserving** move (git tracked as 96–99% renames — only `ns`/require lines changed).

## What moved
**8 promoted** (`agentmodels.X` → `genmlx.agents.X`): `gridworld`, `helpers`, `agent`, `inverse`, `pomdp`, `pomdp-env`, `presentation`, `biased-planners`.

**3 stay as demos** in `examples/agentmodels/` (own ns kept `agentmodels.*`, deps re-pointed to the new src nses): `biased_inverse` (the z4si showcase), `joint_5d_inference` (5d), `multi_agent` (Ch 7). Plus 5 TUI demos + 6 tests + README re-pointed.

**New:** `test/genmlx/agents_api_test.cljs` (19/19) — the library contract: each ns reachable, **agent-is-a-GF** (`p/simulate`/`p/assess`), **tensor-VI ≡ recursive-EU** at the new ns.

## Verification
- Full re-pointed suite green under nbb 1.4.206: helpers 22, planners 41, slice 51, pomdp 22, bandit 18, biased_inverse 42, 5d 21, multi_agent 34 + api_test 19 = **270 assertions**.
- 3-dimension adversarial review (completeness / layering-purity / partition-contract): **18 findings, all positive, zero defects**. `src/genmlx/agents/*` imports only Layers 0–8 (never `examples/*` or `genmlx.llm.*`), acyclic DAG, **zero engine change** (no `src/genmlx` edits outside `agents/`).

## Also
`package.json` gains a **drift-proof pinned nbb script** (`bun run nbb` → `bunx nbb@1.4.206`) so a global-nbb upgrade cant silently break tests. Zero-install (deliberately not a devDependency — avoids `bun install` disturbing the `file:`-linked `@mlx-node` native build). **Run tests with `bun run nbb test/genmlx/<f>.cljs`** (nbb 1.4.207 breaks on `cm/Node`).

## Decisions (approved)
`biased-planners` promoted whole (world builders provisionally public); tests stayed flat + re-pointed; no `agentmodels.*` back-compat aliases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)