### PR TITLE
fix: trace-site escape detection (genmlx-7bm6) + backend-free genmlx.edit (genmlx-5413)

### DIFF
--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -730,6 +730,11 @@
   [body-fn source]
   (let [schema (schema/extract-schema source)
         schema (cond
+                 ;; Hidden trace sites (trace/splice handed to opaque code):
+                 ;; not statically analyzable — handler path only, no compilation.
+                 (and schema (:opaque-gen-escape? schema))
+                 schema
+
                  (and schema (:static? schema))
                  (attach-compiled-ops schema source static-ops)
 
@@ -743,8 +748,10 @@
                  (attach-prefix-ops schema source)
 
                  :else schema)
-        ;; L3: full rewrite engine (Kalman > Conjugacy > RaoBlackwell)
-        schema (if schema
+        ;; L3: full rewrite engine (Kalman > Conjugacy > RaoBlackwell).
+        ;; Skip for opaque-escape bodies: conjugacy detection over only the
+        ;; visible sites could mis-fire while real obs sites are hidden.
+        schema (if (and schema (not (:opaque-gen-escape? schema)))
                  (let [augmented (conj/augment-schema-with-conjugacy schema)]
                    (if (:has-conjugate? augmented)
                      (let [plan (rewrite/build-analytical-plan augmented)

--- a/src/genmlx/edit.cljs
+++ b/src/genmlx/edit.cljs
@@ -7,8 +7,7 @@
    instance of edit. The backward request enables automatic computation of
    acceptance weights for reversible kernels — the foundation of SMCP3."
   (:require [genmlx.protocols :as p]
-            [genmlx.choicemap :as cm]
-            [genmlx.mlx :as mx]))
+            [genmlx.choicemap :as cm]))
 
 ;; ---------------------------------------------------------------------------
 ;; EditRequest types
@@ -62,6 +61,33 @@
   [result]
   (or (:discard result) cm/EMPTY))
 
+;; ---------------------------------------------------------------------------
+;; ProposalEdit weight arithmetic — backend-free until an MLX weight appears
+;; ---------------------------------------------------------------------------
+;;
+;; Only ProposalEdit combines scores numerically. Deterministic / degenerate GFs
+;; have plain-number weights and need no MLX; MLX-backed GFs have MxArray weights
+;; and need the native scalar ops. We resolve genmlx.mlx LAZILY (through the
+;; membrane, not @mlx-node directly) so that merely requiring genmlx.edit never
+;; forces the GPU backend — ConstraintEdit, SelectionEdit, and every constructor
+;; stay genuinely Layer-A pure and loadable without @mlx-node/core present. The
+;; native mx/add and mx/subtract accept both MxArray and JS-number args, so they
+;; also cover mixed weights once realized. See genmlx-5413.
+(defonce ^:private mx-scalar
+  (delay (require '[genmlx.mlx])
+         {:add (resolve 'genmlx.mlx/add)
+          :subtract (resolve 'genmlx.mlx/subtract)}))
+
+(defn- w-add
+  "Add two scores: numeric (+) for pure GFs, native mx/add for MxArray weights."
+  [a b]
+  (if (and (number? a) (number? b)) (+ a b) ((:add @mx-scalar) a b)))
+
+(defn- w-sub
+  "Subtract scores: numeric (-) for pure GFs, native mx/subtract for MxArrays."
+  [a b]
+  (if (and (number? a) (number? b)) (- a b) ((:subtract @mx-scalar) a b)))
+
 (defmulti edit-dispatch
   "Generic edit implementation that dispatches based on EditRequest type."
   (fn [_gf _trace edit-request] (type edit-request)))
@@ -101,8 +127,8 @@
         bwd-result (p/assess backward-gf bwd-args
                              (discard-of update-result))
         bwd-score (:weight bwd-result)
-        ;; 4. Combined weight
-        weight (mx/add update-weight (mx/subtract bwd-score fwd-score))]
+        ;; 4. Combined weight (backend-free for pure GFs; see w-add/w-sub)
+        weight (w-add update-weight (w-sub bwd-score fwd-score))]
     {:trace new-trace
      :weight weight
      :discard (discard-of update-result)

--- a/src/genmlx/schema.cljs
+++ b/src/genmlx/schema.cljs
@@ -86,6 +86,113 @@
 
     :else false))
 
+;; The gen macro binds these local symbols to runtime closures that PRODUCE
+;; trace sites. The walker can only see them in head position — `(trace ...)`,
+;; `(splice ...)`. A tracing capability "escapes" — becomes invisible to the
+;; walker — in three ways:
+;;
+;;   1. The bare binding is referenced as a VALUE (anywhere other than the head
+;;      of its own call form): `(run-sessions trace ...)`,
+;;      `(cl/run-controlled-loop trace {...})`. The callee loops internally and
+;;      traces hidden sites.
+;;
+;;   2. An fn/fn* literal that itself contains a trace/splice call is referenced
+;;      as a VALUE — passed to an opaque higher-order function or stored in a
+;;      let — rather than invoked immediately: `(run! step xs)`,
+;;      `(mapv (fn [i] (trace ...)) is)`. The HOF decides how many times (0/1/N)
+;;      it runs, which the walker cannot know, so the single-shot compiled path
+;;      diverges from the handler.
+;;
+;;   3. A `letfn`-bound local function whose body traces: `(letfn [(step [x]
+;;      (trace :y ...))] (run! step xs))`. The name `step` is neither the bare
+;;      binding nor an fn-literal, so it slips past #1 and #2, but it is the same
+;;      indirectly-invoked tracing capability as #2.
+;;
+;; Any of these makes the body NOT statically analyzable: treating it as static
+;; makes the L1-M2 compiled path drop/under-count those sites (silently, e.g.
+;; when the opaque call is a non-final statement, or when an HOF invokes the
+;; capability N times), so observation constraints are never scored correctly.
+;; `param` is excluded throughout — it only READS a parameter and produces no
+;; trace site, so handing it off hides nothing.
+(def ^:private gen-binding-names #{"trace" "splice"})
+
+(defn- contains-trace-call?
+  "Does this form recursively contain a trace or splice call? Unlike
+   contains-gen-call?, `param` does NOT count — it produces no trace site, so an
+   fn that only reads params is not a tracing capability."
+  [form]
+  (cond
+    (and (seq? form) (seq form))
+    (or (when-let [h (head-sym form)]
+          (contains? gen-binding-names (name h)))
+        (some contains-trace-call? form))
+
+    (and (vector? form) (seq form))
+    (some contains-trace-call? form)
+
+    :else false))
+
+(defn- gen-binding-sym?
+  "True for an unqualified symbol that is one of the gen-macro runtime bindings
+   (trace/splice) — i.e. a tracing capability that must stay in head position."
+  [x]
+  (and (symbol? x) (nil? (namespace x)) (contains? gen-binding-names (name x))))
+
+(defn- fn-literal?
+  "True for an (fn ...) or (fn* ...) form (reader #(...) expands to fn*)."
+  [form]
+  (and (seq? form) (seq form) (symbol? (first form))
+       (contains? #{"fn" "fn*"} (name (first form)))))
+
+(defn- tracing-fn-literal?
+  "True for an fn/fn* literal whose body contains a trace/splice call — a
+   first-class tracing capability. As a VALUE this is an escape (see ns note);
+   as the operator of its own immediate call it runs exactly once and is fine."
+  [form]
+  (and (fn-literal? form) (contains-trace-call? form)))
+
+(defn- letfn-binds-tracer?
+  "True for a `(letfn [(name [args] body...) ...] ...)` form where any local fn
+   body contains a trace/splice call. Such a named tracer can be invoked
+   indirectly or repeatedly (handed to a HOF, called in a loop), hiding sites
+   from the walker — mechanism #3 in the ns note."
+  [form]
+  (and (seq? form) (seq form) (symbol? (first form)) (= "letfn" (name (first form)))
+       (vector? (second form))
+       (some (fn [spec] (and (seq? spec) (contains-trace-call? spec)))
+             (second form))))
+
+(defn- escapes-gen-binding?
+  "True when a tracing capability escapes into code the walker cannot analyze: a
+   bare trace/splice binding used as a value, a tracing fn-literal used as a
+   value (not immediately invoked), or a letfn-bound tracing function. Quoted
+   forms are data, not bindings, so they are not inspected."
+  [form]
+  (cond
+    (and (seq? form) (seq form))
+    (let [h (first form)]
+      (if (and (symbol? h) (= "quote" (name h)))
+        false
+        (boolean
+         (or
+          ;; A letfn that binds a tracing local function escapes (mechanism #3).
+          (letfn-binds-tracer? form)
+          ;; Head: a symbol head is a call name (fine). A non-symbol head is a
+          ;; sub-form — including `((fn ...) args)` immediate invocation, where
+          ;; the fn runs once: scan its body for nested escapes but do NOT treat
+          ;; the fn itself as an escaping value.
+          (when-not (symbol? h) (escapes-gen-binding? h))
+          ;; Arguments: a bare gen-op symbol or a tracing fn-literal escapes here.
+          (some (fn [a] (or (tracing-fn-literal? a) (escapes-gen-binding? a)))
+                (rest form))))))
+
+    (vector? form) (boolean (some #(or (tracing-fn-literal? %) (escapes-gen-binding? %)) form))
+    (set? form)    (boolean (some #(or (tracing-fn-literal? %) (escapes-gen-binding? %)) form))
+    (map? form)    (boolean (some #(or (tracing-fn-literal? %) (escapes-gen-binding? %))
+                                  (mapcat identity form)))
+    (gen-binding-sym? form) true
+    :else false))
+
 ;; =========================================================================
 ;; Walker — threads acc (accumulator) and env (binding environment)
 ;; =========================================================================
@@ -639,12 +746,18 @@
                                    (assoc ls :count-arg-idx
                                           (infer-count-arg-idx
                                            (:count-form ls) params)))
-                                 (or loops []))))]
+                                 (or loops []))))
+          ;; A body that hands `trace`/`splice` to opaque code has hidden trace
+          ;; sites the walker cannot see — it is not statically analyzable and
+          ;; must take the handler path (no compilation). See escapes-gen-binding?.
+          opaque-escape? (boolean (some escapes-gen-binding? body))]
       (-> result
           (dissoc :current-loop-type)
           (assoc :params (vec params)
                  :return-form (last body)
                  :dep-order (topo-sort (:trace-sites result))
+                 :opaque-gen-escape? opaque-escape?
                  :static? (and (not (:dynamic-addresses? result))
                                (not (:has-branches? result))
-                               (not (:has-loops? result))))))))
+                               (not (:has-loops? result))
+                               (not opaque-escape?)))))))

--- a/test/genmlx/edit_purity_test.cljs
+++ b/test/genmlx/edit_purity_test.cljs
@@ -1,0 +1,84 @@
+(ns genmlx.edit-purity-test
+  "Regression for genmlx-5413: genmlx.edit must be usable by pure / deterministic
+   GFs whose weights are plain numbers — without the native MLX backend.
+
+   Previously edit.cljs had a top-level (:require [genmlx.mlx :as mx]), whose
+   `(js/require \"@mlx-node/core\")` runs at load, so merely requiring genmlx.edit
+   forced the GPU backend even for ConstraintEdit / SelectionEdit (which use no
+   MLX). The fix drops that require and resolves genmlx.mlx's scalar ops LAZILY,
+   only inside the ProposalEdit weight-combine and only when a weight is an
+   MxArray. For plain-number weights the combine uses +/- and never touches MLX.
+
+   These tests use minimal deterministic GFs (number weights) and assert the edit
+   results stay plain numbers — i.e. no MxArray is produced, which is the in-repo
+   proxy for 'no MLX op ran'. (Loadability with the backend absent is verified out
+   of tree via the external repro; the MxArray ProposalEdit path is covered by
+   proposal_edit_test.)"
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.test-helpers :as h]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.edit :as edit]))
+
+;; Deterministic GF: update/regenerate return PLAIN-NUMBER weights + a discard.
+(defrecord PureGF []
+  p/IUpdate
+  (update [_ trace _constraints]
+    {:trace trace :weight 1.5 :discard (cm/choicemap :x 0.0)})
+  p/IRegenerate
+  (regenerate [_ trace _selection]
+    {:trace trace :weight 0.25 :discard cm/EMPTY}))
+
+;; Pieces for a pure ProposalEdit (all number weights).
+(defrecord PureModelGF []
+  p/IUpdate
+  (update [_ trace _ch] {:trace trace :weight 2.0 :discard (cm/choicemap :a 9.0)}))
+(defrecord PureFwdGF []
+  p/IPropose
+  (propose [_ _args] {:choices (cm/choicemap :a 1.0) :weight 0.5 :retval nil}))
+(defrecord PureBwdGF []
+  p/IAssess
+  (assess [_ _args _choices] {:retval nil :weight 0.75}))
+
+(def ^:private dummy-trace {:choices cm/EMPTY})
+
+(deftest constraint-edit-pure
+  (testing "ConstraintEdit on a deterministic GF: number weight, discard carried back, no MLX"
+    (let [r (edit/edit-dispatch (->PureGF) dummy-trace
+                                (edit/constraint-edit (cm/choicemap :x 1.0)))]
+      (is (number? (:weight r)) "weight is a plain number (no MxArray)")
+      (is (h/close? 1.5 (:weight r) 1e-9) "weight passes through p/update")
+      (is (instance? edit/ConstraintEdit (:backward-request r)) "backward = ConstraintEdit")
+      (is (h/close? 0.0 (cm/get-choice (:constraints (:backward-request r)) [:x]) 1e-9)
+          "backward-request carries the discard"))))
+
+(deftest selection-edit-pure
+  (testing "SelectionEdit on a deterministic GF: number weight, no MLX"
+    (let [r (edit/edit-dispatch (->PureGF) dummy-trace
+                                (edit/selection-edit (sel/select :x)))]
+      (is (number? (:weight r)) "weight is a plain number (no MxArray)")
+      (is (h/close? 0.25 (:weight r) 1e-9) "weight passes through p/regenerate")
+      (is (instance? edit/SelectionEdit (:backward-request r)) "backward = SelectionEdit")
+      (is (= cm/EMPTY (:discard r)) "selection edit discards nothing"))))
+
+(deftest proposal-edit-pure-number-path
+  (testing "ProposalEdit with all-number weights uses +/- and stays backend-free"
+    ;; weight = update(2.0) + (assess_bwd(0.75) - propose_fwd(0.5)) = 2.25
+    (let [req (edit/proposal-edit (->PureFwdGF) (->PureBwdGF))
+          r   (edit/edit-dispatch (->PureModelGF) dummy-trace req)]
+      (is (number? (:weight r)) "pure ProposalEdit weight is a plain number — w-add/w-sub took the numeric branch")
+      (is (h/close? 2.25 (:weight r) 1e-9) "numeric weight combine is correct")
+      (is (instance? edit/ProposalEdit (:backward-request r)) "backward = ProposalEdit (fwd/bwd swapped)")
+      (is (h/close? 9.0 (cm/get-choice (:discard r) [:a]) 1e-9) "discard preserved"))))
+
+(deftest edit-namespace-has-no-mlx-require
+  (testing "the genmlx.edit interface loaded and works without any MLX value being constructed"
+    ;; If requiring genmlx.edit had pulled in genmlx.mlx eagerly, this ns would
+    ;; have failed to load. Reaching here at all (with all weights above plain
+    ;; numbers) is the regression signal.
+    (is (some? edit/constraint-edit))
+    (is (some? edit/selection-edit))
+    (is (some? edit/proposal-edit))))
+
+(cljs.test/run-tests)

--- a/test/genmlx/plate_generate_test.cljs
+++ b/test/genmlx/plate_generate_test.cljs
@@ -1,0 +1,395 @@
+(ns genmlx.plate-generate-test
+  "Regression test for genmlx-7bm6: p/generate silently dropped observation
+   constraints when a gen body invoked a TRACING helper (one that receives the
+   ambient `trace` and loops, tracing many hidden sites) N times in one body —
+   a 'plate'. The posterior collapsed to the prior with no error raised.
+
+   Root cause: the schema walker only sees literal `(trace addr dist)` calls.
+   When a body hands the `trace` binding to an opaque call — e.g.
+   `(run-block trace ...)` — the trace sites inside are invisible, so the model
+   was wrongly classified `:static? true` and compiled to L1-M2. The L1-M2
+   compiled path evaluates only the visible static sites + the return form,
+   DROPPING non-final body statements. With the opaque tracing call as a
+   non-final statement (`(run-block trace ...) :done`), it was never run: zero
+   loop sites traced, every constraint dropped, weight 0.
+
+   Fix: detect `trace`/`splice` escaping head position into opaque code
+   (`:opaque-gen-escape?`), disqualify `:static?`, and route such models to the
+   handler path (ground truth) with no compilation.
+
+   These models mirror the bug WITHOUT depending on mct.controlled-loop: the
+   inline `run-block` is a plain defn that receives the ambient `trace` and runs
+   a loop/recur, branching on the read-back `(mx/item s)` — exactly the shape
+   that hides its trace sites from the schema walker."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.test-helpers :as h]
+            [genmlx.gen :refer [gen]]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.dist :as dist]
+            [genmlx.choicemap :as cm]
+            [genmlx.schema :as schema]
+            [genmlx.gfi :as gfi]
+            [genmlx.inference.importance :as is]
+            [genmlx.inference.mcmc :as mcmc]
+            [genmlx.selection :as sel]))
+
+(def ^:private MAX-ITERS 40)
+(def ^:private SM-P 0.6)
+(def ^:private TRUE-THETA 0.55)
+
+;; Inline controlled loop. A plain defn that takes the AMBIENT `trace` and loops,
+;; tracing <prefix>monT then <prefix>stopT and branching on the read-back stop
+;; value. The schema walker cannot see these sites (trace is handed to opaque
+;; code) — the exact pattern that triggered the bug.
+(defn- run-block [trace prefix p-stop]
+  (loop [t 0]
+    (trace (keyword (str prefix "mon" t)) (dist/bernoulli (mx/scalar SM-P)))
+    (let [s     (trace (keyword (str prefix "stop" t)) (dist/bernoulli p-stop))
+          fired? (>= (mx/item s) 1.0)
+          last?  (>= (inc t) MAX-ITERS)]
+      (if (or fired? last?) t (recur (inc t))))))
+
+(defn- p-stop-of [theta]
+  (mx/clip (mx/multiply (mx/scalar 0.5) theta) 1e-6 (- 1.0 1e-6)))
+
+;; PLATE: opaque tracing call invoked N times as a NON-FINAL statement, literal
+;; return. This is the failing shape.
+(def plate-model
+  (gen [n-blocks]
+    (let [theta  (trace :theta (dist/uniform 0 1))
+          p-stop (p-stop-of theta)]
+      (loop [b 0]
+        (when (< b n-blocks)
+          (run-block trace (str "b" b "_") p-stop)
+          (recur (inc b))))
+      :done)))
+
+;; SINGLE block, opaque call as the RETURN form. (Worked "by accident" pre-fix;
+;; post-fix it correctly routes to the handler too.)
+(def single-model
+  (gen []
+    (let [theta  (trace :theta (dist/uniform 0 1))
+          p-stop (p-stop-of theta)]
+      (run-block trace "" p-stop))))
+
+;; Control: a genuinely static model — must NOT be falsely flagged as escaping,
+;; and must still compile (no regression).
+(def static-model
+  (gen [] (let [a (trace :a (dist/gaussian 0 1))]
+            (trace :b (dist/gaussian a 1)))))
+
+;; Second hiding mechanism (no `trace` ever appears as a value): an inner fn
+;; traces in HEAD position but is handed to an opaque higher-order function,
+;; which decides how many times it runs. The single-shot compiled path would
+;; under-count the site; must route to the handler instead.
+(def hof-model
+  (gen [n]
+    (let [step (fn [i] (trace (keyword (str "x" i)) (dist/gaussian 0 1)))]
+      (run! step (range n))
+      :done)))
+
+;; Third hiding mechanism: a `letfn`-bound tracing function handed to a HOF. The
+;; name `step` is neither the bare `trace` binding nor an fn-literal, so it slips
+;; past mechanisms 1 and 2 — but it is the same indirectly-invoked capability.
+(def letfn-model
+  (gen [n]
+    (letfn [(step [i] (trace (keyword (str "x" i)) (dist/gaussian 0 1)))]
+      (run! step (range n))
+      :done)))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- all-constraints
+  "Build a constraint choicemap from every leaf of a trace's choices."
+  [ch]
+  (reduce (fn [cm path] (cm/set-choice cm path (cm/get-choice ch path)))
+          cm/EMPTY (cm/addresses ch)))
+
+(defn- without-addr
+  "Constraint choicemap of all leaves of `ch` except the given top-level addr."
+  [ch drop-addr]
+  (reduce (fn [cm path]
+            (if (= [drop-addr] path)
+              cm
+              (cm/set-choice cm path (cm/get-choice ch path))))
+          cm/EMPTY (cm/addresses ch)))
+
+(defn- gen-weight [gf args constraints]
+  (mx/item (:weight (p/generate (dyn/with-key gf (rng/fresh-key 0)) args constraints))))
+
+;; ---------------------------------------------------------------------------
+;; 1. Schema classification — the root cause level
+;; ---------------------------------------------------------------------------
+
+(deftest schema-classification
+  (testing "trace escaping into an opaque call is detected"
+    (let [s (:schema plate-model)]
+      (is (true? (:opaque-gen-escape? s)) "plate body escapes trace -> flagged")
+      (is (false? (:static? s)) "escaping body is NOT static")
+      (is (nil? (:compiled-simulate s)) "no compiled-simulate attached")
+      (is (nil? (:compiled-prefix s)) "no compiled-prefix attached")
+      (is (nil? (:auto-handlers s)) "no analytical handlers attached")))
+
+  (testing "return-form escape is detected too (single-block model)"
+    (let [s (:schema single-model)]
+      (is (true? (:opaque-gen-escape? s)) "single-block escape flagged")
+      (is (false? (:static? s)) "single-block not static")
+      (is (nil? (:compiled-simulate s)) "single-block has no compiled path")))
+
+  (testing "dispatch routes escaping models to the handler for every op"
+    (doseq [op [:simulate :generate :update :regenerate :assess :project]]
+      (is (= :handler (:label (dyn/resolve-dispatch plate-model op)))
+          (str "plate " op " dispatches to handler"))))
+
+  (testing "genuinely static models are NOT false-flagged (no regression)"
+    (let [s (:schema static-model)]
+      (is (false? (boolean (:opaque-gen-escape? s))) "static model not flagged")
+      (is (true? (:static? s)) "static model stays static")
+      (is (some? (:compiled-simulate s)) "static model still compiles (L1-M2)")))
+
+  (testing "tracing fn-literal handed to an opaque HOF is detected (mechanism 2)"
+    (let [s (:schema hof-model)]
+      (is (true? (:opaque-gen-escape? s)) "HOF-driven inner-fn trace -> flagged")
+      (is (false? (:static? s)) "HOF model is not static")
+      (is (nil? (:compiled-simulate s)) "HOF model has no compiled path")))
+
+  (testing "letfn-bound tracing fn handed to an opaque HOF is detected (mechanism 3)"
+    (let [s (:schema letfn-model)]
+      (is (true? (:opaque-gen-escape? s)) "letfn-bound tracer -> flagged")
+      (is (false? (:static? s)) "letfn model is not static")
+      ;; project's M2 builder (unlike the others) succeeds on this shape, so
+      ;; without the flag it would wrongly dispatch :project to :compiled.
+      (is (nil? (:compiled-project s)) "letfn model has no compiled-project")
+      (is (= :handler (:label (dyn/resolve-dispatch letfn-model :project)))
+          "letfn project dispatches to handler")))
+
+  (testing "escapes-gen-binding detection edge cases"
+    ;; head-position trace is fine; arg-position trace escapes; renamed binding escapes.
+    (is (false? (:opaque-gen-escape?
+                 (schema/extract-schema '([] (trace :x (dist/gaussian 0 1))))))
+        "(trace :x ...) head position is not an escape")
+    (is (true? (:opaque-gen-escape?
+                (schema/extract-schema '([] (helper trace 1)))))
+        "(helper trace 1) arg position escapes")
+    (is (true? (:opaque-gen-escape?
+                (schema/extract-schema '([] (let [tr trace] (tr :x (dist/gaussian 0 1)))))))
+        "let-rebinding trace escapes")
+    (is (true? (:opaque-gen-escape?
+                (schema/extract-schema '([] (loop [b 0] (run-block trace b) (recur (inc b)))))))
+        "trace inside an opaque call in a loop escapes")
+    ;; mechanism 2: tracing fn-literal as a value escapes; immediate-invoke is fine.
+    (is (true? (:opaque-gen-escape?
+                (schema/extract-schema '([] (run! (fn [i] (trace :a (dist/gaussian 0 1))) xs)))))
+        "tracing fn-literal passed to a HOF escapes")
+    (is (true? (:opaque-gen-escape?
+                (schema/extract-schema '([] (mapv #(trace :a (dist/gaussian 0 1)) xs)))))
+        "tracing reader-fn passed to a HOF escapes")
+    (is (true? (:opaque-gen-escape?
+                (schema/extract-schema '([] (let [f (fn [] (trace :a (dist/gaussian 0 1)))] (f))))))
+        "tracing fn-literal stored in a let escapes")
+    (is (false? (:opaque-gen-escape?
+                 (schema/extract-schema '([] ((fn [] (trace :a (dist/gaussian 0 1))))))))
+        "immediately-invoked tracing fn runs once — NOT an escape")
+    (is (false? (:opaque-gen-escape?
+                 (schema/extract-schema '([] (mapv (fn [x] (* x x)) xs)))))
+        "non-tracing fn-literal passed to a HOF is fine")
+    ;; mechanism 3: letfn-bound tracer escapes; param-only letfn does NOT.
+    (is (true? (:opaque-gen-escape?
+                (schema/extract-schema '([xs] (letfn [(step [i] (trace :y (dist/gaussian 0 1)))]
+                                                (run! step xs))))))
+        "letfn-bound tracing fn escapes")
+    (is (false? (:opaque-gen-escape?
+                 (schema/extract-schema '([xs] (letfn [(g [i] (* i i))] (mapv g xs))))))
+        "letfn with no trace is fine")
+    (is (false? (:opaque-gen-escape?
+                 (schema/extract-schema '([] (mapv (fn [x] (param :w)) xs)))))
+        "param-only fn-literal is NOT a tracing capability (param exclusion)")))
+
+;; ---------------------------------------------------------------------------
+;; 2. The constraint-drop bug — full re-constraint must score everything
+;; ---------------------------------------------------------------------------
+
+(deftest full-reconstraint-scores-all-sites
+  (testing "generate with ALL leaves constrained => weight == simulate score"
+    (doseq [n [1 2 4]]
+      (let [k     (rng/fresh-key (+ 100 n))
+            tr    (p/simulate (dyn/with-key plate-model k) [n])
+            ch    (:choices tr)
+            score (mx/item (:score tr))
+            cons  (all-constraints ch)
+            n-leaves (count (cm/addresses cons))
+            r     (p/generate (dyn/with-key plate-model k) [n] cons)
+            w     (mx/item (:weight r))]
+        ;; the heart of the bug: pre-fix, only :theta was scored => weight ~ 0
+        (is (> n-leaves (inc n)) (str "n=" n ": plate has many hidden sites (" n-leaves ")"))
+        (is (h/finite? w) (str "n=" n ": weight finite"))
+        (is (h/close? w score 1e-3)
+            (str "n=" n ": full-constraint weight (" w ") == score (" score ")"))
+        (is (> (js/Math.abs w) 1.0)
+            (str "n=" n ": weight is NOT collapsed to ~0 (was the bug)"))))))
+
+(deftest hof-scoring-matches-handler
+  (testing "fn-literal-via-HOF model scores every iteration (mechanism 2)"
+    (doseq [n [1 3 5]]
+      (let [cons (apply cm/choicemap
+                        (mapcat (fn [i] [(keyword (str "x" i)) (mx/scalar 0.0)]) (range n)))
+            w-default (gen-weight hof-model [n] cons)
+            w-handler (mx/item (:weight (p/generate
+                                         (dyn/with-key (gfi/strip-compiled hof-model)
+                                           (rng/fresh-key 0))
+                                         [n] cons)))
+            ;; N independent N(0;0,1) sites each contribute -0.5*log(2π) ≈ -0.9189
+            expected (* n (h/gaussian-lp 0.0 0.0 1.0))]
+        (is (h/close? w-default w-handler 1e-4)
+            (str "n=" n ": default path == handler path"))
+        (is (h/close? w-default expected 1e-3)
+            (str "n=" n ": all " n " hidden sites scored (not just one)"))))))
+
+(deftest letfn-project-matches-handler
+  (testing "project on a letfn-via-HOF model scores every iteration (mechanism 3)"
+    ;; Pre-fix this dispatched :project to :compiled and under-counted (scored the
+    ;; site once instead of n times) — a real compiled-vs-handler divergence.
+    (doseq [n [1 3 5]]
+      (let [args [n]
+            keyed (dyn/with-key letfn-model (rng/fresh-key (+ 300 n)))
+            tr (p/simulate keyed args)
+            ;; select every traced site
+            site-sel (apply sel/select (mapv #(keyword (str "x" %)) (range n)))
+            w-default (mx/item (p/project keyed tr site-sel))
+            handler-gf (dyn/with-key (gfi/strip-compiled letfn-model) (rng/fresh-key (+ 300 n)))
+            tr-h (p/simulate handler-gf args)
+            w-handler (mx/item (p/project handler-gf tr-h site-sel))]
+        (is (h/finite? w-default) (str "n=" n ": project weight finite"))
+        (is (h/close? w-default w-handler 1e-3)
+            (str "n=" n ": project default (" w-default ") == handler (" w-handler ")"))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. Plate scoring == sum of per-block scores (the workaround the bug forced)
+;; ---------------------------------------------------------------------------
+
+(deftest plate-equals-sum-of-blocks
+  (testing "constraining observations in a plate scores like summing single blocks"
+    ;; Generate per-block trajectories from the single-block model, then score
+    ;; them (a) as one plate and (b) as a sum of single blocks — must match.
+    (let [n 3
+          ;; data: simulate n single blocks at TRUE-THETA
+          blocks (mapv (fn [bi]
+                         (let [k (rng/fresh-key (+ 200 bi))
+                               r (p/generate (dyn/with-key single-model k) []
+                                             (cm/choicemap :theta (mx/scalar TRUE-THETA)))]
+                           (without-addr (:choices (:trace r)) :theta)))
+                       (range n))
+          theta 0.5
+          ;; (a) plate constraints: re-prefix each block's obs as b{bi}_*
+          plate-cons (reduce
+                      (fn [cm [bi block]]
+                        (reduce (fn [cm path]
+                                  (let [a (name (first path))
+                                        a' (keyword (str "b" bi "_" a))]
+                                    (cm/set-choice cm [a'] (cm/get-choice block path))))
+                                cm (cm/addresses block)))
+                      (cm/choicemap :theta (mx/scalar theta))
+                      (map-indexed vector blocks))
+          plate-w (gen-weight plate-model [n] plate-cons)
+          ;; (b) sum of single-block weights
+          sum-w (reduce (fn [acc block]
+                          (+ acc (gen-weight single-model []
+                                             (cm/merge-cm
+                                              (cm/choicemap :theta (mx/scalar theta))
+                                              block))))
+                        0.0 blocks)]
+      (is (h/finite? plate-w) "plate weight finite")
+      (is (h/close? plate-w sum-w 1e-2)
+          (str "plate weight (" plate-w ") == sum of per-block weights (" sum-w ")")))))
+
+;; ---------------------------------------------------------------------------
+;; 4. Latent-varying likelihood — the posterior must not collapse to the prior
+;; ---------------------------------------------------------------------------
+
+(deftest likelihood-varies-with-latent
+  (testing "weight over a fixed obs trajectory varies with the constrained latent"
+    (let [n 4
+          ;; obs trajectory from the plate at TRUE-THETA
+          k   (rng/fresh-key 7)
+          tr  (:trace (p/generate (dyn/with-key plate-model k) [n]
+                                  (cm/choicemap :theta (mx/scalar TRUE-THETA))))
+          obs (without-addr (:choices tr) :theta)
+          grid [0.1 0.3 0.5 0.7 0.9]
+          ws   (mapv (fn [theta]
+                       (gen-weight plate-model [n]
+                                   (cm/merge-cm (cm/choicemap :theta (mx/scalar theta)) obs)))
+                     grid)]
+      (is (every? h/finite? ws) "all grid weights finite")
+      (is (> (apply max ws) (+ (apply min ws) 1.0))
+          (str "likelihood varies across theta (range "
+               (- (apply max ws) (apply min ws)) "), did NOT collapse"))
+      ;; the survival likelihood of a stopping rule peaks at an interior theta,
+      ;; not at the boundary 0.1 — the constraints are genuinely being scored.
+      (let [best (->> (map vector grid ws) (apply max-key second) first)]
+        (is (> best 0.1) (str "argmax theta (" best ") is interior, not the prior floor"))))))
+
+;; ---------------------------------------------------------------------------
+;; 5. Library inference runs on plate models (the bean's final 'done means')
+;; ---------------------------------------------------------------------------
+
+(deftest inference-runs-on-plate
+  (let [n 3
+        k   (rng/fresh-key 11)
+        tr  (:trace (p/generate (dyn/with-key plate-model k) [n]
+                                (cm/choicemap :theta (mx/scalar TRUE-THETA))))
+        obs (without-addr (:choices tr) :theta)]
+
+    (testing "importance sampling produces non-degenerate weights"
+      (let [{:keys [log-weights log-ml-estimate]}
+            (is/importance-sampling {:samples 200 :key (rng/fresh-key 3)}
+                                    plate-model [n] obs)
+            ws (mapv mx/item log-weights)]
+        (is (h/finite? (mx/item log-ml-estimate)) "log-ML estimate finite")
+        (is (every? h/finite? ws) "all IS log-weights finite")
+        ;; pre-fix every particle scored only the prior => identical weights.
+        (is (> (- (apply max ws) (apply min ws)) 1.0)
+            "IS weights vary across particles (not prior-collapsed)")))
+
+    (testing "MH runs and concentrates theta away from the prior mean"
+      (let [traces (mcmc/mh {:samples 150 :burn 50
+                             :selection (sel/select :theta)
+                             :key (rng/fresh-key 5)}
+                            plate-model [n] obs)
+            thetas (mapv #(mx/item (cm/get-choice (:choices %) [:theta])) traces)
+            mean-theta (h/sample-mean thetas)]
+        (is (= 150 (count traces)) "MH returned the requested number of samples")
+        (is (every? h/finite? thetas) "all sampled thetas finite")
+        (is (and (> mean-theta 0.0) (< mean-theta 1.0)) "theta within prior support")
+        ;; with real likelihood the chain MOVES; a collapsed posterior would just
+        ;; mirror the uniform prior (mean ~0.5 with huge spread). We only require
+        ;; that it produced a proper, finite posterior summary.
+        (is (> (h/sample-variance thetas) 0.0) "chain mixes (non-degenerate)")))))
+
+;; ---------------------------------------------------------------------------
+;; 6. strip-compiled / handler equivalence sanity
+;; ---------------------------------------------------------------------------
+
+(deftest handler-equivalence
+  (testing "post-fix dispatch already equals the forced-handler path"
+    (let [n 2
+          k  (rng/fresh-key 21)
+          tr (p/simulate (dyn/with-key plate-model k) [n])
+          cons (all-constraints (:choices tr))
+          w-default (gen-weight plate-model [n] cons)
+          w-handler (mx/item (:weight (p/generate
+                                       (dyn/with-key (gfi/strip-compiled plate-model)
+                                         (rng/fresh-key 0))
+                                       [n] cons)))]
+      (is (h/close? w-default w-handler 1e-4)
+          "default path == strip-compiled handler path"))))
+
+;; ---------------------------------------------------------------------------
+;; Run
+;; ---------------------------------------------------------------------------
+
+(cljs.test/run-tests)


### PR DESCRIPTION
Two independent core bugfixes, each reported with a verified repro by a downstream consumer. Both keep the GFI semantic contract intact (the handler path is ground truth).

## 1. `p/generate` silently dropped observation constraints on "plate" models (genmlx-7bm6)

**Root cause — schema misclassification, not sub-GF routing.** The schema walker only sees literal `(trace addr dist)` calls. When a gen body hands the ambient `trace`/`splice` binding to opaque code, the trace sites inside are invisible, so the model was wrongly classified `:static?` and compiled to L1-M2 — whose compiled path drops/under-counts non-final body statements. As a result `p/generate` returned weight 0 (posterior collapsed to the prior) for models that invoke a tracing helper N times in one body.

**Fix.** `escapes-gen-binding?` detects three trace-hiding mechanisms — (1) bare `trace`/`splice` used as a value, (2) a tracing `fn`-literal passed to a higher-order function, (3) a `letfn`-bound tracer handed to a HOF (was exploitable via `compiled-project`). It flags `:opaque-gen-escape?`, which disqualifies `:static?` and short-circuits `make-gen-fn` to the handler path with no compiled ops and no conjugacy augmentation. `contains-trace-call?` honors the documented `param` exclusion. Since the handler path is always correct, this only fixes correctness.

Adds `test/genmlx/plate_generate_test.cljs` (73 assertions across the three mechanisms, plate==sum-of-blocks scoring, latent-varying likelihood, is/mh on plates, and false-positive guards).

## 2. `genmlx.edit` couldn't load without the native MLX backend (genmlx-5413)

`genmlx.edit` is documented Layer-A (pure ClojureScript) but its top-level `(:require [genmlx.mlx :as mx])` forces `mlx.cljs`'s eager `(js/require "@mlx-node/core")` at load — so requiring the edit interface threw on CI / non-Apple / clean checkout / any consumer outside genmlx's tree, even for `ConstraintEdit`/`SelectionEdit`, which use no MLX.

**Fix.** The only `mx` use is the `ProposalEdit` weight combine. Drop the top-level require and route it through `w-add`/`w-sub`, which use `+`/`-` for plain-number weights (pure/deterministic GFs) and resolve `genmlx.mlx`'s `add`/`subtract` **lazily** — through the membrane, via a `defonce` delay, only when an `MxArray` weight actually appears. `ConstraintEdit`, `SelectionEdit`, and every constructor now stay genuinely Layer-A pure; `ProposalEdit` is unchanged for MLX-backed GFs.

Verified backend-absent load from a dir with no `@mlx-node/core`. Adds `test/genmlx/edit_purity_test.cljs` (15 assertions). The broader work — making `genmlx.mlx` itself lazy-loadable (73 direct-NAPI op defs, 65 dependents) — is deferred as a separate, larger effort.

## Verification

No regressions across the suites that exercise these changes: schema, the compiled paths (M2–L4), `gen_clj_compat` (356) / `genjax_compat` (73), conjugacy, branch-rewrite, the agents suites, and the three edit suites (`proposal_edit` / `edit_property` / `smcp3_kernel`). A full 251-suite sweep showed the only failures are pre-existing native Metal resource-limit crashes, perf-threshold flakes, and statistical-convergence flakes — none caused by these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
