### PR TITLE
feat(agents): GPU-native agents — tensor belief/bandit, batched inference, fused rollout, differentiable IRL (swxr epic)

### DIFF
--- a/src/genmlx/agents/agent.cljs
+++ b/src/genmlx/agents/agent.cljs
@@ -28,6 +28,7 @@
             [genmlx.protocols :as p]
             [genmlx.dynamic :as dyn]
             [genmlx.inference.exact :as exact]
+            [genmlx.agents.rollout :as rollout]
             [genmlx.agents.helpers :as h])
   (:require-macros [genmlx.gen :refer [gen]]))
 
@@ -204,12 +205,19 @@
   "Roll the agent's policy out from `start` for at most `horizon` steps, stopping
    at a terminal. The action comes from the softmax policy (decision noise) and
    the next state is sampled from T (environment / transition noise). Returns
-   {:states [s0 s1 ...] :actions [a0 a1 ...]} (JS ints); one action per transition."
-  [{:keys [mdp act]} start horizon]
-  (let [{:keys [T terminals]} mdp]
-    (loop [s start, step 0, states [start], actions []]
-      (if (or (>= step horizon) (contains? terminals s))
-        {:states states :actions actions}
-        (let [a  (act s)
-              s' (sample-next T s a)]
-          (recur s' (inc step) (conj states s') (conj actions a)))))))
+   {:states [s0 s1 ...] :actions [a0 a1 ...]} (JS ints); one action per transition.
+
+   `:rollout-mode` (optional trailing opts) selects the loop: :host (default — the
+   per-step act/sample-next loop) or :fused (the single-graph tensor rollout in
+   genmlx.agents.rollout; bean genmlx-5zdd). At alpha=##Inf/noise=0 both produce
+   identical :states/:actions; the seam is unchanged either way."
+  [{:keys [mdp act] :as agent} start horizon & [{:keys [rollout-mode key]}]]
+  (if (= rollout-mode :fused)
+    (rollout/rollout-mdp agent start horizon {:key key})
+    (let [{:keys [T terminals]} mdp]
+      (loop [s start, step 0, states [start], actions []]
+        (if (or (>= step horizon) (contains? terminals s))
+          {:states states :actions actions}
+          (let [a  (act s)
+                s' (sample-next T s a)]
+            (recur s' (inc step) (conj states s') (conj actions a))))))))

--- a/src/genmlx/agents/agent.cljs
+++ b/src/genmlx/agents/agent.cljs
@@ -76,6 +76,30 @@
           (mx/materialize! V')
           (recur V' (inc i) Q'))))))
 
+(defn- soft-value-tensor
+  "soft-value where `alpha` may be a TENSOR (for differentiation) as well as a
+   number — uses mx/multiply directly (Either<MxArray,f64>) instead of mx/scalar,
+   which only accepts numbers. Identical to soft-value for a numeric alpha."
+  [alpha Q]
+  (let [pi (mx/softmax (mx/multiply alpha Q) 1)]
+    (mx/sum (mx/multiply pi Q) [1])))
+
+(defn value-iteration-lazy
+  "value-iteration WITHOUT the per-sweep mx/materialize! — the whole N-sweep unroll
+   stays one lazy graph, so autograd can backprop Q -> R -> utilities and Q -> alpha
+   (bean genmlx-j5um). `alpha` may be a finite number OR a scalar MLX tensor;
+   alpha = ##Inf (hard argmax) is rejected as non-differentiable. Finite-horizon
+   (N sweeps), so it matches value-iteration's Q at the same n for a numeric alpha."
+  [{:keys [S gamma] :as mdp} alpha n]
+  (when (and (number? alpha) (= alpha ##Inf))
+    (throw (ex-info "value-iteration-lazy: alpha must be finite (argmax is non-differentiable)"
+                    {:alpha alpha})))
+  (loop [V (mx/zeros #js [S]), i 0, Q nil]
+    (if (>= i n)
+      {:Q Q :V V}
+      (let [[Q' V'] (bellman-step mdp gamma alpha soft-value-tensor V)]
+        (recur V' (inc i) Q')))))
+
 ;; ---------------------------------------------------------------------------
 ;; Path 2: faithful recursive expectedUtility (exact/with-cache + soft policy)
 ;; ---------------------------------------------------------------------------

--- a/src/genmlx/agents/belief.cljs
+++ b/src/genmlx/agents/belief.cljs
@@ -1,0 +1,100 @@
+(ns genmlx.agents.belief
+  "Tensor belief-update kernel (bean genmlx-kpuo): the pure-MLX observation-Bayes
+   filter that replaces the host Clojure-map belief filters in
+   genmlx.agents.pomdp/update-belief and genmlx.agents.biased-planners/bayes-update.
+
+   CORRECTION TO THE BEAN FORMULA. The swxr epic specifies the textbook
+   state-belief filter `b' = normalize(O[.,.,a] ⊙ (T^T·b))`, which assumes a
+   latent that TRANSITIONS. This codebase's POMDP latent is a STATIC world
+   identity w (which goal pays / which restaurants are open) that never changes
+   for the episode (pomdp.cljs:5-13, pomdp_env.cljs:108-110, biased_planners.cljs:484).
+   The physical state s transitions separately (agent/sample-next); the BELIEF
+   update is pure observation-Bayes with NO `T^T·b` prediction step:
+
+       b'(w) ∝ b(w) · P(obs | world_w, loc)
+             = b(w) · [observe(w, loc) = o]        (deterministic reveal)
+
+   which is exactly what both host filters compute:
+     - pomdp.cljs:76-83   normalize-logs over {log b(w) + (0 if match else -Inf)}
+     - biased_planners.cljs:483-491  raw[w]=(if match b[w] 0) ; b'=raw/Σraw
+
+   So the kernel is a [W]-vector elementwise multiply + sum + divide:
+
+       raw = b ⊙ L                                 ; [W]
+       z   = Σ raw                                 ; []
+       b'  = where(z > eps, raw/z, b)              ; [W], defensive identity at z≈0
+
+   The likelihood L is DATA (built host-side from the host `observe` geometry,
+   then `mx/array`'d once into a [W] vector); only b carries gradient. There is no
+   per-step `mx/item` and no per-step host-map arithmetic, and b stays a
+   differentiable MLX [W] array — which is what the downstream differentiable
+   POMDP work (genmlx-5x3f) needs.
+
+   The default agent paths stay host-side (the seam threads Clojure maps/vectors);
+   this kernel is opt-in via the agents' `:update-belief-tensor` and
+   simulate-pomdp's `:belief-mode :tensor`."
+  (:require [genmlx.mlx :as mx]))
+
+(def ^:private eps
+  "Defensive normalization floor. Host filters keep b unchanged when the observed
+   o is impossible under the current belief (Σraw = 0). With float32 {0,1}
+   likelihoods, Σraw is the exact sum of the surviving belief masses — never a
+   denormal — so any eps below the smallest representable belief mass reproduces
+   the host `(pos? z)` guard. 1e-30 is far below any demo belief mass."
+  1e-30)
+
+(defn obs-likelihood-vec
+  "Build the per-world observation likelihood L : [W] float32, where
+   L[w] = 1.0 if (observe w loc) equals o, else 0.0. Geometry stays host-side:
+   `observe` is the host model and the comparison is Clojure `=` on the obs value
+   (a goal keyword, or a vector of [restaurant open?] pairs, or nil), so the SAME
+   semantics as the host filters. `worlds` is the FIXED world ordering the belief
+   vector is aligned to."
+  [observe worlds loc o]
+  (mx/array (clj->js (mapv (fn [w] (if (= (observe w loc) o) 1.0 0.0)) worlds))
+            mx/float32))
+
+(defn filter-step
+  "Pure differentiable belief filter core: b' = where(Σ(b⊙L) > eps, (b⊙L)/Σ, b).
+   Both b and L are [W] MLX arrays; returns a [W] MLX array. No mx/item, no host
+   arithmetic — the gradient flows through b (L is a constant likelihood)."
+  [b L]
+  (let [raw (mx/multiply b L)
+        z   (mx/sum raw)]
+    (mx/where (mx/greater z eps) (mx/divide raw z) b)))
+
+(defn tensor-update-belief
+  "One Bayes filtering step as pure tensor ops. `b` is a [W] MLX belief aligned to
+   `worlds`; returns the updated [W] MLX belief. o = nil (uninformative cell) is an
+   explicit identity fast-path that bit-matches the host short-circuit and skips
+   building L (every world is consistent with nil, so L would be all-ones anyway)."
+  [observe worlds b loc o]
+  (if (nil? o)
+    b
+    (filter-step b (obs-likelihood-vec observe worlds loc o))))
+
+;; -- belief <-> vector seam (host map/vector callers <-> [W] MLX) --------------
+
+(defn belief->vec
+  "{world -> prob} map  ->  [W] MLX float32 aligned to `worlds` (missing -> 0.0)."
+  [worlds belief]
+  (mx/array (clj->js (mapv (fn [w] (double (get belief w 0.0))) worlds)) mx/float32))
+
+(defn vec->belief
+  "[W] MLX (or clj vector) aligned to `worlds`  ->  {world -> prob} map."
+  [worlds v]
+  (zipmap worlds (if (mx/array? v) (mx/->clj v) v)))
+
+(defn update-belief-map
+  "Map-in / map-out drop-in for pomdp.cljs's host `:update-belief`: routes a
+   {world -> prob} belief through the tensor kernel. Used as the agent's
+   `:update-belief-tensor`."
+  [observe worlds belief loc o]
+  (vec->belief worlds (tensor-update-belief observe worlds (belief->vec worlds belief) loc o)))
+
+(defn update-belief-vec
+  "Clj-vector-in / clj-vector-out drop-in for biased_planners' `:update-belief`
+   (a prob vector aligned to `worlds`): routes through the tensor kernel."
+  [observe worlds bvec loc o]
+  (let [b (mx/array (clj->js (mapv double bvec)) mx/float32)]
+    (vec (mx/->clj (tensor-update-belief observe worlds b loc o)))))

--- a/src/genmlx/agents/biased_planners.cljs
+++ b/src/genmlx/agents/biased_planners.cljs
@@ -55,6 +55,7 @@
             [genmlx.inference.exact :as exact]
             [genmlx.agents.gridworld :as gw]
             [genmlx.agents.agent :as agent]
+            [genmlx.agents.belief :as belief]
             [genmlx.agents.helpers :as h])
   (:require-macros [genmlx.gen :refer [gen]]))
 
@@ -593,6 +594,11 @@
      :eu eu :act act :policy policy
      ;; the ACTUAL belief filter (ungated): the agent really does keep learning.
      :update-belief (fn [bvec s' o] (bayes-update worlds observe bvec s' o))
+     ;; tensor belief kernel (bean genmlx-kpuo): vector-in/vector-out drop-in for
+     ;; the rollout filter only. The PLANNER-side gated bayes-update stays host —
+     ;; the belief vec is part of the build-biased-eu-belief with-cache key and an
+     ;; MLX array is not a stable hash key. Opt-in via simulate-biased-pomdp.
+     :update-belief-tensor (fn [bvec s' o] (belief/update-belief-vec observe worlds bvec s' o))
      :params {:alpha alpha :gamma gamma :horizon H :discount discount :bias bias
               :reward-myopic-bound reward-myopic-bound :update-myopic-bound update-myopic-bound}}))
 
@@ -600,16 +606,22 @@
   "Roll the belief-space biased POMDP agent out from `start` (state idx) under the
    TRUE world. Each step: ACT from belief; transition via the world geometry;
    OBSERVE at the new cell; FILTER (real, ungated). Returns
-   {:states :actions :observations :beliefs} (beliefs as prob vectors)."
-  [{:keys [act update-belief observe T terminals]} true-world start horizon prior-vec]
-  (loop [s start, b prior-vec, step 0, states [start], actions [], obss [], beliefs [prior-vec]]
-    (if (or (>= step horizon) (contains? terminals s))
-      {:states states :actions actions :observations obss :beliefs beliefs}
-      (let [a  (act b s)
-            s' (agent/sample-next T s a)
-            o  (observe true-world s')
-            b' (update-belief b s' o)]
-        (recur s' b' (inc step) (conj states s') (conj actions a) (conj obss o) (conj beliefs b'))))))
+   {:states :actions :observations :beliefs} (beliefs as prob vectors).
+
+   `:belief-mode` (optional trailing opts) selects the rollout filter: :host
+   (default) or :tensor (the pure-MLX kernel genmlx.agents.belief; bean
+   genmlx-kpuo). Both produce prob vectors aligned to :worlds — seam unchanged."
+  [{:keys [act update-belief update-belief-tensor observe T terminals]} true-world start horizon prior-vec
+   & [{:keys [belief-mode] :or {belief-mode :host}}]]
+  (let [update-belief (if (= belief-mode :tensor) update-belief-tensor update-belief)]
+    (loop [s start, b prior-vec, step 0, states [start], actions [], obss [], beliefs [prior-vec]]
+      (if (or (>= step horizon) (contains? terminals s))
+        {:states states :actions actions :observations obss :beliefs beliefs}
+        (let [a  (act b s)
+              s' (agent/sample-next T s a)
+              o  (observe true-world s')
+              b' (update-belief b s' o)]
+          (recur s' b' (inc step) (conj states s') (conj actions a) (conj obss o) (conj beliefs b')))))))
 
 (defn voi-world
   "A small 'walk-and-check' POMDP where information is a deliberate DETOUR. Two

--- a/src/genmlx/agents/differentiable.cljs
+++ b/src/genmlx/agents/differentiable.cljs
@@ -1,0 +1,112 @@
+(ns genmlx.agents.differentiable
+  "Differentiable MDP utility/alpha learning (bean genmlx-j5um): recover an agent's
+   planted utilities and rationality by GRADIENT through the planner + policy
+   log-likelihood — the payoff of the tensor-native rewrite.
+
+   SCOPE. This is the MDP (no-belief) case. It does NOT differentiate through a
+   stochastic rollout (the env-step sample uses mx/item — non-differentiable). It
+   differentiates through the PLANNER (lazy value iteration) and the policy
+   log-likelihood at FIXED observed (s,a) pairs — exactly the inverse/action-loglik
+   quantity the IRL posterior is built from. That graph
+       utilities[G] -> R[S,A] -> lazy VI -> Q[S,A] -> log_softmax -> gather
+   is fully lazy/differentiable with no Scan combinator or belief filter, so it
+   lands independently of genmlx-5zdd / genmlx-kpuo. (The POMDP-belief-gradient and
+   expected-fused-rollout-gradient variants are follow-ons: genmlx-5x3f, genmlx-h833.)
+
+   IDENTIFIABILITY. utilities are identifiable only up to scale/offset and a
+   multiplicative interaction with alpha (alpha·Q enters the policy). So recovery
+   is to LIKELIHOOD-EQUIVALENCE (loss at recovered ≈ loss at the plant), not exact
+   params — plant a 2-goal world for relative ordering, or fix one of {alpha,
+   utility-scale} and learn the other.
+
+   KEY INVARIANT. ZERO mx/item / mx/eval! / mx/materialize! inside the loss — they
+   sever the backward pass (silent zero gradients). Materialization happens only in
+   learning/train between iterations, after autograd has run."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.agent :as agent]
+            [genmlx.learning :as learn]))
+
+(defn build-diff-mdp
+  "Static MDP scaffolding for differentiable learning: the geometry tensors
+   (T/term/S/A/gamma) — which DON'T depend on the utilities — plus the [S,G]
+   goal-onehot. The utilities become the learnable [G] tensor theta-u fed to
+   gridworld/diff-reward. `:goals` fixes the (deterministic) goal ordering for
+   theta-u's axis."
+  [{:keys [grid goals start gamma noise] :or {gamma 1.0 noise 0.0 start [0 0]}}]
+  (let [base      (gw/build-mdp {:grid grid :utilities {} :start start :gamma gamma :noise noise})
+        goals-vec (vec goals)]
+    (assoc base
+           :goal-onehot (gw/goal-onehot grid goals-vec)
+           :goals-vec   goals-vec
+           :G           (count goals-vec))))
+
+(defn diff-q
+  "Differentiable finite-horizon Q[S,A] for utilities `theta-u` ([G] tensor), time
+   cost `tc` (scalar) and `alpha` (finite number or scalar tensor): build R via
+   diff-reward, then lazy value iteration. Pure lazy graph (no materialize)."
+  [{:keys [goal-onehot S A G] :as dmdp} theta-u tc alpha n-iters]
+  (let [R   (gw/diff-reward goal-onehot theta-u tc S A G)
+        mdp (assoc dmdp :R R)]
+    (:Q (agent/value-iteration-lazy mdp alpha n-iters))))
+
+(defn action-loglik-loss
+  "Negative marginal action-log-likelihood of the observed (s,a) pairs under the
+   softmax policy induced by diff-q — inverse/action-loglik made a tensor, summed
+   over observations. `states-obs`/`actions-obs` are host int vectors (constants
+   outside the gradient); the gather is index-only, so the whole graph stays lazy
+   and differentiable in (theta-u, log-alpha). Returns a [] scalar (the loss).
+   `alpha = exp(log-alpha)` keeps alpha positive and unconstrained for Adam."
+  [{:keys [S A] :as dmdp} theta-u tc log-alpha n-iters states-obs actions-obs]
+  (let [alpha  (mx/exp log-alpha)
+        Q      (diff-q dmdp theta-u tc alpha n-iters)                    ; [S,A]
+        logits (mx/multiply alpha Q)                                     ; [S,A]
+        logp   (mx/subtract logits (mx/expand-dims (mx/logsumexp logits [-1]) -1))  ; log_softmax over actions
+        flat   (mx/reshape logp #js [(* S A)])
+        idx    (mx/array (clj->js (mapv (fn [s a] (+ (* s A) a)) states-obs actions-obs)) mx/int32)
+        ll     (mx/sum (mx/take-idx flat idx 0))]                        ; Σ_m log π(a_m|s_m)
+    (mx/negative ll)))
+
+(defn- pack   [theta-u-vec log-alpha] (mx/array (clj->js (conj (vec theta-u-vec) log-alpha)) mx/float32))
+(defn- unpack [params G] {:theta-u (mx/take-idx params (mx/arange G) 0)  ; [G]
+                          :log-alpha (mx/idx params G)})                 ; scalar
+
+(defn recover-params
+  "Recover (utilities, alpha) by Adam on the action-loglik loss through the
+   differentiable planner. Params = [theta-u(0..G-1), log-alpha] as one [G+1] MLX
+   array. Returns {:theta-u [G] MLX :alpha number :log-history [...]}.
+   Options: :iterations (300) :lr (0.05) :init-utils ([G] of 0.0) :init-log-alpha (0)
+            :fixed-log-alpha (when set, alpha is held fixed and only utilities learn).
+   `observations` is a seq of [state action] pairs (non-terminal states)."
+  [dmdp tc n-iters observations
+   {:keys [iterations lr init-utils init-log-alpha fixed-log-alpha key]
+    :or   {iterations 300 lr 0.05}}]
+  (let [G          (:G dmdp)
+        states-obs (mapv first observations)
+        actions-obs (mapv second observations)
+        init-la    (or fixed-log-alpha init-log-alpha 0.0)
+        init       (pack (or init-utils (repeat G 0.0)) init-la)
+        ;; loss as a fn of the packed [G+1] params; if alpha is fixed, override the
+        ;; log-alpha slot with the constant so its gradient slot is inert.
+        raw    (fn [params _key]
+                 (let [{:keys [theta-u log-alpha]} (unpack params G)
+                       la (if fixed-log-alpha (mx/scalar (double fixed-log-alpha)) log-alpha)]
+                   (action-loglik-loss dmdp theta-u tc la n-iters states-obs actions-obs)))
+        vg     (mx/value-and-grad raw [0])
+        lgf    (fn [params k] (let [[loss grad] (vg params (rng/ensure-key k))]
+                                {:loss loss :grad grad}))
+        {:keys [params loss-history]}
+        (learn/train {:iterations iterations :optimizer :adam :lr lr :key (rng/ensure-key key)} lgf init)
+        {:keys [theta-u log-alpha]} (unpack params G)]
+    {:theta-u theta-u
+     :alpha   (mx/item (mx/exp (if fixed-log-alpha (mx/scalar (double fixed-log-alpha)) log-alpha)))
+     :loss-history loss-history}))
+
+(defn loss-at
+  "The loss evaluated at given host utilities + log-alpha (a convenience for the
+   likelihood-equivalence success check: loss(recovered) ≤ loss(plant) + tol)."
+  [dmdp tc utils-vec log-alpha n-iters observations]
+  (mx/item (action-loglik-loss dmdp (mx/array (clj->js (vec utils-vec)) mx/float32)
+                               tc (mx/scalar (double log-alpha)) n-iters
+                               (mapv first observations) (mapv second observations))))

--- a/src/genmlx/agents/gridworld.cljs
+++ b/src/genmlx/agents/gridworld.cljs
@@ -76,6 +76,30 @@
                                 :when (and (keyword? c) (not (#{:empty :wall} c)))]
                             [idx c]))}))
 
+(defn goal-onehot
+  "Host-side [S,G] float32 one-hot incidence of terminal goals: goal-onehot[s,g] = 1
+   iff terminal cell s is `goals-vec`[g], else 0 (non-terminal rows all zero). Lets
+   a learnable [G] utility tensor flow into the reward as a single matmul (bean
+   genmlx-j5um)."
+  [grid goals-vec]
+  (let [{:keys [S terminals]} (parse-grid grid)
+        g->idx (zipmap goals-vec (range))]
+    (mx/array
+      (clj->js (vec (for [s (range S)]
+                      (let [gi (get g->idx (get terminals s))]
+                        (vec (for [g (range (count goals-vec))] (if (= g gi) 1.0 0.0)))))))
+      mx/float32)))
+
+(defn diff-reward
+  "Differentiable reward [S,A] from a [G] utility tensor `theta-u` and scalar time
+   cost `tc`: R[s,a] = (goal-onehot @ theta-u)[s] + tc, broadcast over actions.
+   d R / d theta-u = goal-onehot (exact), so utilities flow as gradients. Equals
+   build-mdp's R when theta-u = the planted utilities (bean genmlx-j5um)."
+  [goal-onehot theta-u tc S A G]
+  (let [u-col (mx/matmul goal-onehot (mx/reshape theta-u #js [G 1]))   ; [S,G]@[G,1] -> [S,1]
+        r-col (mx/add u-col (mx/scalar (double tc)))]                  ; [S,1]
+    (mx/broadcast-to r-col #js [S A])))                               ; [S,A]
+
 (defn build-mdp
   "Compile {:grid :utilities :start :gamma} into the MDP tensors.
 

--- a/src/genmlx/agents/inverse.cljs
+++ b/src/genmlx/agents/inverse.cljs
@@ -56,20 +56,61 @@
         z  (reduce + (vals ex))]
     (into {} (map (fn [[g e]] [g (/ e z)]) ex))))
 
+(defn- stack-log-policies
+  "Stack the goal policies into one [G,S,A] log-action-probability tensor (bean
+   genmlx-y2hh). LOGP[g,s,a] = log_softmax(alpha · Q_g[s,:])[a] — which is EXACTLY
+   action-loglik(agent_g,s,a): the agent's policy is Categorical(alpha·Q_g[s,:])
+   (agent.cljs make-mdp-agent), and the categorical assess weight is dist's
+   logits->logprobs = logits - logsumexp(logits, last-axis). Computing it for all
+   goals/states at once lets each observed [s,a] be scored against EVERY goal in
+   one gather, with no per-cell mx/item. Requires a finite, shared alpha (a hard
+   argmax would give -inf likelihoods for sub-optimal actions and collapse the
+   posterior — the soft-rationality invariant of inverse inference)."
+  [goals goal-agents]
+  (let [alpha (:alpha (:params (goal-agents (first goals))))]
+    (assert (and (number? alpha) (js/isFinite alpha))
+            "posterior-sequence: batched inverse inference needs a finite alpha (hard argmax is degenerate)")
+    (doseq [g (rest goals)]
+      (assert (== alpha (:alpha (:params (goal-agents g))))
+              "posterior-sequence: all goal agents must share one alpha to batch the policy stack"))
+    (let [qstack (mx/stack (mapv #(:Q (goal-agents %)) goals))          ; [G,S,A]
+          logits (mx/multiply (mx/scalar alpha) qstack)                 ; [G,S,A]
+          logp   (mx/subtract logits (mx/expand-dims (mx/logsumexp logits [-1]) -1))]
+      (mx/materialize! logp)                                            ; eval the stack once
+      logp)))
+
+(defn- softmax->map
+  "Stable tensor softmax of a [G] log-weight vector -> {goal -> prob} map. Same
+   max-shift recipe as normalize-logs, in tensor space (exp(-inf)=0 for zero-prior
+   goals); the single host extraction per prefix posterior."
+  [goals logp]
+  (let [e (mx/exp (mx/subtract logp (mx/amax logp)))]
+    (zipmap goals (mx/->clj (mx/divide e (mx/sum e))))))
+
 (defn posterior-sequence
   "Incremental Bayesian update. `observations` is a seq of [state action] pairs.
    Returns a vector of posterior maps {goal -> prob}, one per prefix length:
-   index 0 is the prior, index k is the posterior after k observed actions."
+   index 0 is the prior, index k is the posterior after k observed actions.
+
+   Shape-batched over the goal axis (bean genmlx-y2hh): the goal policies are
+   stacked into one [G,S,A] log-prob tensor and each observation is scored against
+   ALL goals at once, accumulating into a single [G] log-weight tensor. Extraction
+   is one [G] readout per prefix posterior (T+1 total), not G·T per-cell mx/item.
+   Numerically identical (to float32) to the per-cell action-loglik path, which is
+   retained above as the ground truth."
   [goal-agents prior observations]
-  (let [goals (keys goal-agents)]
+  (let [goals (vec (keys goal-agents))                 ; pin order: same axis for stack + readout
+        logp-policies (stack-log-policies goals goal-agents)
+        logp0 (mx/log (mx/array (clj->js (mapv #(double (prior %)) goals)) mx/float32))]
     (loop [obs  observations
-           logp (into {} (map (fn [g] [g (Math/log (prior g))]) goals))
-           acc  [(normalize-logs logp)]]
+           logp logp0
+           acc  [(softmax->map goals logp0)]]
       (if (empty? obs)
         acc
         (let [[s a] (first obs)
-              logp' (into {} (map (fn [g] [g (+ (logp g) (action-loglik (goal-agents g) s a))]) goals))]
-          (recur (rest obs) logp' (conj acc (normalize-logs logp'))))))))
+              cell  (mx/idx (mx/idx logp-policies s 1) a 1)   ; [G,S,A] -> [G,A] -> [G]
+              logp' (mx/add logp cell)]
+          (recur (rest obs) logp' (conj acc (softmax->map goals logp'))))))))
 
 (defn observe-rollout
   "Turn an agent rollout {:states :actions} into [state action] observation pairs."

--- a/src/genmlx/agents/pomdp.cljs
+++ b/src/genmlx/agents/pomdp.cljs
@@ -31,6 +31,7 @@
             [genmlx.agents.inverse :as inv]
             [genmlx.agents.gridworld :as gw]
             [genmlx.agents.agent :as agent]
+            [genmlx.agents.belief :as belief]
             [genmlx.agents.helpers :as h])
   (:require-macros [genmlx.gen :refer [gen]]))
 
@@ -88,6 +89,11 @@
                 (int (mx/item (:retval (p/simulate (dyn/auto-key policy) []))))))]
     {:worlds (vec worlds) :world-agents world-agents :prior prior :observe observe
      :belief-Q belief-Q :update-belief update-belief :act act
+     ;; tensor belief kernel (bean genmlx-kpuo): same map-in/map-out contract as
+     ;; :update-belief but the filter runs as pure MLX [W] ops (no per-step host
+     ;; map arithmetic, no mx/item). Opt-in via simulate-pomdp :belief-mode :tensor.
+     :update-belief-tensor (fn [belief loc obs]
+                             (belief/update-belief-map observe (vec worlds) belief loc obs))
      :expected-utility (fn [belief s a]
                          (reduce + (map (fn [[w b]]
                                           (* b ((:expected-utility (world-agents w)) s a)))
@@ -101,12 +107,19 @@
    OBSERVES at the new location; (4) it FILTERS its belief. Returns
      {:states [...] :actions [...] :observations [...] :beliefs [b0 b1 ...]}
    where :beliefs index k is the belief held at state k (when choosing action k) —
-   so :states and :beliefs align and both feed the seam (env->trajectory / dist->bars)."
-  [{:keys [act update-belief observe world-agents prior]} env start horizon]
+   so :states and :beliefs align and both feed the seam (env->trajectory / dist->bars).
+
+   `:belief-mode` (optional trailing opts) selects the belief filter: :host
+   (default — the original Clojure-map normalize-logs filter, byte-identical seam)
+   or :tensor (the pure-MLX kernel genmlx.agents.belief; bean genmlx-kpuo). Both
+   produce {world -> prob} beliefs, so the seam is unchanged either way."
+  [{:keys [act update-belief update-belief-tensor observe world-agents prior]} env start horizon
+   & [{:keys [belief-mode] :or {belief-mode :host}}]]
   (let [true-world (:true-world env)
         true-mdp   (:mdp (world-agents true-world))
         T          (:T true-mdp)
-        terminals  (:terminals true-mdp)]
+        terminals  (:terminals true-mdp)
+        update-belief (if (= belief-mode :tensor) update-belief-tensor update-belief)]
     (loop [s start, b prior, step 0
            states [start], actions [], obss [], beliefs [prior]]
       (if (or (>= step horizon) (contains? terminals s))

--- a/src/genmlx/agents/pomdp.cljs
+++ b/src/genmlx/agents/pomdp.cljs
@@ -232,3 +232,52 @@
         (recur b' (inc step) k3
                (conj arms i) (conj rewards r) (conj beliefs b')
                cum' reg' (conj cum-reward cum') (conj regret reg'))))))
+
+(defn simulate-bandit-batched
+  "Run N independent Thompson bandit episodes at once via shape-based batching
+   (bean genmlx-tl6p). Belief is [N,K] alpha/beta tensors; each step is ONE [N,K]
+   Beta draw + [N] argmax pull + [N] Bernoulli reward + a one-hot-masked [N,K]
+   conjugate increment — the N×K particle dimension is fully tensorized, so the
+   only host loop is over the (small) horizon and there is no per-step mx/item.
+
+   Equivalence to N independent simulate-bandit calls is DISTRIBUTIONAL (aggregate
+   means over N), not per-episode: the batched path draws all N×K Beta values in
+   one op rather than the host's per-arm split tree, so individual trajectories
+   differ but the N-distribution matches. Reward at the pulled arm uses the TRUE
+   thetas (the observation channel), exactly like the host `pull`. Returns
+     {:arms [N,H] :rewards [N,H] :regret [N,H] (cumulative) :final-means [N,K]
+      :cum-reward [N] :n N}  — every non-:n leaf has a leading [N] axis."
+  [{:keys [thetas theta* horizon prior]} n master-key]
+  (let [K        (count thetas)
+        true-th  (mx/array (clj->js (vec thetas)) mx/float32)            ; [K] true payoffs
+        thstar   (mx/scalar (double (or theta* (apply max thetas))))
+        prior-ab (or (:arms prior) (vec (repeat K [1.0 1.0])))           ; per-arm Beta prior
+        a0       (mx/array (clj->js (vec (repeat n (mapv first prior-ab)))) mx/float32)  ; [N,K]
+        b0       (mx/array (clj->js (vec (repeat n (mapv second prior-ab)))) mx/float32)
+        arange-K (mx/arange K)]
+    (loop [t 0, alpha a0, beta b0
+           cum-reward (mx/zeros [n]), cum-regret (mx/zeros [n])
+           key (rng/ensure-key master-key)
+           arms [], rewards [], regrets []]
+      (if (>= t horizon)
+        {:arms (mx/stack arms 1) :rewards (mx/stack rewards 1) :regret (mx/stack regrets 1)
+         :final-means (mx/divide alpha (mx/add alpha beta)) :cum-reward cum-reward :n n}
+        (let [[k-th k-rest] (rng/split key)
+              [k-rew k-next] (rng/split k-rest)
+              theta   (dist/beta-sample-vec alpha beta k-th)             ; [N,K] posterior draw
+              arm     (mx/argmax theta 1)                               ; [N] pulled arm
+              p-chos  (mx/take-idx true-th arm 0)                        ; [N] true theta of pull
+              r       (mx/where (mx/less (rng/uniform k-rew [n]) p-chos)
+                                (mx/scalar 1.0) (mx/scalar 0.0))         ; [N] Bernoulli reward
+              mask    (mx/where (mx/equal arange-K (mx/reshape arm [n 1]))
+                                (mx/scalar 1.0) (mx/scalar 0.0))         ; [N,K] one-hot of pull
+              r-col   (mx/reshape r [n 1])
+              alpha'  (mx/add alpha (mx/multiply mask r-col))            ; conjugate increment
+              beta'   (mx/add beta  (mx/multiply mask (mx/subtract (mx/scalar 1.0) r-col)))
+              cum-reward' (mx/add cum-reward r)
+              cum-regret' (mx/add cum-regret (mx/subtract thstar p-chos))]  ; theta* - theta_pull
+          ;; break the lazy graph each step (carries + recorded outputs) so horizon×N
+          ;; does not accumulate one giant graph; matches value-iteration's cadence.
+          (mx/materialize! alpha' beta' cum-reward' cum-regret' arm r)
+          (recur (inc t) alpha' beta' cum-reward' cum-regret' k-next
+                 (conj arms arm) (conj rewards r) (conj regrets cum-regret')))))))

--- a/src/genmlx/agents/pomdp.cljs
+++ b/src/genmlx/agents/pomdp.cljs
@@ -66,12 +66,17 @@
         worlds    (if world-utils (vec (keys world-utils)) goals)
         A         (:A (:mdp (val (first world-agents))))
         prior     (or prior (zipmap worlds (repeat (/ 1.0 (count worlds)))))
-        ;; QMDP belief-space Q at state s: Σ_w b(w) · Q_w[s]  (plain mx reduction)
+        worlds-vec (vec worlds)
+        W         (count worlds-vec)
+        ;; QMDP belief-space Q at state s: Σ_w b(w) · Q_w[s]. Tensorized (bean
+        ;; genmlx-4ifp): stack the per-world solved Q into [W,S,A] ONCE, then
+        ;; contract the [W] belief vector against the [W,A] Q-rows at s as a single
+        ;; fused reduction, instead of a host reduce over the belief map. Agrees
+        ;; with the old reduce to float32 (1e-5) — only the summation reassociates.
+        Qstack    (mx/stack (mapv #(:Q (world-agents %)) worlds-vec))    ; [W,S,A]
         belief-Q  (fn [belief s]
-                    (reduce (fn [acc [w b]]
-                              (mx/add acc (mx/multiply (mx/scalar b)
-                                                       (mx/idx (:Q (world-agents w)) s))))
-                            (mx/zeros #js [A]) belief))
+                    (let [bvec (mx/array (clj->js (mapv #(double (get belief % 0.0)) worlds-vec)) mx/float32)]
+                      (mx/sum (mx/multiply (mx/reshape bvec [W 1]) (mx/idx Qstack s 1)) [0])))
         ;; one Bayes filtering step: b'(w) ∝ b(w) · P(obs | w, loc).
         ;; obs = nil (uninformative location) => belief unchanged (flat-then-snap).
         update-belief (fn [belief loc obs]
@@ -156,6 +161,20 @@
   (update-in belief [:arms i]
              (fn [[a b]] (if (== reward 1) [(inc a) b] [a (inc b)]))))
 
+(defn tensor-bb-increment
+  "One-hot-masked Beta-Bernoulli conjugate increment on [K] alpha/beta MLX tensors
+   (bean genmlx-4ifp) — the pure-tensor form of update-arm, same algebra as
+   genmlx.inference.conjugate/bb-update. For chosen arm `i` with reward r∈{0,1}:
+     alpha' = alpha + onehot_i · r ,  beta' = beta + onehot_i · (1 - r).
+   Returns [alpha' beta']. Element-wise and differentiable; produces the same
+   numbers as update-arm. (The live :thompson path keeps the {:arms [[a b]…]} map
+   for seam compatibility; the [N,K] batched form drives genmlx-tl6p.)"
+  [alpha beta i reward k]
+  (let [mask (mx/where (mx/equal (mx/arange k) (mx/scalar (int i))) (mx/scalar 1.0) (mx/scalar 0.0))
+        r    (mx/scalar (double reward))]
+    [(mx/add alpha (mx/multiply mask r))
+     (mx/add beta  (mx/multiply mask (mx/subtract (mx/scalar 1.0) r)))]))
+
 
 (defn make-bandit-agent
   "Bandit POMDP agent. Belief = {:arms [[alpha beta] ...]} (per-arm Beta).
@@ -176,13 +195,16 @@
             (case strategy
               :thompson
               ;; posterior sampling: draw theta_i ~ Beta(alpha_i,beta_i) per arm and
-              ;; pull the argmax. The action is the argmax of K draws (not one random
-              ;; choice), so we sample directly. dist/beta-dist now uses the stable
-              ;; gamma-ratio sampler (genmlx-gcw4 fixed), so this is exact + crash-free
-              ;; at the high concentration a converging bandit reaches.
-              (let [ks (rng/split-n key (count arms))
-                    ss (mapv (fn [k [a b]] (mx/item (dist/sample (dist/beta-dist a b) k))) ks arms)]
-                (int (apply max-key #(nth ss %) (range (count ss)))))
+              ;; pull the argmax. Tensorized (bean genmlx-4ifp): one [K] Beta draw via
+              ;; the per-element gamma-ratio sampler (genmlx-gcw4-stable, crash-free at
+              ;; high concentration) + a single mx/argmax — replacing the K per-arm
+              ;; mx/item draws with ONE extraction. Belief stays {:arms [[a b]…]} for
+              ;; seam compatibility (RNG path now draws all arms in one op — the seeded
+              ;; convergence/regret tests assert invariants, not the exact pull order).
+              (let [av    (mx/array (clj->js (mapv first arms)) mx/float32)    ; [K] alpha
+                    bv    (mx/array (clj->js (mapv second arms)) mx/float32)   ; [K] beta
+                    theta (dist/beta-sample-vec av bv key)]                    ; [K] posterior draw
+                (int (mx/item (mx/argmax theta))))
               :softmax
               (let [eu  (mx/array (clj->js (arm-values {:arms arms})))
                     pol (gen [] (trace :action (h/softmax-action alpha eu)))]

--- a/src/genmlx/agents/rollout.cljs
+++ b/src/genmlx/agents/rollout.cljs
@@ -1,0 +1,82 @@
+(ns genmlx.agents.rollout
+  "Fused-rollout combinator (bean genmlx-5zdd). The host rollout loops sample an
+   action and an environment transition each step and extract BOTH to the host via
+   mx/item (~2 GPU→CPU round-trips per step). This re-expresses the MDP rollout as a
+   single lazy Metal graph: the state is threaded as an MLX int tensor and the
+   action + next-state are sampled IN-GRAPH (argmax at alpha=##Inf / noise=0, else
+   Gumbel-max via rng/categorical), with exactly ONE mx/materialize! + one ->clj at
+   the end, then a host truncation at the first terminal. No per-step mx/item.
+
+   Scope. Only the MDP rollout fuses cleanly. A POMDP/biased rollout must call the
+   host `observe` geometry at the new state each step, which needs s' as a host int
+   — so it cannot shed the per-step extraction and stays the host loop. The bandit
+   rollout's tensor form is exactly genmlx.agents.pomdp/simulate-bandit-batched at
+   N=1 (bean genmlx-tl6p). So this namespace fuses the MDP case; the others are
+   covered or inherently host-bound (see genmlx-5zdd notes).
+
+   EQUIVALENCE. alpha=##Inf (argmax policy) + noise=0 (one-hot transitions) =>
+   vector-IDENTICAL :states/:actions to agent/simulate-mdp (no tolerance, on
+   non-degenerate Q). Finite-alpha / noisy paths match the host DISTRIBUTION
+   (Gumbel-max == the host categorical draw), not the exact per-step sequence (the
+   noise threads differently).
+
+   TIE-BREAK. At an EXACT Q tie the host's exact/categorical-argmax breaks uniformly
+   at random, while the fused mx/argmax takes the first index — a measure-zero
+   divergence on symmetric worlds. Exact-equivalence holds on non-tied Q."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]))
+
+(defn- step-action
+  "In-graph action sample at lazy int state `s`: argmax(Q[s]) at alpha=##Inf, else
+   Gumbel-max(alpha·Q[s]) via rng/categorical. Returns a lazy int32 [] index (cast
+   so it stacks with the int32 state carry — argmax/categorical return uint32)."
+  [Q s alpha key]
+  (let [q (mx/idx Q s)]                                       ; [A]
+    (mx/astype
+      (if (= alpha ##Inf)
+        (mx/argmax q)
+        (rng/categorical key (mx/multiply (mx/scalar alpha) q)))
+      mx/int32)))
+
+(defn- step-next
+  "In-graph env transition at lazy (s,a): argmax(T[s,a]) at noise=0 (one-hot rows),
+   else Gumbel-max(log T[s,a]). Returns a lazy int32 [] index."
+  [T s a noise key]
+  (let [trow (mx/idx (mx/idx T s) a)]                         ; [S'] transition row
+    (mx/astype
+      (if (zero? noise)
+        (mx/argmax trow)
+        (rng/categorical key (mx/log trow)))
+      mx/int32)))
+
+(defn rollout-mdp
+  "Fused MDP rollout (drop-in for agent/simulate-mdp). Threads the state as a lazy
+   MLX int tensor for `horizon` steps, samples action + next-state in-graph,
+   materializes ONCE, then host-truncates at the first terminal so the output
+   matches the host loop exactly. `agent` is a make-mdp-agent (carries :mdp with
+   :T/:terminals/:alpha/:noise and the solved :Q). Returns {:states [...] :actions
+   [...]} (JS ints). Pass {:key k} to seed the finite-alpha / noisy draws."
+  [{:keys [mdp Q]} start horizon & [{:keys [key]}]]
+  (let [{:keys [T terminals alpha noise]} mdp
+        noise     (or noise 0.0)
+        det?      (and (= alpha ##Inf) (zero? noise))
+        keys      (when-not det? (rng/split-n (rng/ensure-key key) (* 2 (max 1 horizon))))
+        s0        (mx/array (int start) mx/int32)]
+    (loop [s s0, t 0, states [s0], actions []]
+      (if (>= t horizon)
+        (let [st (mx/stack states)
+              ac (when (seq actions) (mx/stack actions))]
+          (mx/materialize! st)
+          (when ac (mx/materialize! ac))
+          (let [svec (mapv int (mx/->clj st))
+                avec (if ac (mapv int (mx/->clj ac)) [])
+                ;; host truncation: stop at the first terminal (terminals are
+                ;; absorbing one-hot rows, so post-terminal tensor steps dwell and
+                ;; are discarded) — reproduces the host loop's variable length.
+                term-idx (or (first (keep-indexed (fn [i sv] (when (contains? terminals sv) i)) svec))
+                             (count avec))]
+            {:states  (subvec svec 0 (inc term-idx))
+             :actions (subvec avec 0 (min term-idx (count avec)))}))
+        (let [a  (step-action Q s alpha (when keys (nth keys (* 2 t))))
+              s' (step-next T s a noise (when keys (nth keys (inc (* 2 t)))))]
+          (recur s' (inc t) (conj states s') (conj actions a)))))))

--- a/src/genmlx/dist.cljs
+++ b/src/genmlx/dist.cljs
@@ -410,6 +410,61 @@
     ;; round to exactly 0.0/1.0, where the beta density (and log-prob) is +inf.
     (mx/clip (mx/divide g1 (mx/add g1 g2)) 1e-7 (- 1.0 1e-7))))
 
+(defn gamma-sample-vec
+  "Marsaglia-Tsang gamma sampling with a per-ELEMENT shape TENSOR (rate 1). `shape`
+   is an MLX array of any shape (e.g. [K] arms or [N,K] particles×arms); returns
+   gamma draws of the SAME shape. Generalizes gamma-sample-n (whose shape is a JS
+   scalar): the constants a/d/c become element-wise tensors and the alpha<1
+   Ahrens-Dieter boost becomes an mx/where mask, so a single tensor mixing shapes
+   <1 and >=1 is sampled in one call. Used by beta-sample-vec for the tensor bandit
+   (bean genmlx-4ifp / genmlx-tl6p). The scalar gamma-sample-n is left untouched."
+  [shape key]
+  (let [key (rng/ensure-key key)
+        sh  (mx/shape shape)                                 ; output element shape
+        a<1 (mx/less shape ONE)                              ; per-element mask
+        a   (mx/where a<1 (mx/add shape ONE) shape)          ; boost shape where <1
+        d   (mx/subtract a (mx/scalar (/ 1.0 3.0)))
+        c   (mx/divide ONE (mx/sqrt (mx/multiply (mx/scalar 9.0) d)))
+        max-iter 20]
+    (loop [iter 0, result (mx/zeros sh), done (mx/zeros sh), k key]
+      (if (>= iter max-iter)
+        ;; Ahrens-Dieter boost only where shape<1: multiply by U^(1/shape)
+        (let [[ku _] (rng/split k)
+              u (rng/uniform ku sh)
+              boosted (mx/multiply result (mx/power u (mx/divide ONE shape)))]
+          (mx/where a<1 boosted result))
+        (let [[k1 k2 k3] (rng/split-n k 3)
+              x  (rng/normal k1 sh)
+              u  (rng/uniform k2 sh)
+              v  (mx/power (mx/add ONE (mx/multiply c x)) (mx/scalar 3.0))   ; (1+c*x)^3
+              v-pos  (mx/greater v ZERO)
+              safe-v (mx/maximum v (mx/scalar 1e-30))
+              ;; log(u) < 0.5*x^2 + d*(1 - v + log v)
+              log-accept (mx/add (mx/multiply HALF (mx/square x))
+                                 (mx/multiply d (mx/add (mx/subtract ONE safe-v) (mx/log safe-v))))
+              accepted   (mx/multiply v-pos (mx/less (mx/log u) log-accept))
+              not-done   (mx/equal done ZERO)
+              newly-done (mx/multiply accepted not-done)
+              result (mx/where newly-done (mx/multiply d safe-v) result)
+              done   (mx/where newly-done ONE done)]
+          ;; Cut the lazy chain so 20 iterations don't accumulate one giant graph,
+          ;; and periodically release dead Metal buffers (matches gamma-sample-n).
+          (mx/eval! result done)
+          (when (zero? (mod iter 5)) (mx/sweep-dead-arrays!))
+          (recur (inc iter) result done k3))))))
+
+(defn beta-sample-vec
+  "Per-element Beta sampling: given `alpha` and `beta` MLX tensors of the SAME
+   shape, return Beta(alpha,beta) draws of that shape. Beta(a,b)=G1/(G1+G2),
+   G1~Gamma(a,1), G2~Gamma(b,1); clipped into (1e-7,1-1e-7) like dist-sample-n*
+   :beta-dist. One call draws a whole [K] (or [N,K]) posterior — the tensor bandit
+   Thompson draw (bean genmlx-4ifp / genmlx-tl6p)."
+  [alpha beta key]
+  (let [[k1 k2] (rng/split (rng/ensure-key key))
+        g1 (gamma-sample-vec alpha k1)
+        g2 (gamma-sample-vec beta k2)]
+    (mx/clip (mx/divide g1 (mx/add g1 g2)) 1e-7 (- 1.0 1e-7))))
+
 ;; Dirichlet batch sampling via k independent gamma samples, then normalize
 (defmethod dc/dist-sample-n* :dirichlet [d key n]
   (let [{:keys [alpha]} (:params d)

--- a/test/genmlx/agentmodels_diff_learn_test.cljs
+++ b/test/genmlx/agentmodels_diff_learn_test.cljs
@@ -1,0 +1,146 @@
+;; Headless tests for differentiable MDP utility/alpha learning (bean genmlx-j5um):
+;; genmlx.agents.differentiable. Recover planted agent params by gradient through
+;; the planner (lazy value iteration) + the policy log-likelihood at fixed observed
+;; (s,a) — exactly the inverse/action-loglik quantity. MDP-only scope (no belief /
+;; no stochastic-rollout gradient). Identifiability: recovery is to LIKELIHOOD-
+;; equivalence (loss at recovered ≈ loss at plant), with fix-one-learn-the-other
+;; sub-tests; the data is a deterministic expected-counts dataset of a finite-alpha
+;; policy, so the test is seed-free.
+;;
+;; Run: bunx nbb@1.4.206 test/genmlx/agentmodels_diff_learn_test.cljs
+
+(ns genmlx.agentmodels-diff-learn-test
+  (:require [genmlx.agents.differentiable :as diff]
+            [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.agent :as agent]
+            [genmlx.agents.inverse :as inv]
+            [genmlx.mlx :as mx]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-close [msg expected actual tol]
+  (if (<= (Math/abs (- expected actual)) tol)
+    (do (vswap! passed inc) (println " PASS" msg "  =" actual))
+    (do (vswap! failed inc) (println " FAIL" msg "  expected:" expected "  got:" actual))))
+
+(defn maxerr [a b] (apply max 0.0 (map (fn [x y] (Math/abs (- x y))) (flatten a) (flatten b))))
+
+;; Deterministic dataset: for each non-terminal state, emit (s,a) round(K·π[s,a])
+;; times — an "expected counts" dataset whose MLE is exactly the planted policy
+;; (so loss→loss-at-plant and a finite alpha is identifiable). Seed-free.
+(defn policy-dataset [mdp alpha k n-iters]
+  (let [{:keys [Q]} (agent/value-iteration mdp alpha n-iters)
+        S (:S mdp) A (:A mdp) terms (set (keys (:terminals mdp)))
+        pol (mx/->clj (mx/softmax (mx/multiply (mx/scalar alpha) Q) 1))]
+    (vec (for [s (range S) :when (not (terms s))
+               a (range A)
+               _ (range (Math/round (* k (double (nth (nth pol s) a)))))]
+           [s a]))))
+
+(def N 40)              ; VI sweeps (finite horizon; same for plant + learner)
+(def TC -0.1)
+
+;; ---------------------------------------------------------------------------
+(println "\n== Section 1: diff-reward reconstructs build-mdp's R ==")
+(doseq [[label grid goals utils]
+        [["1x5 corridor" [[:A :empty :empty :empty :B]] [:A :B] {:A 3.0 :B 1.0}]
+         ["3x3 hike"      [[:A :empty :B] [:empty :empty :empty] [:empty :empty :C]] [:A :B :C] {:A 5.0 :B 2.0 :C -1.0}]]]
+  (let [dmdp   (diff/build-diff-mdp {:grid grid :goals goals})
+        theta  (mx/array (clj->js (mapv utils goals)) mx/float32)
+        diff-R (gw/diff-reward (:goal-onehot dmdp) theta TC (:S dmdp) (:A dmdp) (:G dmdp))
+        host-R (:R (gw/build-mdp {:grid grid :utilities (assoc utils :timeCost TC)}))]
+    (assert-true (str label ": diff-reward == build-mdp R (1e-5)")
+                 (< (maxerr (mx/->clj diff-R) (mx/->clj host-R)) 1e-5))))
+
+(println "\n== Section 2: value-iteration-lazy Q == eager value-iteration Q ==")
+(doseq [[label grid goals utils]
+        [["corridor" [[:A :empty :empty :empty :B]] [:A :B] {:A 3.0 :B 1.0}]
+         ["hike"     [[:A :empty :B] [:empty :empty :empty] [:empty :empty :C]] [:A :B :C] {:A 5.0 :B 2.0 :C -1.0}]]]
+  (let [dmdp (diff/build-diff-mdp {:grid grid :goals goals})
+        R    (gw/diff-reward (:goal-onehot dmdp) (mx/array (clj->js (mapv utils goals)) mx/float32) TC (:S dmdp) (:A dmdp) (:G dmdp))
+        mdp  (assoc dmdp :R R)
+        ql   (:Q (agent/value-iteration-lazy mdp 2.0 N))
+        qe   (:Q (agent/value-iteration mdp 2.0 N))]
+    (assert-true (str label ": lazy Q == eager Q (1e-4)") (< (maxerr (mx/->clj ql) (mx/->clj qe)) 1e-4))))
+
+(println "\n== Section 3: tensor loss == host Σ action-loglik at the plant ==")
+;; The differentiable loss at the planted params must equal -Σ inverse/action-loglik
+;; over the same observed (s,a) (the inverse posterior's own quantity).
+(let [grid  [[:A :empty :empty :empty :B]]
+      goals [:A :B]
+      utils {:A 3.0 :B 1.0}
+      alpha 2.0
+      dmdp  (diff/build-diff-mdp {:grid grid :goals goals})
+      mdp   (gw/build-mdp {:grid grid :utilities (assoc utils :timeCost TC)})
+      hostagent (agent/make-mdp-agent {:mdp mdp :alpha alpha :n-iters N})
+      ;; a goal-agent style wrapper so inverse/action-loglik can score it
+      obs   [[1 0] [2 1] [3 1] [2 0] [1 0]]
+      tensor-loss (diff/loss-at dmdp TC [3.0 1.0] (Math/log alpha) N obs)
+      host-loss   (- (reduce + (map (fn [[s a]] (inv/action-loglik {:policy (:policy hostagent)} s a)) obs)))]
+  (println "  tensor-loss" (.toFixed tensor-loss 4) " host-loss" (.toFixed host-loss 4))
+  (assert-close "tensor loss == -Σ action-loglik at plant (1e-3)" host-loss tensor-loss 1e-3))
+
+(println "\n== Section 4: gradient is finite and non-zero at a wrong init ==")
+(let [grid  [[:A :empty :empty :empty :B]]
+      goals [:A :B]
+      dmdp  (diff/build-diff-mdp {:grid grid :goals goals})
+      obs   [[1 0] [2 0] [3 1]]
+      states (mapv first obs) actions (mapv second obs)
+      raw   (fn [p _k]
+              (let [tu (mx/take-idx p (mx/arange 2) 0)
+                    la (mx/idx p 2)]
+                (diff/action-loglik-loss dmdp tu TC la N states actions)))
+      vg    (mx/value-and-grad raw [0])
+      [_loss grad] (vg (mx/array (clj->js [0.0 0.0 0.0]) mx/float32) (genmlx.mlx.random/fresh-key 1))
+      g     (vec (mx/->clj grad))]
+  (println "  grad =" (mapv #(.toFixed % 4) g))
+  (assert-true "gradient is all finite" (every? #(js/isFinite %) g))
+  (assert-true "gradient is non-zero (backward pass intact)" (some #(> (Math/abs %) 1e-3) g)))
+
+(println "\n== Section 5: recover RELATIVE utilities (alpha fixed) ==")
+(let [grid  [[:A :empty :empty :empty :B]]
+      goals [:A :B]
+      alpha 2.0
+      dmdp  (diff/build-diff-mdp {:grid grid :goals goals})
+      mdp   (gw/build-mdp {:grid grid :utilities {:A 4.0 :B 0.0 :timeCost TC}})   ; plant A≫B
+      data  (policy-dataset mdp alpha 30 N)
+      plant-loss (diff/loss-at dmdp TC [4.0 0.0] (Math/log alpha) N data)
+      res   (diff/recover-params dmdp TC N data
+                                 {:iterations 250 :lr 0.1 :init-utils [0.0 0.0]
+                                  :fixed-log-alpha (Math/log alpha)})
+      tu    (vec (mx/->clj (:theta-u res)))
+      rec-loss (diff/loss-at dmdp TC tu (Math/log alpha) N data)]
+  (println "  planted A≫B | recovered theta-u" (mapv #(.toFixed % 3) tu)
+           "| plant-loss" (.toFixed plant-loss 3) " recovered-loss" (.toFixed rec-loss 3))
+  (assert-true "recovered A-utility > B-utility (correct ordering)" (> (first tu) (second tu)))
+  (assert-true "final loss <= plant loss + 1e-2 (likelihood-equivalent)" (<= rec-loss (+ plant-loss 1e-2)))
+  (assert-true "loss decreased from init" (< (last (:loss-history res)) (first (:loss-history res)))))
+
+(println "\n== Section 6: recover ALPHA (utilities fixed) ==")
+(let [grid  [[:A :empty :empty :empty :B]]
+      goals [:A :B]
+      plant-alpha 2.0
+      dmdp  (diff/build-diff-mdp {:grid grid :goals goals})
+      mdp   (gw/build-mdp {:grid grid :utilities {:A 3.0 :B 1.0 :timeCost TC}})
+      data  (policy-dataset mdp plant-alpha 50 N)
+      ;; fix utilities at the plant via init-utils + (no fixed-log-alpha so alpha learns)
+      ;; — but to isolate alpha we hold utils by setting lr low won't fix them; instead
+      ;; learn the full vector from a utils-correct init and check alpha lands near 2.
+      res   (diff/recover-params dmdp TC N data
+                                 {:iterations 300 :lr 0.08 :init-utils [3.0 1.0] :init-log-alpha (Math/log 0.5)})]
+  (println "  plant alpha 2.0 | recovered alpha" (.toFixed (:alpha res) 3)
+           "| recovered theta-u" (mapv #(.toFixed % 3) (mx/->clj (:theta-u res))))
+  (assert-true "recovered alpha is in the right ballpark [1.0, 4.0]" (<= 1.0 (:alpha res) 4.0)))
+
+(println "\n== Section 7: alpha=##Inf is rejected (non-differentiable) ==")
+(let [dmdp (diff/build-diff-mdp {:grid [[:A :empty :B]] :goals [:A :B]})
+      R    (gw/diff-reward (:goal-onehot dmdp) (mx/array (clj->js [1.0 0.0]) mx/float32) TC (:S dmdp) (:A dmdp) (:G dmdp))]
+  (assert-true "value-iteration-lazy rejects alpha=##Inf"
+               (try (agent/value-iteration-lazy (assoc dmdp :R R) ##Inf 10) false
+                    (catch :default _ true))))
+
+(println (str "\n== Results: " @passed " passed, " @failed " failed =="))
+(when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/agentmodels_pomdp_test.cljs
+++ b/test/genmlx/agentmodels_pomdp_test.cljs
@@ -99,6 +99,24 @@
   (assert-equal "POMDP act under certain belief == the MDP agent's action"
                 ((:act (wa :A)) s) ((:act pa) {:A 1.0 :B 0.0} s)))
 
+(println "\n== Section 4b: tensorized belief-Q == host reduce over a belief sweep (genmlx-4ifp) ==")
+;; belief-Q is now a [W,S,A] Qstack contraction; assert it agrees with the old
+;; host reduce (Σ_w b(w)·Q_w[s]) to 1e-5 across a sweep of beliefs and states.
+(let [[_ pa] (build :A 2.0)
+      wa     (:world-agents pa)
+      bq     (:belief-Q pa)
+      A      (:A (:mdp (val (first wa))))
+      host-bq (fn [belief s]
+                (reduce (fn [acc [w b]]
+                          (mx/add acc (mx/multiply (mx/scalar b) (mx/idx (:Q (wa w)) s))))
+                        (mx/zeros #js [A]) belief))
+      beliefs [{:A 1.0 :B 0.0} {:A 0.0 :B 1.0} {:A 0.5 :B 0.5} {:A 0.7 :B 0.3} {:A 0.1 :B 0.9}]]
+  (assert-true "tensor belief-Q == host reduce to 1e-5 over beliefs×states"
+               (every? identity
+                 (for [b beliefs, s [0 1 4 7 10]]
+                   (every? (fn [[t h]] (< (Math/abs (- t h)) 1e-5))
+                           (map vector (mx/->clj (bq b s)) (mx/->clj (host-bq b s))))))))
+
 (println "\n== Section 5: the seam — belief -> PosteriorBars ==")
 (let [bars (pres/dist->bars "P(world)" {:A 1.0 :B 0.0} :A)]
   (assert-close "bars sum to 1" 1.0 (reduce + (map :weight (:bars bars))) 1e-9)

--- a/test/genmlx/agents_api_test.cljs
+++ b/test/genmlx/agents_api_test.cljs
@@ -84,5 +84,47 @@
   (assert-true "inverse/goal-agents builds one agent per goal" (= #{:A :B} (set (keys gas))))
   (assert-close "inverse/posterior-sequence prior sums to 1" 1.0 (reduce + (vals (first seq))) 1e-9))
 
+;; ---- inverse: BATCHED [G,S,A] posterior == per-cell host action-loglik (bean genmlx-y2hh) ----
+;; Ground truth = the original per-cell algorithm, re-implemented here from the
+;; UNCHANGED inv/action-loglik + inv/normalize-logs. The shape-batched
+;; posterior-sequence must reproduce it to float32 tolerance on every prefix.
+(defn host-posterior-sequence
+  [goal-agents prior observations]
+  (let [goals (keys goal-agents)]
+    (loop [obs observations
+           logp (into {} (map (fn [g] [g (Math/log (prior g))]) goals))
+           acc  [(inv/normalize-logs logp)]]
+      (if (empty? obs)
+        acc
+        (let [[s a] (first obs)
+              logp' (into {} (map (fn [g] [g (+ (logp g) (inv/action-loglik (goal-agents g) s a))]) goals))]
+          (recur (rest obs) logp' (conj acc (inv/normalize-logs logp'))))))))
+(defn max-posterior-err [a b]
+  (apply max 0.0 (for [[ma mb] (map vector a b), g (keys ma)]
+                   (Math/abs (- (double (ma g)) (double (mb g)))))))
+;; (a) 2-goal slice fixture
+(let [grid [[:empty :empty :empty :empty :empty]
+            [:empty :empty :empty :empty :empty]
+            [:A     :empty :empty :empty :B]]
+      gas  (inv/goal-agents {:grid grid :goals [:A :B] :alpha 2.0})
+      obs  [[2 3] [7 3] [12 1] [13 1]]
+      bat  (inv/posterior-sequence gas {:A 0.5 :B 0.5} obs)
+      hos  (host-posterior-sequence gas {:A 0.5 :B 0.5} obs)]
+  (assert-true  "batched: one posterior per prefix (2-goal)" (= (count hos) (count bat) 5))
+  (assert-true  "batched == host action-loglik to 1e-4 (2-goal)" (< (max-posterior-err bat hos) 1e-4)))
+;; (b) 4-goal corner fixture
+(let [grid [[:A :empty :B]
+            [:empty :empty :empty]
+            [:C :empty :D]]
+      gas  (inv/goal-agents {:grid grid :goals [:A :B :C :D] :alpha 2.0})
+      obs  [[4 0] [4 1] [1 3] [2 2]]
+      pri  {:A 0.25 :B 0.25 :C 0.25 :D 0.25}
+      bat  (inv/posterior-sequence gas pri obs)
+      hos  (host-posterior-sequence gas pri obs)]
+  (assert-true  "batched: one posterior per prefix (4-goal)" (= (count hos) (count bat) 5))
+  (assert-true  "every batched posterior sums to 1 (4-goal)"
+                (every? (fn [m] (< (Math/abs (- 1.0 (reduce + (vals m)))) 1e-6)) bat))
+  (assert-true  "batched == host action-loglik to 1e-4 (4-goal)" (< (max-posterior-err bat hos) 1e-4)))
+
 (println (str "\n" @passed " passed, " @failed " failed"))
 (when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/bandit_batched_test.cljs
+++ b/test/genmlx/bandit_batched_test.cljs
@@ -1,0 +1,135 @@
+;; Headless tests for the BATCHED bandit inference path (bean genmlx-tl6p):
+;; pomdp/simulate-bandit-batched runs N independent Thompson episodes at once as
+;; [N,K]-shaped tensor steps. The batched aggregate (final posterior means, modal
+;; best-arm fraction, mean cumulative regret) must match N independent host
+;; simulate-bandit calls to DISTRIBUTIONAL tolerance (means over N — the RNG path
+;; differs, so per-episode bit-exactness is not expected), and be materially faster
+;; on a large operand.
+;;
+;; Run: bunx nbb@1.4.206 test/genmlx/bandit_batched_test.cljs
+
+(ns genmlx.bandit-batched-test
+  (:require [genmlx.agents.pomdp :as pomdp]
+            [genmlx.agents.pomdp-env :as env]
+            [genmlx.dist :as dist]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-close [msg expected actual tol]
+  (if (<= (Math/abs (- expected actual)) tol)
+    (do (vswap! passed inc) (println " PASS" msg "  =" actual))
+    (do (vswap! failed inc) (println " FAIL" msg "  expected:" expected "  got:" actual))))
+
+(defn modal-arm [row k] (apply max-key #(get (frequencies row) % 0) (range k)))
+
+;; ENV CONSTRAINT (genmlx-5ucd): under `bunx nbb` there is no exposed JS GC, so the
+;; rejection-sampler scratch buffers from sequential HOST rollouts are never
+;; reclaimed and the Metal buffer-COUNT limit (~499000) is hit at trivial memory
+;; (~4MB) — an uncatchable crash after ~13 rollouts. That is precisely the pathology
+;; the batched [N,K] path removes (one rollout, per-step materialize). So the host
+;; cross-check here is run at a small feasible N; the PRIMARY validation is the
+;; batched path against analytical ground truth (moments, mass conservation,
+;; convergence to the true theta, sublinear regret) at full N.
+;; Each host rollout leaves ~75k unreclaimable Metal buffers (60 steps × the
+;; Marsaglia-Tsang gamma loop), so the whole process can do only ~6 rollouts before
+;; the ~499k buffer-count limit (genmlx-5ucd). HOST-N=4 leaves room for the one
+;; batched(256) rollout. The host cross-check is therefore a loose feasible-N sanity
+;; tie; batched→analytical (Section 3b) is the real validation.
+(def HOST-N 4)
+(def BATCH-N 256)
+
+(def THETAS [0.25 0.50 0.80])
+(def BEST 2)
+(def H 60)
+(def bandit (env/bandit-pomdp {:thetas THETAS :horizon H}))
+(def ag (pomdp/make-bandit-agent {:strategy :thompson}))
+
+(println "\n== Section 1: [N,K] Beta sampler moments (distinct per-row shapes) ==")
+(let [N 20000
+      av (mx/array (clj->js (vec (repeat N [2.0 5.0 8.0]))) mx/float32)
+      bv (mx/array (clj->js (vec (repeat N [8.0 5.0 2.0]))) mx/float32)
+      means (vec (mx/->clj (mx/mean (dist/beta-sample-vec av bv (rng/fresh-key 7)) [0])))]
+  (println "  column means:" (mapv #(.toFixed % 3) means))
+  (doseq [[m e] (map vector means [0.2 0.5 0.8])]
+    (assert-close "[N,K] Beta column mean == alpha/(alpha+beta)" e m 0.02)))
+
+;; --- Run the HOST reference (N=8, timed) and the BATCHED path (N=256, timed) ONCE ---
+;; (Both reused across Sections 2-5; total stays within the buffer-count budget.)
+(def host-t0 (js/Date.now))
+(def host-stats
+  (mapv (fn [k]
+          (let [r (pomdp/simulate-bandit ag bandit k)]
+            {:best (nth ((:arm-values ag) (last (:beliefs r))) BEST)
+             :modal (modal-arm (:arms r) 3)
+             :reg (last (:regret r))
+             :npulls (count (:arms r))}))
+        (rng/split-n (rng/fresh-key 42) HOST-N)))
+(def host-ms (- (js/Date.now) host-t0))
+(def host-best-mean (/ (reduce + (map :best host-stats)) (double HOST-N)))
+(def host-modal-frac (/ (count (filter #(= BEST (:modal %)) host-stats)) (double HOST-N)))
+(def host-reg-mean (/ (reduce + (map :reg host-stats)) (double HOST-N)))
+
+(def bat-t0 (js/Date.now))
+(def bat (pomdp/simulate-bandit-batched bandit BATCH-N (rng/fresh-key 42)))
+(mx/materialize! (:final-means bat) (:regret bat) (:arms bat) (:cum-reward bat))
+(def bat-ms (- (js/Date.now) bat-t0))
+(def bat-arms (mx/->clj (:arms bat)))
+(def bat-best-mean (mx/item (mx/mean (mx/idx (:final-means bat) BEST 1))))      ; mean over N
+(def bat-modal-frac (/ (count (filter (fn [row] (= BEST (modal-arm row 3))) bat-arms)) (double BATCH-N)))
+(def bat-step-mean (vec (mx/->clj (mx/mean (:regret bat) [0]))))                 ; [H] mean cum regret
+(def bat-reg-mean (last bat-step-mean))
+
+(println "\n== Section 2: conjugate-increment exactness (mass conservation) ==")
+;; The one-hot-masked increment must add exactly one pull per step (no mass lost or
+;; duplicated) and the reward channel must stay in {0,1}.
+(assert-true "every batched episode ran exactly H pulls" (every? #(= H (count %)) bat-arms))
+(assert-true "every host episode ran exactly H pulls" (every? #(= H (:npulls %)) host-stats))
+(assert-true "cumulative reward per episode in [0,H]"
+             (every? #(<= 0 % H) (mx/->clj (:cum-reward bat))))
+
+(println "\n== Section 3: batched aggregate matches host + converges to analytical ==")
+(println (str "  best-arm posterior mean  host(" HOST-N "): " (.toFixed host-best-mean 3) "  batched(" BATCH-N "): " (.toFixed bat-best-mean 3)))
+(println (str "  modal-best fraction      host(" HOST-N "): " (.toFixed host-modal-frac 3) "  batched(" BATCH-N "): " (.toFixed bat-modal-frac 3)))
+(println (str "  mean cumulative regret   host(" HOST-N "): " (.toFixed host-reg-mean 2) "  batched(" BATCH-N "): " (.toFixed bat-reg-mean 2)))
+;; (a) host(feasible N) vs batched(256) — loose direction-agreement tie (the host
+;;     aggregate is noisy at the small feasible N; best-arm mean is the most
+;;     concentrated statistic, regret mean looser, modal-frac too noisy to cross-check).
+(assert-close "best-arm posterior mean agrees with host (feasible N, 0.1)" host-best-mean bat-best-mean 0.1)
+(assert-close "mean cumulative regret agrees with host (feasible N, 0.2*H)" host-reg-mean bat-reg-mean (* 0.2 H))
+;; (b) batched(256) converges to the analytical target (true theta of the best arm)
+;;     and concentrates pulls on it — the primary, full-N validation.
+(assert-close "batched best-arm posterior mean -> true theta 0.8" 0.80 bat-best-mean 0.05)
+(assert-true  "batched modal pull is the best arm in a clear majority of episodes" (> bat-modal-frac 0.7))
+(assert-true  "host modal pull is the best arm in a majority of (feasible-N) episodes" (>= host-modal-frac 0.5))
+
+(println "\n== Section 4: sublinear regret in batched form (mean over N) ==")
+(let [early (/ (nth bat-step-mean 9) 10.0)
+      late  (/ (- (nth bat-step-mean (dec H)) (nth bat-step-mean 49)) 10.0)]
+  (println "  mean-over-N regret: early-slope" (.toFixed early 3) " late-slope" (.toFixed late 3)
+           " total" (.toFixed bat-reg-mean 2))
+  (assert-true "regret accrues early"              (> early 0.0))
+  (assert-true "regret slope flattens (sublinear)" (< late early))
+  (assert-true "total regret below worst-arm bound" (< bat-reg-mean (* H (- 0.80 0.25)))))
+
+(println "\n== Section 5: speed — per-episode wall-clock (batched vs host) ==")
+;; Per-episode cost: host runs HOST-N episodes sequentially; batched runs BATCH-N at
+;; once. (A 512-host-vs-batched comparison is infeasible in one process under the
+;; buffer-count limit genmlx-5ucd; per-episode cost is the honest, feasible metric.)
+(let [host-per-ep (/ host-ms (double HOST-N))
+      bat-per-ep  (/ bat-ms  (double BATCH-N))]
+  (println "  host:" host-ms "ms /" HOST-N "ep =" (.toFixed host-per-ep 2) "ms/ep   "
+           "batched:" bat-ms "ms /" BATCH-N "ep =" (.toFixed bat-per-ep 3) "ms/ep   "
+           "per-episode speedup:" (.toFixed (/ host-per-ep (max 0.001 bat-per-ep)) 1) "x")
+  (assert-true "batched per-episode cost is >= 3x lower than the host path"
+               (< bat-per-ep (/ host-per-ep 3.0))))
+
+(println "\n== Section 6: scalar host path unchanged ==")
+(assert-true "host simulate-bandit still returns H pulls per episode" (every? #(= H (:npulls %)) host-stats))
+
+(println (str "\n== Results: " @passed " passed, " @failed " failed =="))
+(when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/bandit_test.cljs
+++ b/test/genmlx/bandit_test.cljs
@@ -9,6 +9,8 @@
   (:require [genmlx.agents.pomdp :as pomdp]
             [genmlx.agents.pomdp-env :as env]
             [genmlx.agents.presentation :as pres]
+            [genmlx.dist :as dist]
+            [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]))
 
 (def passed (volatile! 0))
@@ -69,6 +71,55 @@
   (assert-close "arm2 weight = posterior mean 9/11" (/ 9.0 11.0) (:weight (nth (:bars bars) 2)) 1e-9)
   (assert-true  "true-best arm highlighted"        (:highlight (nth (:bars bars) 2)))
   (assert-true  "other arms not highlighted"       (not (:highlight (nth (:bars bars) 0)))))
+
+;; ===========================================================================
+;; Tensor bandit (bean genmlx-4ifp): [K] alpha/beta tensors + masked bb-update
+;; ===========================================================================
+(println "\n== Section 6: tensor masked bb-increment == host update-arm ==")
+;; The one-hot-masked tensor increment must produce EXACTLY the same counts as the
+;; host update-arm for every (arm, reward) pair (increments are exact in float32).
+(let [K 3
+      a0 (mx/array (clj->js [1.0 1.0 1.0]) mx/float32)
+      b0 (mx/array (clj->js [1.0 1.0 1.0]) mx/float32)
+      host0 {:arms [[1.0 1.0] [1.0 1.0] [1.0 1.0]]}]
+  (doseq [i (range K), r [0 1]]
+    (let [[a' b'] (pomdp/tensor-bb-increment a0 b0 i r K)
+          host    (:arms (pomdp/update-arm host0 i r))]
+      (assert-equal (str "bb-increment arm " i " reward " r ": alpha matches update-arm")
+                    (mapv first host)  (vec (mx/->clj a')))
+      (assert-equal (str "bb-increment arm " i " reward " r ": beta matches update-arm")
+                    (mapv second host) (vec (mx/->clj b'))))))
+
+(println "\n== Section 7: [K] Thompson sampler — moments + selection agreement ==")
+;; (a) per-arm Beta moments: column means of N [K] draws match alpha/(alpha+beta).
+(let [N 20000
+      av (mx/array (clj->js (vec (repeat N [2.0 5.0 8.0]))) mx/float32)   ; [N,K]
+      bv (mx/array (clj->js (vec (repeat N [8.0 5.0 2.0]))) mx/float32)
+      theta (dist/beta-sample-vec av bv (rng/fresh-key 7))
+      means (vec (mx/->clj (mx/mean theta [0])))]
+  (println "  [K] Beta column means:" (mapv #(.toFixed % 3) means) "(expect 0.2/0.5/0.8)")
+  (doseq [[m e] (map vector means [0.2 0.5 0.8])]
+    (assert-close "[K] Beta column mean matches alpha/(alpha+beta)" e m 0.01)))
+;; (b) argmax-selection frequencies from the [K] sampler match the OLD per-arm
+;;     dist/beta-dist-then-argmax method to small tolerance (same posteriors).
+(let [M 4000, K 3
+      a [2.0 4.0 5.0], b [6.0 4.0 3.0]                                    ; distinct Beta arms
+      av (mx/array (clj->js (vec (repeat M a))) mx/float32)               ; [M,K]
+      bv (mx/array (clj->js (vec (repeat M b))) mx/float32)
+      ;; new [K] (batched as [M,K]) sampler: argmax along arm axis per row
+      new-sel (vec (mx/->clj (mx/argmax (dist/beta-sample-vec av bv (rng/fresh-key 123)) 1)))
+      new-freq (mapv (fn [k] (/ (count (filter #(= k %) new-sel)) (double M))) (range K))
+      ;; old reference: K scalar dist/beta-dist draws per trial, argmax
+      old-sel (mapv (fn [t]
+                      (let [ks (rng/split-n (rng/fresh-key (+ 9000 t)) K)
+                            ss (mapv (fn [ki [aa bb]] (mx/item (dist/sample (dist/beta-dist aa bb) ki)))
+                                     ks (map vector a b))]
+                        (apply max-key #(nth ss %) (range K))))
+                    (range M))
+      old-freq (mapv (fn [k] (/ (count (filter #(= k %) old-sel)) (double M))) (range K))]
+  (println "  selection freq  new:" (mapv #(.toFixed % 3) new-freq) " old:" (mapv #(.toFixed % 3) old-freq))
+  (assert-true "[K] sampler arm-selection freq matches per-arm sampler (max diff < 0.05)"
+               (< (apply max (map (fn [n o] (Math/abs (- n o))) new-freq old-freq)) 0.05)))
 
 (println (str "\n" @passed " passed, " @failed " failed"))
 (when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/belief_tensor_test.cljs
+++ b/test/genmlx/belief_tensor_test.cljs
@@ -1,0 +1,172 @@
+;; Headless tests for the TENSOR belief-update kernel (bean genmlx-kpuo):
+;; genmlx.agents.belief. The pure-MLX observation-Bayes filter b'=normalize(b⊙L)
+;; must agree to float32 tolerance (1e-6) with the host Clojure-map filters
+;; (pomdp.cljs normalize-logs and biased_planners.cljs bayes-update) on every demo,
+;; both as a one-step kernel and threaded through simulate-pomdp /
+;; simulate-biased-pomdp in :belief-mode :tensor. The host filters stay default
+;; (:host) and remain ground truth.
+;;
+;; Run: bunx nbb@1.4.206 test/genmlx/belief_tensor_test.cljs
+
+(ns genmlx.belief-tensor-test
+  (:require [genmlx.agents.belief :as belief]
+            [genmlx.agents.pomdp :as pomdp]
+            [genmlx.agents.pomdp-env :as env]
+            [genmlx.agents.biased-planners :as bp]
+            [genmlx.mlx :as mx]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-close [msg expected actual tol]
+  (if (<= (Math/abs (- expected actual)) tol)
+    (do (vswap! passed inc) (println " PASS" msg "  =" actual))
+    (do (vswap! failed inc) (println " FAIL" msg "  expected:" expected "  got:" actual))))
+(defn assert-equal [msg expected actual]
+  (if (= expected actual) (do (vswap! passed inc) (println " PASS" msg "  =" (pr-str actual)))
+      (do (vswap! failed inc) (println " FAIL" msg "  expected:" (pr-str expected) "  got:" (pr-str actual)))))
+
+(defn maps-close?
+  "Every world's prob in two {world->prob} beliefs agrees within tol."
+  [m1 m2 tol]
+  (and (= (set (keys m1)) (set (keys m2)))
+       (every? (fn [k] (<= (Math/abs (- (double (m1 k)) (double (m2 k)))) tol)) (keys m1))))
+
+(defn vecs-close? [v1 v2 tol]
+  (and (= (count v1) (count v2))
+       (every? (fn [[a b]] (<= (Math/abs (- (double a) (double b))) tol)) (map vector v1 v2))))
+
+;; ===========================================================================
+;; Fixture 1 — hidden-goal restaurant gridworld (worlds = [:A :B], signpost reveal)
+;; ===========================================================================
+(def grid [[:A    :empty :B]
+           [:wall :empty :wall]
+           [:wall :empty :wall]
+           [:wall :empty :wall]
+           [:wall :empty :wall]])
+(def signpost 7)
+(def goals [:A :B])
+(def gw-env (env/restaurant-gridworld {:grid grid :goals goals :signpost signpost
+                                       :true-world :A :start [1 4]}))
+(def gw-agent (pomdp/make-pomdp-agent (assoc gw-env :alpha ##Inf :gamma 1.0 :n-iters 40)))
+(def gw-worlds (:worlds gw-agent))             ; [:A :B]
+(def gw-observe (:observe gw-env))
+(def gw-prior (:prior gw-agent))               ; {:A 0.5 :B 0.5}
+
+(println "\n== Section 1: obs-likelihood-vec (host geometry -> [W] indicator) ==")
+(assert-equal "L at (signpost,:A) == [1 0]" [1.0 0.0]
+              (vec (mx/->clj (belief/obs-likelihood-vec gw-observe gw-worlds signpost :A))))
+(assert-equal "L at (signpost,:B) == [0 1]" [0.0 1.0]
+              (vec (mx/->clj (belief/obs-likelihood-vec gw-observe gw-worlds signpost :B))))
+
+(println "\n== Section 2: tensor kernel == host filter (restaurant gridworld) ==")
+(let [ub-host (:update-belief gw-agent)]
+  (doseq [[loc o] [[10 nil] [signpost :A] [signpost :B]]]
+    (let [host   (ub-host gw-prior loc o)
+          tens   (belief/update-belief-map gw-observe gw-worlds gw-prior loc o)]
+      (assert-true (str "tensor == host at (loc " loc ", o " o ")") (maps-close? host tens 1e-6))
+      (when o
+        (assert-close (str "normalized at (loc " loc ", o " o ")")
+                      1.0 (reduce + (vals tens)) 1e-6)))))
+
+(println "\n== Section 3: nil identity + z=0 defensive (kernel) ==")
+(let [b (belief/belief->vec gw-worlds gw-prior)]
+  ;; nil obs -> bit-identical input belief (fast-path), no L built
+  (assert-equal "nil obs -> belief unchanged (bit-equal)"
+                (vec (mx/->clj b))
+                (vec (mx/->clj (belief/tensor-update-belief gw-observe gw-worlds b signpost nil))))
+  ;; impossible obs (:C, which no world produces at the signpost) -> keep b (mirrors
+  ;; biased_planners.cljs:491 (pos? z) guard); the host pomdp path would NaN here.
+  (assert-true "impossible obs -> belief unchanged (z=0 defensive)"
+               (vecs-close? (vec (mx/->clj b))
+                            (vec (mx/->clj (belief/tensor-update-belief gw-observe gw-worlds b signpost :C)))
+                            1e-6)))
+
+(println "\n== Section 4: belief<->vec round-trip ==")
+(doseq [[label m] [["uniform" gw-prior] ["skewed" {:A 0.8 :B 0.2}]]]
+  (assert-true (str "round-trip preserves " label " belief")
+               (maps-close? m (belief/vec->belief gw-worlds (belief/belief->vec gw-worlds m)) 1e-6)))
+
+;; ===========================================================================
+;; Fixture 2 — adjacency-reveal restaurant POMDP (2^2 worlds, partial reveal)
+;; ===========================================================================
+(def adj-grid [[:a     :empty :empty :b]
+               [:empty :empty :empty :empty]
+               [:empty :empty :empty :empty]])
+(def adj-env (env/restaurant-pomdp {:grid adj-grid :utilities {:a 5.0 :b 3.0}
+                                    :open-prob {:a 0.6 :b 0.9} :true-world {:a true :b true} :start [1 2]}))
+(def adj-agent (pomdp/make-pomdp-agent (assoc adj-env :alpha ##Inf :gamma 1.0 :noise 0.0 :n-iters 40)))
+(def adj-worlds (:worlds adj-agent))
+(def adj-observe (:observe adj-env))
+(def adj-prior (:prior adj-agent))
+(defn P-b-open [m] (reduce + (map (fn [[w p]] (if (:b w) p 0.0)) m)))
+
+(println "\n== Section 5: tensor kernel == host filter (adjacency POMDP, 4 worlds) ==")
+(let [ub-host (:update-belief adj-agent)]
+  (doseq [[loc o] [[5 nil] [1 [[:a true]]] [1 [[:a false]]] [2 [[:b true]]]]]
+    (let [host (ub-host adj-prior loc o)
+          tens (belief/update-belief-map adj-observe adj-worlds adj-prior loc o)]
+      (assert-true (str "tensor == host at (loc " loc ", o " o ")") (maps-close? host tens 1e-6)))))
+;; the discriminating partial-reveal: observing A pins A but leaves B at its prior 0.9
+(let [tens (belief/update-belief-map adj-observe adj-worlds adj-prior 1 [[:a true]])]
+  (assert-close "partial reveal: P(B-open) stays prior 0.9 after observing A" 0.9 (P-b-open tens) 1e-6))
+
+;; ===========================================================================
+;; Section 6 — full-rollout agreement: :belief-mode :host vs :tensor
+;; ===========================================================================
+(println "\n== Section 6: simulate-pomdp host-mode == tensor-mode ==")
+(doseq [tw [:A :B]]
+  (let [e     (env/restaurant-gridworld {:grid grid :goals goals :signpost signpost
+                                         :true-world tw :start [1 4]})
+        pa    (pomdp/make-pomdp-agent (assoc e :alpha ##Inf :gamma 1.0 :n-iters 40))
+        host  (pomdp/simulate-pomdp pa e (:start-idx e) 12)
+        tens  (pomdp/simulate-pomdp pa e (:start-idx e) 12 {:belief-mode :tensor})]
+    (assert-equal (str "true " tw ": same :states")  (:states host) (:states tens))
+    (assert-equal (str "true " tw ": same :actions") (:actions host) (:actions tens))
+    (assert-true  (str "true " tw ": #beliefs == #states") (= (count (:beliefs tens)) (count (:states tens))))
+    (assert-true  (str "true " tw ": per-step beliefs agree to 1e-6")
+                  (every? (fn [[h t]] (maps-close? h t 1e-6)) (map vector (:beliefs host) (:beliefs tens))))))
+
+(println "\n== Section 7: adjacency rollout host-mode == tensor-mode ==")
+(doseq [tw [{:a true :b true} {:a false :b true}]]
+  (let [e    (env/restaurant-pomdp {:grid adj-grid :utilities {:a 5.0 :b 3.0}
+                                    :open-prob {:a 0.6 :b 0.9} :true-world tw :start [1 2]})
+        pa   (pomdp/make-pomdp-agent (assoc e :alpha ##Inf :gamma 1.0 :noise 0.0 :n-iters 40))
+        host (pomdp/simulate-pomdp pa e (:start-idx e) 14)
+        tens (pomdp/simulate-pomdp pa e (:start-idx e) 14 {:belief-mode :tensor})]
+    (assert-equal (str tw ": same :states") (:states host) (:states tens))
+    (assert-equal (str tw ": same :observations") (:observations host) (:observations tens))
+    (assert-true  (str tw ": per-step beliefs agree to 1e-6")
+                  (every? (fn [[h t]] (maps-close? h t 1e-6)) (map vector (:beliefs host) (:beliefs tens))))))
+
+;; ===========================================================================
+;; Section 8 — biased POMDP rollout (voi-world, prob-vector belief)
+;; ===========================================================================
+(println "\n== Section 8: biased filter (voi-world) — tensor == host bayes-update ==")
+;; The voi-world agent (alpha=Inf) has argmax action TIES, so two independent
+;; rollouts can take different paths run-to-run — that is action stochasticity, not
+;; a belief disagreement. We isolate the FILTER: take ONE host rollout's
+;; (state', observation) sequence and replay the TENSOR filter along that same
+;; trajectory, asserting the resulting belief vectors equal the host :beliefs
+;; (done-means [4]: tensor :update-belief == host bayes-update vectors to 1e-6).
+(let [voi  (bp/voi-world {})
+      opt  (bp/make-biased-pomdp-agent (assoc voi :alpha ##Inf :n-iters 8)
+                                       {:discount 0.0 :bias :sophisticated :update-myopic-bound ##Inf})
+      s0   (:start-idx opt)
+      pv   (:prior-vec opt)
+      host (bp/simulate-biased-pomdp opt :B s0 8 pv)        ; host-filter beliefs (ground truth)
+      ub-t (:update-belief-tensor opt)
+      ;; replay the tensor filter along the host trajectory's (s', o) pairs
+      tens-beliefs (reductions (fn [b [s' o]] (ub-t b s' o))
+                               pv
+                               (map vector (rest (:states host)) (:observations host)))]
+  (assert-true  "voi: tensor filter produces one belief per state (replay aligns)"
+                (= (count tens-beliefs) (count (:beliefs host))))
+  (assert-true  "voi: tensor filter == host bayes-update at every step (1e-6)"
+                (every? (fn [[h t]] (vecs-close? h t 1e-6))
+                        (map vector (:beliefs host) tens-beliefs))))
+
+(println (str "\n== Results: " @passed " passed, " @failed " failed =="))
+(when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/rollout_fused_test.cljs
+++ b/test/genmlx/rollout_fused_test.cljs
@@ -1,0 +1,106 @@
+;; Headless tests for the FUSED MDP rollout (bean genmlx-5zdd):
+;; genmlx.agents.rollout/rollout-mdp, reached via agent/simulate-mdp :rollout-mode
+;; :fused. The whole trajectory is one lazy Metal graph (state threaded as an MLX
+;; tensor, action + next-state sampled in-graph, one materialize at the end) — no
+;; per-step mx/item. At alpha=##Inf/noise=0 it must produce vector-IDENTICAL
+;; :states/:actions to the host loop; the host (:host, default) path is unchanged.
+;;
+;; Run: bunx nbb@1.4.206 test/genmlx/rollout_fused_test.cljs
+
+(ns genmlx.rollout-fused-test
+  (:require [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.agent :as agent]
+            [genmlx.mlx.random :as rng]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-equal [msg expected actual]
+  (if (= expected actual) (do (vswap! passed inc) (println " PASS" msg "  =" (pr-str actual)))
+      (do (vswap! failed inc) (println " FAIL" msg "  expected:" (pr-str expected) "  got:" (pr-str actual)))))
+
+(defn mk [grid utilities alpha noise]
+  (agent/make-mdp-agent {:mdp (gw/build-mdp {:grid grid :utilities utilities :noise noise})
+                         :alpha alpha :n-iters 40}))
+
+;; ---------------------------------------------------------------------------
+(println "\n== Section 1: deterministic (alpha=Inf, noise=0) fused == host exactly ==")
+;; TIE-FREE worlds (single-corridor geometry / asymmetric utilities) — every state
+;; has a UNIQUE optimal action, so the fused argmax and the host's categorical-argmax
+;; agree and :states/:actions are vector-IDENTICAL.
+(def GRIDS-TIEFREE
+  {"corridor" {:grid [[:A :empty :empty :empty :B]] :utils {:A 3.0 :B 1.0 :timeCost -0.1}}
+   "tall"     {:grid [[:A    :empty :B]
+                      [:wall :empty :wall]
+                      [:wall :empty :wall]
+                      [:empty :empty :empty]]
+               :utils {:A 4.0 :B 3.0 :timeCost -0.1}}})
+(doseq [[label {:keys [grid utils]}] GRIDS-TIEFREE]
+  (let [ag (mk grid utils ##Inf 0.0)
+        S  (:S (:mdp ag))
+        all-ok (every? (fn [start]
+                         (let [h (agent/simulate-mdp ag start 30)
+                               f (agent/simulate-mdp ag start 30 {:rollout-mode :fused})]
+                           (and (= (:states h) (:states f)) (= (:actions h) (:actions f)))))
+                       (remove (:walls (:mdp ag)) (range S)))]
+    (assert-true (str label ": fused == host :states/:actions for every start state") all-ok)))
+
+(println "\n== Section 1b: tied world — fused reaches the same goal in the same length ==")
+;; An open 2D world has MULTIPLE equal-length optimal paths to the corner goal, so
+;; host and fused legitimately pick different (equally optimal) routes (the tie-break
+;; divergence). Equivalence then is: same terminal reached, same trajectory length.
+(let [ag (mk [[:A :empty :B] [:empty :empty :empty] [:empty :empty :C]]
+             {:A 5.0 :B 2.0 :C -1.0 :timeCost -0.1} ##Inf 0.0)
+      S  (:S (:mdp ag))
+      ok (every? (fn [start]
+                   (let [h (agent/simulate-mdp ag start 30)
+                         f (agent/simulate-mdp ag start 30 {:rollout-mode :fused})]
+                     (and (= (last (:states h)) (last (:states f)))         ; same goal
+                          (= (count (:states h)) (count (:states f))))))    ; same (optimal) length
+                 (remove (:walls (:mdp ag)) (range S)))]
+  (assert-true "open hike: fused reaches the same goal in the same #steps (ties allowed)" ok))
+
+(println "\n== Section 2: terminal truncation matches host length ==")
+(let [{:keys [grid utils]} (GRIDS-TIEFREE "corridor")
+      ag (mk grid utils ##Inf 0.0)]
+  (doseq [start [1 2 3]]
+    (let [h (agent/simulate-mdp ag start 30)
+          f (agent/simulate-mdp ag start 30 {:rollout-mode :fused})]
+      (assert-equal (str "start " start ": same trajectory length") (count (:states h)) (count (:states f)))
+      (assert-true  (str "start " start ": fused ends at a terminal")
+                    (contains? (:terminals (:mdp ag)) (last (:states f))))
+      (assert-true  (str "start " start ": one action per transition")
+                    (= (count (:actions f)) (dec (count (:states f))))))))
+
+(println "\n== Section 3: already-terminal start ==")
+(let [{:keys [grid utils]} (GRIDS-TIEFREE "corridor")
+      ag (mk grid utils ##Inf 0.0)]
+  (let [f (agent/simulate-mdp ag 0 30 {:rollout-mode :fused})]   ; idx 0 = :A terminal
+    (assert-equal "terminal start -> single state, no actions" {:states [0] :actions []} f)))
+
+(println "\n== Section 4: noisy / soft fused rollout stays valid + terminates ==")
+;; finite alpha + noise => stochastic; can't match the host sequence (different RNG
+;; thread), but the fused path must stay in-bounds (off walls) and reach a terminal.
+(let [ag (mk [[:A :empty :B] [:empty :empty :empty] [:empty :empty :C]]
+             {:A 5.0 :B 2.0 :C -1.0 :timeCost -0.1} 50.0 0.1)
+      walls (:walls (:mdp ag))
+      S (:S (:mdp ag)) terms (:terminals (:mdp ag))]
+  (let [results (mapv (fn [seed] (agent/simulate-mdp ag 6 40 {:rollout-mode :fused :key (rng/fresh-key seed)}))
+                      (range 8))]
+    (assert-true "noisy fused stays in-bounds and off walls"
+                 (every? (fn [r] (every? #(and (<= 0 % (dec S)) (not (walls %))) (:states r))) results))
+    (assert-true "noisy fused reaches a terminal within horizon (high alpha)"
+                 (every? (fn [r] (contains? terms (last (:states r)))) results))))
+
+(println "\n== Section 5: host (default) path byte-identical (no regression) ==")
+(let [{:keys [grid utils]} (GRIDS-TIEFREE "corridor")
+      ag (mk grid utils ##Inf 0.0)
+      h1 (agent/simulate-mdp ag 2 30)
+      h2 (agent/simulate-mdp ag 2 30 {:rollout-mode :host})]
+  (assert-equal "explicit :host == default" h1 h2)
+  (assert-true  "default reaches goal" (contains? (:terminals (:mdp ag)) (last (:states h1)))))
+
+(println (str "\n== Results: " @passed " passed, " @failed " failed =="))
+(when (pos? @failed) (js/process.exit 1))


### PR DESCRIPTION
Completes the **swxr epic** (`genmlx-swxr`): the future-proof, tensor-native (Layer B / GPU) realization of the agentmodels port. All 6 child tasks delivered, each with a self-checking test asserting host-equivalence. Every default path stays byte-identical — tensor/batched/fused/differentiable paths are **opt-in** and slot *under* the unchanged presentation seam, mirroring GenMLX's "a model written today runs unchanged at higher compilation levels" principle.

## What landed (one commit per task)

| Task | What | Test | Key result |
|---|---|---|---|
| `genmlx-kpuo` | tensor belief-update kernel `b'=normalize(b⊙L)` | `belief_tensor_test` 32/32 | host-equiv to 1e-6 |
| `genmlx-y2hh` | batched `[G,S,A]` inverse-goal inference | `agents_api_test` +6 | batched == host action-loglik to <1e-4 |
| `genmlx-4ifp` | `[K]` tensor bandit + tensorized QMDP belief-Q | `bandit_test` 34, `pomdp` +1 | masked bb-update == `update-arm` exactly |
| `genmlx-tl6p` | `simulate-bandit-batched` (N seeds, `[N,K]`) | `bandit_batched_test` 16/16 | ~216× per-episode speedup |
| `genmlx-j5um` | differentiable MDP utility/α learning | `diff_learn_test` 12/12 | recovers α 1.959 (planted 2.0) by gradient |
| `genmlx-5zdd` | fused single-graph MDP rollout | `rollout_fused_test` 17/17 | exact `fused==host`, no per-step `mx/item` |

## Two corrections to the spec (approved)
- **kpuo:** the bean's `normalize(O[.,.,a]⊙(T^T·b))` is the textbook *state-belief* filter, wrong for this codebase's **static world-identity latent** (verified against `pomdp.cljs`/`pomdp_env.cljs`/`biased_planners.cljs`). The correct kernel is pure observation-Bayes with no transition step.
- **j5um:** scoped to the MDP case — it differentiates the **planner + policy log-likelihood at fixed (s,a)** (= `inverse/action-loglik`), not the stochastic rollout (which uses `mx/item`). So it lands independently of 5zdd/kpuo. POMDP-belief / fused-rollout gradient variants are follow-ons (`genmlx-5x3f`, `genmlx-h833`).

## Honest scope notes
- **5zdd** only fuses the MDP rollout cleanly. POMDP/biased rollouts must call the host `observe` geometry at each new state (need `s'` host-side), so they can't shed per-step `mx/item`; the bandit's tensor rollout is exactly `simulate-bandit-batched` at N=1. Follow-on: `genmlx-r35c` (tensor-observe POMDP rollout).
- **tl6p / 4ifp** RNG equivalence is *distributional* (means over N), not per-episode — the batched/vectorized draws consume entropy differently than the host per-arm split tree. Deterministic alpha=∞/noise=0 MDP/POMDP rollouts ARE bit-exact.

## Robustness finding (filed, not fixed here): `genmlx-5ucd` (high)
Surfaced while building tl6p: sequential sampling-heavy host rollouts hit Metal's **buffer-COUNT** limit (~499k) at **~4 MB** of memory and crash **uncatchably**. The membrane's auto-cleanup is *memory*-pressure-based (512 MB), so it never fires; and `bunx nbb` exposes no JS GC, so `tidy`/`force-gc!` can't reclaim. This is precisely the pathology the batched `[N,K]` path removes; it capped tl6p's host comparison at N=4 (the batched path itself is unaffected).

## Verification
Full sweep green: 14 agent suites + `dist_test` / `clip_contract_test` / `exact_test` (120) / `gradient_fd_test` / `score_gradient_test` membrane guards. All new tests are deterministic (seeded). Pre-existing flaky `agentmodels_irl_test` filed separately (`genmlx-ooof`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)