### PR TITLE
feat(agentmodels): Ch 5e temptation geometry + Ch 4 IRL + Ch 3d PSRL

### DIFF
--- a/examples/agentmodels/irl.cljs
+++ b/examples/agentmodels/irl.cljs
@@ -1,0 +1,164 @@
+(ns agentmodels.irl
+  "Inverse Reinforcement Learning over an MDP agent (agentmodels Ch 4, 'Reasoning
+   about agents') — inferring an agent's full UTILITY TABLE, timeCost, and softmax
+   alpha from observed Gridworld trajectories.
+
+   This generalizes the shipped discrete-goal inverse-planning (genmlx.agents.inverse)
+   to a multi-valued utility table per restaurant plus the timeCost and alpha
+   nuisance parameters — agentmodels' Equation 1:
+
+       P(U,α | (s,a)_{0:n}) ∝ P(U,α) · Π_i P(a_i | s_i, U, α)
+
+   The per-timestep likelihood P(a_i|s_i,U,α) is EXACTLY inverse/action-loglik — the
+   GFI `p/assess` weight of the observed action under that agent's softmax policy (no
+   bespoke likelihood). Inference is exact host-side enumeration over the finite
+   prior grid, the same pattern as the 5d/5e joint inference. The forward agent is the
+   standard (non-discounting) MDP agent (agent/make-mdp-agent) over the Restaurant-
+   Choice grid (reused from the Ch 5e geometry); utilities are scalar terminals.
+
+   Two inference styles (both in the chapter):
+     - FACTORIZED SOFTMAX (Equation 1): score each observed [state,action] via
+       action-loglik; the substantive joint inference of utility+timeCost+alpha.
+     - GENERATE-AND-COMPARE: at high alpha, predict the trajectory and keep tables
+       whose prediction matches the observation (the chapter's motivating example).
+
+   Faithful (qualitative) targets: (1) one leftward step (α=2 fixed) → the agent's
+   FAVOURITE is inferred to be Donut, but Veg vs Noodle stay ~equal (unidentifiable —
+   the step gives no evidence distinguishing them); (2) jointly inferring timeCost+α,
+   that same single step no longer strongly favours Donut (a high timeCost or low α
+   explains it), pulling the posterior back toward the prior; (3) a longer trajectory
+   sharpens the posterior.
+
+   Reuse, zero engine change: agent/make-mdp-agent + gw/build-mdp (forward model),
+   bp/restaurant-temptation-grid (geometry), inverse/action-loglik + normalize-logs."
+  (:require [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.agent :as agent]
+            [genmlx.agents.biased-planners :as bp]
+            [genmlx.agents.inverse :as inv]))
+
+;; The Restaurant-Choice grid (agentmodels Ch4 uses the same grid as Ch5b/5e).
+(def grid bp/restaurant-temptation-grid)
+(def start-xy [3 6])                 ; agentmodels start [3,1] (y-up) in top-first coords
+(def N-ITERS 15)                     ; value-iteration sweeps (paths ≤ ~11 steps)
+
+;; agentmodels actions: 0=left 1=right 2=up 3=down (gw/action-deltas).
+;; The canonical Donut-South observation: from the start, step left ×3 then down to
+;; Donut-South (idx 42). The single-step example uses just its first pair.
+(def start-idx (+ 3 (* 6 6)))        ; = 39
+(def single-left-obs   [[start-idx 0]])
+(def donut-south-obs   [[39 0] [38 0] [37 0] [36 3]])
+
+;; agentmodels Ch4 prior support
+(def food-vals      [0 1 2])
+(def time-cost-vals [-0.1 -0.3 -0.6])
+(def alpha-vals     [0.1 1.0 10.0 100.0])
+
+;; ===========================================================================
+;; Forward agents over the joint finite prior (Donut-N = Donut-S, agentmodels)
+;; ===========================================================================
+
+(defn- restaurant-mdp [utils]
+  (gw/build-mdp {:grid grid :utilities utils :start start-xy :gamma 1.0 :noise 0.0}))
+
+(defn build-agents
+  "Map {[di vi ni ti ai] -> {:agent :donut :veg :noodle :time-cost :alpha}} over the
+   joint prior grid. One standard MDP agent per (utility-table, timeCost, alpha). The
+   utility table is scalar per restaurant; Donut-N and Donut-S share the donut value."
+  [{:keys [donut-vals veg-vals noodle-vals time-cost-vals alpha-vals n-iters]
+    :or {n-iters N-ITERS}}]
+  (into {}
+        (for [di (range (count donut-vals)), vi (range (count veg-vals)), ni (range (count noodle-vals))
+              ti (range (count time-cost-vals)), ai (range (count alpha-vals))]
+          (let [donut (nth donut-vals di) veg (nth veg-vals vi) noodle (nth noodle-vals ni)
+                tc (nth time-cost-vals ti) alpha (nth alpha-vals ai)
+                mdp (restaurant-mdp {:donut-n donut :donut-s donut :veg veg :noodle noodle :timeCost tc})]
+            [[di vi ni ti ai]
+             {:agent (agent/make-mdp-agent {:mdp mdp :alpha alpha :gamma 1.0 :n-iters n-iters})
+              :donut donut :veg veg :noodle noodle :time-cost tc :alpha alpha}]))))
+
+;; ===========================================================================
+;; Factorized-softmax posterior (Equation 1) + summary statistics
+;; ===========================================================================
+
+(defn joint-posterior
+  "Exact P(U,timeCost,alpha | observations). observations = seq of [state action].
+   Weight = Σ_i action-loglik (the factorized softmax likelihood); uniform prior
+   cancels in normalize-logs. Returns {tuple -> probability}."
+  [agents observations]
+  (inv/normalize-logs
+    (into {} (for [[tup {:keys [agent]}] agents]
+               [tup (reduce (fn [acc [s a]] (+ acc (inv/action-loglik agent s a))) 0.0 observations)]))))
+
+(defn- fav [{:keys [donut veg noodle]} which]
+  (case which
+    :donut  (and (> donut veg)  (> donut noodle))
+    :veg    (and (> veg donut)  (> veg noodle))
+    :noodle (and (> noodle donut) (> noodle veg))))
+
+(defn summarize
+  "Posterior summary statistics over a {tuple -> prob} distribution."
+  [weighted agents]
+  (reduce (fn [acc [tup pr]]
+            (let [a (agents tup)]
+              (-> acc
+                  (update :p-donut-favorite  + (* pr (if (fav a :donut)  1.0 0.0)))
+                  (update :p-veg-favorite    + (* pr (if (fav a :veg)    1.0 0.0)))
+                  (update :p-noodle-favorite + (* pr (if (fav a :noodle) 1.0 0.0)))
+                  (update :e-donut     + (* pr (:donut a)))
+                  (update :e-alpha     + (* pr (:alpha a)))
+                  (update :e-time-cost + (* pr (:time-cost a))))))
+          {:p-donut-favorite 0.0 :p-veg-favorite 0.0 :p-noodle-favorite 0.0
+           :e-donut 0.0 :e-alpha 0.0 :e-time-cost 0.0}
+          weighted))
+
+(defn prior-summary
+  "Summary statistics under the uniform prior (each tuple equally likely)."
+  [agents]
+  (let [n (count agents)]
+    (summarize (mapv (fn [t] [t (/ 1.0 n)]) (keys agents)) agents)))
+
+;; ===========================================================================
+;; Generate-and-compare (the chapter's motivating example; high-alpha only)
+;; ===========================================================================
+
+(defn generate-and-compare
+  "agentmodels' literal generate-and-compare: at high alpha the agent is near-
+   deterministic, so for each candidate utility table predict the argmax trajectory
+   and keep tables whose predicted [state,action] prefix matches the observation.
+   Returns {[di vi ni] -> prob} (uniform over the matching tables)."
+  [{:keys [donut-vals veg-vals noodle-vals time-cost alpha horizon] :or {time-cost -0.04 alpha 100.0 horizon 16}} observations]
+  (let [obs-len (count observations)
+        matches (for [di (range (count donut-vals)), vi (range (count veg-vals)), ni (range (count noodle-vals))
+                      :let [donut (nth donut-vals di) veg (nth veg-vals vi) noodle (nth noodle-vals ni)
+                            mdp (restaurant-mdp {:donut-n donut :donut-s donut :veg veg :noodle noodle :timeCost time-cost})
+                            ag  (agent/make-mdp-agent {:mdp mdp :alpha alpha :gamma 1.0 :n-iters N-ITERS})
+                            {:keys [states actions]} (agent/simulate-mdp ag start-idx horizon)
+                            pred (mapv vector states actions)]
+                      :when (= (vec observations) (vec (take obs-len pred)))]
+                  [di vi ni])
+        n (count matches)]
+    (into {} (map (fn [t] [t (/ 1.0 n)]) matches))))
+
+;; ===========================================================================
+;; Model specs (agentmodels Ch4)
+;; ===========================================================================
+
+(defn utility-only-spec
+  "Infer the utility table only; timeCost fixed -0.04, alpha fixed 2 (chapter's first
+   single-step example)."
+  []
+  {:donut-vals food-vals :veg-vals food-vals :noodle-vals food-vals
+   :time-cost-vals [-0.04] :alpha-vals [2.0]})
+
+(defn joint-spec
+  "Joint inference of utility + timeCost + alpha (chapter's joint example)."
+  []
+  {:donut-vals food-vals :veg-vals food-vals :noodle-vals food-vals
+   :time-cost-vals time-cost-vals :alpha-vals alpha-vals})
+
+(defn analyze
+  "Build agents for `spec`, condition on `observations`, return {:posterior :prior}."
+  [spec observations]
+  (let [agents (build-agents spec)]
+    {:posterior (summarize (joint-posterior agents observations) agents)
+     :prior     (prior-summary agents)}))

--- a/examples/agentmodels/pomdp_irl.cljs
+++ b/examples/agentmodels/pomdp_irl.cljs
@@ -1,0 +1,208 @@
+(ns agentmodels.pomdp-irl
+  "POMDP Inverse Reinforcement Learning (agentmodels Ch 4, 'Learning about agents in
+   POMDPs') — jointly inferring an agent's UTILITIES and its BELIEFS from observed
+   actions in a partially-observed world, and the preference-vs-belief
+   UNIDENTIFIABILITY that results.
+
+   agentmodels' Equation 2 (the POMDP analog of Equation 1):
+
+       P(U,α,b₀ | (s,o,a)_{0:n}) ∝ P(U,α,b₀) · Π_i P(a_i | s_i, b_i, U, α)
+
+   The belief b_i is THREADED through the observed trajectory (b_i = b_{i-1} | s_i,o_i,
+   a_{i-1}) — agentmodels' `factorSequence`. Here that thread is a host-side recursion
+   (the literal factorSequence), with the per-step action likelihood P(a_i|b_i,U,α)
+   scored by the proven GFI path inverse/action-loglik (`p/assess` on the agent's
+   softmax policy). The two-level prior over (utility, initial belief) is expressed
+   with the Switch combinator (select-belief-branch); the belief thread is also
+   exposed as a Scan in simulate mode. (We deliberately do NOT route the likelihood
+   through p/generate over a tracing combinator — see bug genmlx-7bm6 — and instead
+   score via assess, which is robust.)
+
+   Testbed (the canonical agentmodels example): a 2-armed bandit. arm0 deterministically
+   yields a KNOWN prize (chocolate); arm1 yields champagne (true) or nothing. The agent
+   has prize utilities (likes-champagne or likes-chocolate) and a belief about arm1
+   (informed = knows champagne; misinformed = thinks arm1 is probably nothing). A
+   finite-horizon belief-space VOI planner: with few trials left, exploring arm1 is not
+   worth it, so a misinformed champagne-lover still pulls arm0 — making the observed
+   arm0-pull explainable by EITHER a chocolate preference OR a misinformed belief
+   (unidentifiable). As the horizon grows, exploration becomes valuable, so a
+   misinformed champagne-lover WOULD explore — and persistent arm0-pulls then identify
+   a genuine chocolate preference.
+
+   Reuse: inverse/action-loglik + normalize-logs, helpers/softmax-action, the Switch &
+   Scan combinators. Zero engine change."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.dynamic :as dyn]
+            [genmlx.combinators :as comb]
+            [genmlx.agents.helpers :as h]
+            [genmlx.agents.inverse :as inv])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+;; ===========================================================================
+;; Bandit prizes + the agent's utility hypotheses (agentmodels)
+;; ===========================================================================
+(def likes-champagne {:nothing 0.0 :champagne 5.0 :chocolate 3.0})
+(def likes-chocolate {:nothing 0.0 :champagne 3.0 :chocolate 5.0})
+
+;; arm 0 always yields :chocolate; arm 1 yields :champagne (true world) or :nothing.
+;; belief b = P(arm1 = :champagne). informed → 1.0; misinformed → small p.
+;; A misinformed belief of ~0.3 puts the exploration threshold inside a short horizon
+;; (so the identifiability-vs-horizon effect is visible in N ∈ [4..9]); agentmodels
+;; uses 0.05 with a much longer horizon. (Documented parameter choice.)
+(def MISINFORMED-P 0.3)
+
+;; ===========================================================================
+;; Finite-horizon belief-space VOI value (exact, memoized; tiny reachable belief set)
+;; ===========================================================================
+
+(defn make-bandit-voi-agent
+  "Exact finite-horizon belief-space VOI bandit agent. `utility` is a prize→value map;
+   `belief` = P(arm1 = :champagne); `alpha` = softmax rationality. Returns
+     {:q (fn [arm b n] -> Q) :policy (gen [b n]) :act-loglik (fn [b n arm] -> logp)}.
+   Reachable beliefs are {belief, 0.0, 1.0} (arm0 reveals nothing; arm1 reveals arm1),
+   so the recursion is small. Pulling arm0 yields :chocolate; pulling arm1 yields its
+   true prize and REVEALS arm1 (belief → 0 or 1)."
+  [{:keys [utility belief alpha] :or {alpha 1000.0}}]
+  (let [u      (fn [prize] (double (get utility prize 0.0)))
+        u-choc (u :chocolate)
+        ;; exploit value once arm1 is revealed: pull the better arm for all n trials
+        exploit (fn [arm1-prize n] (* n (max u-choc (u arm1-prize))))
+        q-atom (atom nil)
+        soft-v (fn [b n]
+                 (if (<= n 0) 0.0
+                     (let [qs [(@q-atom 0 b n) (@q-atom 1 b n)]
+                           m  (apply max qs)
+                           es (mapv #(Math/exp (* alpha (- % m))) qs)
+                           z  (reduce + es)]
+                       (reduce + (map * (mapv #(/ % z) es) qs)))))
+        q     (memoize
+                (fn [arm b n]
+                  (case arm
+                    0 (+ u-choc (soft-v b (dec n)))                          ; arm0: known, belief unchanged
+                    1 (+ (+ (* b (u :champagne)) (* (- 1.0 b) (u :nothing))) ; arm1: expected prize now
+                         (* b (exploit :champagne (dec n)))                   ; + exploit after reveal
+                         (* (- 1.0 b) (exploit :nothing (dec n)))))))]
+    (reset! q-atom q)
+    (let [policy (gen [b n] (trace :arm (h/softmax-action alpha
+                                          (mx/array (clj->js [(q 0 b n) (q 1 b n)]) mx/float32))))]
+      {:q q
+       :policy policy
+       :act-loglik (fn [b n arm]
+                     (mx/item (:weight (p/assess (dyn/auto-key policy) [b n] (cm/choicemap :arm arm)))))})))
+
+;; ===========================================================================
+;; factorSequence — thread belief through observed pulls, accumulate action log-lik
+;; ===========================================================================
+
+(defn reveal-belief
+  "Belief update on an observed pull: arm0 reveals nothing about arm1; arm1 reveals it
+   (belief collapses to 1.0 for :champagne, 0.0 otherwise)."
+  [belief arm prize]
+  (if (= arm 0) belief (if (= prize :champagne) 1.0 0.0)))
+
+(def ^:private reveal reveal-belief)
+
+(defn factor-sequence-loglik
+  "agentmodels' factorSequence (Equation 2): thread the agent's belief through the
+   observed sequence and sum the per-step action log-likelihoods. `observed` is a seq
+   of {:arm :prize} pulls; `horizon` is the total number of trials (so the pull at
+   index t is scored at the remaining horizon horizon-t, delay 0). The belief updates
+   on the observed prize (arm1 reveals arm1; arm0 reveals nothing)."
+  [agent initial-belief horizon observed]
+  (loop [obs observed, t 0, b initial-belief, ll 0.0]
+    (if (empty? obs)
+      ll
+      (let [{:keys [arm prize]} (first obs)
+            n   (- horizon t)
+            ll' (+ ll ((:act-loglik agent) b n arm))]
+        (recur (rest obs) (inc t) (reveal b arm prize) ll')))))
+
+;; ===========================================================================
+;; Two-level prior (utility × initial belief) via the Switch combinator
+;; ===========================================================================
+;; The initial belief is selected by a Switch over two branches (informed /
+;; misinformed); the utility is selected alongside. We enumerate the 2×2 joint exactly.
+
+(def utility-hyps [[:champagne likes-champagne] [:chocolate likes-chocolate]])
+(def belief-hyps  [[:informed 1.0] [:misinformed MISINFORMED-P]])
+
+;; Switch realization of the two-level belief prior: each branch returns its initial
+;; belief value (a deterministic GF), the Switch index selects which.
+(def ^:private belief-branch-informed    (dyn/auto-key (gen [] 1.0)))
+(def ^:private belief-branch-misinformed (dyn/auto-key (gen [] MISINFORMED-P)))
+(def belief-prior-switch
+  (comb/switch-combinator belief-branch-informed belief-branch-misinformed))
+
+(defn switch-initial-belief
+  "Select the initial belief through the Switch combinator (idx 0 = informed,
+   1 = misinformed). Demonstrates the two-level prior's belief branch as a GF.
+   The branch retval is a plain double, so no mx/item extraction is needed."
+  [idx]
+  (:retval (p/simulate (dyn/auto-key belief-prior-switch) [idx])))
+
+(defn joint-posterior
+  "Exact P(utility, initial-belief | observed pulls) over the 2×2 joint prior, via the
+   factorSequence likelihood. Returns
+     {:joint {[util-kw belief-kw] -> prob}
+      :p-likes-chocolate p :p-informed p}."
+  [{:keys [observed horizon alpha] :or {alpha 1000.0}}]
+  (let [logw (into {}
+               (for [[uk utility] utility-hyps
+                     [bk b0]      belief-hyps]
+                 (let [agent (make-bandit-voi-agent {:utility utility :belief b0 :alpha alpha})]
+                   [[uk bk] (factor-sequence-loglik agent b0 horizon observed)])))
+        post (inv/normalize-logs logw)]
+    {:joint post
+     :p-likes-chocolate (reduce (fn [s [[uk _] pr]] (+ s (if (= uk :chocolate) pr 0.0))) 0.0 post)
+     :p-informed        (reduce (fn [s [[_ bk] pr]] (+ s (if (= bk :informed) pr 0.0))) 0.0 post)}))
+
+;; ===========================================================================
+;; Observations + analyses
+;; ===========================================================================
+
+(defn all-arm0
+  "The observed sequence: the agent pulls arm0 (the known arm) every trial. arm0
+   always yields :chocolate, so the belief never updates."
+  [n]
+  (vec (repeat n {:arm 0 :prize :chocolate})))
+
+(defn unidentifiability
+  "Observe all-arm0 over a short horizon: the pull is explained by EITHER a chocolate
+   preference OR a misinformed belief about arm1, so neither is identified."
+  [horizon]
+  (joint-posterior {:observed (all-arm0 horizon) :horizon horizon}))
+
+(defn horizon-sweep
+  "P(likes-chocolate | all-arm0) as the horizon grows. With more trials, exploring
+   arm1 becomes valuable, so a misinformed champagne-lover WOULD explore — persistent
+   arm0-pulls then identify a genuine chocolate preference."
+  [horizons]
+  (mapv (fn [N] {:horizon N :p-likes-chocolate (:p-likes-chocolate (unidentifiability N))}) horizons))
+
+;; ===========================================================================
+;; factorSequence's belief thread, realized via the Scan combinator (simulate mode)
+;; ===========================================================================
+;; The kernel carries the belief and updates it on each observed prize; the per-step
+;; OUTPUT is the belief held BEFORE the pull (the belief the action was chosen under) —
+;; exactly the belief factor-sequence-loglik scores against. Run in simulate mode (no
+;; constraints) so it is unaffected by the p/generate-over-combinator bug (genmlx-7bm6).
+
+(def ^:private belief-scan-kernel
+  (dyn/auto-key (gen [belief obs] [(reveal belief (:arm obs) (:prize obs)) belief])))
+(def ^:private belief-scan (comb/scan-combinator belief-scan-kernel))
+
+(defn belief-trajectory-via-scan
+  "The belief held at each pull, threaded through the Scan combinator (carry = belief).
+   Demonstrates factorSequence's belief threading as a GFI combinator."
+  [initial-belief observed]
+  (:outputs (:retval (p/simulate (dyn/auto-key belief-scan) [initial-belief (vec observed)]))))
+
+(defn belief-trajectory-host
+  "Reference host-side belief thread (the same recursion factor-sequence-loglik uses)."
+  [initial-belief observed]
+  (loop [obs observed, b initial-belief, acc []]
+    (if (empty? obs) acc
+        (let [{:keys [arm prize]} (first obs)]
+          (recur (rest obs) (reveal b arm prize) (conj acc b))))))

--- a/examples/agentmodels/psrl.cljs
+++ b/examples/agentmodels/psrl.cljs
@@ -1,0 +1,179 @@
+(ns agentmodels.psrl
+  "Posterior Sampling Reinforcement Learning on a gridworld (agentmodels Ch 3d).
+
+   The agent knows the transition structure but NOT the reward: exactly one (free)
+   cell of a 4×4 gridworld is rewarding, and the agent has a posterior over which.
+   Each EPISODE it runs the canonical Osband PSRL loop:
+
+     1. SAMPLE a reward model (a goal cell) from the posterior  (Thompson sampling)
+     2. SOLVE that model optimally by value iteration → a policy
+     3. ACT — run one episode following that policy, observing each visited cell's
+        true reward
+     4. UPDATE the posterior on the observations (exact Bayes)
+
+   When the posterior is uncertain, sampling yields diverse goals → the agent visits
+   diverse cells → it learns (explores); as the posterior concentrates, it exploits.
+   Cumulative regret (V*_true(start) − achieved return per episode) decreases as the
+   posterior concentrates on the true goal. (agentmodels plots regret only for its
+   bandit example and merely visualizes gridworld-PSRL trajectories — the regret curve
+   here is the faithful Osband-theory extension the bean asks for.)
+
+   Reward model: per-cell reward applied each step over a finite horizon, with a 5th
+   'stay' action so the agent can dwell on the goal — the clean realization of
+   agentmodels' finite-horizon utility(state)=rewardGrid[loc]. The planner reuses
+   agent/value-iteration (value-iteration ≡ agentmodels' recursive expectedUtility).
+   The shipped multi-armed bandit (genmlx.agents.pomdp/make-bandit-agent, bandit_test
+   18/18) already covers the chapter's Thompson/softmax-greedy bandit + bandit regret.
+
+   Reuse: gw/parse-grid + gw/next-state (geometry), agent/value-iteration +
+   make-mdp-agent + simulate-mdp (planning/rollout). Zero engine change."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.agent :as agent]))
+
+;; 5 actions: left right up down STAY (the stay action lets the agent dwell on the
+;; rewarding cell to collect its per-step reward over the finite horizon).
+(def action-deltas [[-1 0] [1 0] [0 -1] [0 1] [0 0]])
+
+;; agentmodels 4×4 Restaurant-free RL grid (top-first; '#' walls). Start [0,0]
+;; (idx 0); the true reward sits in the bottom-right free cell (idx 15).
+(def grid
+  [[:empty :empty :wall  :empty]
+   [:empty :empty :empty :empty]
+   [:wall  :empty :wall  :wall]
+   [:empty :empty :empty :empty]])
+
+(def W 4)
+(def START-IDX 0)
+(def TRUE-GOAL 15)         ; bottom-right [x=3,y=3]
+(def HORIZON 9)
+
+(defn free-cells
+  "Reachable (non-wall) cell indices of `grid`."
+  [grid]
+  (let [{:keys [S walls]} (gw/parse-grid grid)]
+    (vec (remove walls (range S)))))
+
+;; ===========================================================================
+;; Per-cell-reward MDP (non-terminal, finite-horizon, 5-action, deterministic)
+;; ===========================================================================
+
+(defn reward-grid-mdp
+  "MDP over `grid` whose reward is `reward` ([S] of per-cell rewards, applied each
+   step — NOT terminal). Deterministic 5-action geometry (incl. stay). Finite-horizon
+   value iteration accumulates reward over the horizon."
+  [grid reward]
+  (let [{:keys [W H S walls]} (gw/parse-grid grid)
+        A       (count action-deltas)
+        ns-fn   (fn [s a]
+                  (let [x (mod s W) y (quot s W)
+                        [dx dy] (nth action-deltas a)
+                        nx (max 0 (min (dec W) (+ x dx)))
+                        ny (max 0 (min (dec H) (+ y dy)))
+                        n  (+ nx (* W ny))]
+                    (if (contains? walls n) s n)))
+        ns-rows (vec (for [s (range S)] (vec (for [a (range A)] (ns-fn s a)))))
+        T       (mx/array (clj->js (vec (for [s (range S)]
+                                          (vec (for [a (range A)]
+                                                 (let [s' (get-in ns-rows [s a])]
+                                                   (mapv #(if (= % s') 1.0 0.0) (range S))))))))
+                          mx/float32)
+        R       (mx/array (clj->js (vec (for [s (range S)] (vec (repeat A (double (nth reward s))))))) mx/float32)
+        term    (mx/array (clj->js (vec (repeat S 0.0))) mx/float32)]
+    (mx/eval! T R term)
+    {:W W :H H :S S :A A :T T :R R :term term :terminals {} :walls walls
+     :start-idx START-IDX :ns-fn ns-fn :action-kw [:left :right :up :down :stay] :gamma 1.0 :noise 0.0}))
+
+(defn- one-hot [S i] (vec (for [s (range S)] (if (= s i) 1.0 0.0))))
+
+(defn optimal-return
+  "V*(start) over `horizon` steps under the true reward (the best achievable return)."
+  [grid reward start horizon]
+  (let [mdp (reward-grid-mdp grid reward)
+        {:keys [V]} (agent/value-iteration (assoc mdp :gamma 1.0) ##Inf horizon)]
+    (mx/item (mx/idx V start))))
+
+;; ===========================================================================
+;; Reward posterior (categorical over which free cell is the goal) + exact update
+;; ===========================================================================
+
+(defn uniform-posterior
+  "Uniform one-hot prior over the free cells (exactly one is the goal)."
+  [free]
+  (let [p (/ 1.0 (count free))] (into {} (map (fn [c] [c p]) free))))
+
+(defn update-posterior
+  "Exact Bayes update on observing reward `r` at cell `c`: hypotheses inconsistent
+   with the observation are dropped (h=c requires r=1; h≠c requires r=0) and the rest
+   renormalized. Observing the reward (r=1 at c) collapses the posterior to c."
+  [post c r]
+  (let [keep (into {} (filter (fn [[h p]] (= (if (= h c) 1.0 0.0) (double r))) post))
+        z    (reduce + (vals keep))]
+    (if (pos? z) (into {} (map (fn [[h p]] [h (/ p z)]) keep)) post)))
+
+;; deterministic LCG, so Thompson sampling is reproducible in tests
+(defn- lcg [s] (mod (+ (* s 1103515245) 12345) 2147483648))
+(defn- unit [s] (/ (lcg (lcg s)) 2147483648.0))
+
+(defn sample-goal
+  "Thompson sample: draw a goal cell from the posterior with seed `s`."
+  [post s]
+  (let [cells (vec (keys post)), u (unit s)]
+    (loop [i 0, acc 0.0]
+      (let [acc' (+ acc (post (nth cells i)))]
+        (if (or (>= i (dec (count cells))) (< u acc')) (nth cells i) (recur (inc i) acc'))))))
+
+;; ===========================================================================
+;; The PSRL episode loop
+;; ===========================================================================
+
+(defn- argmax-first
+  "Index of the first maximal entry (deterministic; no random tie-break)."
+  [xs]
+  (reduce (fn [best i] (if (> (nth xs i) (nth xs best)) i best)) 0 (range 1 (count xs))))
+
+(defn- run-episode
+  "Plan optimally on `sampled-goal` (value iteration), roll out one episode in the
+   TRUE world with a DETERMINISTIC greedy policy (argmax over Q, first-index tie-break,
+   noise-0 transitions), and return {:states :return} — the visited states and realized
+   true return. Deterministic so a seed fully reproduces the PSRL run (the only
+   randomness is the Thompson model-sample)."
+  [grid true-reward sampled-goal horizon S]
+  (let [mdp   (reward-grid-mdp grid (one-hot S sampled-goal))
+        {:keys [Q]} (agent/value-iteration (assoc mdp :gamma 1.0) ##Inf horizon)
+        Qh    (mx/->clj Q)
+        ns-fn (:ns-fn mdp)
+        states (loop [s START-IDX, step 0, acc [START-IDX]]
+                 (if (>= step horizon)
+                   acc
+                   (let [a  (argmax-first (nth Qh s))
+                         s' (ns-fn s a)]
+                     (recur s' (inc step) (conj acc s')))))
+        ret    (reduce + (map #(nth true-reward %) (take horizon states)))]
+    {:states states :return ret}))
+
+(defn psrl
+  "Run PSRL for `n-episodes`. Returns per-episode {:sampled :posterior :return :regret}
+   plus :cum-regret and :final-posterior. `learn?` false = no-learning baseline (keep
+   sampling from the fixed prior, never update) — for comparison."
+  [{:keys [grid true-goal horizon n-episodes seed learn?]
+    :or {grid grid true-goal TRUE-GOAL horizon HORIZON n-episodes 10 seed 1 learn? true}}]
+  (let [{:keys [S]} (gw/parse-grid grid)
+        free        (free-cells grid)
+        true-reward (one-hot S true-goal)
+        v-star      (optimal-return grid true-reward START-IDX horizon)]
+    (loop [ep 0, post (uniform-posterior free), eps []]
+      (if (>= ep n-episodes)
+        (let [regrets (map :regret eps)]
+          {:episodes eps
+           :cum-regret (vec (reductions + regrets))
+           :final-posterior post
+           :v-star v-star})
+        (let [g   (sample-goal post (+ (* seed 1000) ep))
+              {:keys [states return]} (run-episode grid true-reward g horizon S)
+              post' (if learn?
+                      (reduce (fn [b s] (update-posterior b s (nth true-reward s))) post states)
+                      post)]
+          (recur (inc ep) post'
+                 (conj eps {:sampled g :return return :regret (- v-star return)
+                            :posterior post' :reached-goal? (boolean (some #(= true-goal %) states))})))))))

--- a/examples/agentmodels/restaurant_joint_inference.cljs
+++ b/examples/agentmodels/restaurant_joint_inference.cljs
@@ -1,0 +1,285 @@
+(ns agentmodels.restaurant-joint-inference
+  "Restaurant-Choice JOINT inference of biases AND preferences (agentmodels Ch 5e).
+
+   From a single observed Gridworld trajectory we jointly infer the agent's
+   [immediate,delayed] utility TABLE, whether it is naive or sophisticated, its
+   hyperbolic discount, and its softmax alpha — by exact host-side enumeration over
+   finite priors, exactly the 5d (`joint_5d_inference.cljs`) pattern lifted to the
+   full restaurant geometry (`bp/restaurant-temptation-mdp`, Phase 1).
+
+   The headline (agentmodels 5e): conditioning on the Naive path (short route, ends
+   at Donut-North) the posterior P(donutTempting) rises from a prior < 0.1 to ~0.9,
+   E[vegMinusDonut] turns positive (the agent net-prefers Veg yet was tempted), and
+   repeating the observation makes the discounting explanation beat the high-noise one.
+
+   Three nested models (agentmodels 5e):
+     :discounting  discount=1 fixed, alpha=1000 fixed, infer naive/soph + the full
+                   4^4 utility table over {-10,0,10,20}.            (the headline)
+     :optimal      discount=0 (no time-inconsistency), infer utilities (delayed=0)
+                   + alpha over {.1,10,100,1000}. Explains the path only via noise.
+     :full         infer discount∈{0,1}, naive/soph, alpha∈{.1,10,1000}, utilities
+                   (delayed fixed donut=-10/veg=20 to bound the grid).
+
+   The likelihood of an observed action is the softmax policy probability of the
+   forward biased planner, scored with `p/assess` — no bespoke likelihood. agentmodels
+   observes `act(state, 0)`, so every action is scored at delay 0 and the full
+   planning horizon (the agent re-plans from delay 0 each real step).
+
+   `donutTempting` / `vegMinusDonut` are the verbatim webppl-agents library predicates
+   (getRestaurantHyperbolicInfer): PARAMETER conditions on the sampled table+discount,
+   not behavioral — see `donut-tempting?`.
+
+   Reuse, zero engine change: bp/restaurant-temptation-mdp (Phase-1 geometry),
+   bp/make-biased-mdp-agent (forward model), inv/normalize-logs (stable softmax),
+   h/uniform-draw (finite priors), bi/action-cm (action choicemap)."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.dynamic :as dyn]
+            [genmlx.agents.biased-planners :as bp]
+            [genmlx.agents.helpers :as h]
+            [genmlx.agents.inverse :as inv]
+            [agentmodels.biased-inverse :as bi])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(def H 18)            ; planning + scoring horizon (≈ agentmodels plan-until-terminal)
+
+;; ===========================================================================
+;; Geometry reuse: the temptation MDP's T/terminals/twins are identical across
+;; utility tables — only R (the restaurant [imm,del] values) changes. Build the
+;; base ONCE, then swap R per candidate table (avoids 512× grid-parse + T build).
+;; ===========================================================================
+
+(def base-mdp (bp/restaurant-temptation-mdp {}))
+
+(defn- mdp-with-utilities
+  "Return the base temptation MDP with R recomputed for `utilities`
+   {:donut-n [imm del] :donut-s [imm del] :veg [imm del] :noodle [imm del]
+    :timeCost t}. Reuses the base :T/:terminals/:twin/:restaurants (same geometry)."
+  [{:keys [S A terminals restaurants] :as base} utilities]
+  (let [time-cost (double (get utilities :timeCost 0.0))
+        comp-of   (fn [kw i] (let [u (get utilities kw)]
+                               (double (if (sequential? u) (nth u i) u))))
+        reward-of (fn [s]
+                    (cond
+                      (contains? terminals s)   (comp-of (terminals s) 1)    ; L@1: delayed
+                      (contains? restaurants s) (comp-of (restaurants s) 0)  ; L@0: immediate
+                      :else                     time-cost))
+        R (mx/array (clj->js (vec (for [s (range S)] (vec (repeat A (reward-of s)))))) mx/float32)]
+    (mx/eval! R)
+    (assoc base :R R)))
+
+;; ===========================================================================
+;; The webppl-agents library summary statistics (verbatim parameter predicates)
+;; ===========================================================================
+
+(defn veg-minus-donut
+  "sum(Veg) − sum(DonutN): the net-utility advantage of Veg over Donut."
+  [{:keys [donut veg]}]
+  (- (+ (veg 0) (veg 1)) (+ (donut 0) (donut 1))))
+
+(defn donut-tempting?
+  "agentmodels' getRestaurantHyperbolicInfer predicate (verbatim):
+     dis(d)      = 1/(1 + discount·d)
+     disU(u,d)   = dis(d)·u[0] + dis(d+1)·u[1]
+     donutTempting = (disUDonut(4) < disUVeg(6)) ∧ (disUDonut(0) > disUVeg(2))
+   True iff the discounted utilities encode a preference reversal: Veg preferred at
+   distance (start) but Donut-North preferred when adjacent. discount=0 ⇒ never true."
+  [{:keys [donut veg discount]}]
+  (let [dis  (fn [d] (/ 1.0 (+ 1.0 (* (double discount) d))))
+        disU (fn [u d] (+ (* (dis d) (u 0)) (* (dis (inc d)) (u 1))))]
+    (and (< (disU donut 4) (disU veg 6))
+         (> (disU donut 0) (disU veg 2)))))
+
+;; ===========================================================================
+;; Forward agents over the joint finite prior  (7 latent dims; fixed dims = 1 value)
+;; ===========================================================================
+;; spec keys: :donut-imm-vals :donut-del-vals :veg-imm-vals :veg-del-vals
+;;            :discount-vals :bias-vals :alpha-vals :noodle :time-cost :n-iters
+;; latent index tuple = [di dd vi vd dc bi ai]
+
+(defn- tuples-of [spec]
+  (let [{:keys [donut-imm-vals donut-del-vals veg-imm-vals veg-del-vals
+                discount-vals bias-vals alpha-vals]} spec]
+    (for [di (range (count donut-imm-vals)), dd (range (count donut-del-vals))
+          vi (range (count veg-imm-vals)),   vd (range (count veg-del-vals))
+          dc (range (count discount-vals)),  bi (range (count bias-vals))
+          ai (range (count alpha-vals))]
+      [di dd vi vd dc bi ai])))
+
+(defn build-agents
+  "Map {[di dd vi vd dc bi ai] -> {:agent :donut :veg :discount :bias :alpha}} over
+   the full joint prior grid. One temptation agent per parameter tuple (geometry
+   reused; only R varies). Donut-S shares Donut-N's table (agentmodels)."
+  [{:keys [donut-imm-vals donut-del-vals veg-imm-vals veg-del-vals
+           discount-vals bias-vals alpha-vals noodle time-cost n-iters]
+    :or {noodle [-10 -10] time-cost -0.01 n-iters H} :as spec}]
+  (into {}
+        (for [[di dd vi vd dc bi ai :as tup] (tuples-of spec)]
+          (let [donut [(nth donut-imm-vals di) (nth donut-del-vals dd)]
+                veg   [(nth veg-imm-vals vi)   (nth veg-del-vals vd)]
+                k     (nth discount-vals dc)
+                bias  (nth bias-vals bi)
+                alpha (nth alpha-vals ai)
+                mdp   (mdp-with-utilities base-mdp
+                        {:donut-n donut :donut-s donut :veg veg :noodle noodle :timeCost time-cost})]
+            [tup {:agent    (bp/make-biased-mdp-agent
+                              {:mdp mdp :alpha alpha :gamma 1.0 :n-iters n-iters}
+                              {:discount k :bias bias})
+                  :donut donut :veg veg :discount k :bias bias :alpha alpha}]))))
+
+(defn- eu-row
+  "EU vector over the 4 grid actions at state s, planning horizon t, delay 0."
+  [agent s t]
+  (mapv #((:eu agent) s % t 0) (range 4)))
+
+;; ===========================================================================
+;; The joint generative function (extends the 5d multi-latent model)
+;; ===========================================================================
+
+(defn joint-restaurant-model
+  "Joint GF tracing the 7 latent indices; the sampled tuple selects a precomputed
+   agent; one softmax-action site :a0 :a1 ... per observed state, scored at horizon
+   H, delay 0 (agentmodels' observe(act(state,0), action)). EU-rows for every agent
+   are precomputed before `gen` (the body is re-run per enumerated tuple, so it only
+   indexes)."
+  [{:keys [donut-imm-vals donut-del-vals veg-imm-vals veg-del-vals
+           discount-vals bias-vals alpha-vals n-iters] :or {n-iters H} :as spec}
+   states agents]
+  (let [boxes [(h/uniform-draw donut-imm-vals) (h/uniform-draw donut-del-vals)
+               (h/uniform-draw veg-imm-vals)   (h/uniform-draw veg-del-vals)
+               (h/uniform-draw discount-vals)  (h/uniform-draw bias-vals)
+               (h/uniform-draw alpha-vals)]
+        rows  (into {} (for [[tup {:keys [agent]}] agents]
+                         [tup (mapv (fn [s] (mx/array (clj->js (eu-row agent s n-iters)) mx/float32))
+                                    states)]))]
+    (gen []
+      (let [di (trace :di (:dist (nth boxes 0)))
+            dd (trace :dd (:dist (nth boxes 1)))
+            vi (trace :vi (:dist (nth boxes 2)))
+            vd (trace :vd (:dist (nth boxes 3)))
+            dc (trace :dc (:dist (nth boxes 4)))
+            bi (trace :bi (:dist (nth boxes 5)))
+            ai (trace :ai (:dist (nth boxes 6)))
+            tup [di dd vi vd dc bi ai]
+            er    (rows tup)
+            alpha (:alpha (agents tup))]
+        (doseq [i (range (count states))]
+          (trace (keyword (str "a" i)) (h/softmax-action alpha (nth er i))))
+        tup))))
+
+(defn- full-cm
+  "Choicemap {:di .. :dd .. :vi .. :vd .. :dc .. :bi .. :ai .. :a0 .. :a1 ..}."
+  [[di dd vi vd dc bi ai] actions]
+  (-> (bi/action-cm actions)
+      (cm/set-choice [:di] di) (cm/set-choice [:dd] dd)
+      (cm/set-choice [:vi] vi) (cm/set-choice [:vd] vd)
+      (cm/set-choice [:dc] dc) (cm/set-choice [:bi] bi)
+      (cm/set-choice [:ai] ai)))
+
+;; ===========================================================================
+;; Exact enumeration + summary statistics
+;; ===========================================================================
+
+(defn- summarize
+  "Reduce a seq of [tuple prob] into the chapter's summary statistics, using the
+   agents map for each tuple's (donut, veg, discount, bias)."
+  [weighted agents]
+  (reduce (fn [acc [tup pr]]
+            (let [a (agents tup)]
+              (-> acc
+                  (update :p-donut-tempting + (* pr (if (donut-tempting? a) 1.0 0.0)))
+                  (update :e-veg-minus-donut + (* pr (veg-minus-donut a)))
+                  (update :p-naive           + (* pr (if (= :naive (:bias a)) 1.0 0.0)))
+                  (update :p-discounting     + (* pr (if (pos? (:discount a)) 1.0 0.0)))
+                  (update :alpha-marginal    (fn [m] (update m (:alpha a) (fnil + 0.0) pr))))))
+          {:p-donut-tempting 0.0 :e-veg-minus-donut 0.0 :p-naive 0.0
+           :p-discounting 0.0 :alpha-marginal {}}
+          weighted))
+
+(defn joint-posterior
+  "Exact P(params | trajectory). Enumerate the joint finite prior; for each tuple
+   assess the joint GF on the full choicemap (latent indices + observed actions);
+   normalize. `:number-repeats` r conditions on the SAME action sequence r+1 times
+   (agentmodels numberRepeats — strengthens the evidence). Returns
+   {:joint {tuple prob} :posterior <summary> :prior <summary> :n-tuples n}."
+  [{:keys [states actions number-repeats] :or {number-repeats 0} :as spec} agents]
+  (assert (= (count states) (count actions))
+          (str "5e joint: states/actions length mismatch " (count states) " vs " (count actions)))
+  (let [model   (joint-restaurant-model spec states agents)
+        ;; numberRepeats: condition on the same observed path (r+1) times. The assess
+        ;; weight w = log-prior + log-likelihood; since EVERY latent prior here is a
+        ;; uniform-draw, log-prior is the SAME constant for all tuples, so the correct
+        ;; reps-posterior weight (log-prior + reps·log-likelihood) equals reps·w up to
+        ;; a tuple-independent constant that cancels in normalize-logs.
+        reps    (inc number-repeats)
+        tuples  (keys agents)
+        logw    (into {}
+                      (for [tup tuples]
+                        [tup (* reps (mx/item (:weight (p/assess (dyn/auto-key model) []
+                                                                 (full-cm tup actions)))))]))
+        post    (inv/normalize-logs logw)
+        uniform (let [n (count tuples)] (mapv (fn [t] [t (/ 1.0 n)]) tuples))]
+    {:joint     post
+     :posterior (summarize post agents)
+     :prior     (summarize uniform agents)
+     :n-tuples  (count tuples)}))
+
+;; ===========================================================================
+;; The observed Naive trajectory (the agent's own short-route-to-Donut-North path)
+;; ===========================================================================
+
+(defn observed-trajectory
+  "Roll a ground-truth forward agent out from the start and return
+   {:states <non-terminal states> :actions <actions>} for scoring (one (s,a) pair
+   per transition; the terminal twin is dropped since no action is taken there)."
+  [bias k]
+  (let [ag (bp/make-biased-mdp-agent {:mdp base-mdp :alpha ##Inf :gamma 1.0 :n-iters H}
+                                     {:discount k :bias bias})
+        {:keys [states actions]} (bp/simulate-biased-mdp ag (:start-idx base-mdp) H)]
+    {:states (vec (butlast states)) :actions (vec actions)}))
+
+(def naive-trajectory         (delay (observed-trajectory :naive 1.0)))
+(def sophisticated-trajectory (delay (observed-trajectory :sophisticated 1.0)))
+(def veg-direct-trajectory    (delay (observed-trajectory :naive 0.0)))  ; rational → straight Veg
+
+;; ===========================================================================
+;; The three model priors (agentmodels 5e)
+;; ===========================================================================
+
+(defn discounting-spec
+  "Assume discounting (k=1), alpha=1000; infer naive/soph + the full 4^4 utility
+   table over {-10,0,10,20}. (The headline P(donutTempting) model.)"
+  []
+  (let [u [-10 0 10 20]]
+    {:donut-imm-vals u :donut-del-vals u :veg-imm-vals u :veg-del-vals u
+     :discount-vals [1.0] :bias-vals [:naive :sophisticated] :alpha-vals [1000.0]
+     :noodle [-10 -10] :time-cost -0.01 :n-iters H}))
+
+(defn optimal-spec
+  "Assume non-discounting (k=0, sophisticated inert); infer utilities (delayed
+   omitted = 0) over {-10,0,10,20,30,40} + alpha ∈ {.1,10,100,1000}. The only way to
+   explain an anomalous path is softmax noise (low alpha)."
+  []
+  (let [u [-10 0 10 20 30 40]]
+    {:donut-imm-vals u :donut-del-vals [0] :veg-imm-vals u :veg-del-vals [0]
+     :discount-vals [0.0] :bias-vals [:sophisticated] :alpha-vals [0.1 10.0 100.0 1000.0]
+     :noodle [-10 -10] :time-cost -0.01 :n-iters H}))
+
+(defn full-spec
+  "Full joint: discount ∈ {0,1}, naive/soph, alpha ∈ {.1,10,1000}, utilities over
+   {-10,0,10,20,30} with delayed fixed (donut=-10, veg=20) to bound the grid."
+  []
+  (let [u [-10 0 10 20 30]]
+    {:donut-imm-vals u :donut-del-vals [-10] :veg-imm-vals u :veg-del-vals [20]
+     :discount-vals [0.0 1.0] :bias-vals [:naive :sophisticated] :alpha-vals [0.1 10.0 1000.0]
+     :noodle [-10 -10] :time-cost -0.01 :n-iters H}))
+
+(defn analyze
+  "Build agents for `spec`, condition on (states, actions[, number-repeats]), and
+   return the joint posterior + prior/posterior summary statistics."
+  [spec {:keys [states actions number-repeats] :or {number-repeats 0}}]
+  (let [agents (build-agents spec)]
+    (joint-posterior (assoc spec :states states :actions actions
+                            :number-repeats number-repeats)
+                     agents)))

--- a/src/genmlx/agents/biased_planners.cljs
+++ b/src/genmlx/agents/biased_planners.cljs
@@ -325,6 +325,118 @@
     (get (:terminals mdp) (last states))))
 
 ;; ===========================================================================
+;; Section 5b — World B′: the FULL [immediate,delayed] Restaurant geometry (5b/5e)
+;; ===========================================================================
+;;
+;; The scalar `restaurant-mdp` above is enough to show plan↔do divergence at α=∞,
+;; but it CANNOT produce graded temptation at finite α: with a single scalar reward
+;; per terminal there is no immediate-vs-delayed asymmetry, so naive/sophisticated
+;; only differ as an argmax tie-break (which washes out for any finite α). The
+;; faithful agentmodels Restaurant-Choice (chapters 5b/5e) instead gives each
+;; restaurant a PAIRED [immediate, delayed] utility and makes the agent occupy the
+;; restaurant for TWO timesteps (maxTimeAtRestaurant = 2): the immediate component
+;; is collected on arrival and the delayed component one step later — so the delayed
+;; part is discounted by δ(d+1) relative to δ(d). Donut = [10,-10] is a temptation
+;; (great now, net 0); Veg = [-10,20] is net +10 but bad now.
+;;
+;; We realise the 2-step stay on the existing flat tensor recursion by STATE
+;; AUGMENTATION: each restaurant cell L expands to two states — L@0 (arrival, the
+;; grid index L itself, reward = immediate) and L@1 (a fresh twin state, reward =
+;; delayed, terminal). Entering L from a neighbour lands on L@0; ANY action at L@0
+;; advances to L@1; L@1 is terminal. Then with the unchanged `build-biased-eu`
+;; recursion and γ = 1,
+;;
+;;     EU(L@0, a, d) = δ(d)·imm + δ(d+1)·del
+;;
+;; which is EXACTLY agentmodels' library `disU(d) = dis(d)·u[0] + dis(d+1)·u[1]`.
+;; No engine/recursion change — only the geometry the scalar builder lacks.
+;;
+;; Grid (6 wide × 8 tall, agentmodels 5b/5e verbatim, top row first — GenMLX's
+;; top-first y-down convention is geometrically identical to agentmodels' y-up after
+;; its library row-reverse). Short route: straight up column 3 from the start, which
+;; passes adjacent to Donut-North (left of [3,5]≡idx 15). Long route: branch right at
+;; row 4 (idx 27) and climb column 5, reaching Veg from the right without ever being
+;; adjacent to a donut. Donut-South (net-equal decoy) sits bottom-left; Noodle ([0,0])
+;; on the long-route column. start = [3 6] (= agentmodels start [3,1] in y-up).
+
+(def restaurant-temptation-grid
+  "agentmodels 5b/5e Restaurant-Choice grid (6 wide × 8 tall, top-first), verbatim.
+   Veg top (idx 4); Donut-North pocket (idx 14) adjacent to the short route up
+   column 3; Noodle (idx 35) and Donut-South (idx 42) are decoys."
+  [[:wall    :wall  :wall     :wall  :veg   :wall]
+   [:wall    :wall  :wall     :empty :empty :empty]
+   [:wall    :wall  :donut-n  :empty :wall  :empty]
+   [:wall    :wall  :wall     :empty :wall  :empty]
+   [:wall    :wall  :wall     :empty :empty :empty]
+   [:wall    :wall  :wall     :empty :wall  :noodle]
+   [:empty   :empty :empty    :empty :wall  :wall]
+   [:donut-s :wall  :wall     :empty :wall  :wall]])
+
+(defn restaurant-temptation-mdp
+  "Build the FULL [immediate,delayed] Restaurant-Choice MDP (agentmodels 5b/5e) as
+   a state-augmented flat [S,A,S'] tensor MDP feeding `make-biased-mdp-agent`
+   directly. Each restaurant cell L → two states: L@0 (= grid index L, reward =
+   immediate component) and L@1 (twin state S_grid+i, reward = delayed component,
+   terminal). Any action at L@0 advances to L@1; L@1 is absorbing & terminal. So the
+   unchanged biased-EU recursion yields EU(L@0,a,d)=δ(d)·imm+δ(d+1)·del — agentmodels'
+   2-step `disU(d)`. Non-restaurant cells pay :timeCost (restaurants pay only the
+   table value, matching agentmodels' restaurantUtility).
+
+   Options (agentmodels defaults):
+     :utilities {:donut-n [10 -10] :donut-s [10 -10] :veg [-10 20] :noodle [0 0]
+                 :timeCost -0.01}     ; restaurant values are [immediate delayed] pairs
+     :start [3 6]                     ; = agentmodels [3,1] (y-up) in top-first coords
+     :gamma 1.0
+   Returns an MDP map with the usual keys plus:
+     :grid-S    number of grid states (the augmented twins are S_grid..S-1)
+     :twin      {grid-idx -> L@1 state}     :restaurants {grid-idx -> kw}
+   Note :terminals maps ONLY the L@1 twin states to their restaurant keyword, so the
+   recursion continues through L@0 and `restaurant-endpoint` reports the right cell."
+  [{:keys [utilities start gamma]
+    :or   {utilities {:donut-n [10 -10] :donut-s [10 -10] :veg [-10 20]
+                      :noodle [0 0] :timeCost -0.01}
+           start [3 6] gamma 1.0}}]
+  (let [{:keys [W H walls terminals]} (gw/parse-grid restaurant-temptation-grid)
+        S-grid    (* W H)
+        rest-idxs (vec (sort (keys terminals)))               ; restaurant grid cells = L@0
+        n-rest    (count rest-idxs)
+        twin      (zipmap rest-idxs (range S-grid (+ S-grid n-rest)))   ; L -> L@1 idx
+        twin-kw   (into {} (for [L rest-idxs] [(twin L) (terminals L)])); L@1 idx -> kw
+        rest-set  (set rest-idxs)
+        S         (+ S-grid n-rest)
+        A         (count gw/action-deltas)
+        time-cost (double (get utilities :timeCost 0.0))
+        comp-of   (fn [kw i] (let [u (get utilities kw)]
+                               (double (if (sequential? u) (nth u i) u))))
+        ;; next-state on the augmented space (deterministic):
+        ;;  L@1 twin  -> absorbing;  L@0 (= L) -> L@1 for every action;
+        ;;  ordinary  -> grid geometry (entering L lands on L@0 = idx L)
+        ns-fn     (fn [s a]
+                    (cond
+                      (>= s S-grid) s
+                      (rest-set s)  (twin s)
+                      :else         (gw/next-state W H walls s a)))
+        ns-rows   (vec (for [s (range S)] (vec (for [a (range A)] (ns-fn s a)))))
+        T         (gw/transition-tensor S A ns-rows 0.0)
+        reward-of (fn [s]
+                    (cond
+                      (contains? twin-kw s) (comp-of (twin-kw s) 1)   ; L@1: delayed
+                      (rest-set s)          (comp-of (terminals s) 0) ; L@0: immediate
+                      :else                 time-cost))               ; ordinary: timeCost
+        R         (mx/array (clj->js (vec (for [s (range S)] (vec (repeat A (reward-of s))))))
+                            mx/float32)
+        term      (mx/array (clj->js (vec (for [s (range S)] (if (contains? twin-kw s) 1.0 0.0))))
+                            mx/float32)
+        [sx sy]   start
+        start-idx (+ sx (* W sy))]
+    (mx/eval! T R term)
+    {:W W :H H :S S :A A :grid-S S-grid
+     :T T :R R :term term
+     :terminals twin-kw :walls walls :start-idx start-idx
+     :twin twin :restaurants (into {} (for [L rest-idxs] [L (terminals L)]))
+     :ns-fn ns-fn :action-kw gw/action-kw :gamma gamma :noise 0.0}))
+
+;; ===========================================================================
 ;; Section 6 — World C: a reward-myopia line MDP (agentmodels 5c)
 ;; ===========================================================================
 ;;

--- a/test/genmlx/agentmodels_5e_joint_test.cljs
+++ b/test/genmlx/agentmodels_5e_joint_test.cljs
@@ -1,0 +1,204 @@
+;; Headless tests for agentmodels Ch 5e — full [immediate,delayed] Restaurant
+;; geometry + joint inference of biases and preferences (genmlx-69s8).
+;; Run: bunx nbb@1.4.206 test/genmlx/agentmodels_5e_joint_test.cljs
+
+(ns genmlx.agentmodels-5e-joint-test
+  (:require [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.biased-planners :as bp]
+            [genmlx.mlx :as mx]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-equal [msg expected actual]
+  (if (= expected actual) (do (vswap! passed inc) (println " PASS" msg "  =" (pr-str actual)))
+      (do (vswap! failed inc) (println " FAIL" msg "  expected:" (pr-str expected) "  got:" (pr-str actual)))))
+(defn assert-close [msg expected actual tol]
+  (if (<= (Math/abs (- expected actual)) tol) (do (vswap! passed inc) (println " PASS" msg "  =" actual))
+      (do (vswap! failed inc) (println " FAIL" msg "  expected:" expected "  got:" actual))))
+
+(defn- argmax-idx [xs] (first (apply max-key second (map-indexed vector xs))))
+
+;; agentmodels disU reference (the donutTempting/value math): with γ=1 and the
+;; 2-step stay, EU(L@0,a,d) must equal dis(d)·imm + dis(d+1)·del.
+(defn dis [k d] (/ 1.0 (+ 1.0 (* (double k) (double d)))))
+(defn disU [k [imm del] d] (+ (* (dis k d) imm) (* (dis k (inc d)) del)))
+
+;; ===========================================================================
+(println "\n== Phase 1.1: the [imm,del] Restaurant geometry (state augmentation) ==")
+(def tmdp (bp/restaurant-temptation-mdp {}))
+;; agentmodels plans until terminal (no fixed t-cap); we approximate that with a
+;; horizon comfortably longer than the longest route (the soph long route is ~10
+;; transitions), so the t≤1 base case never binds before a restaurant is reached.
+(def H 18)
+(def t-start (:start-idx tmdp))
+(assert-equal "grid is 6×8 (48 grid states)"            48 (:grid-S tmdp))
+(assert-equal "augmented S = 48 grid + 4 restaurant twins" 52 (:S tmdp))
+(assert-equal "start cell = [3,6] → idx 39"             39 t-start)
+(assert-equal "four restaurants"                        #{:veg :donut-n :donut-s :noodle}
+              (set (vals (:restaurants tmdp))))
+(assert-equal "ONLY the 4 L@1 twins are terminal"       4 (count (:terminals tmdp)))
+(assert-true  "Donut-N grid cell is idx 14"             (= :donut-n (get (:restaurants tmdp) 14)))
+(assert-true  "Veg grid cell is idx 4"                  (= :veg (get (:restaurants tmdp) 4)))
+(assert-true  "T rows each sum to 1 (S*A = 208)"
+              (< (Math/abs (- 208.0 (mx/item (mx/sum (:T tmdp))))) 1e-3))
+
+;; ===========================================================================
+(println "\n== Phase 1.2: 2-step stay delivers δ(d)·imm + δ(d+1)·del (= disU) ==")
+;; Build a naive k=1 agent and read its memoized EU at the Donut-N arrival state.
+(defn t-agent [alpha bias k]
+  (bp/make-biased-mdp-agent {:mdp tmdp :alpha alpha :gamma 1.0 :n-iters H}
+                            {:discount k :bias bias}))
+(let [naive (t-agent ##Inf :naive 1.0)
+      eu    (:eu naive)
+      dn    14                         ; Donut-N arrival (L@0)
+      vg    4]                         ; Veg arrival (L@0)
+  ;; EU(L@0,a,d) at the arrival state IS the agentmodels 2-step discounted value.
+  (assert-close "EU(DonutN@0, ·, d=0) = disUDonut(0) = +5"
+                (disU 1.0 [10 -10] 0) (eu dn 0 H 0) 1e-6)
+  (assert-close "EU(DonutN@0, ·, d=2) = disUDonut(2)"
+                (disU 1.0 [10 -10] 2) (eu dn 0 H 2) 1e-6)
+  (assert-close "EU(Veg@0, ·, d=0) = disUVeg(0) = -10 + 20/2 = 0"
+                (disU 1.0 [-10 20] 0) (eu vg 0 H 0) 1e-6)
+  (assert-close "EU(Veg@0, ·, d=3) = disUVeg(3)"
+                (disU 1.0 [-10 20] 3) (eu vg 0 H 3) 1e-6)
+  ;; the delayed component lands one step later, discounted by δ(d+1).
+  (let [dn-twin (get (:twin tmdp) dn)]
+    (assert-close "EU(DonutN@1 twin, ·, d=1) = δ(1)·(delayed -10) = -5"
+                  (* (dis 1.0 1) -10) (eu dn-twin 0 H 1) 1e-6)))
+
+;; ===========================================================================
+(println "\n== Phase 1.3: endpoints at α=##Inf — rational→Veg, naive→DonutN, soph→Veg ==")
+(let [rational (t-agent ##Inf :naive 0.0)   ; k=0 ⇒ unbiased
+      naive    (t-agent ##Inf :naive 1.0)
+      soph     (t-agent ##Inf :sophisticated 1.0)]
+  (assert-equal "rational (k=0) reaches Veg (net-best, no temptation)"
+                :veg (bp/restaurant-endpoint rational t-start H))
+  (assert-equal "Naive (k=1) is captured by Donut-North (temptation)"
+                :donut-n (bp/restaurant-endpoint naive t-start H))
+  (assert-equal "Sophisticated (k=1) reaches Veg (routes around the temptation)"
+                :veg (bp/restaurant-endpoint soph t-start H))
+  ;; preference reversal: the Naive agent PLANS to reach Veg but DOES reach Donut-N.
+  (let [planned (get (:terminals tmdp) (last (:states (bp/planned-rollout naive t-start H))))
+        did     (bp/restaurant-endpoint naive t-start H)]
+    (println "  naive planned endpoint:" planned "  actual endpoint:" did)
+    (assert-equal "Naive PLANS to reach Veg"   :veg planned)
+    (assert-true  "Naive's plan ≠ what it does (time-inconsistency)" (not= planned did)))
+  ;; sophisticated is time-consistent: plan == do
+  (let [planned (get (:terminals tmdp) (last (:states (bp/planned-rollout soph t-start H))))]
+    (assert-equal "Sophisticated plan == do (both Veg)" :veg planned))
+  ;; the equal-net-utility Donut-South decoy is reached by nobody
+  (assert-true  "Donut-South (net-equal decoy) is never chosen"
+                (not-any? #(= :donut-s (bp/restaurant-endpoint % t-start H))
+                          [rational naive soph])))
+
+;; ===========================================================================
+(println "\n== Phase 1.4: temptation is DECISIVE at FINITE α (does NOT wash out) ==")
+;; The bean's prior failure: scalar utilities → naive/soph differ only as an argmax
+;; tie-break (gap 0) → washes out at finite α. With paired [imm,del] utilities the
+;; decision gaps are bounded away from 0, so a finite-α softmax is near-deterministic.
+;; junction idx 15 (=[3,2]): action 0 = left → Donut-N (idx 14); action 2 = up → Veg.
+;; crossover idx 27 (=[3,4]): action 1 = right → long route; action 2 = up → short route.
+(def junction 15)
+(def crossover 27)
+(let [naive (t-agent 500.0 :naive 1.0)
+      soph  (t-agent 500.0 :sophisticated 1.0)
+      euN   (:eu naive)
+      euS   (:eu soph)
+      ;; junction: at d=0 re-planning, the present-biased agent prefers Donut-N.
+      gap-j (- (euN junction 0 H 0) (euN junction 2 H 0))
+      ;; routing divergence at the crossover (the soph pre-commits to the long route).
+      naive-up?   (> (euN crossover 2 H 0) (euN crossover 1 H 0))
+      soph-right? (> (euS crossover 1 H 0) (euS crossover 2 H 0))]
+  (println "  junction EU(→DonutN) − EU(→Veg) =" (.toFixed gap-j 4)
+           "  ⇒ softmax(α=500·gap) ≈" (.toFixed (/ 1.0 (+ 1.0 (Math/exp (* -500.0 gap-j)))) 4))
+  (assert-true "junction: defection gap > 0 (finite-α agent still prefers Donut-N)" (> gap-j 0.0))
+  (assert-true "junction: gap is decisive (>0.05 ⇒ α=500 softmax ≈ 1, no wash-out)" (> gap-j 0.05))
+  (assert-true "crossover: Naive heads UP the short route (toward the temptation)" naive-up?)
+  (assert-true "crossover: Sophisticated branches RIGHT onto the long route" soph-right?)
+  ;; and the finite-α (α=500) rollout endpoints match the α=##Inf ones (decisive).
+  (assert-equal "finite-α Naive still ends at Donut-North"
+                :donut-n (bp/restaurant-endpoint naive t-start H))
+  (assert-equal "finite-α Sophisticated still ends at Veg"
+                :veg (bp/restaurant-endpoint soph t-start H)))
+
+;; ===========================================================================
+;; PHASE 2 — joint inference of biases and preferences (agentmodels 5e)
+;; ===========================================================================
+(require '[agentmodels.restaurant-joint-inference :as r])
+(defn E-alpha [s] (reduce (fn [a [al pr]] (+ a (* al pr))) 0.0 (:alpha-marginal s)))
+(def nv @r/naive-trajectory)
+(def vd @r/veg-direct-trajectory)
+
+;; Each model's agents (and their EU caches) are scoped to a single `let` so they
+;; become garbage-collectable before the next model builds — peak heap stays at one
+;; model's grid (the 512-agent discounting model fits comfortably).
+
+(println "\n== Phase 2.1-2.3: Discounting model — the P(donutTempting) headline + repeats + VegDirect ==")
+(let [spec   (r/discounting-spec)
+      agents (r/build-agents spec)
+      p1     (r/joint-posterior (assoc spec :states (:states nv) :actions (:actions nv)) agents)
+      p3     (r/joint-posterior (assoc spec :states (:states nv) :actions (:actions nv) :number-repeats 2) agents)
+      pvd    (r/joint-posterior (assoc spec :states (:states vd) :actions (:actions vd)) agents)
+      pr     (:prior p1) po (:posterior p1) po3 (:posterior p3)]
+  ;; 2.1 — headline
+  (println "  prior  P(tempt)=" (.toFixed (:p-donut-tempting pr) 4) " E[vmd]=" (.toFixed (:e-veg-minus-donut pr) 2))
+  (println "  post   P(tempt)=" (.toFixed (:p-donut-tempting po) 4) " E[vmd]=" (.toFixed (:e-veg-minus-donut po) 2)
+           " P(naive)=" (.toFixed (:p-naive po) 3))
+  (assert-true "prior P(donutTempting) < 0.1 (agentmodels: 'less than 0.1')"   (< (:p-donut-tempting pr) 0.1))
+  (assert-true "posterior P(donutTempting) ≥ 0.7 (agentmodels: 'closer to 0.9')" (>= (:p-donut-tempting po) 0.7))
+  (assert-true "prior E[vegMinusDonut] ≈ 0 (equal utility most likely a priori)"  (< (Math/abs (:e-veg-minus-donut pr)) 0.5))
+  (assert-true "posterior E[vegMinusDonut] > 0 (net Veg preference; rules out equal/donut)" (> (:e-veg-minus-donut po) 0.0))
+  (assert-true "posterior P(naive) > 0.8 (the path is explained by naivety)"      (> (:p-naive po) 0.8))
+  ;; 2.2 — graded with repeats
+  (println "  graded P(naive):" (.toFixed (:p-naive po) 3) "→" (.toFixed (:p-naive po3) 3)
+           "   P(tempt):" (.toFixed (:p-donut-tempting po) 3) "→" (.toFixed (:p-donut-tempting po3) 3))
+  (assert-true "P(naive) non-decreasing with repeats (1× → 3×)"         (>= (:p-naive po3) (- (:p-naive po) 1e-9)))
+  (assert-true "P(donutTempting) non-decreasing with repeats (1× → 3×)" (>= (:p-donut-tempting po3) (- (:p-donut-tempting po) 1e-9)))
+  (assert-true "3× observation is (near-)decisive about naivety (≥ 0.99)" (>= (:p-naive po3) 0.99))
+  ;; 2.3 — VegDirect uninformative about bias
+  (println "  VegDirect P(naive) =" (.toFixed (:p-naive (:posterior pvd)) 3) "  (prior 0.5)")
+  (assert-true "P(naive | VegDirect) ≈ prior 0.5 (no information about bias)"
+               (< (Math/abs (- (:p-naive (:posterior pvd)) 0.5)) 0.1)))
+
+(println "\n== Phase 2.4: Optimal (non-discounting) model — the Naive path looks like noise ==")
+(let [spec   (r/optimal-spec)
+      agents (r/build-agents spec)
+      o1     (r/joint-posterior (assoc spec :states (:states nv) :actions (:actions nv)) agents)
+      o3     (r/joint-posterior (assoc spec :states (:states nv) :actions (:actions nv) :number-repeats 2) agents)
+      pri (E-alpha (:prior o1)) a1 (E-alpha (:posterior o1)) a3 (E-alpha (:posterior o3))
+      vmd (:e-veg-minus-donut (:posterior o1))]
+  (println "  E[vegMinusDonut]=" (.toFixed vmd 2) "  E[alpha]: prior" (.toFixed pri 1)
+           " 1×" (.toFixed a1 1) " 3×" (.toFixed a3 1))
+  (assert-true "optimal model infers a DONUT preference (E[vegMinusDonut] < 0)" (< vmd 0.0))
+  (assert-true "optimal model explains the path via NOISE (E[alpha] 1× < prior)" (< a1 pri))
+  (assert-true "repeats make noise less plausible (E[alpha] 3× > 1×)" (> a3 a1))
+  (assert-true "no discounting ⇒ P(donutTempting) = 0" (< (:p-donut-tempting (:posterior o1)) 1e-9)))
+
+(println "\n== Phase 2.5: Full joint model — discount∈{0,1}, naive/soph, alpha, utilities ==")
+;; NOTE on fidelity: agentmodels describes the full model at 1× as 'ambiguous, like
+;; the optimal model'. GenMLX's forward agents are faithful and DECISIVE (α=1000), so
+;; the high-likelihood naive+discounting+temptation explanation already wins at 1×.
+;; We therefore assert the robust DIRECTIONS (favors naive+discounting+temptation on
+;; the naive path; sharpens with repeats) rather than that exact qualitative nuance.
+(let [spec   (r/full-spec)
+      agents (r/build-agents spec)
+      f1     (r/joint-posterior (assoc spec :states (:states nv) :actions (:actions nv)) agents)
+      f3     (r/joint-posterior (assoc spec :states (:states nv) :actions (:actions nv) :number-repeats 2) agents)
+      pri (:prior f1) po1 (:posterior f1) po3 (:posterior f3)]
+  (println "  prior P(naive)=" (.toFixed (:p-naive pri) 2) " P(disc)=" (.toFixed (:p-discounting pri) 2))
+  (println "  1×    P(naive)=" (.toFixed (:p-naive po1) 3) " P(disc)=" (.toFixed (:p-discounting po1) 3)
+           " P(tempt)=" (.toFixed (:p-donut-tempting po1) 3))
+  (println "  3×    P(naive)=" (.toFixed (:p-naive po3) 3) " P(tempt)=" (.toFixed (:p-donut-tempting po3) 3))
+  (assert-close "prior P(naive) = 0.5"      0.5 (:p-naive pri) 1e-6)
+  (assert-close "prior P(discounting) = 0.5" 0.5 (:p-discounting pri) 1e-6)
+  (assert-true "1×: posterior favors naive over prior"        (> (:p-naive po1) (:p-naive pri)))
+  (assert-true "1×: posterior favors discounting over prior"  (> (:p-discounting po1) (:p-discounting pri)))
+  (assert-true "1×: posterior P(donutTempting) up over prior" (> (:p-donut-tempting po1) (:p-donut-tempting pri)))
+  (assert-true "3×: P(naive) sharpens (≥ 1× and ≥ 0.99)"      (and (>= (:p-naive po3) (- (:p-naive po1) 1e-9))
+                                                                   (>= (:p-naive po3) 0.99))))
+
+(println (str "\n" @passed " passed, " @failed " failed"))
+(when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/agentmodels_irl_test.cljs
+++ b/test/genmlx/agentmodels_irl_test.cljs
@@ -1,0 +1,140 @@
+;; Headless tests for agentmodels Ch 4 — Inverse Reinforcement Learning.
+;; Part A: MDP IRL (utility table + timeCost + alpha) — agentmodels Equation 1.
+;; Part B: POMDP-IRL (factorSequence belief threading) — agentmodels Equation 2.
+;; Run: bunx nbb@1.4.206 test/genmlx/agentmodels_irl_test.cljs
+
+(ns genmlx.agentmodels-irl-test
+  (:require [agentmodels.irl :as irl]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-close [msg expected actual tol]
+  (if (<= (Math/abs (- expected actual)) tol) (do (vswap! passed inc) (println " PASS" msg "  =" actual))
+      (do (vswap! failed inc) (println " FAIL" msg "  expected:" expected "  got:" actual))))
+
+(def food irl/food-vals)
+
+;; ===========================================================================
+(println "\n== Phase A.1: utility-table inference (Eq 1) — donut favoured, Veg/Noodle unidentifiable ==")
+(let [uspec   (irl/utility-only-spec)       ; alpha=2, timeCost=-0.04 fixed (chapter's first example)
+      uagents (irl/build-agents uspec)
+      prior   (irl/prior-summary uagents)
+      post    (irl/summarize (irl/joint-posterior uagents irl/single-left-obs) uagents)]
+  (println "  prior  P(donut/veg/noodle Fav)=" (.toFixed (:p-donut-favorite prior) 3)
+           "/" (.toFixed (:p-veg-favorite prior) 3) "/" (.toFixed (:p-noodle-favorite prior) 3))
+  (println "  1-left P(donut/veg/noodle Fav)=" (.toFixed (:p-donut-favorite post) 3)
+           "/" (.toFixed (:p-veg-favorite post) 3) "/" (.toFixed (:p-noodle-favorite post) 3))
+  ;; prior is symmetric over the three restaurants
+  (assert-close "prior P(donutFav) = P(vegFav)"   (:p-donut-favorite prior) (:p-veg-favorite prior) 1e-9)
+  (assert-close "prior P(vegFav)   = P(noodleFav)" (:p-veg-favorite prior)  (:p-noodle-favorite prior) 1e-9)
+  ;; one leftward step (toward Donut South) → Donut favoured
+  (assert-true "1 leftward step: P(donutFav) rises above prior"
+               (> (:p-donut-favorite post) (:p-donut-favorite prior)))
+  (assert-true "1 leftward step: Donut is the favoured restaurant"
+               (and (> (:p-donut-favorite post) (:p-veg-favorite post))
+                    (> (:p-donut-favorite post) (:p-noodle-favorite post))))
+  ;; agentmodels' unidentifiability: the step gives no evidence distinguishing Veg from Noodle
+  (assert-true "Veg vs Noodle UNIDENTIFIABLE (|P(vegFav) − P(noodleFav)| < 0.05)"
+               (< (Math/abs (- (:p-veg-favorite post) (:p-noodle-favorite post))) 0.05)))
+
+;; ===========================================================================
+(println "\n== Phase A.2: soft rationality — low alpha (noise) washes out the evidence ==")
+;; agentmodels: 'if the agent has a low value for alpha, this step to the left is
+;; fairly likely even if the agent prefers Noodle or Veg' — a controlled low-vs-high
+;; alpha comparison on the SAME single step.
+(let [base   {:donut-vals food :veg-vals food :noodle-vals food :time-cost-vals [-0.04]}
+      lo-ag  (irl/build-agents (assoc base :alpha-vals [0.1]))
+      hi-ag  (irl/build-agents (assoc base :alpha-vals [100.0]))
+      prior  (:p-donut-favorite (irl/prior-summary lo-ag))
+      lo     (:p-donut-favorite (irl/summarize (irl/joint-posterior lo-ag irl/single-left-obs) lo-ag))
+      hi     (:p-donut-favorite (irl/summarize (irl/joint-posterior hi-ag irl/single-left-obs) hi-ag))]
+  (println "  P(donutFav | 1-left): prior" (.toFixed prior 3) "  low-α(0.1)" (.toFixed lo 3) "  high-α(100)" (.toFixed hi 3))
+  (assert-true "low-α agent: a single step is ~uninformative (P(donutFav) ≈ prior)"
+               (< (Math/abs (- lo prior)) 0.03))
+  (assert-true "high-α agent: the same step IS diagnostic (P(donutFav) ≫ low-α)"
+               (> hi (+ lo 0.1))))
+
+;; ===========================================================================
+(println "\n== Phase A.3: more evidence sharpens the posterior (joint utility+timeCost+alpha) ==")
+(let [jspec   (irl/joint-spec)
+      jagents (irl/build-agents jspec)
+      p1 (irl/summarize (irl/joint-posterior jagents irl/single-left-obs) jagents)
+      p4 (irl/summarize (irl/joint-posterior jagents irl/donut-south-obs) jagents)]
+  (println "  P(donutFav): 1-left" (.toFixed (:p-donut-favorite p1) 3) "→ donut-south(4)" (.toFixed (:p-donut-favorite p4) 3)
+           "   P(noodleFav):" (.toFixed (:p-noodle-favorite p1) 3) "→" (.toFixed (:p-noodle-favorite p4) 3))
+  (assert-true "4-step Donut-South trajectory sharpens P(donutFav) over the single step"
+               (> (:p-donut-favorite p4) (:p-donut-favorite p1)))
+  (assert-true "4-step trajectory suppresses Noodle (the far restaurant)"
+               (< (:p-noodle-favorite p4) (:p-noodle-favorite p1))))
+
+;; ===========================================================================
+(println "\n== Phase A.4: generate-and-compare (the chapter's motivating example) ==")
+;; At high alpha the agent is near-deterministic; keep tables whose predicted path
+;; matches. Donut South is the NEAREST restaurant, so many tables (even all-equal)
+;; route through it — which is exactly why the factorized softmax likelihood (A.1-A.3)
+;; is the preferred method.
+(let [gc (irl/generate-and-compare {:donut-vals food :veg-vals food :noodle-vals food} irl/donut-south-obs)]
+  (println "  gen-compare matched" (count gc) "of 27 tables (incl all-equal [0 0 0] — less discriminative)")
+  (assert-true "gen-compare keeps the donut-preferring table [2 0 0]" (contains? gc [2 0 0]))
+  (assert-true "gen-compare is LESS discriminative than factorized (≥ half the tables match)"
+               (>= (count gc) 10)))
+
+;; ===========================================================================
+;; PART B — POMDP-IRL (factorSequence / Equation 2): the Bandit testbed
+;; ===========================================================================
+(require '[agentmodels.pomdp-irl :as pi])
+
+(println "\n== Phase B.1: forward VOI agent + the Switch two-level belief prior ==")
+;; Switch combinator selecting the initial belief (the two-level prior's belief axis).
+(assert-close "Switch idx 0 → informed belief (P(arm1=champagne)=1.0)"  1.0 (pi/switch-initial-belief 0) 1e-9)
+(assert-close "Switch idx 1 → misinformed belief"  pi/MISINFORMED-P (pi/switch-initial-belief 1) 1e-9)
+;; the belief-space VOI planner must value exploration only when the horizon is long.
+(let [champ-inf (pi/make-bandit-voi-agent {:utility pi/likes-champagne :belief 1.0})
+      champ-mis (pi/make-bandit-voi-agent {:utility pi/likes-champagne :belief pi/MISINFORMED-P})
+      choc      (pi/make-bandit-voi-agent {:utility pi/likes-chocolate :belief pi/MISINFORMED-P})
+      q (fn [ag arm b n] ((:q ag) arm b n))]
+  (assert-true "informed champagne-lover pulls arm1 (knows champagne 5 > chocolate 3)"
+               (> (q champ-inf 1 1.0 6) (q champ-inf 0 1.0 6)))
+  (assert-true "misinformed champagne-lover EXPLORES arm1 at a long horizon (VOI)"
+               (> (q champ-mis 1 pi/MISINFORMED-P 6) (q champ-mis 0 pi/MISINFORMED-P 6)))
+  (assert-true "misinformed champagne-lover pulls arm0 at a SHORT horizon (no VOI)"
+               (> (q champ-mis 0 pi/MISINFORMED-P 2) (q champ-mis 1 pi/MISINFORMED-P 2)))
+  (assert-true "chocolate-lover pulls arm0 (chocolate is the known best)"
+               (> (q choc 0 pi/MISINFORMED-P 6) (q choc 1 pi/MISINFORMED-P 6))))
+
+(println "\n== Phase B.2: preference-vs-belief UNIDENTIFIABILITY (short horizon) ==")
+(let [u (pi/unidentifiability 2)]
+  (println "  N=2 all-arm0: P(likesChocolate)=" (.toFixed (:p-likes-chocolate u) 3)
+           " P(informed)=" (.toFixed (:p-informed u) 3))
+  ;; arm0-pulls are explained by EITHER a chocolate preference OR a misinformed belief,
+  ;; so neither is identified — P(likesChocolate) is well below 1 (≈ 2/3).
+  (assert-true "P(likesChocolate) is NOT identified after short-horizon arm0 pulls (< 0.8)"
+               (< (:p-likes-chocolate u) 0.8))
+  (assert-true "...but the informed-champagne-lover IS ruled out (P(likesChocolate) > prior 0.5)"
+               (> (:p-likes-chocolate u) 0.5)))
+
+(println "\n== Phase B.3: identifiability GROWS with the horizon ==")
+(let [sweep (pi/horizon-sweep [2 3 4 6 8])
+      pc    (fn [N] (:p-likes-chocolate (first (filter #(= N (:horizon %)) sweep))))]
+  (doseq [{:keys [horizon p-likes-chocolate]} sweep]
+    (println "  N=" horizon " P(likesChocolate)=" (.toFixed p-likes-chocolate 3)))
+  (assert-true "short horizon (N=2) is unidentified (P < 0.8)" (< (pc 2) 0.8))
+  (assert-true "long horizon (N=8) identifies the chocolate preference (P ≥ 0.99)" (>= (pc 8) 0.99))
+  (assert-true "P(likesChocolate) is non-decreasing in the horizon (2 → 8)"
+               (<= (pc 2) (pc 3) (pc 4) (pc 6) (pc 8))))
+
+(println "\n== Phase B.4: factorSequence belief threading via the Scan combinator ==")
+;; A sequence where the agent EXPLORES arm1 (reveals champagne) then pulls arm0.
+(let [obs   [{:arm 1 :prize :champagne} {:arm 0 :prize :chocolate} {:arm 0 :prize :chocolate}]
+      scanned (pi/belief-trajectory-via-scan pi/MISINFORMED-P obs)
+      hosted  (pi/belief-trajectory-host     pi/MISINFORMED-P obs)]
+  (println "  Scan-threaded beliefs:" (vec scanned) "  host-threaded:" (vec hosted))
+  (assert-true "Scan belief thread matches the host recursion" (= (vec scanned) (vec hosted)))
+  (assert-true "belief reveals arm1=champagne after the exploring pull (→ 1.0 thereafter)"
+               (and (= pi/MISINFORMED-P (first hosted)) (= 1.0 (second hosted)))))
+
+(println (str "\n" @passed " passed, " @failed " failed"))
+(when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/agentmodels_psrl_test.cljs
+++ b/test/genmlx/agentmodels_psrl_test.cljs
@@ -1,0 +1,76 @@
+;; Headless tests for agentmodels Ch 3d — Posterior Sampling RL (PSRL) on a gridworld.
+;; (The bandit Thompson/softmax-greedy + bandit regret are shipped & tested in
+;; bandit_test.cljs; this covers the remaining model-based gridworld PSRL.)
+;; Run: bunx nbb@1.4.206 test/genmlx/agentmodels_psrl_test.cljs
+
+(ns genmlx.agentmodels-psrl-test
+  (:require [agentmodels.psrl :as ps]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-equal [msg expected actual]
+  (if (= expected actual) (do (vswap! passed inc) (println " PASS" msg "  =" (pr-str actual)))
+      (do (vswap! failed inc) (println " FAIL" msg "  expected:" (pr-str expected) "  got:" (pr-str actual)))))
+
+;; ===========================================================================
+(println "\n== Phase 1: the reward-grid MDP + optimal value ==")
+(let [free (ps/free-cells ps/grid)
+      v*   (ps/optimal-return ps/grid (#'agentmodels.psrl/one-hot 16 ps/TRUE-GOAL) ps/START-IDX ps/HORIZON)]
+  (println "  free cells:" free "  true-goal:" ps/TRUE-GOAL "  V*(start)=" v*)
+  (assert-equal "12 free (non-wall) cells" 12 (count free))
+  (assert-true  "true goal (idx 15) is a free cell" (some #(= ps/TRUE-GOAL %) free))
+  ;; the goal is 6 steps from the start; over a 9-step horizon the optimal agent
+  ;; reaches it and dwells (stay action), collecting reward on 3 of the 9 steps.
+  (assert-true  "V*(start) = 3 (reach in 6, dwell for 3 of 9 steps)" (= 3.0 v*)))
+
+;; ===========================================================================
+(println "\n== Phase 2: exact reward-posterior update (Bayes) ==")
+(let [post (ps/uniform-posterior (ps/free-cells ps/grid))]
+  (assert-true "uniform prior over the 12 free cells (each ≈ 1/12)"
+               (< (Math/abs (- (get post 0) (/ 1.0 12))) 1e-9))
+  ;; observing reward 0 at a cell rules that cell out
+  (let [p1 (ps/update-posterior post 0 0)]
+    (assert-true "observing reward 0 at cell 0 removes it from the posterior" (nil? (get p1 0)))
+    (assert-true "...and renormalizes the survivors" (< (Math/abs (- 1.0 (reduce + (vals p1)))) 1e-9)))
+  ;; observing reward 1 at a cell collapses the posterior to it
+  (let [p2 (ps/update-posterior post ps/TRUE-GOAL 1)]
+    (assert-equal "observing reward 1 at the goal collapses the posterior to it" 1 (count p2))
+    (assert-true  "...with all mass on the goal" (> (get p2 ps/TRUE-GOAL) 0.999))))
+
+;; ===========================================================================
+(println "\n== Phase 3: PSRL learns the reward — concentration, regret, beats baseline ==")
+;; over several seeds the posterior must concentrate on the true goal, cumulative
+;; regret must stay sublinear (plateau) and beat the no-learning baseline.
+(let [seeds [1 2 3 4 5]]
+  (doseq [seed seeds]
+    (let [r (ps/psrl {:seed seed :n-episodes 10})
+          b (ps/psrl {:seed seed :n-episodes 10 :learn? false})
+          p-true (get (:final-posterior r) ps/TRUE-GOAL 0.0)
+          tot    (last (:cum-regret r))
+          base   (last (:cum-regret b))
+          last-ep (last (:episodes r))]
+      (println "  seed" seed " P(true)=" (.toFixed p-true 3) " regret=" (.toFixed tot 1)
+               " baseline=" (.toFixed base 1) " final-ep regret=" (.toFixed (:regret last-ep) 1))
+      (assert-true (str "seed " seed ": posterior concentrates on the true goal (P ≥ 0.99)") (>= p-true 0.99))
+      (assert-true (str "seed " seed ": final episode has zero regret (converged to optimal)") (= 0.0 (:regret last-ep)))
+      (assert-true (str "seed " seed ": final episode reaches the goal") (:reached-goal? last-ep))
+      (assert-true (str "seed " seed ": PSRL beats the no-learning baseline") (< tot base))
+      (assert-true (str "seed " seed ": cumulative regret is sublinear (< n·V* = 30)") (< tot 30.0)))))
+
+;; ===========================================================================
+(println "\n== Phase 4: regret plateaus — the agent stops paying once it has learned ==")
+(let [r (ps/psrl {:seed 1 :n-episodes 12})
+      cr (:cum-regret r)
+      first-half  (- (nth cr 5) (nth cr 0))          ; regret accrued over episodes 1..6
+      second-half (- (last cr) (nth cr 5))]          ; regret accrued over episodes 7..12
+  (println "  cum-regret:" (mapv #(.toFixed % 1) cr))
+  (assert-true "regret accrual in the 2nd half ≪ 1st half (it plateaus once learned)"
+               (< second-half (inc first-half)))
+  (assert-true "no further regret once the posterior has collapsed (2nd-half accrual = 0)"
+               (= 0.0 second-half)))
+
+(println (str "\n" @passed " passed, " @failed " failed"))
+(when (pos? @failed) (js/process.exit 1))


### PR DESCRIPTION
Closes the three remaining agentmodels capability gaps — all faithful ports verified against the agentmodels.org references, on top of the existing GFI / handler / combinator infrastructure (zero engine changes; one additive `biased_planners.cljs` section, everything else new files).

## Ch 5e — full-geometry restaurant joint inference
The scalar restaurant MDP structurally couldn't produce graded temptation (two prior attempts stalled here). Fix: `restaurant-temptation-mdp` — a state-augmented `[S=52]` MDP with paired `[immediate, delayed]` utilities consumed over a **2-step restaurant stay**, so the *existing* biased-EU recursion yields `EU(L@0,a,d) = δ(d)·imm + δ(d+1)·del` — exactly the library's `disU`, with **no recursion changes**.
- `restaurant_joint_inference.cljs`: 5-latent joint (utility table × discount × bias × alpha) exact enumeration; verbatim `donutTempting` / `vegMinusDonut` predicates.
- Reproduces the chapter headline: **P(donutTempting) 0.09 → 0.93** ("< 0.1" → "≈ 0.9"), E[vegMinusDonut] 0 → +10.9, decisive at finite α (junction gap 0.175). VegDirect uninformative; optimal→donut+noise; full→temptation.

## Ch 4 — Reasoning about agents (IRL)
- `irl.cljs`: **MDP IRL (Equation 1)** — joint utility-table + timeCost + alpha via the factorized softmax likelihood (reuses `inverse/action-loglik`); Veg/Noodle unidentifiability; low-α noise washes out evidence; generate-and-compare.
- `pomdp_irl.cljs`: **bandit POMDP-IRL (Equation 2 / `factorSequence`)** — a finite-horizon belief-space VOI bandit agent, two-level (utility × belief) prior via the **Switch** combinator, belief threading via the **Scan** combinator; reproduces the **preference-vs-belief unidentifiability** that resolves as the horizon grows.

## Ch 3d — Reinforcement Learning (PSRL)
- `psrl.cljs`: **posterior-sampling RL on a 4×4 gridworld** — posterior over the reward grid, value iteration per sampled model, exact Bayesian belief update across episodes, cumulative regret. Concentrates to **P(true-goal)=1.0** (all seeds), regret **plateaus (sublinear)** and beats a no-learning baseline. (The bandit Thompson/softmax-greedy + bandit regret were already shipped in `bandit_test`.)

## Tests
New, all deterministic: `agentmodels_5e_joint_test` (45), `agentmodels_irl_test` (24), `agentmodels_psrl_test` (35) = **104 assertions**. Regression green: bandit 18, pomdp 22, slice 51, agents_api 19, combinators (67 assertions), biased_planners 41, biased_inverse 42, 5d 21.

## Honest fidelity notes
The agentmodels chapters report most results as bar charts, so tests assert **directions + the one stated figure** (the 0.1→0.9). Documented deviations: the full-model "1× ≈ optimal" nuance doesn't reproduce (faithful α=1000 agents make temptation win at 1×); gridworld-PSRL regret is a faithful Osband *extension* (agentmodels plots regret only for bandits); the PSRL reward model uses a 5th "stay" action over a one-hot-free-cell prior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)