### PR TITLE
feat(agents): goal+lava PSRL exploration world

### DIFF
--- a/examples/agentmodels/psrl.cljs
+++ b/examples/agentmodels/psrl.cljs
@@ -55,43 +55,63 @@
     (vec (remove walls (range S)))))
 
 ;; ===========================================================================
-;; Per-cell-reward MDP (non-terminal, finite-horizon, 5-action, deterministic)
+;; Per-cell-reward MDP (non-terminal, finite-horizon, 5-action)
 ;; ===========================================================================
+
+;; Orthogonal slip for the 5-action grid: left/right slip to up/down and vice
+;; versa; the stay action (4) never slips. (Same convention as gridworld.cljs.)
+(def ^:private perp {0 [2 3] 1 [2 3] 2 [0 1] 3 [0 1]})
+
+(defn- t-row
+  "Transition distribution [S] for (s,a): mass (1-noise) on the intended next
+   state and noise/2 on each orthogonal slip target (no slip for stay or noise 0).
+   Slipping into a wall/edge keeps the agent put, since ns-rows encodes that."
+  [S ns-rows s a noise]
+  (let [mass (if (and (pos? noise) (perp a))
+               (let [[p q] (perp a)]
+                 (merge-with +
+                   {(get-in ns-rows [s a]) (- 1.0 noise)}
+                   {(get-in ns-rows [s p]) (* 0.5 noise)}
+                   {(get-in ns-rows [s q]) (* 0.5 noise)}))
+               {(get-in ns-rows [s a]) 1.0})]
+    (mapv #(get mass % 0.0) (range S))))
 
 (defn reward-grid-mdp
   "MDP over `grid` whose reward is `reward` ([S] of per-cell rewards, applied each
-   step — NOT terminal). Deterministic 5-action geometry (incl. stay). Finite-horizon
+   step — NOT terminal). 5-action geometry (incl. stay); with `noise` > 0 each
+   non-stay action slips orthogonally with probability `noise`. Finite-horizon
    value iteration accumulates reward over the horizon."
-  [grid reward]
-  (let [{:keys [W H S walls]} (gw/parse-grid grid)
-        A       (count action-deltas)
-        ns-fn   (fn [s a]
-                  (let [x (mod s W) y (quot s W)
-                        [dx dy] (nth action-deltas a)
-                        nx (max 0 (min (dec W) (+ x dx)))
-                        ny (max 0 (min (dec H) (+ y dy)))
-                        n  (+ nx (* W ny))]
-                    (if (contains? walls n) s n)))
-        ns-rows (vec (for [s (range S)] (vec (for [a (range A)] (ns-fn s a)))))
-        T       (mx/array (clj->js (vec (for [s (range S)]
-                                          (vec (for [a (range A)]
-                                                 (let [s' (get-in ns-rows [s a])]
-                                                   (mapv #(if (= % s') 1.0 0.0) (range S))))))))
-                          mx/float32)
-        R       (mx/array (clj->js (vec (for [s (range S)] (vec (repeat A (double (nth reward s))))))) mx/float32)
-        term    (mx/array (clj->js (vec (repeat S 0.0))) mx/float32)]
-    (mx/eval! T R term)
-    {:W W :H H :S S :A A :T T :R R :term term :terminals {} :walls walls
-     :start-idx START-IDX :ns-fn ns-fn :action-kw [:left :right :up :down :stay] :gamma 1.0 :noise 0.0}))
+  ([grid reward] (reward-grid-mdp grid reward 0.0))
+  ([grid reward noise]
+   (let [{:keys [W H S walls]} (gw/parse-grid grid)
+         A       (count action-deltas)
+         ns-fn   (fn [s a]
+                   (let [x (mod s W) y (quot s W)
+                         [dx dy] (nth action-deltas a)
+                         nx (max 0 (min (dec W) (+ x dx)))
+                         ny (max 0 (min (dec H) (+ y dy)))
+                         n  (+ nx (* W ny))]
+                     (if (contains? walls n) s n)))
+         ns-rows (vec (for [s (range S)] (vec (for [a (range A)] (ns-fn s a)))))
+         T       (mx/array (clj->js (vec (for [s (range S)]
+                                           (vec (for [a (range A)] (t-row S ns-rows s a noise))))))
+                           mx/float32)
+         R       (mx/array (clj->js (vec (for [s (range S)] (vec (repeat A (double (nth reward s))))))) mx/float32)
+         term    (mx/array (clj->js (vec (repeat S 0.0))) mx/float32)]
+     (mx/eval! T R term)
+     {:W W :H H :S S :A A :T T :R R :term term :terminals {} :walls walls
+      :start-idx START-IDX :ns-fn ns-fn :action-kw [:left :right :up :down :stay] :gamma 1.0 :noise noise})))
 
 (defn- one-hot [S i] (vec (for [s (range S)] (if (= s i) 1.0 0.0))))
 
 (defn optimal-return
-  "V*(start) over `horizon` steps under the true reward (the best achievable return)."
-  [grid reward start horizon]
-  (let [mdp (reward-grid-mdp grid reward)
-        {:keys [V]} (agent/value-iteration (assoc mdp :gamma 1.0) ##Inf horizon)]
-    (mx/item (mx/idx V start))))
+  "V*(start) over `horizon` steps under the true reward (the best achievable
+   expected return). Pass `noise` for the stochastic variant."
+  ([grid reward start horizon] (optimal-return grid reward start horizon 0.0))
+  ([grid reward start horizon noise]
+   (let [mdp (reward-grid-mdp grid reward noise)
+         {:keys [V]} (agent/value-iteration (assoc mdp :gamma 1.0) ##Inf horizon)]
+     (mx/item (mx/idx V start)))))
 
 ;; ===========================================================================
 ;; Reward posterior (categorical over which free cell is the goal) + exact update
@@ -132,36 +152,64 @@
   [xs]
   (reduce (fn [best i] (if (> (nth xs i) (nth xs best)) i best)) 0 (range 1 (count xs))))
 
+(defn- sample-cat
+  "Index sampled from categorical `probs` using uniform `u` ∈ [0,1)."
+  [probs u]
+  (loop [i 0, acc 0.0]
+    (let [acc' (+ acc (nth probs i))]
+      (if (or (>= i (dec (count probs))) (< u acc')) i (recur (inc i) acc')))))
+
 (defn- run-episode
-  "Plan optimally on `sampled-goal` (value iteration), roll out one episode in the
-   TRUE world with a DETERMINISTIC greedy policy (argmax over Q, first-index tie-break,
-   noise-0 transitions), and return {:states :return} — the visited states and realized
-   true return. Deterministic so a seed fully reproduces the PSRL run (the only
-   randomness is the Thompson model-sample)."
-  [grid true-reward sampled-goal horizon S]
-  (let [mdp   (reward-grid-mdp grid (one-hot S sampled-goal))
+  "Plan optimally on `plan-reward` (value iteration over the same `noise` MDP the
+   agent acts in), roll out one episode with a greedy policy (argmax over Q,
+   first-index tie-break), and return {:states :return} scored under `true-reward`.
+   Transitions are deterministic when noise = 0, else sampled from the noisy T with
+   a `seed`-driven LCG — so the whole PSRL run stays reproducible."
+  [grid plan-reward true-reward horizon S noise seed]
+  (let [mdp   (reward-grid-mdp grid plan-reward noise)
         {:keys [Q]} (agent/value-iteration (assoc mdp :gamma 1.0) ##Inf horizon)
         Qh    (mx/->clj Q)
+        Th    (when (pos? noise) (mx/->clj (:T mdp)))
         ns-fn (:ns-fn mdp)
-        states (loop [s START-IDX, step 0, acc [START-IDX]]
+        states (loop [s START-IDX, step 0, acc [START-IDX], r (lcg (+ (* seed 31) 7))]
                  (if (>= step horizon)
                    acc
                    (let [a  (argmax-first (nth Qh s))
-                         s' (ns-fn s a)]
-                     (recur s' (inc step) (conj acc s')))))
+                         [s' r'] (if (pos? noise)
+                                   [(sample-cat (nth (nth Th s) a) (/ r 2147483648.0)) (lcg r)]
+                                   [(ns-fn s a) r])]
+                     (recur s' (inc step) (conj acc s') r'))))
         ret    (reduce + (map #(nth true-reward %) (take horizon states)))]
     {:states states :return ret}))
 
+(defn combined-reward
+  "Per-cell reward [S]: +1 on the `goal`, `penalty` on each known `lava` cell, 0
+   elsewhere. Lava is a known feature shared by every reward hypothesis; only the
+   +1 goal is the latent the posterior is over."
+  [S lava penalty goal]
+  (mapv (fn [s] (cond (= s goal) 1.0
+                      (contains? lava s) (double penalty)
+                      :else 0.0))
+        (range S)))
+
 (defn psrl
   "Run PSRL for `n-episodes`. Returns per-episode {:sampled :posterior :return :regret}
-   plus :cum-regret and :final-posterior. `learn?` false = no-learning baseline (keep
-   sampling from the fixed prior, never update) — for comparison."
-  [{:keys [grid true-goal horizon n-episodes seed learn?]
-    :or {grid grid true-goal TRUE-GOAL horizon HORIZON n-episodes 10 seed 1 learn? true}}]
+   plus :cum-regret, :final-posterior, :v-star. `learn?` false = no-learning baseline
+   (keep sampling from the fixed prior, never update) — for comparison.
+
+   Goal+lava variant (genmlx.agents.worlds/lava-world): `:lava` (set of known
+   penalty cells, excluded from the goal posterior), `:penalty` (their per-step
+   reward), and `:noise` (orthogonal-slip transition probability). Under noise,
+   crossing near the lava risks the penalty, so exploring toward the wrong cell is
+   costly and learning the goal visibly reduces regret. Defaults (lava #{}, penalty
+   0, noise 0) reproduce the bland-grid PSRL exactly."
+  [{:keys [grid true-goal horizon n-episodes seed learn? lava penalty noise]
+    :or {grid grid true-goal TRUE-GOAL horizon HORIZON n-episodes 10 seed 1 learn? true
+         lava #{} penalty 0.0 noise 0.0}}]
   (let [{:keys [S]} (gw/parse-grid grid)
-        free        (free-cells grid)
-        true-reward (one-hot S true-goal)
-        v-star      (optimal-return grid true-reward START-IDX horizon)]
+        free        (vec (remove lava (free-cells grid)))     ; goal candidates exclude known lava
+        true-reward (combined-reward S lava penalty true-goal)
+        v-star      (optimal-return grid true-reward START-IDX horizon noise)]
     (loop [ep 0, post (uniform-posterior free), eps []]
       (if (>= ep n-episodes)
         (let [regrets (map :regret eps)]
@@ -169,11 +217,16 @@
            :cum-regret (vec (reductions + regrets))
            :final-posterior post
            :v-star v-star})
-        (let [g   (sample-goal post (+ (* seed 1000) ep))
-              {:keys [states return]} (run-episode grid true-reward g horizon S)
-              post' (if learn?
-                      (reduce (fn [b s] (update-posterior b s (nth true-reward s))) post states)
-                      post)]
+        (let [g       (sample-goal post (+ (* seed 1000) ep))
+              plan-r  (combined-reward S lava penalty g)
+              {:keys [states return]} (run-episode grid plan-r true-reward horizon S noise
+                                                   (+ (* seed 1000) ep))
+              ;; the posterior is over the +1 goal only; lava is known, so update on
+              ;; the goal signal (1 at the true goal, 0 elsewhere), not the penalty.
+              post'   (if learn?
+                        (reduce (fn [b s] (update-posterior b s (if (= s true-goal) 1.0 0.0))) post states)
+                        post)]
           (recur (inc ep) post'
                  (conj eps {:sampled g :return return :regret (- v-star return)
-                            :posterior post' :reached-goal? (boolean (some #(= true-goal %) states))})))))))
+                            :posterior post' :states states
+                            :reached-goal? (boolean (some #(= true-goal %) states))})))))))

--- a/src/genmlx/agents/worlds.cljs
+++ b/src/genmlx/agents/worlds.cljs
@@ -74,3 +74,36 @@
     :or {noise 0.0 utilities hike-utilities start [0 1] gamma 1.0}}]
   (gw/build-mdp {:grid hike-grid :utilities utilities
                  :start start :gamma gamma :noise noise}))
+
+;; ===========================================================================
+;; Ch 3d — goal+lava exploration world (for Posterior Sampling RL)
+;; ===========================================================================
+
+(def lava-world
+  "A goal+lava exploration world for the PSRL driver (agentmodels.psrl). A 5×5
+   open grid (rows top-first; start is idx 0, top-left) with:
+     - LAVA flanking the only row-2 crossing: idx {10,11,13,14}, so the single gap
+       at idx 12 is bracketed by lava on both sides. Descending through the gap, an
+       orthogonal slip lands on lava — KNOWN, fixed per-step penalty cells;
+     - the rewarding GOAL in the SAFE top region (idx 3) — reachable without ever
+       crossing the lava;
+     - transition NOISE (orthogonal slip, default 0.2).
+
+   The PSRL reward is per-cell, applied each step (NOT terminal), matching the
+   driver's finite-horizon utility(state); lava is a known feature shared by every
+   reward hypothesis, while the +1 goal is the unknown the posterior is over.
+
+   Why it makes exploration visibly meaningful: while the agent is UNCERTAIN it
+   samples goals all over — including the bottom — and chasing a bottom goal forces
+   it across the lava gap, where it slips into the penalty. Once it LEARNS the true
+   goal is in the safe top, it stops crossing. So learning REDUCES both the lava
+   exposure and the regret versus the no-learning baseline (empirically ~halves the
+   lava hits and cuts regret several-fold).
+
+   Consume via (agentmodels.psrl/psrl (merge worlds/lava-world {:seed s :n-episodes n}))."
+  {:grid       (vec (repeat 5 (vec (repeat 5 :empty))))
+   :lava       #{10 11 13 14}
+   :true-goal  3
+   :penalty    -3.0
+   :noise      0.2
+   :horizon    12})

--- a/test/genmlx/agentmodels_psrl_lava_test.cljs
+++ b/test/genmlx/agentmodels_psrl_lava_test.cljs
@@ -1,0 +1,84 @@
+;; Headless test for the goal+lava PSRL exploration world (genmlx.agents.worlds/
+;; lava-world) on the agentmodels Ch 3d PSRL driver. Demonstrates that lava + noise
+;; make exploration VISIBLY MEANINGFUL: while uncertain, the agent samples goals all
+;; over and chasing a bottom goal forces it across the lava gap (slip -> penalty);
+;; once it learns the true goal is in the safe top, it stops crossing. So learning
+;; both REDUCES lava exposure and cuts regret vs the no-learning baseline.
+;;
+;; The PSRL run is seed-driven (deterministic LCG for Thompson sampling AND the
+;; orthogonal-slip transitions), so these summed-over-seeds results are reproducible.
+;; Run: bun run --bun nbb test/genmlx/agentmodels_psrl_lava_test.cljs
+
+(ns genmlx.agentmodels-psrl-lava-test
+  (:require [agentmodels.psrl :as ps]
+            [genmlx.agents.worlds :as w]
+            [genmlx.agents.gridworld :as gw]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-equal [msg expected actual]
+  (if (= expected actual) (do (vswap! passed inc) (println " PASS" msg "  =" (pr-str actual)))
+      (do (vswap! failed inc) (println " FAIL" msg "  expected:" (pr-str expected) "  got:" (pr-str actual)))))
+
+(defn- cum [r] (last (:cum-regret r)))
+(defn- lava-hits [r lava]
+  (reduce + (map (fn [e] (count (filter lava (butlast (:states e))))) (:episodes r))))
+
+;; ---------------------------------------------------------------------------
+(println "\n-- world structure --")
+(let [{:keys [lava true-goal grid]} w/lava-world
+      free (set (remove lava (ps/free-cells grid)))]
+  (assert-equal "lava flanks the row-2 gap (idx {10 11 13 14})" #{10 11 13 14} lava)
+  (assert-equal "the gap (idx 12) is NOT lava" false (contains? lava 12))
+  (assert-equal "the true goal (idx 3) is in the safe top region" 3 true-goal)
+  (assert-true  "goal candidates exclude the known lava cells" (not (some lava free)))
+  (assert-true  "the goal is a candidate; lava cells are not"
+                (and (free true-goal) (not (some free lava)))))
+
+;; ---------------------------------------------------------------------------
+(println "\n-- learning reduces lava exposure AND regret (vs no-learning) --")
+(def seeds [1 2 3 4 5 6])
+(def runs
+  (vec (for [s seeds]
+         {:seed s
+          :learn    (ps/psrl (merge w/lava-world {:seed s :n-episodes 12 :learn? true}))
+          :baseline (ps/psrl (merge w/lava-world {:seed s :n-episodes 12 :learn? false}))})))
+
+(let [lava (:lava w/lava-world)
+      sum  (fn [k f] (reduce + (map (fn [r] (f (k r))) runs)))
+      hl   (sum :learn    #(lava-hits % lava))
+      hb   (sum :baseline #(lava-hits % lava))
+      rl   (sum :learn    cum)
+      rb   (sum :baseline cum)
+      reach (reduce + (map (fn [r] (count (filter :reached-goal? (:episodes (:learn r))))) runs))]
+  (println (str "   summed over " (count seeds) " seeds: lava-hits learn=" hl " baseline=" hb
+                " | regret learn=" (.toFixed rl 1) " baseline=" (.toFixed rb 1)
+                " | goal-reaches=" reach "/" (* (count seeds) 12)))
+  ;; each seed converges to the true goal
+  (doseq [{:keys [seed learn]} runs]
+    (assert-true (str "seed " seed ": posterior concentrates on the true goal (P >= 0.99)")
+                 (>= (get (:final-posterior learn) (:true-goal w/lava-world) 0.0) 0.99)))
+  ;; lava genuinely bites (it is not inert geometry) ...
+  (assert-true "lava genuinely bites: the no-learning baseline incurs lava penalties" (pos? hb))
+  ;; ... and learning REDUCES the lava exposure (stops crossing once it knows the goal)
+  (assert-true "learning reduces total lava exposure vs the no-learning baseline" (< hl hb))
+  ;; the headline: learning cuts cumulative regret substantially
+  (assert-true "learning cuts total cumulative regret vs the baseline" (< rl rb))
+  (assert-true "the regret reduction is large (learn < 0.6 * baseline)" (< rl (* 0.6 rb)))
+  ;; the agent does reach the (safe) goal in the majority of episodes
+  (assert-true "the agent reaches the goal in the majority of episodes" (> reach (* 0.5 (count seeds) 12))))
+
+;; ---------------------------------------------------------------------------
+(println "\n-- backward-compat: the bland-grid PSRL is unchanged (defaults) --")
+;; no lava / no noise => identical to the original deterministic PSRL: final episode
+;; converges to zero regret and reaches the goal.
+(let [r (ps/psrl {:seed 1 :n-episodes 10})
+      last-ep (last (:episodes r))]
+  (assert-true "default PSRL still converges (final-episode regret = 0)" (= 0.0 (:regret last-ep)))
+  (assert-true "default PSRL final episode reaches the goal" (:reached-goal? last-ep)))
+
+(println (str "\n== Results: " @passed " passed, " @failed " failed =="))
+(when (pos? @failed) (js/process.exit 1))


### PR DESCRIPTION
Adds a goal+lava stochastic gridworld that makes PSRL (agentmodels Ch 3d) exploration **visibly meaningful**, wired into the existing driver. Closes item (5) of the iconic-environments task.

## World — `genmlx.agents.worlds/lava-world`

A 5×5 grid where lava `{10,11,13,14}` flanks the **only** row-2 crossing (the gap at idx 12), the +1 goal sits in the **safe top** (idx 3), with orthogonal-slip noise (0.2). Descending through the gap, a slip lands on lava.

## Driver — `examples/agentmodels/psrl.cljs` (backward-compatible)

- `reward-grid-mdp` now takes optional `noise` (5-action orthogonal slip, with a no-slip `stay` action);
- `psrl` takes `:lava` / `:penalty` / `:noise` — excludes lava from the goal posterior, bakes the lava penalty into the per-cell reward, rolls out **stochastically via the seed-driven LCG** (runs stay reproducible), and updates the posterior on the goal signal only; episodes now also carry `:states`.
- Defaults (`lava #{}`, `penalty 0`, `noise 0`) reproduce the original bland-grid PSRL exactly.

## The story

While uncertain, the agent samples goals all over — chasing a *bottom* goal forces it across the lava gap and it slips into the penalty. Once it **learns** the goal is in the safe top, it stops crossing. So learning **reduces both lava exposure and regret** vs the no-learning baseline.

## Test — `test/genmlx/agentmodels_psrl_lava_test.cljs` (18 assertions)

Summed over 6 seeds: lava hits **11 vs 24**, regret **172 vs 588**. Over 16 seeds, regret-learn < baseline on **16/16** — not cherry-picked. No regressions: existing PSRL **35/35**, worlds **22/22**, and the other agents suites stay green.

> Note: kept the driver's non-terminal per-cell-reward model (with the `stay` action) rather than a literal `build-mdp` terminal goal — that is the model PSRL requires; the noisy transition tensor is built in `reward-grid-mdp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
