### PR TITLE
feat(agents): big-hiking world + hiker inverse planning

### DIFF
--- a/examples/agentmodels/hike_irl.cljs
+++ b/examples/agentmodels/hike_irl.cljs
@@ -1,0 +1,71 @@
+(ns agentmodels.hike-irl
+  "Hiker inverse planning (agentmodels Ch 4) on the Big-Hiking terrain — a SECOND
+   IRL domain beyond the Restaurant-Choice grid. Observe a hiker's path and infer
+   which PEAK they value more (East vs West) by INVERTING the same softmax MDP
+   agent through the GFI. Reuses genmlx.agents.inverse — goal-agents /
+   action-loglik / posterior-sequence, the very machinery used for restaurant goal
+   inference — pointed at the hiking world.
+
+   The Big-Hike peaks are close in value (East 10 / West 7) with a steep Hill cliff
+   (-40) every hiker avoids, so a hiker's destination is genuinely informative: the
+   posterior over {:east :west} starts uniform and sharpens as the path commits
+   toward one peak. The Hill is shared KNOWN terrain, passed to goal-agents as
+   :fixed (so each peak hypothesis still avoids the cliff).
+
+   The observed hiker is the deterministic (argmax-Q) near-optimal path of the
+   peak-preferring hypothesis, so a fixed seed is not needed — the demonstration is
+   reproducible. Reuse, zero engine change: worlds/big-hike-grid (terrain),
+   inverse/goal-agents + posterior-sequence (the inversion)."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.agents.worlds :as w]
+            [genmlx.agents.inverse :as inv]))
+
+(def ALPHA 3.0)            ; softmax rationality of the modelled hiker
+(def TIME-COST -0.4)
+(def NOISE 0.03)
+(def HORIZON 12)
+
+(defn peak-agents
+  "One hiker hypothesis per peak: :east values East (10) > West (7); :west values
+   West (10) > East (7). Both carry the fixed Hill cliff (-40) and the timeCost.
+   Built via inverse/goal-agents (the restaurant goal-inference machinery)."
+  []
+  (inv/goal-agents {:grid w/big-hike-grid :goals [:east :west]
+                    :high 10.0 :low 7.0 :fixed {:hill -40.0}
+                    :time-cost TIME-COST :alpha ALPHA :noise NOISE :start [1 1]}))
+
+(defn- argmax-first [xs]
+  (reduce (fn [best i] (if (> (nth xs i) (nth xs best)) i best)) 0 (range 1 (count xs))))
+
+(defn greedy-observations
+  "The deterministic argmax-Q trajectory of `agent` from its start, as [state
+   action] observation pairs (one per step until a terminal). RNG-free, so it is a
+   reproducible 'observed hiker' path."
+  [agent]
+  (let [{:keys [Q mdp]} agent
+        Qh (mx/->clj Q)
+        {:keys [ns-fn terminals start-idx]} mdp
+        terms (set (keys terminals))]
+    (loop [s start-idx, step 0, obs []]
+      (if (or (>= step HORIZON) (terms s))
+        obs
+        (let [a  (argmax-first (nth Qh s))
+              s' (ns-fn s a)]
+          (recur s' (inc step) (conj obs [s a])))))))
+
+(defn infer-peak
+  "Posterior over {:east :west} after each observed action (a vector of maps, one
+   per prefix; index 0 is the uniform prior)."
+  [agents obs]
+  (inv/posterior-sequence agents {:east 0.5 :west 0.5} obs))
+
+(defn demo
+  "Build the hypotheses, observe a true East-preferring hiker, and report how the
+   peak-preference posterior sharpens toward :east along the path."
+  []
+  (let [agents (peak-agents)
+        obs    (greedy-observations (:east agents))
+        seq    (infer-peak agents obs)]
+    {:observations obs
+     :posterior-sequence seq
+     :final (last seq)}))

--- a/src/genmlx/agents/inverse.cljs
+++ b/src/genmlx/agents/inverse.cljs
@@ -24,13 +24,18 @@
 (defn goal-agents
   "Build one agent per candidate goal: the agent that VALUES that goal gives it
    `high` utility and every other goal `low`. Same grid/noise for all. Returns an
-   ordered map {goal -> agent} (agents carry :policy and :Q)."
-  [{:keys [grid goals high low time-cost alpha noise gamma]
-    :or   {high 5.0 low 0.0 time-cost -0.1 alpha 2.0 noise 0.0 gamma 1.0}}]
+   ordered map {goal -> agent} (agents carry :policy and :Q).
+
+   `:fixed` is a map of utilities merged into EVERY hypothesis (terrain that is
+   known and shared, not part of the inferred preference) — e.g. a hiking Hill
+   cliff {:hill -40} so all peak-preference hypotheses still avoid the cliff.
+   `:start` only affects rollout, not the policy/Q used for action-loglik."
+  [{:keys [grid goals high low time-cost alpha noise gamma fixed start]
+    :or   {high 5.0 low 0.0 time-cost -0.1 alpha 2.0 noise 0.0 gamma 1.0 fixed {} start [0 0]}}]
   (reduce
     (fn [m g]
-      (let [utils (assoc (zipmap goals (repeat low)) g high :timeCost time-cost)
-            mdp   (gw/build-mdp {:grid grid :utilities utils :start [0 0]
+      (let [utils (merge (assoc (zipmap goals (repeat low)) g high :timeCost time-cost) fixed)
+            mdp   (gw/build-mdp {:grid grid :utilities utils :start start
                                  :gamma gamma :noise noise})]
         (assoc m g (agent/make-mdp-agent {:mdp mdp :alpha alpha :gamma gamma :n-iters 40}))))
     {} goals))

--- a/src/genmlx/agents/worlds.cljs
+++ b/src/genmlx/agents/worlds.cljs
@@ -75,6 +75,32 @@
   (gw/build-mdp {:grid hike-grid :utilities utilities
                  :start start :gamma gamma :noise noise}))
 
+(def big-hike-grid
+  "agentmodels' makeBigHikeMDP — a 6×6 grid (rows top-first; screen coords). West
+   (idx 21) and East (idx 23) peaks sit in row 3 as walled pockets (walls at idx
+   14, 20, 22); the whole bottom row (idx 30–35) is the Hill cliff. Start [1,1] = idx 7."
+  [[:empty :empty :empty :empty :empty :empty]
+   [:empty :empty :empty :empty :empty :empty]
+   [:empty :empty :wall  :empty :empty :empty]
+   [:empty :empty :wall  :west  :wall  :east]
+   [:empty :empty :empty :empty :empty :empty]
+   [:hill  :hill  :hill  :hill  :hill  :hill]])
+
+(def big-hike-utilities
+  "Big-hike payoffs: East 10, West 7 (a closer-valued peak than the 5×5's West=1,
+   so the choice is genuinely contestable), a steep Hill cliff (-40), and a larger
+   -0.4 per-step timeCost."
+  {:east 10.0 :west 7.0 :hill -40.0 :timeCost -0.4})
+
+(defn big-hike-mdp
+  "Build the Big-Hiking MDP (agentmodels makeBigHikeMDP, totalTime 12). `:noise`
+   defaults to 0.03 (the agentmodels value). Options: :noise :utilities
+   (default big-hike-utilities) :start (default [1 1]) :gamma (default 1.0)."
+  [{:keys [noise utilities start gamma]
+    :or {noise 0.03 utilities big-hike-utilities start [1 1] gamma 1.0}}]
+  (gw/build-mdp {:grid big-hike-grid :utilities utilities
+                 :start start :gamma gamma :noise noise}))
+
 ;; ===========================================================================
 ;; Ch 3d — goal+lava exploration world (for Posterior Sampling RL)
 ;; ===========================================================================

--- a/test/genmlx/agentmodels_hike_irl_test.cljs
+++ b/test/genmlx/agentmodels_hike_irl_test.cljs
@@ -1,0 +1,67 @@
+;; Headless test for the Big-Hiking world + hiker inverse planning (agentmodels
+;; Ch 3b world + Ch 4 IRL) — a SECOND IRL domain beyond the Restaurant-Choice grid.
+;; Observe a hiker's path and infer which PEAK they value (East vs West), reusing
+;; genmlx.agents.inverse/{goal-agents,posterior-sequence}. The peaks are close in
+;; value (East 10 / West 7) with a steep Hill cliff (-40) both hypotheses avoid, so
+;; the destination is informative: the posterior is flat over the shared prefix and
+;; sharpens to the true peak as the path commits. RNG-free (argmax-Q observed path).
+;; Run: bun run --bun nbb test/genmlx/agentmodels_hike_irl_test.cljs
+
+(ns genmlx.agentmodels-hike-irl-test
+  (:require [agentmodels.hike-irl :as hi]
+            [genmlx.agents.worlds :as w]
+            [genmlx.mlx :as mx]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-equal [msg expected actual]
+  (if (= expected actual) (do (vswap! passed inc) (println " PASS" msg "  =" (pr-str actual)))
+      (do (vswap! failed inc) (println " FAIL" msg "  expected:" (pr-str expected) "  got:" (pr-str actual)))))
+(defn- close? [a b tol] (<= (Math/abs (- a b)) tol))
+
+;; --- Big-Hiking world structure -------------------------------------------
+(println "\n-- Big-Hiking gridworld (agentmodels makeBigHikeMDP) --")
+(let [m (w/big-hike-mdp {})]
+  (assert-equal "big-hike S = 36"          36 (:S m))
+  (assert-equal "big-hike walls {14 20 22}" #{14 20 22} (:walls m))
+  (assert-equal "big-hike terminals (W=21 E=23 Hill=30..35)"
+                {21 :west 23 :east 30 :hill 31 :hill 32 :hill 33 :hill 34 :hill 35 :hill} (:terminals m))
+  (assert-equal "big-hike start-idx = 7 ([1,1])" 7 (:start-idx m))
+  (assert-equal "big-hike T shape [36 4 36]" [36 4 36] (mx/shape (:T m)))
+  (assert-true  "big-hike T rows each sum to 1 (total 144)"
+                (close? 144.0 (mx/item (mx/sum (:T m))) 1e-2)))
+
+;; --- hiker inverse planning: infer the preferred peak from the path -------
+(println "\n-- hiker IRL: infer East-vs-West preference from a trajectory --")
+(def agents (hi/peak-agents))
+(assert-equal "two peak hypotheses {:east :west}" #{:east :west} (set (keys agents)))
+
+(let [e-obs (hi/greedy-observations (:east agents))
+      e-seq (hi/infer-peak agents e-obs)
+      e-ps  (mapv :east e-seq)
+      w-obs (hi/greedy-observations (:west agents))
+      w-seq (hi/infer-peak agents w-obs)
+      w-ps  (mapv :east w-seq)]
+  (println "   East-hiker path :" (mapv first e-obs) "  P(east):" (mapv #(.toFixed % 2) e-ps))
+  (println "   West-hiker path :" (mapv first w-obs) "  P(east):" (mapv #(.toFixed % 2) w-ps))
+  ;; prior is uniform over the two peaks
+  (assert-true "prior over peaks is uniform (P(east) = 0.5)" (close? 0.5 (first e-ps) 1e-6))
+  ;; the shared prefix is UNINFORMATIVE — the posterior only moves once paths diverge
+  (assert-true "after the (shared) 2nd action the posterior is still ~uniform" (close? 0.5 (nth e-ps 2) 0.05))
+  ;; observing an East-preferring hiker concentrates the posterior on :east; its
+  ;; evidence never meaningfully supports West (any shared-prefix wobble is < 0.05)
+  (assert-true "East-hiker: P(east) never swings toward West (stays >= 0.45)" (every? #(>= % 0.45) e-ps))
+  (assert-true "East-hiker: final P(east) > 0.99 (preference identified)" (> (last e-ps) 0.99))
+  ;; ...and a West-preferring hiker concentrates it on :west (symmetric, identifiable)
+  (assert-true "West-hiker: P(east) never swings toward East (stays <= 0.55)" (every? #(<= % 0.55) w-ps))
+  (assert-true "West-hiker: final P(east) < 0.01 (i.e. P(west) > 0.99)" (< (last w-ps) 0.01))
+  ;; the two hikers' paths share a prefix then diverge (what makes it informative)
+  (assert-true "the two paths share their first action but reach different states"
+               (and (= (ffirst e-obs) (ffirst w-obs))
+                    (not= (first (last e-obs)) (first (last w-obs))))))
+
+(println (str "\n== Results: " @passed " passed, " @failed " failed =="))
+(when (pos? @failed) (js/process.exit 1))


### PR DESCRIPTION
Adds the 6×6 Big-Hiking variant and a hiker IRL driver — a **second inverse-planning domain** beyond the Restaurant-Choice grid. Closes item (4) of the iconic-environments task.

## World — `genmlx.agents.worlds/big-hike-{grid,mdp}`

agentmodels' `makeBigHikeMDP`: 6×6, walls `{14,20,22}`, West (7) @21 / East (10) @23 / a Hill cliff (−40) @30–35, start `[1,1]`, noise 0.03, timeCost −0.4. The closer-valued peaks make the hiker's destination genuinely informative.

## Reuse — `genmlx.agents.inverse/goal-agents` (backward-compatible)

Extended with `:fixed` (utilities merged into **every** hypothesis — for shared known terrain like the Hill cliff, so all peak-preference hypotheses still avoid it) and `:start`. Existing callers (pomdp, ch5 demo, slice test) are unaffected — defaults reproduce prior behavior.

## Driver — `examples/agentmodels/hike_irl.cljs`

Infer which **peak** a hiker values (East vs West) from a trajectory, reusing `goal-agents` + `posterior-sequence` + `action-loglik` — the same machinery as restaurant goal inference. Hypotheses `{:east (E10,W7), :west (E7,W10)}` share the fixed cliff; the observed path is the deterministic argmax-Q trajectory (RNG-free, reproducible).

## Test — `agentmodels_hike_irl_test.cljs` (14 assertions)

The peak-preference posterior is **flat over the shared prefix** `[7 8 9]` then **sharpens to the true peak** as the path commits:
- East-hiker → P(east) `0.50 → 0.92 → 1.00` (final > 0.99);
- West-hiker → mirror (final P(east) < 0.01).

Identifiable both directions. **No regressions** — every `goal-agents` consumer passes: slice 51, irl 24, pomdp 22, api 19, worlds 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
