### PR TITLE
feat(agentmodels-tui): extract reusable trajectory-player view primitive

### DIFF
--- a/examples/agentmodels-tui/ch3_demo.cljs
+++ b/examples/agentmodels-tui/ch3_demo.cljs
@@ -10,7 +10,10 @@
    only wires + renders.
 
    Demo state lives in one r/atom (the proven reactive model); the gallery routes
-   keys here via on-key and starts/stops the autoplay timer via enter!/leave!."
+   keys here via on-key and starts/stops the demo via enter!/leave!. Frame
+   stepping + autoplay are owned by a reusable views/trajectory-player — this
+   file only decides WHEN to resample (alpha/noise/r) and what to render around
+   the player."
   (:require ["ink" :refer [Text Box]]
             [reagent.core :as r]
             [genmlx.agents.gridworld :as gw]
@@ -34,13 +37,17 @@
 (def alpha-ladder [0.3 1.0 3.0 10.0 100.0 ##Inf])
 (def noise-ladder [0.0 0.1 0.2 0.4])
 
-(defonce ds (r/atom {:alpha-i 4 :noise-i 1 :idx 0 :frames [] :timer nil}))
+(defonce ds (r/atom {:alpha-i 4 :noise-i 1 :frames []}))
+
+;; The reusable player owns the frame index + autoplay; it reads our frames
+;; through a thunk, so a resample is just (swap! ds ...) followed by :replay!.
+(defonce player (views/make-trajectory-player {:frames-fn #(:frames @ds)}))
 
 (defn- alpha-label [a] (if (= a ##Inf) "INF (optimal)" (str a)))
 
 (defn- rollout!
   "Rebuild the MDP at the current noise, plan (value iteration -> Q), sample a
-   softmax rollout, and produce the frames. The whole pipeline, in five lines."
+   softmax rollout, produce the frames, and rewind the player to frame 0."
   []
   (let [alpha  (nth alpha-ladder (:alpha-i @ds))
         noise  (nth noise-ladder (:noise-i @ds))
@@ -49,43 +56,36 @@
         ag     (agent/make-mdp-agent {:mdp mdp :alpha alpha :gamma 1.0 :n-iters 40})
         roll   (agent/simulate-mdp ag (:start-idx mdp) 30)
         frames (pres/env->trajectory mdp roll (:V ag))]
-    (swap! ds assoc :frames frames :idx 0)))
+    (swap! ds assoc :frames frames)
+    ((:replay! player))))
 
-(defn- step! []
-  (swap! ds update :idx #(min (dec (count (:frames @ds))) (inc %))))
+(defn enter! [] (rollout!) ((:start! player)))
 
-(defn enter! []
-  (rollout!)
-  (when-not (:timer @ds)
-    (swap! ds assoc :timer (js/setInterval step! 450))))
-
-(defn leave! []
-  (when-let [t (:timer @ds)] (js/clearInterval t) (swap! ds assoc :timer nil)))
+(defn leave! [] ((:stop! player)))
 
 (defn on-key [k]
   (case k
-    :space  (step!)
+    ;; r resamples a fresh path; alpha/noise also force a resample
     :replay (rollout!)
     :plus   (do (swap! ds update :alpha-i #(min (dec (count alpha-ladder)) (inc %))) (rollout!))
     :minus  (do (swap! ds update :alpha-i #(max 0 (dec %))) (rollout!))
     :noise  (do (swap! ds update :noise-i #(mod (inc %) (count noise-ladder))) (rollout!))
-    nil))
+    ;; everything else (space stepping) belongs to the player
+    ((:on-key player) k)))
 
 (defn view []
-  (let [{:keys [alpha-i noise-i idx frames]} @ds
+  (let [{:keys [alpha-i noise-i frames]} @ds
         a (nth alpha-ladder alpha-i)
         e (nth noise-ladder noise-i)
         n (max 1 (count frames))
-        i (min idx (dec n))
-        f (when (seq frames) (nth frames i))]
+        i (min @(:index player) (dec n))]
     [:> Box {:flexDirection "column" :padding 1}
      [views/status-bar {:title "Ch 3: Gridworld MDP"
                         :status (str "alpha = " (alpha-label a)
                                      "    noise = " e
                                      "    step " i "/" (dec n))}]
-     (when f [views/grid-view f])
+     [(:view player)]
      [:> Text {:dimColor true}
-      (str " action: " (or (some-> f :meta :action name) "-")
-           "   [space] step  [r] resample  [+/-] alpha  [n] noise  [q/esc] menu")]
+      " [space] step  [r] resample  [+/-] alpha  [n] noise  [q/esc] menu"]
      [:> Text {:color "gray"}
       " @ agent   A/B goals (util 1 / 5)   block = wall   shading = value fn"]]))

--- a/examples/agentmodels-tui/views.cljs
+++ b/examples/agentmodels-tui/views.cljs
@@ -9,6 +9,8 @@
    grid-view        Frame        -> column of colored rows
    bars-view        PosteriorBars-> labeled horizontal bars
    frames-view      [Frame] + idx-atom -> grid-view of the current frame
+   trajectory-player [Frame] thunk -> a stateful player that OWNS frame
+                    stepping (space), replay (r), and autoplay
    status-bar       map          -> a one-line title/status strip"
   (:require ["ink" :refer [Text Box]]
             [reagent.core :as r]))
@@ -41,15 +43,53 @@
 
 (defn frames-view
   "[Frame] + an index r/atom -> the current frame + a step line. Derefing the
-   atom makes this re-render as the index advances (proven reagent reactivity)."
-  [frames idx]
-  (let [i (min @idx (dec (count frames)))
-        f (nth frames i)]
+   atom makes this re-render as the index advances (proven reagent reactivity).
+   An optional `status-fn` (fn [i n] -> string) appends extra text to the step
+   line. Robust to an empty/shrunk frame list (clamps the index)."
+  [frames idx & [status-fn]]
+  (let [n (max 1 (count frames))
+        i (min @idx (dec n))
+        f (when (seq frames) (nth frames i))]
     [:> Box {:flexDirection "column"}
-     [grid-view f]
+     (when f [grid-view f])
      [:> Text {:dimColor true}
-      (str "step " i "/" (dec (count frames))
-           (when-let [a (:action (:meta f))] (str "   →" (name a))))]]))
+      (str "step " i "/" (dec n)
+           (when-let [a (:action (:meta f))] (str "   →" (name a)))
+           (when status-fn (str "   " (status-fn i n))))]]))
+
+(defn make-trajectory-player
+  "Construct a stateful trajectory player that OWNS frame stepping. Returns a map
+   {:view :on-key :start! :stop! :replay! :step! :index} closing over a private
+   frame-index r/atom; rendering delegates to frames-view, so this stays above
+   the seam — it knows nothing of how frames are produced. `frames-fn` is a thunk
+   returning the current [Frame], which makes upstream resampling transparent
+   (call :replay! after a resample to rewind to frame 0).
+
+     :on-key  :space advances one frame, :replay (r) rewinds to frame 0
+     :start!  begin autoplay (no-op if already running or :interval-ms is nil)
+     :stop!   halt autoplay
+     :view    a reagent component rendering the current frame + step line
+
+   opts:
+     :frames-fn   thunk -> current [Frame]                       (required)
+     :interval-ms autoplay period in ms, default 450; nil disables autoplay
+     :status-fn   (fn [i n] -> string) extra step-line text       (optional)"
+  [{:keys [frames-fn interval-ms status-fn] :or {interval-ms 450}}]
+  (let [idx     (r/atom 0)
+        timer   (atom nil)
+        n-now   #(max 1 (count (frames-fn)))
+        step!   (fn [] (swap! idx #(min (dec (n-now)) (inc %))))
+        replay! (fn [] (reset! idx 0))]
+    {:index   idx
+     :step!   step!
+     :replay! replay!
+     :view    (fn [] [frames-view (frames-fn) idx status-fn])
+     :on-key  (fn [k] (case k :space (step!) :replay (replay!) nil))
+     :start!  (fn [] (when (and interval-ms (nil? @timer))
+                       (reset! timer (js/setInterval step! interval-ms))))
+     :stop!   (fn [] (when-let [t @timer]
+                       (js/clearInterval t)
+                       (reset! timer nil)))}))
 
 (defn bars-view
   "PosteriorBars -> labeled horizontal bars; widths normalized to `width` cells.


### PR DESCRIPTION
## Summary

Extracts a reusable, stateful `trajectory-player` view primitive into the agentmodels TUI gallery — the last open item on the **view primitives** feature (genmlx-bfwz, now complete).

Previously each demo hand-rolled frame stepping (its own `:idx`, autoplay `setInterval`, and `step!`/`on-key`). This factors that into a single shared primitive so future demos (and the Studio TUI, genmlx-tw52) compose it instead of duplicating it.

## Changes

**`views.cljs`**
- Add `views/make-trajectory-player`: a constructor returning `{:view :on-key :start! :stop! :replay! :step! :index}`, closing over a private frame-index `r/atom` + autoplay timer. `:on-key` owns `:space` (step) and `:replay`/r (rewind); `:start!`/`:stop!` manage the `setInterval`.
- `frames-fn` is a thunk → `[Frame]`, so upstream resampling is transparent (call `:replay!` to rewind).
- Extend `frames-view` with an optional `status-fn` and make it robust to an empty/shrunk frame list (clamps the index).

**`ch3_demo.cljs`**
- Compose the player instead of hand-rolling stepping: `ds` now holds only `{:alpha-i :noise-i :frames}`; `rollout!` swaps frames + `(:replay! player)`; `enter!`/`leave!` delegate to `:start!`/`:stop!`; `on-key` routes alpha/noise/r to resample and `:space` to the player.

## Verification

- `views_demo` renders clean (views.cljs compiles).
- Headless drive of the player: step / replay / clamp + shrink-safety all correct.
- `ch3_demo` compiles and composes with a real MLX value-iteration rollout (14 frames, rewind on resample, `:space` advances).
- `agentmodels_slice_test`: 51/51, no regression.

Remaining for the parent epic (genmlx-698r): live interactive TTY confirmation of the Ch 3 demo (genmlx-kdp6) — requires a real terminal, not coverable in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)