### PR TITLE
fix(mlx): self-healing, catchable MLX resource exhaustion (no process abort)

### DIFF
--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -28,7 +28,7 @@
 (defonce ^:private M (.-MxArray c))
 
 ;; Forward declarations for functions referenced before definition.
-(declare scalar array shape array? astype)
+(declare scalar array shape array? astype force-gc! clear-cache!)
 
 ;; Scope tracking atoms — defined here because functional combinators
 ;; (grad, value-and-grad) reference grad-depth before the Memory
@@ -376,14 +376,40 @@
 
 ;; --- Array construction (creates graph leaf nodes — also pure) ---
 
+;; Catchable MLX resource exhaustion (bean genmlx-5ucd). The mlx-node shim now
+;; catches a Metal allocation throw (e.g. "[metal::malloc] Resource limit (499000)
+;; exceeded") and returns it as a thrown napi error instead of aborting the whole
+;; process. Such an error is almost always dead-but-unfinalized MxArray wrappers
+;; pinning their Metal buffers: force-gc! finalizes them (frees the buffers) and
+;; clear-cache! drops the Metal cache, so a retry typically succeeds. Genuine
+;; exhaustion rethrows for the caller to handle.
+(defn- mlx-resource-error?
+  [e]
+  (let [msg (str (or (.-message e) e))]
+    (boolean (or (re-find #"Resource limit" msg)
+                 (re-find #"metal::malloc" msg)
+                 (re-find #"out of memory" msg)))))
+
+(defn- with-alloc-retry
+  "Run thunk; on an MLX resource-exhaustion error, reclaim dead GPU buffers and
+   retry ONCE. Any other error (or a second failure) propagates."
+  [thunk]
+  (try
+    (thunk)
+    (catch :default e
+      (if (mlx-resource-error? e)
+        (do (force-gc!) (clear-cache!) (thunk))
+        (throw e)))))
+
 (defn scalar
   "Create a scalar MLX array. Always float32 by default."
-  ([v]   (.scalar c v))
+  ([v]   (with-alloc-retry #(.scalar c v)))
   ([v dtype]
-   (if (= dtype int32)
-     (.scalarInt c (int v))
-     (let [arr (.scalar c v)]
-       (if (= dtype float32) arr (.astype c arr dtype))))))
+   (with-alloc-retry
+     #(if (= dtype int32)
+        (.scalarInt c (int v))
+        (let [arr (.scalar c v)]
+          (if (= dtype float32) arr (.astype c arr dtype)))))))
 
 (defn array
   ([v]
@@ -393,9 +419,10 @@
      ;; infer-shape, not just flat ones. The old flat-only (js/Array.isArray v)
      ;; branch coerced #js [#js [..] #js [..]] to NaN — see infer-shape.
      (or (vector? v) (seq? v) (sequential? v) (js/Array.isArray v))
-     (let [[flat-data sh] (infer-shape v)
-           f32 (js/Float32Array.from (clj->js flat-data))]
-       (.fromFloat32 c f32 (clj->js sh)))
+     (with-alloc-retry
+       #(let [[flat-data sh] (infer-shape v)
+              f32 (js/Float32Array.from (clj->js flat-data))]
+          (.fromFloat32 c f32 (clj->js sh))))
      :else (scalar v)))
   ([v shape-or-dtype]
    (if (or (vector? shape-or-dtype) (seq? shape-or-dtype))
@@ -603,7 +630,7 @@
   "Extract scalar value from a 0-d or 1-element array.
    EFFECTFUL: fused eval + read in one NAPI call."
   [a]
-  (.item c a))
+  (with-alloc-retry #(.item c a)))
 
 (defn ->clj
   "Evaluate an MLX array and convert to nested ClojureScript data.

--- a/test/genmlx/resource_recovery_test.cljs
+++ b/test/genmlx/resource_recovery_test.cljs
@@ -1,0 +1,69 @@
+(ns genmlx.resource-recovery-test
+  "Regression for genmlx-5ucd: a Metal buffer-count exhaustion must be SURVIVABLE
+   — self-healing or, at worst, a CATCHABLE error — never an uncatchable process
+   abort (libc++abi terminate -> SIGTRAP).
+
+   Mechanism under test (the catchable-boundary fix):
+     - mlx-node's C++ shim catches MLX allocation throws and returns a sentinel
+       (null/false) instead of letting the exception unwind out and abort.
+     - the Rust napi layer turns that into a thrown, catchable error carrying the
+       real MLX message.
+     - mlx.cljs's `with-alloc-retry` catches a resource error on the construction/
+       read boundary, runs force-gc! (finalizes dead MxArray wrappers -> frees
+       their Metal buffers) + clear-cache!, and retries once.
+
+   On the PRE-FIX binary the loop below SIGTRAPs around the ~499000-buffer limit
+   (each scalar eagerly allocates a Metal buffer; the dead-but-unfinalized wrappers
+   pin them). Post-fix it completes (self-heal) or throws catchably — either way the
+   PROCESS SURVIVES and we reach the assertions."
+  (:require [genmlx.mlx :as mx]))
+
+(def pass (atom 0))
+(def fail (atom 0))
+(defn assert-true [desc x]
+  (if x
+    (do (swap! pass inc) (println "  PASS:" desc))
+    (do (swap! fail inc) (println "  FAIL:" desc))))
+
+(defn resource-error? [e]
+  (boolean (re-find #"Resource limit|metal::malloc|out of memory|MLX error"
+                    (str (.-message e)))))
+
+(println "\n-- resource recovery / catchable OOM (genmlx-5ucd) --")
+
+;; 1. Sanity: the guard wrappers did not break ordinary construction + read.
+(assert-true "scalar->item roundtrips"
+             (< (js/Math.abs (- (mx/item (mx/scalar 3.5)) 3.5)) 1e-5))
+(assert-true "from-vec->item roundtrips"
+             (< (js/Math.abs (- (mx/item (mx/sum (mx/array [1.0 2.0 3.0]))) 6.0)) 1e-5))
+
+;; 2. THE regression: allocate well past the ~499000 live-buffer limit in ONE
+;;    process. Pre-fix => SIGTRAP (process dies, we never get here). Post-fix =>
+;;    the loop self-heals (or throws a catchable error), and we continue.
+(def N 700000)
+(println (str "  allocating " N " scalar arrays in one process"
+              " (pre-fix this aborts at ~499000)..."))
+(let [outcome (try
+                (dotimes [i N]
+                  (mx/scalar (double i))
+                  (when (and (pos? i) (zero? (mod i 100000)))
+                    (println (str "    ... " i " allocations, still alive"))))
+                :completed
+                (catch :default e
+                  (if (resource-error? e)
+                    (do (println "    caught a CATCHABLE resource error (not an abort):"
+                                 (.-message e))
+                        :caught-catchable)
+                    (throw e))))]  ; a non-resource error is a real failure
+  (assert-true "buffer-exhaustion loop did NOT abort the process" (some? outcome))
+  (println "    outcome:" outcome))
+
+;; 3. The membrane is still usable after the pressure (explicit reclaim + a fresh op).
+(mx/force-gc!)
+(mx/clear-cache!)
+(assert-true "membrane usable after exhaustion + recovery"
+             (try (< (js/Math.abs (- (mx/item (mx/scalar 9.0)) 9.0)) 1e-5)
+                  (catch :default _ false)))
+
+(println (str "\n== resource-recovery: " @pass " pass, " @fail " fail =="))
+(when (pos? @fail) (js/process.exit 1))


### PR DESCRIPTION
Bumps the mlx-node submodule to catch MLX allocation throws at the C++/NAPI boundary (mlx-node PR #4) and adds the CLJS recovery + a regression test. Resolves the genmlx-5ucd buffer-count crash.

- `mlx.cljs`: `with-alloc-retry` wraps scalar/array/item; on a catchable MLX resource error it runs force-gc! (finalizes dead MxArray wrappers -> frees their pinned Metal buffers) + clear-cache! and retries once. The dead-wrapper buffer-count crash now self-heals.
- `test/genmlx/resource_recovery_test.cljs`: allocates 700000 scalars in one process (pre-fix this SIGTRAPs at ~499000) and asserts survival + usability.

Validation: gfi_combinator_invariants_test + l3_5_gate_test (previously SIGTRAP) now pass; membrane contract guards + 9 core suites pass. Layer-2 follow-up tracked separately.

Refs genmlx-5ucd.