### PR TITLE
feat(agents): Ch 3a line-world + Ch 3b hiking gridworld

### DIFF
--- a/src/genmlx/agents/worlds.cljs
+++ b/src/genmlx/agents/worlds.cljs
@@ -1,0 +1,76 @@
+(ns genmlx.agents.worlds
+  "Canonical agentmodels.org environments as reusable data, compiled through
+   genmlx.agents.gridworld/build-mdp. The two worlds that OPEN the curriculum:
+
+   - `line-mdp` — Ch 3a integer line-world: a 1-D corridor with a single goal.
+     The minimal, hand-traceable MDP (value iteration + softmax policy on a line).
+
+   - `hike-mdp` — Ch 3b Hiking gridworld: West (U=1) and East (U=10) peaks are
+     walled pockets in the middle row; the bottom row is a Hill cliff (U=-10).
+     Deterministic and stochastic (orthogonal-slip) variants. Under noise the
+     agent values cliff-adjacent cells LESS and routes away from the Hill — the
+     canonical noise-induced-detour demonstration. The grid, utilities, start and
+     noise are re-derived from agentmodels' makeHikeMDP (5×5, start [0,1],
+     East 10 / West 1 / Hill -10, timeCost -0.1, noise 0 or 0.1).
+
+   These are pure data; the heavy numeric work (value iteration, rollout) lives in
+   genmlx.agents.agent. New worlds belong here, keeping gridworld.cljs the compiler."
+  (:require [genmlx.agents.gridworld :as gw]))
+
+;; ===========================================================================
+;; Ch 3a — integer line-world (the minimal teaching MDP)
+;; ===========================================================================
+
+(defn line-grid
+  "A 1×n corridor (one row, screen coords) with a single :goal terminal at
+   column `goal-idx`. Every other cell is empty."
+  [n goal-idx]
+  [(vec (for [i (range n)] (if (= i goal-idx) :goal :empty)))])
+
+(defn line-mdp
+  "Build the Ch 3a integer line-world: an n-state 1-D corridor with a single
+   :goal reward and a per-step timeCost (so the agent reaches the goal quickly).
+   Movement is left/right; up/down clamp to a stay since the grid is one row high.
+
+   Options: :n (default 7) :goal-idx (default n-1) :reward (default 1.0)
+            :time-cost (default -0.1) :start (default [0 0]) :gamma (default 1.0)."
+  [{:keys [n goal-idx reward time-cost start gamma]
+    :or {n 7 reward 1.0 time-cost -0.1 gamma 1.0}}]
+  (let [goal-idx (or goal-idx (dec n))]
+    (gw/build-mdp {:grid (line-grid n goal-idx)
+                   :utilities {:goal reward :timeCost time-cost}
+                   :start (or start [0 0]) :gamma gamma :noise 0.0})))
+
+;; ===========================================================================
+;; Ch 3b — Hiking gridworld (the noise-induced-detour demonstration)
+;; ===========================================================================
+
+(def hike-grid
+  "agentmodels' makeHikeMDP, a 5×5 grid (rows top-first; screen coords).
+   West (idx 12) and East (idx 14) peaks sit in the middle row, each a pocket
+   walled off (walls at idx 6, 11, 13). The whole bottom row (idx 20–24) is a
+   Hill cliff. Start is [0,1] = idx 5."
+  [[:empty :empty :empty :empty :empty]
+   [:empty :wall  :empty :empty :empty]
+   [:empty :wall  :west  :wall  :east]
+   [:empty :empty :empty :empty :empty]
+   [:hill  :hill  :hill  :hill  :hill]])
+
+(def hike-utilities
+  "agentmodels hike payoffs: East 10 (the prize peak), West 1 (the lesser peak),
+   Hill -10 (the cliff), and a -0.1 per-step timeCost (preference for short hikes)."
+  {:east 10.0 :west 1.0 :hill -10.0 :timeCost -0.1})
+
+(defn hike-mdp
+  "Build the Hiking MDP. `:noise` selects the agentmodels variant:
+     0.0  → deterministic (totalTime 12);
+     0.1  → stochastic orthogonal slip (totalTime 13), where stepping along the
+            cliff-adjacent bottom rows risks slipping into a Hill, so a
+            noise-aware agent keeps its distance.
+
+   Options: :noise (default 0.0) :utilities (default hike-utilities)
+            :start (default [0 1]) :gamma (default 1.0)."
+  [{:keys [noise utilities start gamma]
+    :or {noise 0.0 utilities hike-utilities start [0 1] gamma 1.0}}]
+  (gw/build-mdp {:grid hike-grid :utilities utilities
+                 :start start :gamma gamma :noise noise}))

--- a/test/genmlx/agentmodels_worlds_test.cljs
+++ b/test/genmlx/agentmodels_worlds_test.cljs
@@ -1,0 +1,97 @@
+;; Headless tests for the canonical opening worlds (genmlx.agents.worlds):
+;; the Ch 3a integer line-world and the Ch 3b Hiking gridworld. Pure data +
+;; asserts (no Ink/terminal). The hiking world reproduces agentmodels' canonical
+;; noise-induced detour: the DETERMINISTIC optimal agent cuts along the
+;; cliff-adjacent bottom row, while the STOCHASTIC (orthogonal-slip) agent detours
+;; along the top, away from the Hill — both reach the East peak. Value iteration
+;; is RNG-free, so the routes below are reproducible.
+;; Run: bun run --bun nbb test/genmlx/agentmodels_worlds_test.cljs
+
+(ns genmlx.agentmodels-worlds-test
+  (:require [genmlx.agents.worlds :as w]
+            [genmlx.agents.agent :as agent]
+            [genmlx.mlx :as mx]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-equal [msg expected actual]
+  (if (= expected actual) (do (vswap! passed inc) (println " PASS" msg "  =" (pr-str actual)))
+      (do (vswap! failed inc) (println " FAIL" msg "  expected:" (pr-str expected) "  got:" (pr-str actual)))))
+
+(defn- vvec [V n] (mapv #(mx/item (mx/idx V %)) (range n)))
+(defn- greedy-path
+  "Follow the agent's argmax-Q action under deterministic geometry (ns-fn) from
+   `start` to a terminal — the agent's INTENDED route, independent of env noise."
+  [ag start]
+  (let [Qm (mx/->clj (:Q ag)) A (:A (:mdp ag)) nsf (:ns-fn (:mdp ag))
+        terms (set (keys (:terminals (:mdp ag))))]
+    (loop [s start path [start] n 0]
+      (if (or (terms s) (> n 30)) path
+          (let [a (apply max-key #(nth (nth Qm s) %) (range A)) s' (nsf s a)]
+            (recur s' (conj path s') (inc n)))))))
+
+;; --- Ch 3a: integer line-world ----------------------------------------------
+(println "\n-- Ch 3a: integer line-world --")
+(let [m  (w/line-mdp {})
+      ag (agent/make-mdp-agent {:mdp m :alpha ##Inf :gamma 1.0 :n-iters 10})
+      {:keys [states actions]} (agent/simulate-mdp ag (:start-idx m) 10)
+      V  (vvec (:V ag) (:S m))]
+  (assert-equal "line S = 7"               7 (:S m))
+  (assert-equal "line terminal {6 :goal}"  {6 :goal} (:terminals m))
+  (assert-equal "line start-idx = 0"       0 (:start-idx m))
+  (assert-equal "line rollout walks 0 -> 6" [0 1 2 3 4 5 6] states)
+  (assert-true  "line rollout is all :right" (every? #{:right} (mapv (:action-kw m) actions)))
+  (assert-equal "line rollout ends at goal" 6 (last states))
+  (assert-true  "line V is maximal at the goal (idx 6)" (= 6 (apply max-key #(nth V %) (range 7)))))
+
+;; --- Ch 3b: Hiking gridworld — structure + deterministic optimal ------------
+(println "\n-- Ch 3b: hiking gridworld (deterministic) --")
+(def hike-det (w/hike-mdp {:noise 0.0}))
+(let [m hike-det]
+  (assert-equal "hike S = 25"            25 (:S m))
+  (assert-equal "hike walls {6 11 13}"   #{6 11 13} (:walls m))
+  (assert-equal "hike terminals (W=12 E=14 Hill=20..24)"
+                {12 :west 14 :east 20 :hill 21 :hill 22 :hill 23 :hill 24 :hill} (:terminals m))
+  (assert-equal "hike start-idx = 5 ([0,1])" 5 (:start-idx m))
+  (assert-equal "hike T shape [25 4 25]" [25 4 25] (mx/shape (:T m)))
+  (assert-true  "hike T rows each sum to 1 (total 100)"
+                (< (Math/abs (- 100.0 (mx/item (mx/sum (:T m))))) 1e-3)))
+
+(def ag-det (agent/make-mdp-agent {:mdp hike-det :alpha ##Inf :gamma 1.0 :n-iters 15}))
+(let [V (vvec (:V ag-det) 25)
+      path (greedy-path ag-det (:start-idx hike-det))
+      hills #{20 21 22 23 24}]
+  (assert-true  "hike det: V is maximal at East (idx 14)" (= 14 (apply max-key #(nth V %) (range 25))))
+  (assert-equal "hike det: greedy route reaches East" 14 (last path))
+  (assert-true  "hike det: route never steps on a Hill" (not (some hills path))))
+
+;; --- Ch 3b: the noise-induced detour (the canonical demonstration) ----------
+(println "\n-- Ch 3b: noise-induced detour --")
+(def hike-noisy (w/hike-mdp {:noise 0.1}))
+(def ag-noisy (agent/make-mdp-agent {:mdp hike-noisy :alpha ##Inf :gamma 1.0 :n-iters 15}))
+(let [vd (vvec (:V ag-det) 25)
+      vn (vvec (:V ag-noisy) 25)
+      cliff-adjacent #{15 16 17 18 19}]   ; row 3, directly above the Hill cliff
+  (assert-true "cliff cells worth less under noise (V_noisy < V_det across row 3)"
+               (every? (fn [i] (< (nth vn i) (nth vd i))) cliff-adjacent))
+  (assert-true "the value drop is large mid-cliff (idx 16,17 lose > 1.0)"
+               (and (> (- (nth vd 16) (nth vn 16)) 1.0)
+                    (> (- (nth vd 17) (nth vn 17)) 1.0))))
+
+(let [row3 #{15 16 17 18 19}
+      pd (greedy-path ag-det (:start-idx hike-det))      ; cuts along the cliff
+      pn (greedy-path ag-noisy (:start-idx hike-noisy))   ; detours along the top
+      cliff-d (count (filter row3 pd))
+      cliff-n (count (filter row3 pn))]
+  (println "   det route  :" pd "  cliff-adjacent cells:" cliff-d)
+  (println "   noisy route:" pn "  cliff-adjacent cells:" cliff-n)
+  (assert-true  "deterministic route hugs the cliff (uses row-3 cells)" (pos? cliff-d))
+  (assert-equal "noisy route avoids the cliff entirely (0 row-3 cells)" 0 cliff-n)
+  (assert-true  "noisy agent DETOURS: strictly fewer cliff-adjacent cells" (< cliff-n cliff-d))
+  (assert-equal "noisy route still reaches East" 14 (last pn)))
+
+(println (str "\n== Results: " @passed " passed, " @failed " failed =="))
+(when (pos? @failed) (js/process.exit 1))


### PR DESCRIPTION
Adds the two iconic worlds that open the agentmodels.org curriculum, as reusable data compiled through `gridworld/build-mdp` in a new `genmlx.agents.worlds` namespace. Purely additive — no existing file changed, no new mechanism (the planner already supports negative-utility terminals + orthogonal slip).

## Worlds

- **`line-mdp`** (Ch 3a — integer line-world): an n-state 1-D corridor with a single `:goal` and a per-step timeCost. The minimal, hand-traceable teaching MDP; the optimal agent walks `0 → 6` (all `:right`).
- **`hike-grid` / `hike-mdp`** (Ch 3b — Hiking gridworld): re-derived from agentmodels' `makeHikeMDP` (5×5, walls `{6,11,13}`, West U=1 @12 / East U=10 @14 / Hill cliff U=-10 @20–24, start `[0,1]`, timeCost −0.1). `:noise` selects the deterministic (0) vs stochastic orthogonal-slip (0.1) variant.

## Test — the canonical noise-induced detour

`test/genmlx/agentmodels_worlds_test.cljs` (22 assertions, RNG-free so stable) reproduces agentmodels' signature result:

- the **deterministic** optimal agent hugs the cliff: `[5 10 15 16 17 18 19 14]` (5 cliff-adjacent cells);
- the **stochastic** agent detours along the top: `[5 0 1 2 3 4 9 14]` (0 cliff-adjacent cells);
- both reach the East peak, and cliff-adjacent cells (row 3) lose > 1.0 value under slip risk.

Closes items (1)–(2) of the iconic-environments task; the restaurant-POMDP adjacency-reveal upgrade, big-hiking IRL, and the goal+lava PSRL grid remain. A visual det-vs-noisy hike rollout is a natural follow-up for the TUI gallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
