### PR TITLE
feat(msa): wire synthesized GFs to exact analytical model evidence

### DIFF
--- a/src/genmlx/llm/msa.cljs
+++ b/src/genmlx/llm/msa.cljs
@@ -23,6 +23,7 @@
      9.9  End-to-end pipeline      (msa)"
   (:require [sci.core :as sci]
             [clojure.string :as str]
+            [cljs.reader :as reader]
             [instaparse.core :as insta]
             ["@mlx-node/lm" :refer [ChatSession]]
             [genmlx.mlx :as mx]
@@ -30,6 +31,7 @@
             [genmlx.dynamic :as dyn]
             [genmlx.protocols :as p]
             [genmlx.choicemap :as cm]
+            [genmlx.method-selection :as ms]
             [promesa.core :as pr])
   (:require-macros [genmlx.gen :refer [gen]]))
 
@@ -42,8 +44,16 @@
    Code evaluated with these opts can reference dist/gaussian, mx/add, etc."
   {:namespaces
    {'dist {'gaussian dist/gaussian
+           'normal dist/gaussian
            'uniform dist/uniform
            'bernoulli dist/bernoulli
+           ;; Canonical genmlx.dist names — these are the symbols whose name the
+           ;; schema walker extracts as :dist-type, so they must match the
+           ;; conjugacy table keys (:beta-dist, :gamma-dist). The short aliases
+           ;; (beta, gamma) are kept for LLM-friendliness and resolve to the
+           ;; same distribution; code->source-form rewrites them to canonical.
+           'beta-dist dist/beta-dist
+           'gamma-dist dist/gamma-dist
            'beta dist/beta-dist
            'gamma dist/gamma-dist
            'exponential dist/exponential
@@ -68,21 +78,75 @@
   [code-str]
   (sci/eval-string code-str msa-sci-opts))
 
+(def ^:private canonical-dist-syms
+  "Rewrite map from short dist aliases (as the LLM/parser emit them) to the
+   canonical genmlx.dist symbol names. The schema walker derives :dist-type from
+   the symbol name, and the conjugacy table keys on the canonical names, so the
+   source form handed to make-gen-fn must use them for conjugacy to fire."
+  {'dist/beta 'dist/beta-dist
+   'dist/gamma 'dist/gamma-dist})
+
+(defn- normalize-dist-syms
+  "Recursively rewrite dist constructor symbols in a source form to their
+   canonical genmlx.dist names (see canonical-dist-syms)."
+  [form]
+  (cond
+    (seq? form)    (map normalize-dist-syms form)
+    (vector? form) (mapv normalize-dist-syms form)
+    (map? form)    (into {} (map (fn [[k v]] [(normalize-dist-syms k)
+                                              (normalize-dist-syms v)]))
+                         form)
+    (symbol? form) (get canonical-dist-syms form form)
+    :else form))
+
+(defn code->source-form
+  "Read a (fn [params] body...) code string and rewrite it into a gen source
+   form ([] body...) with canonical dist symbols. This is what make-gen-fn walks
+   to extract a faithful schema (real keyword trace-sites), so L1 compilation and
+   L3 conjugacy detection fire on synthesized models exactly as they do on
+   hand-written (gen ...) models.
+
+   The body is unchanged — `trace` stays as the gen-runtime local. Model args
+   are [] (synthesized models are zero-argument). Returns nil if the string does
+   not read as an (fn [..] ..) form, so callers can fall back to the opaque
+   wrapper without losing the model."
+  [code-str]
+  (try
+    (let [form (reader/read-string code-str)]
+      (when (and (seq? form)
+                 (symbol? (first form))
+                 (contains? #{"fn" "fn*"} (name (first form)))
+                 (vector? (second form)))
+        (normalize-dist-syms (list* [] (drop 2 form)))))
+    (catch :default _ nil)))
+
 (defn wrap-model
   "Wrap a (fn [trace] body) into a zero-argument DynamicGF.
-   The resulting gen function can be used with simulate, generate, etc."
-  [model-fn]
-  (dyn/auto-key (gen [] (model-fn trace))))
+
+   With a source form (([] body...) — see code->source-form), make-gen-fn
+   extracts a faithful schema: real keyword trace-sites that drive L1 compilation
+   and L3 conjugacy detection. Without one, falls back to the opaque
+   (gen [] (model-fn trace)) wrapper, whose schema sees no trace-sites.
+
+   Execution is identical either way: the SCI closure model-fn is what runs,
+   invoked with the gen-runtime's trace closure."
+  ([model-fn]
+   (dyn/auto-key (gen [] (model-fn trace))))
+  ([model-fn source-form]
+   (if source-form
+     (dyn/auto-key (dyn/make-gen-fn (fn [rt] (model-fn (.-trace rt))) source-form))
+     (wrap-model model-fn))))
 
 (defn eval-model
   "Evaluate a model code string and wrap into a DynamicGF.
-   Combines eval-model-fn and wrap-model in one step.
+   Combines eval-model-fn and wrap-model in one step, deriving a faithful source
+   form from the code so conjugacy/compilation fire.
    Returns the DynamicGF, or nil on failure."
   [code-str]
   (try
     (let [f (eval-model-fn code-str)]
       (when (fn? f)
-        (wrap-model f)))
+        (wrap-model f (code->source-form code-str))))
     (catch :default _ nil)))
 
 ;; ============================================================
@@ -334,32 +398,70 @@ Output ONLY the lines. No explanation.")
          (js/Math.log
           (reduce + (map #(js/Math.exp (- % max-x)) xs)))))))
 
-(defn score-model
-  "Score a gen function against observations via importance sampling.
-   Returns log-mean-exp of N importance weights as log-ML estimate.
-   Returns ##-Inf on any error.
+(defn- score-exact
+  "Exact marginal log-evidence for a conjugate/eliminable model: the weight of a
+   single analytical p/generate IS the marginal likelihood log p(obs) once the
+   latents are eliminated. Mirrors fit's :exact branch (fit.cljs run-method)."
+  [gf obs-cm]
+  (let [{:keys [weight]} (p/generate gf [] obs-cm)]
+    (mx/materialize! weight)
+    (mx/item weight)))
+
+(defn- score-is
+  "Importance-sampling marginal estimate: log-mean-exp of N p/generate weights."
+  [gf obs-cm n-particles]
+  (let [weights (loop [i 0, ws []]
+                  (if (>= i n-particles)
+                    ws
+                    (let [w (try
+                              (mx/item (:weight (p/generate gf [] obs-cm)))
+                              (catch :default _ ##-Inf))]
+                      (when (zero? (mod (inc i) 10))
+                        (mx/force-gc!))
+                      (recur (inc i) (conj ws w)))))]
+    (mx/force-gc!)
+    (- (log-sum-exp weights) (js/Math.log (count weights)))))
+
+(defn score-model*
+  "Score a gen function against observations, returning {:log-ml :method}.
+
+   Routes via method selection: conjugate / fully-eliminable models get EXACT
+   analytical marginal evidence (:method :exact or :kalman — a single
+   p/generate); everything else falls back to importance sampling (:method
+   :handler-is, :smc, :hmc, ... — labeled as whatever was selected, scored by IS).
+   Returns {:log-ml ##-Inf :method nil} on nil gf or any error.
 
    gf:           a DynamicGF (from eval-model or wrap-model)
    observations: {:addr value ...} map
    opts:
-     :n-particles  number of importance samples (default 50)"
-  ([gf observations] (score-model gf observations {}))
+     :n-particles  number of importance samples for the IS fallback (default 50)"
+  ([gf observations] (score-model* gf observations {}))
   ([gf observations opts]
-   (let [{:keys [n-particles] :or {n-particles 50}} opts]
-     (try
-       (let [obs-cm (observations->choicemap observations)
-             weights (loop [i 0, ws []]
-                       (if (>= i n-particles)
-                         ws
-                         (let [w (try
-                                   (mx/item (:weight (p/generate gf [] obs-cm)))
-                                   (catch :default _ ##-Inf))]
-                           (when (zero? (mod (inc i) 10))
-                             (mx/force-gc!))
-                           (recur (inc i) (conj ws w)))))]
-         (mx/force-gc!)
-         (- (log-sum-exp weights) (js/Math.log (count weights))))
-       (catch :default _ ##-Inf)))))
+   (if (nil? gf)
+     {:log-ml ##-Inf :method nil}
+     (let [{:keys [n-particles] :or {n-particles 50}} opts]
+       (try
+         (let [obs-cm (observations->choicemap observations)
+               method (:method (ms/select-method gf obs-cm))]
+           (if (#{:exact :kalman} method)
+             {:log-ml (score-exact gf obs-cm) :method method}
+             {:log-ml (score-is gf obs-cm n-particles) :method method}))
+         (catch :default _ {:log-ml ##-Inf :method nil}))))))
+
+(defn score-model
+  "Score a gen function against observations, returning a log-ML number.
+
+   Conjugate / fully-eliminable models are scored by EXACT analytical marginal
+   evidence; everything else falls back to importance sampling (log-mean-exp of N
+   weights). Returns ##-Inf on nil gf or any error. See score-model* for the
+   variant that also reports which method was used.
+
+   gf:           a DynamicGF (from eval-model or wrap-model)
+   observations: {:addr value ...} map
+   opts:
+     :n-particles  number of importance samples for the IS fallback (default 50)"
+  ([gf observations] (score-model gf observations {}))
+  ([gf observations opts] (:log-ml (score-model* gf observations opts))))
 
 ;; ============================================================
 ;; 9.7 Synthesize and rank
@@ -375,9 +477,11 @@ Output ONLY the lines. No explanation.")
               :mode — :template (default, fine-tuned model + regex parsing)
                       :knowledge (base model + Instaparse grammar)
 
-   Returns a promise of a vector of {:code :gf :weight :dist-map},
-   sorted by weight descending. Failed candidates are included with
-   :gf nil and :weight ##-Inf."
+   Returns a promise of a vector of {:code :gf :weight :score-method :dist-map},
+   sorted by weight descending. :weight is the log-ML (exact marginal for
+   conjugate models, IS estimate otherwise); :score-method labels which path
+   produced it. Failed candidates are included with :gf nil, :weight ##-Inf,
+   :score-method nil."
   ([model-map task] (synthesize-and-rank model-map task {}))
   ([model-map task opts]
    (let [{:keys [n mode] :or {n 10 mode :template}} opts
@@ -392,14 +496,15 @@ Output ONLY the lines. No explanation.")
               vec)
          (pr/let [{:keys [code dist-map]} (gen-fn model-map task opts)
                   gf (eval-model code)
-                  weight (if gf
-                           (score-model gf observations)
-                           ##-Inf)]
+                  {:keys [log-ml method]} (if gf
+                                            (score-model* gf observations)
+                                            {:log-ml ##-Inf :method nil})]
            (pr/recur (inc i)
                      (conj results
                            {:code code
                             :gf gf
-                            :weight weight
+                            :weight log-ml
+                            :score-method method
                             :dist-map dist-map}))))))))
 
 ;; ============================================================

--- a/test/genmlx/synthesis_exact_test.cljs
+++ b/test/genmlx/synthesis_exact_test.cljs
@@ -1,0 +1,183 @@
+(ns genmlx.synthesis-exact-test
+  "Tests for genmlx-w47t: wire LLM model-synthesis to EXACT analytical model
+   evidence. Covers the two load-bearing layers, with no LLM required (models
+   are assembled from dist-maps exactly as the synthesis pipeline does):
+
+   1. REPRESENTATION — eval-model emits a faithful gen source form, so the
+      schema has real keyword trace-sites and conjugacy detection fires.
+   2. SCORE PATH — score-model/score-model* route conjugate models to exact
+      analytical marginal evidence (single p/generate weight), falling back to
+      importance sampling (clearly labeled) for non-conjugate models.
+
+   Run: bun run --bun nbb test/genmlx/synthesis_exact_test.cljs"
+  (:require [genmlx.llm.msa :as msa]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.mlx :as mx]))
+
+;; ---------------------------------------------------------------------------
+;; Test harness
+;; ---------------------------------------------------------------------------
+
+(def pass-count (atom 0))
+(def fail-count (atom 0))
+
+(defn- assert-true [msg pred]
+  (if pred
+    (do (swap! pass-count inc) (println "  PASS:" msg))
+    (do (swap! fail-count inc) (println "  FAIL:" msg))))
+
+(defn- assert-close [msg expected actual tol]
+  (let [ok (and (number? actual) (js/isFinite actual)
+                (< (js/Math.abs (- expected actual)) tol))]
+    (if ok
+      (do (swap! pass-count inc)
+          (println "  PASS:" msg (str "(" (.toFixed actual 4) " ~= " expected ")")))
+      (do (swap! fail-count inc)
+          (println "  FAIL:" msg "expected:" expected "got:" actual)))))
+
+;; ---------------------------------------------------------------------------
+;; Synthesized models (built from dist-maps, exactly as the pipeline does)
+;; ---------------------------------------------------------------------------
+
+(defn- synth
+  "Assemble + eval a model from variables and a dist-map, as the synthesis
+   pipeline does (assemble-gen-fn -> eval-model)."
+  [variables dist-map]
+  (msa/eval-model (msa/assemble-gen-fn variables dist-map)))
+
+;; Beta-Bernoulli: p ~ Beta(2,2), obs ~ Bernoulli(p).
+;; Marginal P(obs=1) = E[p] = 2/(2+2) = 0.5  ->  log 0.5 = -0.6931
+(def ^:private bb-gf
+  (synth [:p :obs] {:p "(dist/beta-dist 2 2)" :obs "(dist/bernoulli p)"}))
+(def ^:private bb-obs {:obs 1.0})
+(def ^:private bb-exact-truth (js/Math.log 0.5))
+
+;; Normal-Normal: mu ~ N(0,3), y ~ N(mu,2).
+;; Marginal y ~ N(0, sqrt(3^2 + 2^2) = sqrt 13). At y=1: log N(1;0,sqrt13)
+(def ^:private nn-gf
+  (synth [:mu :y] {:mu "(dist/gaussian 0 3)" :y "(dist/gaussian mu 2)"}))
+(def ^:private nn-obs {:y 1.0})
+(def ^:private nn-exact-truth
+  (let [var 13.0 y 1.0]
+    (- (* -0.5 (js/Math.log (* 2 js/Math.PI var)))
+       (/ (* y y) (* 2 var)))))
+
+;; Non-conjugate: a ~ N(0,1), b ~ N(a^2, 1) (nonlinear dependency).
+(def ^:private nonconj-gf
+  (synth [:a :b] {:a "(dist/gaussian 0 1)" :b "(dist/gaussian (mx/multiply a a) 1)"}))
+(def ^:private nonconj-obs {:b 2.0})
+
+(defn- strip-analytical
+  "Return a copy of gf with the L3 analytical plan removed from its schema, so
+   p/generate uses the handler/compiled path (genuine importance sampling)
+   instead of the analytical shortcut. Real trace-sites are kept, so method
+   selection still sees residual latents and routes to IS."
+  [gf]
+  (dyn/auto-key
+   (update gf :schema dissoc
+           :auto-handlers :auto-regenerate-transition :auto-regenerate-handlers
+           :conjugate-pairs :has-conjugate? :analytical-plan)))
+
+;; ===========================================================================
+;; done-means 1 — schema has non-empty :conjugate-pairs on synthesized models
+;; ===========================================================================
+
+(println "\n== done-means 1: conjugacy fires on SCI-evaluated GFs ==")
+
+(assert-true "bb-gf is a DynamicGF" (instance? dyn/DynamicGF bb-gf))
+(assert-true "nn-gf is a DynamicGF" (instance? dyn/DynamicGF nn-gf))
+
+(let [pairs (:conjugate-pairs (:schema bb-gf))]
+  (assert-true "Beta-Bernoulli: schema has trace-sites"
+               (= 2 (count (:trace-sites (:schema bb-gf)))))
+  (assert-true "Beta-Bernoulli: :conjugate-pairs non-empty" (boolean (seq pairs)))
+  (assert-true "Beta-Bernoulli: family is :beta-bernoulli"
+               (boolean (some #(= :beta-bernoulli (:family %)) pairs))))
+
+(let [pairs (:conjugate-pairs (:schema nn-gf))]
+  (assert-true "Normal-Normal: schema has trace-sites"
+               (= 2 (count (:trace-sites (:schema nn-gf)))))
+  (assert-true "Normal-Normal: :conjugate-pairs non-empty" (boolean (seq pairs)))
+  (assert-true "Normal-Normal: family is :normal-normal"
+               (boolean (some #(= :normal-normal (:family %)) pairs))))
+
+(let [pairs (:conjugate-pairs (:schema nonconj-gf))]
+  (assert-true "Non-conjugate (a^2 dep): no conjugate pairs" (empty? pairs)))
+
+;; ===========================================================================
+;; done-means 2 — score-model* routes conjugate -> :exact, else IS (labeled)
+;; ===========================================================================
+
+(println "\n== done-means 2: routing (conjugate -> exact, else IS labeled) ==")
+
+(let [{:keys [method log-ml]} (msa/score-model* bb-gf bb-obs)]
+  (assert-true "Beta-Bernoulli routed to :exact" (= :exact method))
+  (assert-true "Beta-Bernoulli exact log-ml finite" (js/isFinite log-ml)))
+
+(let [{:keys [method log-ml]} (msa/score-model* nn-gf nn-obs)]
+  (assert-true "Normal-Normal routed to :exact" (= :exact method))
+  (assert-true "Normal-Normal exact log-ml finite" (js/isFinite log-ml)))
+
+(let [{:keys [method log-ml]} (msa/score-model* nonconj-gf nonconj-obs {:n-particles 100})]
+  (assert-true "Non-conjugate NOT routed to exact"
+               (not (#{:exact :kalman} method)))
+  (assert-true (str "Non-conjugate labeled as IS-family (got " method ")")
+               (#{:handler-is :smc :hmc :vi} method))
+  (assert-true "Non-conjugate IS log-ml finite" (js/isFinite log-ml)))
+
+;; nil gf
+(let [{:keys [method log-ml]} (msa/score-model* nil bb-obs)]
+  (assert-true "nil gf -> :method nil" (nil? method))
+  (assert-true "nil gf -> log-ml ##-Inf" (= ##-Inf log-ml)))
+
+;; ===========================================================================
+;; done-means 3 — exact agrees with IS (and with closed-form truth)
+;; ===========================================================================
+
+(println "\n== done-means 3: exact == IS == closed-form on conjugate models ==")
+
+;; Beta-Bernoulli (low-variance IS): exact, closed-form, and IS all agree.
+(let [exact (msa/score-model bb-gf bb-obs)
+      is    (msa/score-model (strip-analytical bb-gf) bb-obs {:n-particles 3000})]
+  (assert-close "Beta-Bernoulli exact == closed-form -0.6931" bb-exact-truth exact 0.05)
+  (assert-close "Beta-Bernoulli exact == IS estimate" exact is 0.15))
+
+;; Normal-Normal (looser IS tolerance — higher-variance estimator).
+(let [exact (msa/score-model nn-gf nn-obs)
+      is    (msa/score-model (strip-analytical nn-gf) nn-obs {:n-particles 6000})]
+  (assert-close "Normal-Normal exact == closed-form" nn-exact-truth exact 0.05)
+  (assert-close "Normal-Normal exact == IS estimate" exact is 0.5))
+
+;; ===========================================================================
+;; Regression — synthesized GFs still simulate; score-model number contract
+;; ===========================================================================
+
+(println "\n== regression: simulate + score-model number contract ==")
+
+(let [tr (p/simulate bb-gf [])]
+  (assert-true "bb-gf simulates with :p" (cm/has-value? (cm/get-submap (:choices tr) :p)))
+  (assert-true "bb-gf simulates with :obs" (cm/has-value? (cm/get-submap (:choices tr) :obs))))
+
+(let [w (msa/score-model nn-gf nn-obs)]
+  (assert-true "score-model returns a finite number" (and (number? w) (js/isFinite w))))
+
+(assert-true "score-model nil -> ##-Inf" (= ##-Inf (msa/score-model nil nn-obs)))
+
+;; code->source-form drops the (fn [trace] ...) wrapper -> ([] body...)
+(let [src (msa/code->source-form
+           "(fn [trace] (let [x (trace :x (dist/gaussian 0 1))] {:x x}))")]
+  (assert-true "code->source-form returns a list" (seq? src))
+  (assert-true "code->source-form: args vector is []" (= [] (first src)))
+  (assert-true "code->source-form: non-fn string -> nil"
+               (nil? (msa/code->source-form "not a fn"))))
+
+;; ---------------------------------------------------------------------------
+;; Summary
+;; ---------------------------------------------------------------------------
+
+(mx/force-gc!)
+(let [p @pass-count f @fail-count]
+  (println (str "\n=== synthesis-exact: " p "/" (+ p f) " PASS ==="))
+  (when (pos? f) (println (str "!!! " f " FAILURES !!!"))))


### PR DESCRIPTION
## What & why

Synthesized models (LLM → SCI-evaluated gen functions) were built via `(gen [] (model-fn trace))`, which captures the opaque source form `([] (model-fn trace))`. Schema extraction flagged this as `:opaque-gen-escape?` → **zero trace-sites** → L3 conjugacy detection had nothing to scan, so `score-model` always fell back to importance sampling. This made Consequence III (synthesis → *exact* model evidence) untrue end-to-end.

All changes are confined to `src/genmlx/llm/msa.cljs` (a Layer-9 leaf — nothing in Layers 0–8 depends on it) plus one new test.

## Changes

**1 — Representation (schema sees real keyword trace-sites)**
- New `code->source-form`: reads the `(fn [trace] body…)` code string via `cljs.reader` and rewrites it to a faithful gen source `([] body…)`, normalizing dist heads to canonical names.
- `wrap-model` gains a 2-arity that calls `make-gen-fn` directly with body-fn `(fn [rt] (model-fn (.-trace rt)))` — **execution is byte-for-byte unchanged** (the SCI closure still runs) — plus the real source form. `nil` source falls back to the opaque wrapper.
- `eval-model` derives and passes the source.
- Aligned `msa-sci-opts` dist names to the canonical `genmlx.dist` symbols (`beta-dist`/`gamma-dist`/`normal`), since `extract-dist-type` keys on the *symbol name* while the conjugacy table keys on `:beta-dist`/`:gamma-dist`.

Net effect: synthesized GFs now carry real trace-sites, so schema extraction, conjugacy detection, and L1 compilation fire exactly as on hand-written `(gen …)` models.

**2 — Score path (exact marginal for conjugate models)**
- `score-model` keeps its bare-number contract (all existing callers/tests/examples stay green).
- New `score-model*` returns `{:log-ml :method}`, routing `:exact`/`:kalman` to a single analytical `p/generate` marginal (`fit`'s `:exact` mechanism, inlined) and everything else to the existing IS loop (labeled).
- `synthesize-and-rank` uses `score-model*` and records `:score-method` per candidate.

## Verification

| Suite | Result |
|---|---|
| **NEW** `synthesis_exact_test` | **29/29** — exact marginals match closed form to f32 precision (Beta-Bernoulli `-0.6931`=log½, Normal-Normal `-2.2399`); handler-path IS converges to exact |
| `smc_scoring_test` | **41/41** (score now exact → variance `0.0000`) |
| `llm_msa_test` | **122/122** (pure + LLM sections) |

## Scope

Wires the two conjugate families needed to make Consequence III true end-to-end (Beta-Bernoulli, Normal-Normal). The remaining 5 families (Gamma-Poisson, Gamma-Exponential, Dirichlet-Categorical, MVN, Normal-iid-Normal) are a tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
