### PR TITLE
feat(agents): adjacency-reveal restaurant POMDP

### DIFF
--- a/src/genmlx/agents/pomdp.cljs
+++ b/src/genmlx/agents/pomdp.cljs
@@ -29,6 +29,7 @@
             [genmlx.protocols :as p]
             [genmlx.dynamic :as dyn]
             [genmlx.agents.inverse :as inv]
+            [genmlx.agents.gridworld :as gw]
             [genmlx.agents.agent :as agent]
             [genmlx.agents.helpers :as h])
   (:require-macros [genmlx.gen :refer [gen]]))
@@ -46,12 +47,24 @@
       :act (fn [belief s] -> action-int)            ; softmax over belief-Q
       :expected-utility (fn [belief s a] -> float)  ; belief-weighted EU
       :params {...}}."
-  [{:keys [grid goals alpha noise gamma prior observe n-iters]
-    :or   {alpha 2.0 noise 0.0 gamma 1.0 n-iters 40}}]
-  (let [world-agents (inv/goal-agents {:grid grid :goals goals :alpha alpha
-                                       :noise noise :gamma gamma})
+  [{:keys [grid goals alpha noise gamma prior observe n-iters world-utils start]
+    :or   {alpha 2.0 noise 0.0 gamma 1.0 n-iters 40 start [0 0]}}]
+  (let [;; Per-world MDP planners. Two ways to specify the worlds:
+        ;;   :world-utils {world -> utilities-map} — general (e.g. open/closed
+        ;;     restaurant configs, where each world has different cell utilities), or
+        ;;   :goals [...] — the single-rewarding-goal shorthand via goal-agents.
+        world-agents (if world-utils
+                       (into {} (map (fn [[w utils]]
+                                       [w (agent/make-mdp-agent
+                                            {:mdp (gw/build-mdp {:grid grid :utilities utils
+                                                                 :start start :gamma gamma :noise noise})
+                                             :alpha alpha :gamma gamma :n-iters n-iters})])
+                                     world-utils))
+                       (inv/goal-agents {:grid grid :goals goals :alpha alpha
+                                         :noise noise :gamma gamma}))
+        worlds    (if world-utils (vec (keys world-utils)) goals)
         A         (:A (:mdp (val (first world-agents))))
-        prior     (or prior (zipmap goals (repeat (/ 1.0 (count goals)))))
+        prior     (or prior (zipmap worlds (repeat (/ 1.0 (count worlds)))))
         ;; QMDP belief-space Q at state s: Σ_w b(w) · Q_w[s]  (plain mx reduction)
         belief-Q  (fn [belief s]
                     (reduce (fn [acc [w b]]
@@ -73,7 +86,7 @@
               (let [q      (belief-Q belief s)
                     policy (gen [] (trace :action (h/softmax-action alpha q)))]
                 (int (mx/item (:retval (p/simulate (dyn/auto-key policy) []))))))]
-    {:worlds (vec goals) :world-agents world-agents :prior prior :observe observe
+    {:worlds (vec worlds) :world-agents world-agents :prior prior :observe observe
      :belief-Q belief-Q :update-belief update-belief :act act
      :expected-utility (fn [belief s a]
                          (reduce + (map (fn [[w b]]

--- a/src/genmlx/agents/pomdp_env.cljs
+++ b/src/genmlx/agents/pomdp_env.cljs
@@ -1,13 +1,17 @@
 (ns genmlx.agents.pomdp-env
   "POMDP environments (bean genmlx-m9m9). Each constructor returns the data
    bundle make-pomdp-agent / simulate-pomdp consume. The per-world MDP tensors
-   themselves are produced inside make-pomdp-agent via inverse/goal-agents ->
-   gridworld/build-mdp, so the env stays pure geometry/config.
+   themselves are produced inside make-pomdp-agent via gridworld/build-mdp (from
+   inverse/goal-agents, or per-world :world-utils), so the env stays pure
+   geometry/config.
 
-   Shipped here: the hidden-goal RESTAURANT GRIDWORLD (latent = which goal pays)
-   and the multi-armed BANDIT (latent = per-arm payoff parameters)."
+   Shipped here: the hidden-goal RESTAURANT GRIDWORLD (latent = which goal pays;
+   single-signpost reveal), the ADJACENCY-REVEAL restaurant POMDP (latent = a
+   per-restaurant open/closed vector; agentmodels' makeGridWorldPOMDP), and the
+   multi-armed BANDIT (latent = per-arm payoff parameters)."
   (:require [genmlx.mlx :as mx]
-            [genmlx.dist :as dist]))
+            [genmlx.dist :as dist]
+            [genmlx.agents.gridworld :as gw]))
 
 (defn restaurant-gridworld
   "Hidden-goal POMDP: a grid with candidate goals, exactly one of which is the
@@ -32,6 +36,70 @@
      ;; deterministic location-gated reveal: standing on the signpost reveals the
      ;; world identity; everywhere else there is no information (obs = nil).
      :observe    (fn [world loc] (when (= loc signpost) world))}))
+
+(defn- neighbors-4
+  "In-bounds 4-neighbour cell indices of `idx` on a W×H grid."
+  [W H idx]
+  (let [x (mod idx W), y (quot idx W)]
+    (set (for [[dx dy] [[-1 0] [1 0] [0 -1] [0 1]]
+               :let [nx (+ x dx), ny (+ y dy)]
+               :when (and (<= 0 nx (dec W)) (<= 0 ny (dec H)))]
+           (+ nx (* W ny))))))
+
+(defn- open-closed-configs
+  "All {restaurant -> open?} maps over `restaurants` (2^k configs)."
+  [restaurants]
+  (reduce (fn [acc r] (mapcat (fn [m] [(assoc m r true) (assoc m r false)]) acc))
+          [{}] restaurants))
+
+(defn restaurant-pomdp
+  "Adjacency-reveal restaurant POMDP (agentmodels Ch 3c makeGridWorldPOMDP). Unlike
+   the single-signpost restaurant-gridworld above, EACH restaurant is independently
+   OPEN or CLOSED — the latent is a per-restaurant vector — and the agent learns a
+   restaurant's status only when ADJACENT to it (a 4-neighbour of its cell). The
+   belief is over the 2^k open/closed configs; an OPEN restaurant pays its utility,
+   a CLOSED one pays 0 (a dead terminal the agent avoids). So the agent heads to the
+   preferred restaurant and, on observing it CLOSED when adjacent, re-plans toward
+   the backup — the canonical local-observation POMDP behaviour.
+
+   Options:
+     :grid       — restaurant cells are terminal keywords (e.g. :a :b);
+     :utilities  — {restaurant -> open-utility} (default {:a 5.0 :b 3.0});
+     :open-prob  — {restaurant -> P(open)} independent prior (default {:a 0.6 :b 0.9});
+     :true-world — {restaurant -> open?} the actual config;
+     :time-cost  — per-step cost (default -0.1);  :start — [x y].
+
+   Returns the make-pomdp-agent/simulate-pomdp bundle, carrying :world-utils (so
+   make-pomdp-agent builds one MDP per open/closed config) and an adjacency :observe."
+  [{:keys [grid utilities open-prob true-world time-cost start]
+    :or   {utilities {:a 5.0 :b 3.0} open-prob {:a 0.6 :b 0.9} time-cost -0.1 start [0 0]}}]
+  (let [{:keys [W H terminals]} (gw/parse-grid grid)
+        restaurants (vec (keys utilities))
+        cell-of     (into {} (map (fn [[idx kw]] [kw idx])) terminals)   ; restaurant -> cell idx
+        adj         (into {} (map (fn [r] [r (neighbors-4 W H (cell-of r))])) restaurants)
+        worlds      (open-closed-configs restaurants)
+        world-utils (into {} (map (fn [w]
+                                    [w (assoc (into {} (map (fn [r] [r (if (w r) (utilities r) 0.0)])) restaurants)
+                                              :timeCost time-cost)]))
+                          worlds)
+        prior       (into {} (map (fn [w]
+                                    [w (reduce * (map (fn [r] (if (w r) (open-prob r) (- 1.0 (open-prob r)))) restaurants))]))
+                          worlds)
+        [sx sy]     start]
+    {:kind        :restaurant-pomdp
+     :grid        grid
+     :restaurants restaurants
+     :worlds      worlds
+     :world-utils world-utils
+     :true-world  true-world
+     :prior       prior
+     :start       start
+     :start-idx   (+ sx (* W sy))
+     ;; adjacency-gated local reveal: observe the open/closed status of every
+     ;; restaurant the agent is currently adjacent to (nil if none).
+     :observe     (fn [world loc]
+                    (let [o (vec (for [r restaurants :when (contains? (adj r) loc)] [r (world r)]))]
+                      (when (seq o) o)))}))
 
 (defn bandit-pomdp
   "Multi-armed bandit POMDP (agentmodels Ch 3c/3d). The hidden state is the

--- a/test/genmlx/agentmodels_pomdp_adjacency_test.cljs
+++ b/test/genmlx/agentmodels_pomdp_adjacency_test.cljs
@@ -1,0 +1,104 @@
+;; Headless tests for the ADJACENCY-REVEAL restaurant POMDP (agentmodels Ch 3c
+;; makeGridWorldPOMDP) — the real local-observation model, vs the single-signpost
+;; restaurant-gridworld. The latent is a per-restaurant OPEN/CLOSED vector (2^k
+;; worlds); the agent learns a restaurant's status only when ADJACENT to it, heads
+;; to the preferred restaurant, and DETOURS to the backup if it observes the
+;; preferred one closed. Deterministic (alpha=Inf, noise 0), so paths/beliefs are
+;; reproducible. Run: bun run --bun nbb test/genmlx/agentmodels_pomdp_adjacency_test.cljs
+
+(ns genmlx.agentmodels-pomdp-adjacency-test
+  (:require [genmlx.agents.pomdp :as pomdp]
+            [genmlx.agents.pomdp-env :as env]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-equal [msg expected actual]
+  (if (= expected actual) (do (vswap! passed inc) (println " PASS" msg "  =" (pr-str actual)))
+      (do (vswap! failed inc) (println " FAIL" msg "  expected:" (pr-str expected) "  got:" (pr-str actual)))))
+(defn- close? [a b tol] (<= (Math/abs (- a b)) tol))
+
+;; 4x3 grid: A (idx 0) top-left, the PREFERRED restaurant; B (idx 3) top-right, the
+;; backup. Start idx 9 (bottom, col 1). A's adjacent cells {1,4}; B's {2,7}.
+;;   A . . B      0 1 2 3
+;;   . . . .      4 5 6 7
+;;   . @ . .      8 9 10 11   start at 9 = [1,2]
+(def grid [[:a     :empty :empty :b]
+           [:empty :empty :empty :empty]
+           [:empty :empty :empty :empty]])
+(def UTIL {:a 5.0 :b 3.0})
+(def OPEN-PROB {:a 0.6 :b 0.9})
+(def A-CELL 0) (def B-CELL 3) (def START 9)
+
+(defn build [true-world]
+  (let [e  (env/restaurant-pomdp {:grid grid :utilities UTIL :open-prob OPEN-PROB
+                                  :true-world true-world :start [1 2]})
+        pa (pomdp/make-pomdp-agent (assoc e :alpha ##Inf :gamma 1.0 :noise 0.0 :n-iters 40))]
+    [e pa]))
+(defn- P-a-open [b] (reduce + (map (fn [[w p]] (if (:a w) p 0.0)) b)))
+
+;; ---------------------------------------------------------------------------
+(println "\n-- world structure: per-restaurant open/closed latent vector --")
+(let [[e _] (build {:a true :b true})]
+  (assert-equal "2 restaurants {:a :b}" [:a :b] (:restaurants e))
+  (assert-equal "2^2 = 4 open/closed worlds" 4 (count (:worlds e)))
+  (assert-true  "worlds are the {restaurant -> open?} configs"
+                (= #{{:a true :b true} {:a true :b false} {:a false :b true} {:a false :b false}}
+                   (set (:worlds e))))
+  (assert-equal "world-utils: A open -> 5, B closed -> 0 (+ timeCost)"
+                {:a 5.0 :b 0.0 :timeCost -0.1} (get (:world-utils e) {:a true :b false}))
+  ;; prior is the product of the independent open-probs
+  (assert-true  "prior P({A-open,B-open}) = 0.6*0.9 = 0.54"
+                (close? 0.54 (get (:prior e) {:a true :b true}) 1e-9))
+  (assert-true  "prior is normalized" (close? 1.0 (reduce + (vals (:prior e))) 1e-9)))
+
+(println "\n-- observation is ADJACENCY-gated (not a single signpost) --")
+(let [[e _] (build {:a false :b true})
+      obs   (:observe e)]
+  (assert-equal "adjacent to A (idx 1): observe A's status only" [[:a false]] (obs {:a false :b true} 1))
+  (assert-equal "adjacent to B (idx 2): observe B's status only" [[:b true]]  (obs {:a false :b true} 2))
+  (assert-equal "not adjacent to any restaurant (idx 5): no observation" nil  (obs {:a false :b true} 5))
+  (assert-equal "on the start cell (idx 9): no observation" nil (obs {:a false :b true} START)))
+
+(println "\n-- belief filter: an adjacency observation reveals only that restaurant --")
+(let [[e pa] (build {:a true :b true})
+      ub     (:update-belief pa)
+      prior  (:prior pa)]
+  (assert-true "obs=nil leaves the belief unchanged" (= prior (ub prior 5 nil)))
+  (let [b' (ub prior 1 [[:a true]])]   ; observe A open at A's neighbour
+    (assert-true "observe A-open -> P(A-open) = 1" (close? 1.0 (P-a-open b') 1e-9))
+    (assert-true "...but B stays uncertain (P(B-open) = prior 0.9)"
+                 (close? 0.9 (reduce + (map (fn [[w p]] (if (:b w) p 0.0)) b')) 1e-6)))
+  (let [b' (ub prior 1 [[:a false]])]
+    (assert-true "observe A-closed -> P(A-open) = 0" (close? 0.0 (P-a-open b') 1e-9))))
+
+;; ---------------------------------------------------------------------------
+(println "\n-- contingent re-planning: head to A, detour to B if A is closed --")
+(let [[e pa] (build {:a true :b true})            ; A is open
+      {:keys [states beliefs]} (pomdp/simulate-pomdp pa e START 14)]
+  (println "   A-open  | path" states "| P(A-open)" (mapv #(.toFixed (P-a-open %) 2) beliefs))
+  (assert-equal "A open: the agent reaches A (the preferred restaurant)" A-CELL (last states))
+  (assert-true  "belief starts at the prior (P(A-open) = 0.6)" (close? 0.6 (P-a-open (first beliefs)) 1e-6))
+  (assert-true  "belief snaps to A-open once adjacent to A" (close? 1.0 (P-a-open (last beliefs)) 1e-9)))
+
+(let [[e pa] (build {:a false :b true})           ; A closed, B open
+      {:keys [states observations beliefs]} (pomdp/simulate-pomdp pa e START 14)]
+  (println "   A-closed| path" states "| obs" (vec (remove nil? observations))
+           "| P(A-open)" (mapv #(.toFixed (P-a-open %) 2) beliefs))
+  (assert-equal "A closed, B open: the agent DETOURS and reaches B (the backup)" B-CELL (last states))
+  (assert-true  "belief still flat before reaching A's neighbour (P(A-open) = prior)"
+                (close? 0.6 (P-a-open (nth beliefs 1)) 1e-6))
+  (assert-true  "belief collapses to A-closed after observing A" (close? 0.0 (P-a-open (last beliefs)) 1e-9))
+  (assert-true  "the agent observed A then B (adjacency reveals, in order)"
+                (= [[[:a false]] [[:b true]]] (vec (remove nil? observations)))))
+
+;; the latent genuinely matters: same prior/agent, different open/closed world ->
+;; different restaurant reached (learned only through the adjacency observations).
+(let [a-open  (last (:states (pomdp/simulate-pomdp (second (build {:a true  :b true})) (first (build {:a true  :b true})) START 14)))
+      a-closed (last (:states (pomdp/simulate-pomdp (second (build {:a false :b true})) (first (build {:a false :b true})) START 14)))]
+  (assert-true "the open/closed latent changes the outcome (A vs B)" (and (= A-CELL a-open) (= B-CELL a-closed))))
+
+(println (str "\n== Results: " @passed " passed, " @failed " failed =="))
+(when (pos? @failed) (js/process.exit 1))


### PR DESCRIPTION
Adds agentmodels Ch 3c's `makeGridWorldPOMDP` — the real local-observation model — alongside the existing single-signpost `restaurant-gridworld`. **Completes the iconic-environments task** (`genmlx-b9rm`, item 3 of 5).

## Agent — `make-pomdp-agent` generalized (backward-compatible)

Besides `:goals` (the single-rewarding-goal shorthand via `goal-agents`), it now accepts **`:world-utils`** `{world → utilities-map}` and builds one MDP per world via `build-mdp` — so worlds can be open/closed *configs* with config-dependent cell utilities. The QMDP `belief-Q` / `update-belief` / `simulate-pomdp` are unchanged (already generic over the worlds + observe model).

## Env — `restaurant-pomdp`

Each restaurant is independently **OPEN or CLOSED** (a per-restaurant latent **vector**, 2^k worlds); the agent observes a restaurant's status only when **ADJACENT** to it (a 4-neighbour of its cell). An open restaurant pays its utility, a closed one pays 0 (a dead terminal the agent avoids). Carries `:world-utils` + an adjacency `:observe` + the product (independent-open) prior.

## Test — `agentmodels_pomdp_adjacency_test.cljs` (22 assertions)

Structure (2^k open/closed worlds, product prior, per-world utilities), the adjacency-gated observation (reveals only the *adjacent* restaurant), the belief filter, and the headline **contingent re-planning**:
- **A-open** → `[9 5 1 0]`, reaches A;
- **A-closed, B-open** → `[9 5 1 2 3]`, observes A-closed, **detours**, observes B-open, reaches B.

The latent changes the outcome, learned only through the local observations. **No regressions** — the full agents suite stays green (pomdp 22, irl 24, biased-planners 41, biased-inverse 42, worlds 22, hike-irl 14, psrl 35/18, 5d 21, multi-agent 34, api 19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
