### PR TITLE
M3a: GFI convergence laws + ESS diagnostics + analytical exactness + L3 elimination + NumPyro baseline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,10 @@ Level 1: Compiled gen functions      ← DONE (506+ tests)
   M4: Branch rewriting (if/if-not with same addr+dist → mx/where)
   M5: Combinator compilation (fused Map/Unfold/Scan loops)
 Level 2: Compiled inference sweeps   ← DONE (881+ tests)
-Level 3: Auto-analytical elimination ← DONE (426 tests, 33.5x variance reduction)
+Level 3: Auto-analytical elimination ← DONE (426 tests, exact marginal LL to float32 floor)
   7 conjugate families detected statically
   Kalman chain detection via affine dependency analysis
+  Joint linear-Gaussian regression (coupled/affine multi-latent) elimination
   Rao-Blackwellization for partial conjugacy
 Level 3.5: Extended analytical       ← DONE (150 tests, MVN Kalman, combinator conjugacy)
 Level 4: Single fused graph          ← DONE (260+ tests, 9.2x compiled Adam speedup)

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Aliases: `normal` → `gaussian`, `flip` → `bernoulli`
 - **Variational Inference** — `vi` (ADVI with mean-field Gaussian guide), `programmable-vi` with pluggable objectives (`elbo`, `iwelbo`, `wake-sleep`) and gradient estimators (`reinforce`, reparameterization); compiled variants via `compiled-vi`, `compiled-programmable-vi`
 - **ADEV** — automatic differentiation of expected values with reparameterization and REINFORCE strategies, vectorized GPU execution, compiled optimization loops, baseline variance reduction
 - **Amortized Inference** — `neural-importance-sampling` (learned neural proposals)
-- **Analytical Elimination** — auto-conjugacy detection (5 families), Rao-Blackwellization, 33.5x variance reduction
+- **Analytical Elimination** — auto-conjugacy detection (5 families), joint linear-Gaussian regression, Rao-Blackwellization; exact marginal likelihood (matches the closed form to the float32 floor, ~1e-6 nats), ESS gains up to ~50×
 - **Kalman Filter** — handler middleware for linear-Gaussian SSMs, sequential updates, exact marginal LL
 - **Extended Kalman Filter** — nonlinear SSMs via auto-diff linearization (1D and N-dimensional)
 - **HMM Forward Algorithm** — discrete latent state-space models, exact marginal likelihood

--- a/bench/conjugacy.cljs
+++ b/bench/conjugacy.cljs
@@ -108,6 +108,90 @@
     (- lse (js/Math.log n))))
 
 ;; ---------------------------------------------------------------------------
+;; Independent closed-form marginal log-ML (the exactness ground truth)
+;; ---------------------------------------------------------------------------
+;; These are derived INDEPENDENTLY of conjugate.cljs / the L3 path, so |L3 - cf|
+;; is a genuine cross-check of analytical elimination, not a circular comparison.
+
+(def ^:private LOG-2PI 1.8378770664093453)
+
+(def ^:private lanczos-c
+  [0.99999999999980993 676.5203681218851 -1259.1392167224028
+   771.32342877765313 -176.61502916214059 12.507343278686905
+   -0.13857109526572012 9.9843695780195716e-6 1.5056327351493116e-7])
+
+(defn lgamma
+  "Log-gamma via the Lanczos approximation (g=7)."
+  [x]
+  (if (< x 0.5)
+    (- (js/Math.log (/ js/Math.PI (js/Math.sin (* js/Math.PI x)))) (lgamma (- 1.0 x)))
+    (let [x (- x 1.0)
+          t (+ x 7.5)
+          a (reduce (fn [a i] (+ a (/ (nth lanczos-c i) (+ x i))))
+                    (nth lanczos-c 0) (range 1 (count lanczos-c)))]
+      (+ (* 0.5 (js/Math.log (* 2.0 js/Math.PI)))
+         (* (+ x 0.5) (js/Math.log t)) (- t) (js/Math.log a)))))
+
+(defn log-beta [a b] (- (+ (lgamma a) (lgamma b)) (lgamma (+ a b))))
+
+(defn nn-shared-marginal
+  "Joint marginal log p(y) for shared-mean Normal-Normal:
+   mu ~ N(m0, prior-var); y_i ~ N(mu, obs-var). y ~ N(m0·1, obs-var·I + prior-var·11ᵀ)."
+  [ys m0 prior-var obs-var]
+  (let [n (count ys)
+        ds (map #(- % m0) ys)
+        sum-d (reduce + ds)
+        sum-d2 (reduce + (map #(* % %) ds))
+        denom (+ obs-var (* n prior-var))
+        logdet (+ (* (dec n) (js/Math.log obs-var)) (js/Math.log denom))
+        quad (/ (- sum-d2 (* (/ prior-var denom) sum-d sum-d)) obs-var)]
+    (* -0.5 (+ (* n LOG-2PI) logdet quad))))
+
+(defn bb-marginal
+  "Beta-Bernoulli marginal: logB(a+s, b+n-s) − logB(a,b). s = #successes."
+  [s n a b]
+  (- (log-beta (+ a s) (+ b (- n s))) (log-beta a b)))
+
+(defn gp-marginal
+  "Gamma-Poisson marginal (Gamma shape al, rate be): rate ~ Gamma(al,be); y_i ~ Poisson(rate)."
+  [ys al be]
+  (let [n (count ys) S (reduce + ys)]
+    (+ (* al (js/Math.log be))
+       (- (lgamma al))
+       (- (reduce + (map #(lgamma (+ % 1.0)) ys)))
+       (lgamma (+ al S))
+       (- (* (+ al S) (js/Math.log (+ be n)))))))
+
+(defn linreg-marginal
+  "Joint marginal for 2-parameter Bayesian linear regression:
+   slope,intercept ~ N(0, prior-var); y_j ~ N(slope·x_j + intercept, obs-var).
+   y ~ N(0, obs-var·I + prior-var·X Xᵀ), X row = [x_j, 1]. Computed via the rank-2
+   Woodbury / matrix-determinant lemma (independent of the eliminator)."
+  [xs ys prior-var obs-var]
+  (let [n (count xs)
+        sx (reduce + xs)
+        sx2 (reduce + (map #(* % %) xs))
+        sxy (reduce + (map * xs ys))
+        sy (reduce + ys)
+        syy (reduce + (map #(* % %) ys))
+        ratio (/ prior-var obs-var)
+        ;; det(I2 + ratio·XᵀX), XᵀX = [[sx2 sx][sx n]]
+        b00 (+ 1.0 (* ratio sx2)) b01 (* ratio sx)
+        b10 (* ratio sx)         b11 (+ 1.0 (* ratio n))
+        det-b (- (* b00 b11) (* b01 b10))
+        logdet (+ (* n (js/Math.log obs-var)) (js/Math.log det-b))
+        ;; quad = (1/obs-var)[yᵀy − vᵀ A⁻¹ v], A = (obs/prior)I2 + XᵀX, v = Xᵀy
+        k (/ obs-var prior-var)
+        a00 (+ k sx2) a01 sx a11 (+ k n)
+        det-a (- (* a00 a11) (* a01 a01))
+        v0 sxy v1 sy
+        ;; A⁻¹ v
+        ai0 (/ (- (* a11 v0) (* a01 v1)) det-a)
+        ai1 (/ (- (* a00 v1) (* a01 v0)) det-a)
+        quad (/ (- syy (+ (* v0 ai0) (* v1 ai1))) obs-var)]
+    (* -0.5 (+ (* n LOG-2PI) logdet quad))))
+
+;; ---------------------------------------------------------------------------
 ;; Strip analytical plan (forces L2 / prior-proposal IS)
 ;; ---------------------------------------------------------------------------
 
@@ -210,48 +294,62 @@
                         " / " n-particles
                         " (" (.toFixed (* 100 (/ (:ess-mean l2-results) n-particles)) 1) "%)"))
 
-        ;; 4. Variance reduction ratio
-        var-ratio (if (> (:log-ml-var l3-results) 1e-20)
-                    (/ (:log-ml-var l2-results) (:log-ml-var l3-results))
-                    js/Infinity)
+        ;; 4. Exactness (the headline) + variance reduction (corollary).
+        ;; The honest headline for analytical elimination is |L3 log-ML − closed
+        ;; form| in nats: ~0 when L3 is exact. Variance reduction is a corollary
+        ;; and is OMITTED when L3 is exact (its var is 0, so the ratio is a
+        ;; divide-by-~0 against a different model — the old >1000x/Inf artifact).
+        cf (:log-ml ground-truth)
+        l3-err (when cf (js/Math.abs (- (:log-ml-mean l3-results) cf)))
+        l2-err (when cf (js/Math.abs (- (:log-ml-mean l2-results) cf)))
+        l3-exact? (< (:log-ml-var l3-results) 1e-20)
+        var-ratio (when-not l3-exact?
+                    (/ (:log-ml-var l2-results) (:log-ml-var l3-results)))
         ess-ratio (/ (:ess-mean l3-results) (max (:ess-mean l2-results) 0.01))
         _ (println (str "\n  --- Summary ---"))
-        _ (println (str "  Variance reduction:  " (if (= var-ratio js/Infinity)
-                                                     "Inf (L3 exact)"
-                                                     (str (.toFixed var-ratio 1) "x"))))
+        _ (when cf
+            (println (str "  |L3 log-ML − closed form|: " (.toExponential l3-err 3)
+                          " nats  (exactness — the headline)"))
+            (println (str "  |L2 log-ML − closed form|: " (.toFixed l2-err 4) " nats")))
+        _ (println (str "  Variance reduction:  "
+                        (if l3-exact? "n/a (L3 exact, var=0)"
+                            (str (.toFixed var-ratio 1) "x"))))
         _ (println (str "  ESS improvement:     " (.toFixed ess-ratio 1) "x"))
         _ (println (str "  L3 time: " (.toFixed (:mean-ms l3-timing) 3) " ms"
                         ", L2 time: " (.toFixed (:mean-ms l2-timing) 3) " ms"))]
 
-    ;; Return result map
-    {:label label
-     :method_selection {:method (name (:method sel))
-                        :reason (:reason sel)
-                        :eliminated (vec (map name (:eliminated sel)))
-                        :residual (vec (map name (:residual-addrs sel)))
-                        :n_eliminated (count (:eliminated sel))
-                        :n_residual (:n-residual sel)}
-     :conjugate_pairs (mapv (fn [p] {:prior (name (:prior-addr p))
-                                      :obs (name (:obs-addr p))
-                                      :family (name (:family p))})
-                            conj-pairs)
-     :l3 {:log_ml_mean (:log-ml-mean l3-results)
-          :log_ml_std (:log-ml-std l3-results)
-          :log_ml_var (:log-ml-var l3-results)
-          :ess_mean (:ess-mean l3-results)
-          :time_ms (:mean-ms l3-timing)
-          :time_std_ms (:std-ms l3-timing)}
-     :l2 {:log_ml_mean (:log-ml-mean l2-results)
-          :log_ml_std (:log-ml-std l2-results)
-          :log_ml_var (:log-ml-var l2-results)
-          :ess_mean (:ess-mean l2-results)
-          :time_ms (:mean-ms l2-timing)
-          :time_std_ms (:std-ms l2-timing)}
-     :variance_reduction var-ratio
-     :ess_improvement ess-ratio
-     :ground_truth ground-truth
-     :n_particles n-particles
-     :n_trials n-trials}))
+    ;; Return result map. :variance_reduction is OMITTED when L3 is exact.
+    (cond-> {:label label
+             :method_selection {:method (name (:method sel))
+                                :reason (:reason sel)
+                                :eliminated (vec (map name (:eliminated sel)))
+                                :residual (vec (map name (:residual-addrs sel)))
+                                :n_eliminated (count (:eliminated sel))
+                                :n_residual (:n-residual sel)}
+             :conjugate_pairs (mapv (fn [p] {:prior (name (:prior-addr p))
+                                              :obs (name (:obs-addr p))
+                                              :family (name (:family p))})
+                                    conj-pairs)
+             :closed_form_log_ml cf
+             :l3 {:log_ml_mean (:log-ml-mean l3-results)
+                  :log_ml_std (:log-ml-std l3-results)
+                  :log_ml_var (:log-ml-var l3-results)
+                  :log_ml_abs_error_nats l3-err
+                  :ess_mean (:ess-mean l3-results)
+                  :time_ms (:mean-ms l3-timing)
+                  :time_std_ms (:std-ms l3-timing)}
+             :l2 {:log_ml_mean (:log-ml-mean l2-results)
+                  :log_ml_std (:log-ml-std l2-results)
+                  :log_ml_var (:log-ml-var l2-results)
+                  :log_ml_abs_error_nats l2-err
+                  :ess_mean (:ess-mean l2-results)
+                  :time_ms (:mean-ms l2-timing)
+                  :time_std_ms (:std-ms l2-timing)}
+             :ess_improvement ess-ratio
+             :ground_truth ground-truth
+             :n_particles n-particles
+             :n_trials n-trials}
+      (some? var-ratio) (assoc :variance_reduction var-ratio))))
 
 ;; =========================================================================
 ;; 5A: Normal-Normal (mean estimation)
@@ -470,7 +568,8 @@
                       :ground-truth {:distribution "Normal"
                                      :mean (:posterior-mean nn-ground-truth)
                                      :std (:posterior-std nn-ground-truth)
-                                     :var (:posterior-var nn-ground-truth)}))
+                                     :var (:posterior-var nn-ground-truth)
+                                     :log-ml (nn-shared-marginal [1.0 1.5 0.8 1.2 1.1] 0.0 100.0 1.0)}))
 
 ;; ---------------------------------------------------------------------------
 ;; 5B: Beta-Bernoulli
@@ -490,7 +589,8 @@
                       :ground-truth {:distribution "Beta"
                                      :alpha (:posterior-alpha bb-ground-truth)
                                      :beta (:posterior-beta bb-ground-truth)
-                                     :mean (:posterior-mean bb-ground-truth)}))
+                                     :mean (:posterior-mean bb-ground-truth)
+                                     :log-ml (bb-marginal 3 5 2.0 2.0)}))
 
 ;; ---------------------------------------------------------------------------
 ;; 5C: Gamma-Poisson
@@ -510,7 +610,8 @@
                       :ground-truth {:distribution "Gamma"
                                      :shape (:posterior-shape gp-ground-truth)
                                      :rate (:posterior-rate gp-ground-truth)
-                                     :mean (:posterior-mean gp-ground-truth)}))
+                                     :mean (:posterior-mean gp-ground-truth)
+                                     :log-ml (gp-marginal [3.0 5.0 2.0 4.0] 2.0 1.0)}))
 
 ;; ---------------------------------------------------------------------------
 ;; 5D: Mixed model (partial conjugacy)
@@ -605,50 +706,60 @@
 (println (str "  L2 ESS:    " (.toFixed (:ess-mean l2-linreg-results) 1)
               " / " n-particles))
 
-;; Variance reduction
+;; Exactness (headline) + variance reduction (corollary, omitted when exact)
+(def linreg-cf (linreg-marginal [1.0 2.0 3.0 4.0 5.0] linreg-ys
+                                (* sigma-prior sigma-prior) (* sigma-obs sigma-obs)))
+(def linreg-l3-err (js/Math.abs (- (:log-ml-mean l3-linreg-results) linreg-cf)))
+(def linreg-l2-err (js/Math.abs (- (:log-ml-mean l2-linreg-results) linreg-cf)))
+(def linreg-l3-exact? (< (:log-ml-var l3-linreg-results) 1e-20))
 (def linreg-var-ratio
-  (if (> (:log-ml-var l3-linreg-results) 1e-20)
-    (/ (:log-ml-var l2-linreg-results) (:log-ml-var l3-linreg-results))
-    js/Infinity))
+  (when-not linreg-l3-exact?
+    (/ (:log-ml-var l2-linreg-results) (:log-ml-var l3-linreg-results))))
 (def linreg-ess-ratio
   (/ (:ess-mean l3-linreg-results) (max (:ess-mean l2-linreg-results) 0.01)))
 
 (println (str "\n  --- Summary ---"))
-(println (str "  Variance reduction:  " (if (= linreg-var-ratio js/Infinity)
-                                            "Inf (L3 exact)"
+(println (str "  |L3 log-ML − closed form|: " (.toExponential linreg-l3-err 3)
+              " nats  (exactness — the headline; closed form = "
+              (.toFixed linreg-cf 4) ")"))
+(println (str "  |L2 log-ML − closed form|: " (.toFixed linreg-l2-err 4) " nats"))
+(println (str "  Variance reduction:  " (if linreg-l3-exact? "n/a (L3 exact, var=0)"
                                             (str (.toFixed linreg-var-ratio 1) "x"))))
 (println (str "  ESS improvement:     " (.toFixed linreg-ess-ratio 1) "x"))
 
 (def result-5e
-  {:label "5E-LinReg"
-   :method_selection (let [sel (ms/select-method linreg-model linreg-obs)]
-                       {:method (name (:method sel))
-                        :reason (:reason sel)
-                        :eliminated (vec (map name (:eliminated sel)))
-                        :residual (vec (map name (:residual-addrs sel)))
-                        :n_eliminated (count (:eliminated sel))
-                        :n_residual (:n-residual sel)})
-   :conjugate_pairs (mapv (fn [p] {:prior (name (:prior-addr p))
-                                    :obs (name (:obs-addr p))
-                                    :family (name (:family p))})
-                          (get-in linreg-model [:schema :conjugate-pairs]))
-   :l3 {:log_ml_mean (:log-ml-mean l3-linreg-results)
-        :log_ml_std (:log-ml-std l3-linreg-results)
-        :log_ml_var (:log-ml-var l3-linreg-results)
-        :ess_mean (:ess-mean l3-linreg-results)
-        :time_ms (:mean-ms l3-linreg-timing)
-        :time_std_ms (:std-ms l3-linreg-timing)}
-   :l2 {:log_ml_mean (:log-ml-mean l2-linreg-results)
-        :log_ml_std (:log-ml-std l2-linreg-results)
-        :log_ml_var (:log-ml-var l2-linreg-results)
-        :ess_mean (:ess-mean l2-linreg-results)
-        :time_ms (:mean-ms l2-linreg-timing)
-        :time_std_ms (:std-ms l2-linreg-timing)}
-   :variance_reduction linreg-var-ratio
-   :ess_improvement linreg-ess-ratio
-   :ground_truth linreg-ground-truth
-   :n_particles n-particles
-   :n_trials n-trials})
+  (cond-> {:label "5E-LinReg"
+           :method_selection (let [sel (ms/select-method linreg-model linreg-obs)]
+                               {:method (name (:method sel))
+                                :reason (:reason sel)
+                                :eliminated (vec (map name (:eliminated sel)))
+                                :residual (vec (map name (:residual-addrs sel)))
+                                :n_eliminated (count (:eliminated sel))
+                                :n_residual (:n-residual sel)})
+           :conjugate_pairs (mapv (fn [p] {:prior (name (:prior-addr p))
+                                            :obs (name (:obs-addr p))
+                                            :family (name (:family p))})
+                                  (get-in linreg-model [:schema :conjugate-pairs]))
+           :closed_form_log_ml linreg-cf
+           :l3 {:log_ml_mean (:log-ml-mean l3-linreg-results)
+                :log_ml_std (:log-ml-std l3-linreg-results)
+                :log_ml_var (:log-ml-var l3-linreg-results)
+                :log_ml_abs_error_nats linreg-l3-err
+                :ess_mean (:ess-mean l3-linreg-results)
+                :time_ms (:mean-ms l3-linreg-timing)
+                :time_std_ms (:std-ms l3-linreg-timing)}
+           :l2 {:log_ml_mean (:log-ml-mean l2-linreg-results)
+                :log_ml_std (:log-ml-std l2-linreg-results)
+                :log_ml_var (:log-ml-var l2-linreg-results)
+                :log_ml_abs_error_nats linreg-l2-err
+                :ess_mean (:ess-mean l2-linreg-results)
+                :time_ms (:mean-ms l2-linreg-timing)
+                :time_std_ms (:std-ms l2-linreg-timing)}
+           :ess_improvement linreg-ess-ratio
+           :ground_truth linreg-ground-truth
+           :n_particles n-particles
+           :n_trials n-trials}
+    (some? linreg-var-ratio) (assoc :variance_reduction linreg-var-ratio)))
 
 ;; =========================================================================
 ;; Summary table
@@ -660,25 +771,20 @@
 
 (def all-results [result-5a result-5b result-5c result-5d result-5e])
 
-(println "\n| Experiment | Family | Eliminated | L2 var(log-ML) | L3 var(log-ML) | Var Reduction | ESS Ratio |")
-(println "|------------|--------|------------|----------------|----------------|---------------|-----------|")
+(println "\n| Experiment | Family | Elim | |L3−cf| (nats) | |L2−cf| (nats) | ESS Ratio |")
+(println "|------------|--------|------|----------------|----------------|-----------|")
 (doseq [r all-results]
   (let [families (if (seq (:conjugate_pairs r))
                    (clojure.string/join "," (distinct (map :family (:conjugate_pairs r))))
                    "none")
-        n-elim (get-in r [:method_selection :n_eliminated])]
+        n-elim (get-in r [:method_selection :n_eliminated])
+        l3e (get-in r [:l3 :log_ml_abs_error_nats])
+        l2e (get-in r [:l2 :log_ml_abs_error_nats])]
     (println (str "| " (.padEnd (:label r) 10)
                   " | " (.padEnd families 6)
-                  " | " (.padStart (str n-elim) 10)
-                  " | " (.padStart (if (> (get-in r [:l2 :log_ml_var]) 0)
-                                     (.toFixed (get-in r [:l2 :log_ml_var]) 6)
-                                     "N/A") 14)
-                  " | " (.padStart (if (> (get-in r [:l3 :log_ml_var]) 0)
-                                     (.toFixed (get-in r [:l3 :log_ml_var]) 6)
-                                     "0 (exact)") 14)
-                  " | " (.padStart (if (= (:variance_reduction r) js/Infinity)
-                                     "Inf"
-                                     (.toFixed (:variance_reduction r) 1)) 13)
+                  " | " (.padStart (str n-elim) 4)
+                  " | " (.padStart (if l3e (.toExponential l3e 2) "n/a (partial)") 14)
+                  " | " (.padStart (if l2e (.toFixed l2e 4) "n/a") 14)
                   " | " (.padStart (.toFixed (:ess_improvement r) 1) 9)
                   " |"))))
 
@@ -711,18 +817,26 @@
     :exp5e result-5e}
    :summary
    {:families_tested ["normal-normal" "beta-bernoulli" "gamma-poisson" "mixed" "linreg"]
-    :variance_reductions (mapv (fn [r] {:label (:label r)
-                                         :ratio (if (= (:variance_reduction r) js/Infinity)
-                                                  "Infinity"
-                                                  (:variance_reduction r))})
-                               all-results)
+    ;; Exactness is the headline: |L3 log-ML − closed form| in nats. Every family
+    ;; with a closed form (all but the partial-conjugacy 5D) eliminates to the
+    ;; float32 floor. This replaces the old >1000x / Infinity / variance=0 artifact
+    ;; (a divide-by-~0 against a different model).
+    :log_ml_abs_error_nats
+    (mapv (fn [r] {:label (:label r)
+                   :l3 (get-in r [:l3 :log_ml_abs_error_nats])
+                   :l2 (get-in r [:l2 :log_ml_abs_error_nats])})
+          all-results)
+    :max_l3_abs_error_nats
+    (apply max (keep #(get-in % [:l3 :log_ml_abs_error_nats]) all-results))
+    ;; Variance reduction is reported ONLY where finite (partial conjugacy / 5D).
+    ;; Where L3 is exact its log-ML variance is 0, so the ratio is undefined and
+    ;; is omitted rather than reported as Infinity.
+    :variance_reductions
+    (vec (keep (fn [r] (when-let [vr (:variance_reduction r)]
+                         {:label (:label r) :ratio vr}))
+               all-results))
     :ess_improvements (mapv (fn [r] {:label (:label r) :ratio (:ess_improvement r)})
                             all-results)
-    :mean_variance_reduction
-    (let [finite-ratios (filter #(not= % js/Infinity)
-                                (map :variance_reduction all-results))]
-      (when (seq finite-ratios)
-        (/ (reduce + finite-ratios) (count finite-ratios))))
     :mean_ess_improvement
     (/ (reduce + (map :ess_improvement all-results)) (count all-results))}})
 

--- a/bench/funnel.cljs
+++ b/bench/funnel.cljs
@@ -2,17 +2,15 @@
   "Neal's Funnel -- challenging posterior geometry for gradient-based samplers.
 
    Model: v ~ N(0, 3), x_i ~ N(0, exp(v/2)) for i=1..10. D=11 total dimensions.
-   Observe all x_i = 0 (funnel center).
+   No observations -- the target IS the joint funnel distribution (the classic
+   Neal funnel benchmark; the narrow neck at small v stresses HMC/NUTS/MH).
 
-   The funnel's correlated geometry (narrow neck at large v, wide base at
-   small v) makes it a standard stress test for HMC, NUTS, and MH.
+   Ground truth: v ~ N(0, 3) marginally -- mean=0, std=3.
 
-   Ground truth: E[v | x=0] = 0 (by symmetry).
-
-   Algorithms:
-   1. HMC (200 samples, burn 100, 10 leapfrog steps)
-   2. NUTS (100 samples, burn 50)
-   3. Compiled MH (500 samples, burn 200)
+   Algorithms (4 chains each -> multi-chain R-hat + bulk/tail-ESS):
+   1. HMC  (600 samples, burn 300, 25 leapfrog, adapt step+metric)
+   2. NUTS (600 samples, burn 300, max-depth 8, adapt step+metric)
+   3. Compiled MH (2000 samples, burn 1000)
 
    Output: results/funnel/data.json
 
@@ -98,13 +96,8 @@
                  (dist/gaussian 0 (mx/exp (mx/divide v (mx/scalar 2))))))
         v))))
 
-;; Observations: all x_i = 0
-(def funnel-obs
-  (reduce (fn [cm i]
-            (cm/set-choice cm [(keyword (str "x" i))] (mx/scalar 0.0)))
-          cm/EMPTY
-          (range 10)))
-
+;; No observations: the target is the joint funnel (v + 10 x_i). We sample the
+;; joint and report diagnostics on the v marginal (ground truth v ~ N(0,3)).
 (def all-addresses [:v :x0 :x1 :x2 :x3 :x4 :x5 :x6 :x7 :x8 :x9])
 
 ;; ---------------------------------------------------------------------------
@@ -130,155 +123,135 @@
         traces))
 
 ;; ---------------------------------------------------------------------------
+;; Multi-chain runner: 4 chains -> R-hat + ESS + bulk/tail-ESS on the v marginal
+;; ---------------------------------------------------------------------------
+;; All three kernels return flat parameter arrays (v is index 0). We run 4
+;; chains per kernel (seeds 42-45) and report honest multi-chain diagnostics:
+;;   - R-hat  (Gelman-Rubin, multi-chain; target <= 1.01, Vehtari et al. 2021)
+;;   - ESS    (sum of per-chain Geyer ESS)
+;;   - bulk-ESS / tail-ESS  (rank-normalized, Vehtari et al. 2021)
+;; Aggressive cache/GC clearing between chains keeps NUTS within the Metal
+;; buffer budget (same approach as paper_bench_funnel).
+
+(defn run-chain
+  "Run one chain with a given seed; return {:v-samples [...] :meta {...}}."
+  [algo-fn opts seed]
+  (let [full-opts (assoc opts :addresses all-addresses :key (rng/fresh-key seed))
+        samples (algo-fn full-opts funnel-model [] cm/EMPTY)
+        v-samples (extract-v-from-params samples)]
+    (mx/clear-cache!) (mx/force-gc!) (mx/clear-cache!)
+    {:v-samples v-samples :meta (meta samples)}))
+
+(defn run-kernel
+  "Run 4 chains and compute multi-chain diagnostics on v. Returns a result map
+   (or an :error map on failure). Timing is chain-1 wall time."
+  [label algo-fn opts]
+  (println (str "\n-- " label " (4 chains) --"))
+  (try
+    (let [t0 (perf-now)
+          r1 (run-chain algo-fn opts 42)
+          t1 (- (perf-now) t0)
+          _  (do (mx/clear-cache!) (mx/force-gc!) (println "  chain 2..."))
+          r2 (run-chain algo-fn opts 43)
+          _  (do (mx/clear-cache!) (mx/force-gc!) (println "  chain 3..."))
+          r3 (run-chain algo-fn opts 44)
+          _  (do (mx/clear-cache!) (mx/force-gc!) (println "  chain 4..."))
+          r4 (run-chain algo-fn opts 45)
+          chains    [(:v-samples r1) (:v-samples r2) (:v-samples r3) (:v-samples r4)]
+          mx-chains (mapv (fn [c] (mapv #(mx/scalar %) c)) chains)
+          all       (vec (apply concat chains))
+          rhat (diag/r-hat mx-chains)
+          ess  (reduce + (map diag/ess mx-chains))
+          be   (diag/bulk-ess chains)
+          te   (diag/tail-ess chains)]
+      (mx/clear-cache!) (mx/force-gc!)
+      (let [res {:algorithm label
+                 :n-chains 4
+                 :n-samples-per-chain (count (:v-samples r1))
+                 :elapsed-ms t1
+                 :v-mean (mean all)
+                 :v-std (std all)
+                 :acceptance-rate (:acceptance-rate (:meta r1))
+                 :r-hat rhat
+                 :ess ess
+                 :bulk-ess be
+                 :tail-ess te}]
+        (println (str "  v: mean=" (.toFixed (:v-mean res) 4)
+                      " std=" (.toFixed (:v-std res) 4) " (truth: 0)"))
+        (println (str "  R-hat=" (.toFixed rhat 3)
+                      "  ESS=" (.toFixed ess 1)
+                      "  bulk-ESS=" (.toFixed be 1)
+                      "  tail-ESS=" (.toFixed te 1)
+                      "  time=" (.toFixed t1 0) "ms"))
+        res))
+    (catch :default e
+      (println (str "  FAILED: " (.-message e)))
+      {:algorithm label :error (str (.-message e))})))
+
+;; ---------------------------------------------------------------------------
 ;; Run experiments
 ;; ---------------------------------------------------------------------------
 
-(println "\n=== Neal's Funnel ===")
+(println "\n=== Neal's Funnel (joint, no observations) ===")
 (println "Model: v ~ N(0,3), x_i ~ N(0, exp(v/2)) for i=1..10")
-(println "Observations: all x_i = 0")
-(println "Ground truth: E[v | x=0] ~ 0 (by symmetry)")
-
-;; --- 1. HMC (100 samples, burn 50) ---
-
-(println "\n--- 1. HMC (100 samples, burn 50, 10 leapfrog steps) ---")
+(println "Ground truth: v ~ N(0,3) marginally  ->  mean=0, std=3")
 (mx/clear-cache!)
 
-(def hmc-result
-  (safe-benchmark "HMC-100"
-    (fn []
-      (mx/clear-cache!)
-      (mcmc/hmc {:samples 100 :burn 50
-                 :leapfrog-steps 10
-                 :step-size 0.01
-                 :addresses all-addresses
-                 :adapt-step-size true
-                 :target-accept 0.65}
-                funnel-model [] funnel-obs))))
+(def hmc-summary
+  (run-kernel "HMC"
+    mcmc/hmc {:samples 600 :burn 300 :leapfrog-steps 25
+              :adapt-step-size true :adapt-metric true :target-accept 0.65}))
 
-(def hmc-v-samples
-  (when-let [samples (:result hmc-result)]
-    (extract-v-from-params samples)))
+(mx/clear-cache!) (mx/force-gc!)
 
-(when hmc-v-samples
-  (let [m (mean hmc-v-samples)
-        s (std hmc-v-samples)]
-    (println (str "  posterior v: mean=" (.toFixed m 4) " std=" (.toFixed s 4)))
-    (println (str "  n-samples: " (count hmc-v-samples)))
-    (when-let [ar (:acceptance-rate (meta (:result hmc-result)))]
-      (println (str "  acceptance rate: " (.toFixed (* 100 ar) 1) "%")))))
+(def nuts-summary
+  (run-kernel "NUTS"
+    mcmc/nuts {:samples 600 :burn 300 :max-depth 8
+               :adapt-step-size true :adapt-metric true :target-accept 0.8}))
 
-(mx/clear-cache!)
+(mx/clear-cache!) (mx/force-gc!)
 
-;; --- 2. NUTS (100 samples, burn 50) ---
-
-(println "\n--- 2. NUTS (100 samples, burn 50) ---")
-(mx/clear-cache!)
-
-(def nuts-result
-  (safe-benchmark "NUTS-100"
-    (fn []
-      (mx/clear-cache!)
-      (mcmc/nuts {:samples 100 :burn 50
-                  :step-size 0.01
-                  :max-depth 8
-                  :addresses all-addresses
-                  :adapt-step-size true
-                  :target-accept 0.8}
-                 funnel-model [] funnel-obs))))
-
-(def nuts-v-samples
-  (when-let [samples (:result nuts-result)]
-    (extract-v-from-params samples)))
-
-(when nuts-v-samples
-  (let [m (mean nuts-v-samples)
-        s (std nuts-v-samples)]
-    (println (str "  posterior v: mean=" (.toFixed m 4) " std=" (.toFixed s 4)))
-    (println (str "  n-samples: " (count nuts-v-samples)))
-    (when-let [ar (:acceptance-rate (meta (:result nuts-result)))]
-      (println (str "  acceptance rate: " (.toFixed (* 100 ar) 1) "%")))))
-
-(mx/clear-cache!)
-
-;; --- 3. Compiled MH (100 samples, burn 50) ---
-
-(println "\n--- 3. Compiled MH (100 samples, burn 50) ---")
-(mx/clear-cache!)
-
-(def cmh-result
-  (safe-benchmark "compiled-MH-100"
-    (fn []
-      (mx/clear-cache!)
-      (mcmc/compiled-mh {:samples 100 :burn 50
-                         :addresses all-addresses
-                         :proposal-std 0.3}
-                        funnel-model [] funnel-obs))))
-
-(def cmh-v-samples
-  (when-let [samples (:result cmh-result)]
-    (extract-v-from-params samples)))
-
-(when cmh-v-samples
-  (let [m (mean cmh-v-samples)
-        s (std cmh-v-samples)]
-    (println (str "  posterior v: mean=" (.toFixed m 4) " std=" (.toFixed s 4)))
-    (println (str "  n-samples: " (count cmh-v-samples)))
-    (when-let [ar (:acceptance-rate (meta (:result cmh-result)))]
-      (println (str "  acceptance rate: " (.toFixed (* 100 ar) 1) "%")))))
+(def cmh-summary
+  (run-kernel "compiled-MH"
+    mcmc/compiled-mh {:samples 2000 :burn 1000 :proposal-std 0.1}))
 
 ;; ---------------------------------------------------------------------------
-;; Summary table
+;; Summary table + write data.json
 ;; ---------------------------------------------------------------------------
+
+(def all-summaries [hmc-summary nuts-summary cmh-summary])
 
 (println "\n\n========================================")
-(println "         FUNNEL RESULTS")
+(println "            FUNNEL RESULTS")
 (println "========================================\n")
+(println "| Algorithm    | v mean  | v std   | R-hat | ESS    | bulk | tail | Time(ms) |")
+(println "|--------------|---------|---------|-------|--------|------|------|----------|")
+(doseq [{:keys [algorithm v-mean v-std r-hat ess bulk-ess tail-ess elapsed-ms error]}
+        all-summaries]
+  (if error
+    (println (str "| " (.padEnd algorithm 12 " ") " | ERROR: " error))
+    (println (str "| " (.padEnd algorithm 12 " ")
+                  " | " (.padStart (.toFixed v-mean 4) 7 " ")
+                  " | " (.padStart (.toFixed v-std 4) 7 " ")
+                  " | " (.padStart (.toFixed r-hat 3) 5 " ")
+                  " | " (.padStart (.toFixed ess 1) 6 " ")
+                  " | " (.padStart (.toFixed bulk-ess 0) 4 " ")
+                  " | " (.padStart (.toFixed tail-ess 0) 4 " ")
+                  " | " (.padStart (.toFixed (or elapsed-ms 0) 0) 8 " ") " |"))))
 
-(println "| Algorithm     | v mean  | v std   | Time (ms) | Samples |")
-(println "|---------------|---------|---------|-----------|---------|")
-
-(doseq [[label v-samples result]
-        [["HMC-100"        hmc-v-samples  hmc-result]
-         ["NUTS-100"       nuts-v-samples nuts-result]
-         ["compiled-MH"   cmh-v-samples  cmh-result]]]
-  (if v-samples
-    (let [m (mean v-samples)
-          s (std v-samples)]
-      (println (str "| " (.padEnd label 13 " ")
-                    " | " (.padStart (.toFixed m 4) 7 " ")
-                    " | " (.padStart (.toFixed s 4) 7 " ")
-                    " | " (.padStart (.toFixed (or (:elapsed-ms result) 0) 1) 9 " ")
-                    " | " (.padStart (str (count v-samples)) 7 " ") " |")))
-    (println (str "| " (.padEnd label 13 " ")
-                  " |    N/A  |    N/A  |       N/A |     N/A |"
-                  (when-let [e (:error result)] (str "  " e))))))
-
-(println "\nGround truth: E[v | x=0] ~ 0")
-
-;; ---------------------------------------------------------------------------
-;; Write data.json
-;; ---------------------------------------------------------------------------
-
-(defn summarize [label v-samples result]
-  (let [base {:algorithm label
-              :elapsed-ms (:elapsed-ms result)
-              :error (:error result)}]
-    (if v-samples
-      (merge base {:n-samples (count v-samples)
-                   :v-mean (mean v-samples)
-                   :v-std (std v-samples)
-                   :acceptance-rate (:acceptance-rate (meta (:result result)))})
-      base)))
+(println "\nGround truth: v ~ N(0,3) (mean=0, std=3). R-hat target <= 1.01 (Vehtari et al. 2021).")
+(println "bulk/tail-ESS are rank-normalized (Vehtari); R-hat + ESS are multi-chain on v.")
 
 (write-json "data.json"
   {:experiment "neals-funnel"
    :model {:name "funnel" :dimensions 11
-           :description "v ~ N(0,3), x_i ~ N(0, exp(v/2)), all x_i observed at 0"}
-   :ground-truth {:v-mean 0.0
-                  :note "E[v|x=0] ~ 0 by symmetry"}
-   :results
-   [(summarize "HMC-100" hmc-v-samples hmc-result)
-    (summarize "NUTS-100" nuts-v-samples nuts-result)
-    (summarize "compiled-MH-100" cmh-v-samples cmh-result)]})
+           :description "joint funnel: v ~ N(0,3), x_i ~ N(0, exp(v/2)), no observations"}
+   :diagnostics {:r-hat-target 1.01
+                 :n-chains 4
+                 :ess-note (str "ess = sum of per-chain Geyer ESS; "
+                                "bulk/tail-ESS rank-normalized (Vehtari et al. 2021)")}
+   :ground-truth {:v-mean 0.0 :v-std 3.0
+                  :note "joint funnel: v ~ N(0,3) marginally (no observations)"}
+   :results all-summaries})
 
 (println "\nFunnel benchmark complete.")

--- a/bench/l3_5_combinator_conjugacy.cljs
+++ b/bench/l3_5_combinator_conjugacy.cljs
@@ -84,6 +84,19 @@
     (- (+ max-w (js/Math.log (reduce + (map #(js/Math.exp (- % max-w)) log-ws))))
        (js/Math.log n))))
 
+;; Independent closed-form marginal log-ML (exactness ground truth). Each Map
+;; element is an independent normal-normal pair mu~N(0,10), y~N(mu,1), so the
+;; per-element marginal is N(y_i; 0, prior-var + obs-var) = N(y_i; 0, 101), and
+;; the block marginal is their sum. obs_i = i + 1.5 (see make-obs).
+(def ^:private LOG-2PI 1.8378770664093453)
+
+(defn nn-single-marginal [y prior-var obs-var]
+  (let [v (+ prior-var obs-var)]
+    (* -0.5 (+ LOG-2PI (js/Math.log v) (/ (* y y) v)))))
+
+(defn combinator-closed-form-log-ml [K]
+  (reduce + (map (fn [i] (nn-single-marginal (+ i 1.5) 100.0 1.0)) (range K))))
+
 ;; ---------------------------------------------------------------------------
 ;; Schema stripping helpers
 ;; ---------------------------------------------------------------------------
@@ -297,38 +310,48 @@
                         " / " n-particles
                         " (" (.toFixed (* 100 (/ (:ess-mean l2-results) n-particles)) 1) "%)"))
 
-        ;; Variance reduction ratio
-        var-ratio (if (> (:log-ml-var l35-results) 1e-20)
-                    (/ (:log-ml-var l2-results) (:log-ml-var l35-results))
-                    js/Infinity)
+        ;; Exactness (headline) vs independent closed form + variance reduction
+        ;; (corollary, omitted when L3.5 exact — the old Inf artifact).
+        cf (combinator-closed-form-log-ml K)
+        l35-err (js/Math.abs (- (:log-ml-mean l35-results) cf))
+        l2-err (js/Math.abs (- (:log-ml-mean l2-results) cf))
+        l35-exact? (< (:log-ml-var l35-results) 1e-20)
+        var-ratio (when-not l35-exact?
+                    (/ (:log-ml-var l2-results) (:log-ml-var l35-results)))
         ess-ratio (/ (:ess-mean l35-results) (max (:ess-mean l2-results) 0.01))]
 
     (println (str "\n  --- Summary K=" K " ---"))
+    (println (str "  closed-form log-ML:  " (.toFixed cf 4)))
+    (println (str "  |L3.5 − closed form|: " (.toExponential l35-err 3)
+                  " nats  (exactness — the headline)"))
+    (println (str "  |L2   − closed form|: " (.toFixed l2-err 4) " nats"))
     (println (str "  Variance reduction:  "
-                  (if (= var-ratio js/Infinity)
-                    "Inf (L3.5 exact)"
-                    (str (.toFixed var-ratio 1) "x"))))
+                  (if l35-exact? "n/a (L3.5 exact, var=0)"
+                      (str (.toFixed var-ratio 1) "x"))))
     (println (str "  ESS improvement:     " (.toFixed ess-ratio 1) "x"))
     (println (str "  L3.5 time: " (.toFixed (:mean-ms l35-timing) 3) " ms"
                   ", L2 time: " (.toFixed (:mean-ms l2-timing) 3) " ms"))
 
-    ;; Return result map
-    {:K K
-     :L2-standard {:log-ml-mean (:log-ml-mean l2-results)
-                   :log-ml-std (:log-ml-std l2-results)
-                   :log-ml-var (:log-ml-var l2-results)
-                   :ess-mean (:ess-mean l2-results)
-                   :timing-ms (:mean-ms l2-timing)
-                   :timing-std-ms (:std-ms l2-timing)}
-     :L3.5-analytical {:log-ml-mean (:log-ml-mean l35-results)
-                       :log-ml-std (:log-ml-std l35-results)
-                       :log-ml-var (:log-ml-var l35-results)
-                       :ess-mean (:ess-mean l35-results)
-                       :timing-ms (:mean-ms l35-timing)
-                       :timing-std-ms (:std-ms l35-timing)}
-     :n-particles n-particles
-     :variance-reduction var-ratio
-     :ess-improvement ess-ratio}))
+    ;; Return result map. :variance-reduction omitted when L3.5 is exact.
+    (cond-> {:K K
+             :closed-form-log-ml cf
+             :L2-standard {:log-ml-mean (:log-ml-mean l2-results)
+                           :log-ml-std (:log-ml-std l2-results)
+                           :log-ml-var (:log-ml-var l2-results)
+                           :log-ml-abs-error-nats l2-err
+                           :ess-mean (:ess-mean l2-results)
+                           :timing-ms (:mean-ms l2-timing)
+                           :timing-std-ms (:std-ms l2-timing)}
+             :L3.5-analytical {:log-ml-mean (:log-ml-mean l35-results)
+                               :log-ml-std (:log-ml-std l35-results)
+                               :log-ml-var (:log-ml-var l35-results)
+                               :log-ml-abs-error-nats l35-err
+                               :ess-mean (:ess-mean l35-results)
+                               :timing-ms (:mean-ms l35-timing)
+                               :timing-std-ms (:std-ms l35-timing)}
+             :n-particles n-particles
+             :ess-improvement ess-ratio}
+      (some? var-ratio) (assoc :variance-reduction var-ratio))))
 
 ;; ---------------------------------------------------------------------------
 ;; Run experiments across Map sizes
@@ -349,16 +372,14 @@
 (println "         L3.5 COMBINATOR CONJUGACY RESULTS")
 (println (apply str (repeat 70 "=")))
 
-(println "\n| K  | L2 var(log-ML) | L3.5 var(log-ML) | Var Reduction | ESS L2 | ESS L3.5 | ESS Ratio |")
-(println "|----|----------------|------------------|---------------|--------|----------|-----------|")
+(println "\n| K  | |L3.5−cf| (nats) | |L2−cf| (nats) | ESS L2 | ESS L3.5 | ESS Ratio |")
+(println "|----|------------------|----------------|--------|----------|-----------|")
 (doseq [r results-by-size]
-  (let [l2-var (get-in r [:L2-standard :log-ml-var])
-        l35-var (get-in r [:L3.5-analytical :log-ml-var])
-        vr (:variance-reduction r)]
+  (let [l35e (get-in r [:L3.5-analytical :log-ml-abs-error-nats])
+        l2e (get-in r [:L2-standard :log-ml-abs-error-nats])]
     (println (str "| " (.padStart (str (:K r)) 2)
-                  " | " (.padStart (if (> l2-var 0) (.toFixed l2-var 6) "N/A") 14)
-                  " | " (.padStart (if (> l35-var 0) (.toFixed l35-var 6) "0 (exact)") 16)
-                  " | " (.padStart (if (= vr js/Infinity) "Inf" (.toFixed vr 1)) 13)
+                  " | " (.padStart (.toExponential l35e 2) 16)
+                  " | " (.padStart (.toFixed l2e 4) 14)
                   " | " (.padStart (.toFixed (get-in r [:L2-standard :ess-mean]) 0) 6)
                   " | " (.padStart (.toFixed (get-in r [:L3.5-analytical :ess-mean]) 0) 8)
                   " | " (.padStart (.toFixed (:ess-improvement r) 1) 9)
@@ -381,7 +402,7 @@
   {:experiment "l3.5-combinator-conjugacy"
    :combinator "Map"
    :kernel "normal-normal conjugate"
-   :description "Conjugacy detection inside Map combinator kernels. Per-element analytical elimination via L3.5."
+   :description "Conjugacy detection inside Map combinator kernels. Per-element analytical elimination via L3.5; exactness = |L3.5 log-ML − closed form| in nats."
    :timestamp (.toISOString (js/Date.))
    :hardware {:platform "macOS" :chip "Apple Silicon" :gpu "Metal"}
    :config {:particles_per_K particles-for-K :n_trials n-trials :map_sizes map-sizes}
@@ -390,16 +411,17 @@
                                                   :obs (name (:obs-addr p))
                                                   :family (name (:family p))})
                                         (get-in kernel-l35 [:schema :conjugate-pairs]))}
-   :results-by-size (mapv (fn [r]
-                           (update r :variance-reduction
-                                   #(if (= % js/Infinity) "Infinity" %)))
-                         results-by-size)
+   :results-by-size results-by-size
    :summary
-   {:mean_variance_reduction
-    (let [finite (filter #(and (number? %) (js/isFinite %))
-                         (map :variance-reduction results-by-size))]
-      (if (seq finite) (mean finite) "Infinity"))
+   {;; Exactness is the headline: |L3.5 log-ML − closed form| in nats, at each K.
+    :log_ml_abs_error_nats
+    (mapv (fn [r] {:K (:K r) :l35 (get-in r [:L3.5-analytical :log-ml-abs-error-nats])
+                   :l2 (get-in r [:L2-standard :log-ml-abs-error-nats])})
+          results-by-size)
+    :max_l35_abs_error_nats
+    (apply max (map #(get-in % [:L3.5-analytical :log-ml-abs-error-nats]) results-by-size))
     :mean_ess_improvement (mean (map :ess-improvement results-by-size))
-    :all_exact? (every? #(= js/Infinity (:variance-reduction %)) results-by-size)}})
+    :all_exact? (every? #(< (get-in % [:L3.5-analytical :log-ml-abs-error-nats]) 1e-3)
+                        results-by-size)}})
 
 (println "\nL3.5 combinator conjugacy benchmark complete.")

--- a/bench/l3_5_mvn_conjugacy.cljs
+++ b/bench/l3_5_mvn_conjugacy.cljs
@@ -436,10 +436,12 @@
 ;; Summary
 ;; =========================================================================
 
+;; Variance reduction is a corollary, OMITTED when L3.5 is exact (var=0 → the ratio
+;; is undefined; reporting it as Infinity was a divide-by-~0 artifact).
+(def l35-exact? (< (:log-ml-var l35-results) 1e-20))
 (def var-ratio
-  (if (> (:log-ml-var l35-results) 1e-20)
-    (/ (:log-ml-var l2-results) (:log-ml-var l35-results))
-    js/Infinity))
+  (when-not l35-exact?
+    (/ (:log-ml-var l2-results) (:log-ml-var l35-results))))
 
 (def ess-ratio
   (/ (:ess-mean l35-results) (max (:ess-mean l2-results) 0.01)))
@@ -476,8 +478,7 @@
               (.toFixed (:mean-ms l2-timing) 3) " | "
               (.toFixed l2-posterior-error 6) " |"))
 
-(println (str "\n  Variance reduction:  " (if (= var-ratio js/Infinity)
-                                              "Inf (L3.5 exact)"
+(println (str "\n  Variance reduction:  " (if l35-exact? "n/a (L3.5 exact, var=0)"
                                               (str (.toFixed var-ratio 1) "x"))))
 (println (str "  ESS improvement:     " (.toFixed ess-ratio 1) "x"))
 (println (str "  |L3.5 log-ML - analytic|: " (.toExponential l35-log-ml-abs-error 3)
@@ -523,7 +524,6 @@
      :posterior-mean-error l35-posterior-error
      :timing-ms (:mean-ms l35-timing)
      :timing-std-ms (:std-ms l35-timing)}}
-   :variance-reduction (if (= var-ratio js/Infinity) "Infinity" var-ratio)
    :ess-improvement ess-ratio
    :log-ml-abs-error l35-log-ml-abs-error  ;; |L3.5 - analytic| in nats (exactness)
    :analytic-posterior

--- a/bench/rao_blackwell.cljs
+++ b/bench/rao_blackwell.cljs
@@ -108,6 +108,28 @@
         lse (+ max-w (js/Math.log (reduce + (map #(js/Math.exp (- % max-w)) log-ws))))]
     (- lse (js/Math.log n))))
 
+;; Independent closed-form marginal log-ML (exactness ground truth).
+(def ^:private LOG-2PI 1.8378770664093453)
+
+(defn nn-shared-marginal
+  "Joint marginal log p(y) for shared-mean Normal-Normal:
+   mu ~ N(m0, prior-var); y_i ~ N(mu, obs-var)."
+  [ys m0 prior-var obs-var]
+  (let [n (count ys)
+        ds (map #(- % m0) ys)
+        sum-d (reduce + ds)
+        sum-d2 (reduce + (map #(* % %) ds))
+        denom (+ obs-var (* n prior-var))
+        logdet (+ (* (dec n) (js/Math.log obs-var)) (js/Math.log denom))
+        quad (/ (- sum-d2 (* (/ prior-var denom) sum-d sum-d)) obs-var)]
+    (* -0.5 (+ (* n LOG-2PI) logdet quad))))
+
+;; sigma ~ Gamma(2,1) is sampled but never enters the likelihood, so the marginal
+;; is purely the two independent Normal-Normal groups (mu1: y1,y2; mu2: y3,y4).
+(def closed-form-log-ml
+  (+ (nn-shared-marginal [1.5 2.0] 0.0 100.0 1.0)
+     (nn-shared-marginal [-0.5 -1.0] 0.0 100.0 1.0)))
+
 ;; ---------------------------------------------------------------------------
 ;; Strip analytical plan (forces L2 / prior-proposal IS)
 ;; ---------------------------------------------------------------------------
@@ -263,21 +285,26 @@
 (println "  Comparison")
 (println (apply str (repeat 60 "-")))
 
+;; Exactness (headline): |L3 log-ML − closed form|. Variance reduction is a
+;; corollary, omitted when L3 is exact (var=0 → undefined ratio, the old Inf artifact).
+(def l3-abs-error (js/Math.abs (- (:log-ml-mean l3-results) closed-form-log-ml)))
+(def l2-abs-error (js/Math.abs (- (:log-ml-mean l2-results) closed-form-log-ml)))
+(def l3-exact? (< (:log-ml-var l3-results) 1e-20))
 (def var-ratio
-  (if (> (:log-ml-var l3-results) 1e-20)
-    (/ (:log-ml-var l2-results) (:log-ml-var l3-results))
-    js/Infinity))
+  (when-not l3-exact?
+    (/ (:log-ml-var l2-results) (:log-ml-var l3-results))))
 
 (def ess-ratio
   (/ (:ess-mean l3-results) (max (:ess-mean l2-results) 0.01)))
 
+(println (str "  Closed-form marginal log-ML: " (.toFixed closed-form-log-ml 6)))
+(println (str "  |L3 log-ML − closed form|: " (.toExponential l3-abs-error 3)
+              " nats  (exactness — the headline)"))
+(println (str "  |L2 log-ML − closed form|: " (.toFixed l2-abs-error 4) " nats"))
 (println (str "  Variance reduction (L2/L3): "
-              (if (= var-ratio js/Infinity)
-                "Inf (L3 exact)"
-                (str (.toFixed var-ratio 1) "x"))))
+              (if l3-exact? "n/a (L3 exact, var=0)"
+                  (str (.toFixed var-ratio 1) "x"))))
 (println (str "  ESS improvement (L3/L2):    " (.toFixed ess-ratio 1) "x"))
-(println (str "  L2 log-ML std: " (.toFixed (:log-ml-std l2-results) 6)))
-(println (str "  L3 log-ML std: " (.toFixed (:log-ml-std l3-results) 6)))
 (println (str "  L2 time: " (.toFixed (:mean-ms l2-timing) 3) " ms"))
 (println (str "  L3 time: " (.toFixed (:mean-ms l3-timing) 3) " ms"))
 
@@ -303,10 +330,10 @@
               " | " (.padStart (.toFixed (:ess-mean l3-results) 1) 9)
               " | " (.padStart (.toFixed (:mean-ms l3-timing) 3) 9)
               " |"))
-(println (str "\n  Variance reduction ratio: "
-              (if (= var-ratio js/Infinity)
-                "Inf (L3 exact)"
-                (str (.toFixed var-ratio 1) "x"))))
+(println (str "\n  |L3 log-ML − closed form|: " (.toExponential l3-abs-error 3) " nats"))
+(println (str "  Variance reduction ratio: "
+              (if l3-exact? "n/a (L3 exact, var=0)"
+                  (str (.toFixed var-ratio 1) "x"))))
 (println (str "  Conjugate sites eliminated: mu1, mu2"))
 (println (str "  Non-conjugate sites sampled: sigma"))
 
@@ -315,29 +342,34 @@
 ;; ---------------------------------------------------------------------------
 
 (write-json "data.json"
-  {:experiment "rao-blackwell"
-   :description "Rao-Blackwellization: partial conjugacy variance reduction"
-   :timestamp (.toISOString (js/Date.))
-   :model "mixed: 2 NN-conjugate + 1 non-conjugate"
-   :config {:n_particles n-particles :n_trials n-trials}
-   :conditions
-   {:L2-no-analytical
-    {:log-ml-mean (:log-ml-mean l2-results)
-     :log-ml-std (:log-ml-std l2-results)
-     :log-ml-var (:log-ml-var l2-results)
-     :ess-mean (:ess-mean l2-results)
-     :timing-ms (:mean-ms l2-timing)
-     :timing-std-ms (:std-ms l2-timing)}
-    :L3-with-analytical
-    {:log-ml-mean (:log-ml-mean l3-results)
-     :log-ml-std (:log-ml-std l3-results)
-     :log-ml-var (:log-ml-var l3-results)
-     :ess-mean (:ess-mean l3-results)
-     :timing-ms (:mean-ms l3-timing)
-     :timing-std-ms (:std-ms l3-timing)}}
-   :variance-reduction (if (= var-ratio js/Infinity) "Infinity" var-ratio)
-   :ess-improvement ess-ratio
-   :conjugate-sites ["mu1" "mu2"]
-   :non-conjugate-sites ["sigma"]})
+  (cond->
+   {:experiment "rao-blackwell"
+    :description (str "Analytical elimination exactness: mu1, mu2 marginalized (sigma "
+                      "sampled but irrelevant to the marginal). |L3 log-ML − closed form|.")
+    :timestamp (.toISOString (js/Date.))
+    :model "mixed: 2 NN-conjugate + 1 non-conjugate"
+    :config {:n_particles n-particles :n_trials n-trials}
+    :closed-form-log-ml closed-form-log-ml
+    :conditions
+    {:L2-no-analytical
+     {:log-ml-mean (:log-ml-mean l2-results)
+      :log-ml-std (:log-ml-std l2-results)
+      :log-ml-var (:log-ml-var l2-results)
+      :log-ml-abs-error-nats l2-abs-error
+      :ess-mean (:ess-mean l2-results)
+      :timing-ms (:mean-ms l2-timing)
+      :timing-std-ms (:std-ms l2-timing)}
+     :L3-with-analytical
+     {:log-ml-mean (:log-ml-mean l3-results)
+      :log-ml-std (:log-ml-std l3-results)
+      :log-ml-var (:log-ml-var l3-results)
+      :log-ml-abs-error-nats l3-abs-error
+      :ess-mean (:ess-mean l3-results)
+      :timing-ms (:mean-ms l3-timing)
+      :timing-std-ms (:std-ms l3-timing)}}
+    :ess-improvement ess-ratio
+    :conjugate-sites ["mu1" "mu2"]
+    :non-conjugate-sites ["sigma"]}
+    (some? var-ratio) (assoc :variance-reduction var-ratio)))
 
 (println "\nRao-Blackwellization benchmark complete.")

--- a/docs/tutorial-v2/src/ch08-vectorization.md
+++ b/docs/tutorial-v2/src/ch08-vectorization.md
@@ -99,7 +99,7 @@ GenMLX implements five compilation levels, each moving more computation into the
 | 0 | Shape-based GPU batching | baseline |
 | 1 | Model body as single Metal dispatch | 3-5x |
 | 2 | Full SMC/MCMC sweep in one graph | 15-77x |
-| 3 | Conjugate structure eliminated analytically | 33x variance reduction |
+| 3 | Conjugate structure eliminated analytically | exact marginal LL (ESS up to ~50×) |
 | 4 | Model + inference + gradient + optimizer fused | 9x |
 
 Each level subsumes the previous. Models written at Level 0 run unchanged at Level 4. The handler path remains ground truth at every stage.

--- a/results/cross-system/numpyro.json
+++ b/results/cross-system/numpyro.json
@@ -1,0 +1,98 @@
+{
+  "system": "numpyro",
+  "family": "out-of-family (Pyro effect-handler paradigm; not GFI/trace-based)",
+  "version": "0.21.0",
+  "jax_version": "0.7.2",
+  "hardware": "Apple M4",
+  "backend": "JAX CPU (cpu)",
+  "timing_protocol": "5 warmup, 20 runs, time.perf_counter (IS); 3 runs, JIT excluded (NUTS)",
+  "comparisons": [
+    {
+      "model": "linreg",
+      "algorithm": "IS",
+      "n_particles": 1000,
+      "time_ms": 0.045056300223222934,
+      "time_ms_std": 0.0037199864191696077,
+      "time_ms_min": 0.03991699850303121,
+      "times_ms": [
+        0.043542000639718026,
+        0.048207999498117715,
+        0.04470800195122138,
+        0.04149999949731864,
+        0.03991699850303121,
+        0.05216699719312601,
+        0.0470000013592653,
+        0.049958998715737835,
+        0.0468340003862977,
+        0.044916003389516845,
+        0.04016700040665455,
+        0.04254100349498913,
+        0.04183299824944697,
+        0.04337499922257848,
+        0.04158400042797439,
+        0.050499998906161636,
+        0.05037500159232877,
+        0.047917001211317256,
+        0.040625000110594556,
+        0.04345799970906228
+      ],
+      "log_ml_estimate": -31.831884384155273,
+      "log_ml_exact": -31.699429613021042,
+      "log_ml_abs_err": 0.1324547711342312,
+      "weight_faithfulness_max_disc": 0.0001220703125
+    },
+    {
+      "model": "linreg",
+      "algorithm": "NUTS",
+      "num_warmup": 500,
+      "num_samples": 1000,
+      "time_ms": 265.6248056676607,
+      "time_ms_std": 1.6883322620363566,
+      "time_ms_min": 264.2274999998335,
+      "times_ms": [
+        264.64675000170246,
+        268.00016700144624,
+        264.2274999998335
+      ],
+      "post_mean_slope": 2.0910866260528564,
+      "post_mean_intercept": 0.5568988919258118,
+      "post_mean_slope_exact": 2.0900464076197363,
+      "post_mean_intercept_exact": 0.5587543775270014,
+      "timing_note": "single MCMC run; one-time JIT compile excluded via a warmup run; mean of 3"
+    }
+  ],
+  "accuracy": {
+    "metric": "log marginal likelihood (linreg, shared spec)",
+    "log_ml_exact_closed_form": -31.699429613021042,
+    "log_ml_genmlx_l3_exact": -31.699430465698242,
+    "log_ml_is_estimate": -31.831884384155273,
+    "log_ml_is_abs_err": 0.1324547711342312,
+    "note": "NumPyro IS reaches GenMLX's exact L3 log-ML within 0.132 nats; NUTS recovers the exact linear-Gaussian posterior mean. Closed-form == GenMLX L3 to float32 floor.",
+    "post_mean_exact": {
+      "slope": 2.0900464076197363,
+      "intercept": 0.5587543775270014
+    },
+    "post_mean_nuts": {
+      "slope": 2.0910866260528564,
+      "intercept": 0.5568988919258118
+    }
+  },
+  "reproducibility": {
+    "env": ".venv-genjax (gitignored)",
+    "install": "~/code/genmlx/.venv-genjax/bin/pip install numpyro",
+    "command": "~/code/genmlx/.venv-genjax/bin/python scripts/exp4_numpyro_baseline.py",
+    "versions": {
+      "numpyro": "0.21.0",
+      "jax": "0.7.2",
+      "numpy": "2.4.3"
+    },
+    "shared_spec": {
+      "model": "linreg",
+      "n_obs": 20,
+      "sigma_prior": 2.0,
+      "sigma_obs": 1.0,
+      "note": "byte-identical xs/ys to scripts/exp4_genjax_benchmarks.py"
+    },
+    "caveats": "Accuracy comparison is apples-to-apples NumPyro-IS vs GenJAX-IS vs closed-form (same 20-point N(0,2) spec). GenMLX's bench/cross_system.cljs + bench/linreg.cljs use N(0,10) on a different 5-point dataset, so the GenMLX timing column is NOT on this shared spec; treat the GenMLX-vs-others IS timing as indicative, not matched."
+  }
+}

--- a/scripts/exp4_numpyro_baseline.py
+++ b/scripts/exp4_numpyro_baseline.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""
+Experiment 4: NumPyro out-of-(Gen-)family baseline for the system comparison.
+
+The cross-system comparison is otherwise Gen-family only (GenMLX + Gen.jl + GenJAX,
+all GFI/trace-based). NumPyro is the Pyro *effect-handler* paradigm — genuinely
+out-of-family — even though it rides on JAX. This adds ONE competently-configured
+out-of-family reference point, reported as matched-accuracy-at-cost.
+
+Shared linear-regression spec (BYTE-IDENTICAL to scripts/exp4_genjax_benchmarks.py):
+  xs       = 20 points evenly spaced in [-2.5, 2.5]
+  priors   = slope, intercept ~ N(0, 2)
+  obs      = y_j ~ N(slope*x_j + intercept, 1)
+(NB: GenMLX's own bench/cross_system.cljs + bench/linreg.cljs use N(0,10) and a
+ different 5-point dataset, so their *timings* are NOT on this shared spec. The
+ clean apples-to-apples accuracy comparison here is NumPyro-IS vs GenJAX-IS vs the
+ closed-form exact log-ML; see the "caveats" block in the emitted JSON.)
+
+Two reported points:
+  1. IS log-ML (N=1000): importance sampling from the prior, log_ml = logsumexp(w) - log N,
+     mirroring the GenJAX make_is_fn row (JIT-compiled, vmapped weights). Accuracy is
+     checked against an INDEPENDENT closed-form Gaussian marginal likelihood (exact MVN),
+     and cross-checked once via NumPyro's own Predictive + log_likelihood machinery.
+  2. NUTS (NumPyro's native idiom): posterior means + wall-clock, validated against the
+     exact linear-Gaussian posterior mean.
+
+Protocol: 5 warmup, 20 timed runs, time.perf_counter, block_until_ready (JAX).
+
+Reproducibility (CPU JAX is fine; versions recorded in the output JSON):
+  ~/code/genmlx/.venv-genjax/bin/pip install numpyro
+  ~/code/genmlx/.venv-genjax/bin/python scripts/exp4_numpyro_baseline.py
+
+Output: results/cross-system/numpyro.json
+"""
+
+import os
+import time
+import json
+import subprocess
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+import numpyro
+import numpyro.distributions as ndist
+from numpyro.infer import MCMC, NUTS
+from numpyro.infer.util import log_likelihood
+
+numpyro.set_host_device_count(1)
+
+# ---------------------------------------------------------------------------
+# Shared spec (byte-identical to exp4_genjax_benchmarks.py lines 24-41)
+# ---------------------------------------------------------------------------
+
+LINREG_XS = jnp.array([
+    -2.5, -2.236842105263158, -1.973684210526316, -1.7105263157894737,
+    -1.4473684210526316, -1.1842105263157896, -0.9210526315789473,
+    -0.6578947368421053, -0.3947368421052633, -0.13157894736842124,
+    0.1315789473684208, 0.3947368421052633, 0.6578947368421053,
+    0.9210526315789473, 1.1842105263157894, 1.4473684210526319,
+    1.7105263157894735, 1.973684210526316, 2.2368421052631575, 2.5
+])
+
+LINREG_YS = jnp.array([
+    -4.645086392760277, -2.232466120468943, -4.743588723634419,
+    -1.3603573410134566, -3.226216689536446, -3.294092987713061,
+    -1.7810833391390348, -1.0100273317412327, 0.3002335711529378,
+    -0.06383435977132734, 0.1810731197658333, 1.4528234914729472,
+    2.0677273100928257, 2.639107370062878, 2.240536426243029,
+    3.3727551091854515, 4.502427813253904, 4.419489033912358,
+    7.114258427368966, 5.38109839707613
+])
+
+SIGMA_PRIOR = 2.0
+SIGMA_OBS = 1.0
+N_PARTICLES = 1000
+
+# GenMLX's L3 analytical eliminator (Kalman) on this exact shared spec, for the
+# matched-accuracy claim. Reproduce (Metal GPU, exact to the float32 floor):
+#   bun run --bun nbb -e '(do (require (quote [genmlx.mlx :as mx])
+#     (quote [genmlx.linear-gaussian :as lg]))
+#     (def specs (mapv (fn [x y] {:y (mx/scalar y) :h (mx/array [x 1.0])
+#       :c (mx/scalar 0.0) :r (mx/scalar 1.0)}) XS YS))
+#     (println (mx/item (:marginal-ll (lg/lg-eliminate (mx/array [0.0 0.0])
+#       (mx/array [[4.0 0.0] [0.0 4.0]]) specs)))))'
+# => -31.699430465698242 ; post-mean [2.090046 0.558755]  (matches closed form below)
+GENMLX_L3_LOG_ML = -31.699430465698242
+
+
+# ---------------------------------------------------------------------------
+# NumPyro model (effect-handler style)
+# ---------------------------------------------------------------------------
+
+def linreg_model(xs, ys=None):
+    slope = numpyro.sample("slope", ndist.Normal(0.0, SIGMA_PRIOR))
+    intercept = numpyro.sample("intercept", ndist.Normal(0.0, SIGMA_PRIOR))
+    mu = slope * xs + intercept
+    with numpyro.plate("data", xs.shape[0]):
+        numpyro.sample("y", ndist.Normal(mu, SIGMA_OBS), obs=ys)
+
+
+# ---------------------------------------------------------------------------
+# Independent closed-form oracle (analytic MVN — NOT NumPyro, NOT GenMLX)
+# ---------------------------------------------------------------------------
+
+def exact_linear_gaussian(xs, ys, sigma_prior, sigma_obs):
+    """Closed-form log marginal likelihood and posterior mean for
+    y ~ N(0, sigma_obs^2 I + Phi diag(sigma_prior^2) Phi^T), Phi = [x, 1]."""
+    xs = np.asarray(xs, dtype=np.float64)
+    ys = np.asarray(ys, dtype=np.float64)
+    n = xs.shape[0]
+    Phi = np.stack([xs, np.ones_like(xs)], axis=1)          # [n, 2]: cols = slope, intercept
+    Lam = np.diag([sigma_prior ** 2, sigma_prior ** 2])     # prior cov of [slope, intercept]
+    Sigma = sigma_obs ** 2 * np.eye(n) + Phi @ Lam @ Phi.T  # marginal cov of y
+    sign, logdet = np.linalg.slogdet(Sigma)
+    quad = ys @ np.linalg.solve(Sigma, ys)
+    log_ml = -0.5 * (n * np.log(2.0 * np.pi) + logdet + quad)
+    # Exact Gaussian posterior over [slope, intercept]
+    post_prec = np.linalg.inv(Lam) + (Phi.T @ Phi) / sigma_obs ** 2
+    post_cov = np.linalg.inv(post_prec)
+    post_mean = post_cov @ (Phi.T @ ys) / sigma_obs ** 2
+    return {
+        "log_ml": float(log_ml),
+        "post_mean_slope": float(post_mean[0]),
+        "post_mean_intercept": float(post_mean[1]),
+    }
+
+
+# ---------------------------------------------------------------------------
+# IS log-ML (N=1000), JIT-compiled & vmapped — mirrors GenJAX make_is_fn
+# ---------------------------------------------------------------------------
+
+def make_is_fn(n_particles):
+    """JIT-compiled importance sampling from the prior.
+
+    Per particle: draw (slope, intercept) ~ prior, weight = log p(y | slope, intercept).
+    log_ml = logsumexp(weights) - log N. Scoring uses NumPyro distributions, so the
+    weight is exactly the generate-weight a NumPyro trace would assign to the
+    constrained y sites under a prior-sampled latent."""
+    prior = ndist.Normal(0.0, SIGMA_PRIOR)
+
+    @jax.jit
+    def run_is(key):
+        k_s, k_i = jax.random.split(key)
+        slope = prior.sample(k_s, (n_particles,))            # [N]
+        intercept = prior.sample(k_i, (n_particles,))        # [N]
+        mu = slope[:, None] * LINREG_XS[None, :] + intercept[:, None]   # [N, 20]
+        loglik = ndist.Normal(mu, SIGMA_OBS).log_prob(
+            LINREG_YS[None, :]).sum(axis=1)                  # [N]
+        return jax.scipy.special.logsumexp(loglik) - jnp.log(n_particles)
+
+    return run_is
+
+
+def faithfulness_check(key, n_particles):
+    """Score the SAME prior draws two ways — the hand-vmapped Normal.log_prob used
+    by run_is, and NumPyro's own log_likelihood machinery — and confirm the
+    per-particle log-weights are identical. This proves the timed hand-rolled
+    estimator computes exactly the generate-weight NumPyro would assign, rather
+    than relying on two independent (differently-seeded) estimates agreeing."""
+    prior = ndist.Normal(0.0, SIGMA_PRIOR)
+    k_s, k_i = jax.random.split(key)
+    slope = prior.sample(k_s, (n_particles,))
+    intercept = prior.sample(k_i, (n_particles,))
+    mu = slope[:, None] * LINREG_XS[None, :] + intercept[:, None]
+    w_hand = ndist.Normal(mu, SIGMA_OBS).log_prob(LINREG_YS[None, :]).sum(axis=1)  # [N]
+    latents = {"slope": slope, "intercept": intercept}
+    w_numpyro = log_likelihood(
+        linreg_model, latents, xs=LINREG_XS, ys=LINREG_YS)["y"].sum(axis=1)        # [N]
+    max_disc = float(jnp.max(jnp.abs(w_hand - w_numpyro)))
+    est = float(jax.scipy.special.logsumexp(w_hand) - jnp.log(n_particles))
+    return est, max_disc
+
+
+# ---------------------------------------------------------------------------
+# Timing helper (matches exp4_genjax_benchmarks.py bench())
+# ---------------------------------------------------------------------------
+
+def bench(f, warmup=5, runs=20):
+    for _ in range(warmup):
+        r = f()
+        if hasattr(r, "block_until_ready"):
+            r.block_until_ready()
+    times = []
+    for _ in range(runs):
+        start = time.perf_counter()
+        r = f()
+        if hasattr(r, "block_until_ready"):
+            r.block_until_ready()
+        times.append((time.perf_counter() - start) * 1000)
+    return times
+
+
+def detect_hardware():
+    try:
+        brand = subprocess.check_output(
+            ["sysctl", "-n", "machdep.cpu.brand_string"]).decode().strip()
+        return brand or "Apple Silicon"
+    except Exception:
+        return "Apple Silicon"
+
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+print("\n=== NumPyro Out-of-Family Baseline (system comparison) ===")
+print(f"  numpyro {numpyro.__version__} | JAX {jax.__version__} "
+      f"({jax.devices()[0].platform})")
+print(f"  Shared linreg: N={LINREG_XS.shape[0]}, priors N(0,{SIGMA_PRIOR}), "
+      f"obs sigma {SIGMA_OBS}")
+print("  Protocol: 5 warmup, 20 timed runs\n")
+
+hardware = detect_hardware()
+key = jax.random.PRNGKey(42)
+
+# --- Ground truth (independent closed form) ---
+exact = exact_linear_gaussian(LINREG_XS, LINREG_YS, SIGMA_PRIOR, SIGMA_OBS)
+print(f"-- Exact (closed-form MVN) --")
+print(f"  log-ML        : {exact['log_ml']:.6f}")
+print(f"  post mean     : slope={exact['post_mean_slope']:.4f} "
+      f"intercept={exact['post_mean_intercept']:.4f}\n")
+
+# --- IS log-ML (N=1000), timed ---
+print(f"-- LinReg IS (N={N_PARTICLES}) --")
+run_is = make_is_fn(N_PARTICLES)
+is_estimate = float(run_is(key))
+is_check, weight_disc = faithfulness_check(key, N_PARTICLES)
+times = bench(lambda: run_is(key))
+print(f"  log-ML (IS)        : {is_estimate:.6f}  "
+      f"(abs err vs exact = {abs(is_estimate - exact['log_ml']):.4f})")
+print(f"  faithfulness       : run_is == shared-draw est: "
+      f"{abs(is_estimate - is_check) < 1e-4} | "
+      f"max |hand - numpyro.log_likelihood| weight disc = {weight_disc:.2e}")
+print(f"  Mean: {np.mean(times):.4f} ms | Std: {np.std(times):.4f} | "
+      f"Min: {np.min(times):.4f}\n")
+
+is_comparison = {
+    "model": "linreg",
+    "algorithm": "IS",
+    "n_particles": N_PARTICLES,
+    "time_ms": float(np.mean(times)),
+    "time_ms_std": float(np.std(times)),
+    "time_ms_min": float(np.min(times)),
+    "times_ms": [float(t) for t in times],
+    "log_ml_estimate": is_estimate,
+    "log_ml_exact": exact["log_ml"],
+    "log_ml_abs_err": abs(is_estimate - exact["log_ml"]),
+    "weight_faithfulness_max_disc": weight_disc,
+}
+
+# --- NUTS (NumPyro's native idiom), timed ---
+print("-- LinReg NUTS (500 warmup + 1000 samples) --")
+NUM_WARMUP, NUM_SAMPLES = 500, 1000
+
+
+def run_nuts(rng):
+    mcmc = MCMC(NUTS(linreg_model), num_warmup=NUM_WARMUP,
+                num_samples=NUM_SAMPLES, progress_bar=False)
+    mcmc.run(rng, xs=LINREG_XS, ys=LINREG_YS)
+    return mcmc
+
+
+# One warmup run to absorb the one-time JIT compile, then 3 timed runs.
+_warm = run_nuts(key)
+_warm.get_samples()["slope"].block_until_ready()
+nuts_times = []
+nuts_keys = jax.random.split(key, 3)
+last = None
+for nk in nuts_keys:
+    t0 = time.perf_counter()
+    last = run_nuts(nk)
+    last.get_samples()["slope"].block_until_ready()
+    nuts_times.append((time.perf_counter() - t0) * 1000)
+
+nuts_samples = last.get_samples()
+nuts_slope = float(np.mean(np.asarray(nuts_samples["slope"])))
+nuts_intercept = float(np.mean(np.asarray(nuts_samples["intercept"])))
+print(f"  post mean : slope={nuts_slope:.4f} intercept={nuts_intercept:.4f} "
+      f"(exact slope={exact['post_mean_slope']:.4f} "
+      f"intercept={exact['post_mean_intercept']:.4f})")
+print(f"  Mean: {np.mean(nuts_times):.2f} ms over {len(nuts_times)} runs "
+      f"(JIT compile excluded)\n")
+
+nuts_comparison = {
+    "model": "linreg",
+    "algorithm": "NUTS",
+    "num_warmup": NUM_WARMUP,
+    "num_samples": NUM_SAMPLES,
+    "time_ms": float(np.mean(nuts_times)),
+    "time_ms_std": float(np.std(nuts_times)),
+    "time_ms_min": float(np.min(nuts_times)),
+    "times_ms": [float(t) for t in nuts_times],
+    "post_mean_slope": nuts_slope,
+    "post_mean_intercept": nuts_intercept,
+    "post_mean_slope_exact": exact["post_mean_slope"],
+    "post_mean_intercept_exact": exact["post_mean_intercept"],
+    "timing_note": "single MCMC run; one-time JIT compile excluded via a warmup run; mean of 3",
+}
+
+# ---------------------------------------------------------------------------
+# Emit JSON (mirrors genjax.json schema + accuracy/reproducibility blocks)
+# ---------------------------------------------------------------------------
+
+output = {
+    "system": "numpyro",
+    "family": "out-of-family (Pyro effect-handler paradigm; not GFI/trace-based)",
+    "version": numpyro.__version__,
+    "jax_version": jax.__version__,
+    "hardware": hardware,
+    "backend": f"JAX CPU ({jax.devices()[0].platform})",
+    "timing_protocol": "5 warmup, 20 runs, time.perf_counter (IS); 3 runs, JIT excluded (NUTS)",
+    "comparisons": [is_comparison, nuts_comparison],
+    "accuracy": {
+        "metric": "log marginal likelihood (linreg, shared spec)",
+        "log_ml_exact_closed_form": exact["log_ml"],
+        "log_ml_genmlx_l3_exact": GENMLX_L3_LOG_ML,
+        "log_ml_is_estimate": is_estimate,
+        "log_ml_is_abs_err": abs(is_estimate - exact["log_ml"]),
+        "note": ("NumPyro IS reaches GenMLX's exact L3 log-ML within "
+                 f"{abs(is_estimate - GENMLX_L3_LOG_ML):.3f} nats; NUTS recovers the "
+                 "exact linear-Gaussian posterior mean. Closed-form == GenMLX L3 to float32 floor."),
+        "post_mean_exact": {
+            "slope": exact["post_mean_slope"],
+            "intercept": exact["post_mean_intercept"],
+        },
+        "post_mean_nuts": {"slope": nuts_slope, "intercept": nuts_intercept},
+    },
+    "reproducibility": {
+        "env": ".venv-genjax (gitignored)",
+        "install": "~/code/genmlx/.venv-genjax/bin/pip install numpyro",
+        "command": "~/code/genmlx/.venv-genjax/bin/python scripts/exp4_numpyro_baseline.py",
+        "versions": {
+            "numpyro": numpyro.__version__,
+            "jax": jax.__version__,
+            "numpy": np.__version__,
+        },
+        "shared_spec": {
+            "model": "linreg",
+            "n_obs": int(LINREG_XS.shape[0]),
+            "sigma_prior": SIGMA_PRIOR,
+            "sigma_obs": SIGMA_OBS,
+            "note": "byte-identical xs/ys to scripts/exp4_genjax_benchmarks.py",
+        },
+        "caveats": (
+            "Accuracy comparison is apples-to-apples NumPyro-IS vs GenJAX-IS vs closed-form "
+            "(same 20-point N(0,2) spec). GenMLX's bench/cross_system.cljs + bench/linreg.cljs "
+            "use N(0,10) on a different 5-point dataset, so the GenMLX timing column is NOT on "
+            "this shared spec; treat the GenMLX-vs-others IS timing as indicative, not matched."
+        ),
+    },
+}
+
+outpath = os.path.join(os.path.dirname(__file__), "..", "results",
+                       "cross-system", "numpyro.json")
+os.makedirs(os.path.dirname(outpath), exist_ok=True)
+with open(outpath, "w") as f:
+    json.dump(output, f, indent=2)
+print(f"Wrote: {os.path.normpath(outpath)}")

--- a/scripts/plot_paper_figures.py
+++ b/scripts/plot_paper_figures.py
@@ -847,10 +847,48 @@ def compilation_table_pdf():
 # Fig 9: System Comparison Bar Chart
 # ---------------------------------------------------------------------------
 
+def load_genmlx_crosssystem():
+    """GenMLX cross-system timings in the unified {'comparisons': [...]} schema,
+    synthesized from the tracked native bench output results/cross-system/data.json
+    (produced by bench/cross_system.cljs). Single source of truth — no derived
+    genmlx.json that could silently drift from data.json. Maps GenMLX-native config
+    labels to the (model, algorithm) pairs the table/bars look up via find().
+
+    NB: GenMLX's bench uses N(0,10) priors on a 5-point linreg, whereas the GenJAX /
+    NumPyro IS rows use the shared 20-point N(0,2) spec. The IS *timing* columns are
+    therefore indicative, not matched-spec; the matched-ACCURACY claim lives in the
+    accuracy blocks of numpyro.json (and is exact for GenMLX's L3)."""
+    data = load_json('cross-system/data.json')
+
+    def native(config, particles=None):
+        for r in data['results']:
+            if r['config'] == config and (particles is None
+                                          or r.get('particles') == particles):
+                return r
+        return None
+
+    def cmp(config, model, algo, particles=None):
+        r = native(config, particles)
+        if r is None:
+            return None
+        return {'model': model, 'algorithm': algo, 'time_ms': r['mean_ms'],
+                'time_ms_std': r.get('std_ms'), 'time_ms_min': r.get('min_ms'),
+                'source_config': config}
+
+    comparisons = [c for c in [
+        cmp('VIS-linreg', 'linreg', 'IS', particles=1000),   # vectorized IS (N=1000)
+        cmp('fused-MH-linreg', 'linreg', 'MH'),              # compiled MH
+        cmp('VIS-gmm', 'gmm', 'IS', particles=1000),
+        cmp('L3-exact', 'linreg', 'L3'),                     # GenMLX-only exact marginal
+    ] if c is not None]
+    return {'system': 'genmlx', 'backend': 'Metal GPU', 'comparisons': comparisons}
+
+
 def fig9_system_bars():
-    genmlx = load_json('exp4_system_comparison/genmlx.json')
-    genjl = load_json('exp4_system_comparison/genjl.json')
-    genjax = load_json('exp4_system_comparison/genjax.json')
+    genmlx = load_genmlx_crosssystem()
+    genjl = load_json('cross-system/genjl.json')
+    genjax = load_json('cross-system/genjax.json')
+    numpyro = load_json('cross-system/numpyro.json')
 
     def find(data, model, algo):
         for c in data['comparisons']:
@@ -858,59 +896,58 @@ def fig9_system_bars():
                 return c
         return None
 
-    # Define comparison groups
+    def t(c):
+        return c['time_ms'] if c else None
+
+    # Define comparison groups. Each group is (GenMLX, Gen.jl, GenJAX, NumPyro);
+    # NumPyro is the out-of-family point (only the shared-spec LinReg IS row).
     groups = []
     labels = []
 
     # LinReg IS
-    mlx_lr = find(genmlx, 'linreg', 'IS')
-    jl_lr = find(genjl, 'linreg', 'IS')
-    jx_lr = find(genjax, 'linreg', 'IS')
-    if mlx_lr and jl_lr and jx_lr:
-        groups.append((mlx_lr['time_ms'], jl_lr['time_ms'], jx_lr['time_ms']))
+    if find(genmlx, 'linreg', 'IS') and find(genjl, 'linreg', 'IS') \
+            and find(genjax, 'linreg', 'IS'):
+        groups.append((t(find(genmlx, 'linreg', 'IS')), t(find(genjl, 'linreg', 'IS')),
+                       t(find(genjax, 'linreg', 'IS')), t(find(numpyro, 'linreg', 'IS'))))
         labels.append('LinReg\nIS(1K)')
 
     # GMM IS
-    mlx_gmm = find(genmlx, 'gmm', 'IS')
-    jl_gmm = find(genjl, 'gmm', 'IS')
-    jx_gmm = find(genjax, 'gmm', 'IS')
-    if mlx_gmm and jl_gmm and jx_gmm:
-        groups.append((mlx_gmm['time_ms'], jl_gmm['time_ms'], jx_gmm['time_ms']))
+    if find(genmlx, 'gmm', 'IS') and find(genjl, 'gmm', 'IS') and find(genjax, 'gmm', 'IS'):
+        groups.append((t(find(genmlx, 'gmm', 'IS')), t(find(genjl, 'gmm', 'IS')),
+                       t(find(genjax, 'gmm', 'IS')), t(find(numpyro, 'gmm', 'IS'))))
         labels.append('GMM\nIS(1K)')
 
-    # HMM IS (GenJAX may be missing)
-    mlx_hmm = find(genmlx, 'hmm', 'IS')
-    jl_hmm = find(genjl, 'hmm', 'IS')
-    jx_hmm = find(genjax, 'hmm', 'IS')
-    if mlx_hmm and jl_hmm:
-        hmm_jx = jx_hmm['time_ms'] if jx_hmm else None
-        groups.append((mlx_hmm['time_ms'], jl_hmm['time_ms'], hmm_jx))
+    # HMM IS (GenJAX/NumPyro may be missing)
+    if find(genmlx, 'hmm', 'IS') and find(genjl, 'hmm', 'IS'):
+        groups.append((t(find(genmlx, 'hmm', 'IS')), t(find(genjl, 'hmm', 'IS')),
+                       t(find(genjax, 'hmm', 'IS')), t(find(numpyro, 'hmm', 'IS'))))
         labels.append('HMM\nIS(1K)')
 
     # LinReg MH
-    mlx_mh = find(genmlx, 'linreg', 'MH')
-    jl_mh = find(genjl, 'linreg', 'MH')
-    if mlx_mh and jl_mh:
-        groups.append((mlx_mh['time_ms'], jl_mh['time_ms'], None))
-        labels.append('LinReg\nMH(5K)')
+    if find(genmlx, 'linreg', 'MH') and find(genjl, 'linreg', 'MH'):
+        groups.append((t(find(genmlx, 'linreg', 'MH')), t(find(genjl, 'linreg', 'MH')),
+                       None, None))
+        labels.append('LinReg\nMH')
 
     # HMM SMC
-    mlx_smc = find(genmlx, 'hmm', 'SMC')
-    jl_smc = find(genjl, 'hmm', 'SMC')
-    if mlx_smc and jl_smc:
-        groups.append((mlx_smc['time_ms'], jl_smc['time_ms'], None))
+    if find(genmlx, 'hmm', 'SMC') and find(genjl, 'hmm', 'SMC'):
+        groups.append((t(find(genmlx, 'hmm', 'SMC')), t(find(genjl, 'hmm', 'SMC')),
+                       None, None))
         labels.append('HMM\nSMC(100)')
 
     n_groups = len(groups)
     x = np.arange(n_groups)
-    width = 0.25
+    width = 0.2
 
-    fig, ax = plt.subplots(figsize=(5.0, 3.0))
+    fig, ax = plt.subplots(figsize=(5.5, 3.0))
 
+    # GenMLX-paper GRVS system palette (genmlx_style.COLORS): purple = our system,
+    # darkblue = Gen.jl, deepskyblue = GenJAX, coral = NumPyro (out-of-family).
     for i, (label, color, offset) in enumerate([
-        ('GenMLX (Metal GPU)', BLUE, -width),
-        ('Gen.jl (CPU)', ORANGE, 0),
-        ('GenJAX (JIT, CPU)', GREEN, width),
+        ('GenMLX (Metal GPU)', '#8B5CF6', -1.5 * width),
+        ('Gen.jl (CPU)', 'darkblue', -0.5 * width),
+        ('GenJAX (JIT, CPU)', 'deepskyblue', 0.5 * width),
+        ('NumPyro (out-of-family, JIT CPU)', 'coral', 1.5 * width),
     ]):
         vals = []
         positions = []
@@ -921,7 +958,7 @@ def fig9_system_bars():
                 positions.append(x[j] + offset)
         if vals:
             ax.bar(positions, vals, width, label=label, color=color,
-                   edgecolor='white', linewidth=0.5)
+                   edgecolor='black', linewidth=0.5, alpha=0.9)
             # Annotate values
             for pos, v in zip(positions, vals):
                 if v >= 1000:
@@ -937,10 +974,10 @@ def fig9_system_bars():
     ax.set_xticks(x)
     ax.set_xticklabels(labels, fontsize=7)
     ax.set_ylabel('Time (ms, log scale)')
-    ax.legend(loc='upper left', fontsize=6.5)
-    ax.set_title('System Comparison: GenMLX vs Gen.jl vs GenJAX')
+    ax.legend(loc='upper left', fontsize=6.0)
+    ax.set_title('System Comparison: GenMLX vs Gen.jl vs GenJAX vs NumPyro')
 
-    outpath = os.path.join(RESULTS, 'exp4_system_comparison', 'fig9_system_bars.pdf')
+    outpath = os.path.join(RESULTS, 'cross-system', 'fig9_system_bars.pdf')
     fig.savefig(outpath)
     plt.close(fig)
     print(f'  Wrote: {outpath}')
@@ -951,9 +988,10 @@ def fig9_system_bars():
 # ---------------------------------------------------------------------------
 
 def fig10_system_table():
-    genmlx = load_json('exp4_system_comparison/genmlx.json')
-    genjl = load_json('exp4_system_comparison/genjl.json')
-    genjax = load_json('exp4_system_comparison/genjax.json')
+    genmlx = load_genmlx_crosssystem()
+    genjl = load_json('cross-system/genjl.json')
+    genjax = load_json('cross-system/genjax.json')
+    numpyro = load_json('cross-system/numpyro.json')
 
     def find(data, model, algo):
         for c in data['comparisons']:
@@ -977,36 +1015,44 @@ def fig10_system_table():
     rows = [
         ('LinReg', 'IS (1K)',
          find(genmlx, 'linreg', 'IS'), find(genjl, 'linreg', 'IS'),
-         find(genjax, 'linreg', 'IS'), 'Vec IS (Metal) vs JIT (CPU)'),
-        ('LinReg', 'MH (5K)',
+         find(genjax, 'linreg', 'IS'), find(numpyro, 'linreg', 'IS'),
+         'Vec IS (Metal) vs JIT vs effect-handler'),
+        ('LinReg', 'MH',
          find(genmlx, 'linreg', 'MH'), find(genjl, 'linreg', 'MH'),
-         None, 'Compiled MH vs Gen.jl MH'),
+         None, None, 'Compiled MH vs Gen.jl MH'),
         ('HMM', 'IS (1K)',
          find(genmlx, 'hmm', 'IS'), find(genjl, 'hmm', 'IS'),
-         find(genjax, 'hmm', 'IS'), 'Vec IS (Metal) vs Gen.jl (CPU)'),
+         find(genjax, 'hmm', 'IS'), find(numpyro, 'hmm', 'IS'),
+         'Vec IS (Metal) vs Gen.jl (CPU)'),
         ('HMM', 'SMC (100)',
          find(genmlx, 'hmm', 'SMC'), find(genjl, 'hmm', 'SMC'),
-         None, 'Unfold PF vs Gen.jl PF'),
+         None, None, 'Unfold PF vs Gen.jl PF'),
         ('GMM', 'IS (1K)',
          find(genmlx, 'gmm', 'IS'), find(genjl, 'gmm', 'IS'),
-         find(genjax, 'gmm', 'IS'), 'Vec IS (Metal) vs JIT (CPU)'),
+         find(genjax, 'gmm', 'IS'), find(numpyro, 'gmm', 'IS'),
+         'Vec IS (Metal) vs JIT (CPU)'),
     ]
 
-    # LaTeX table
+    # LaTeX table. NumPyro is the out-of-(Gen-)family point: the LinReg IS row is
+    # apples-to-apples (shared 20-pt N(0,2) spec); see numpyro.json accuracy block
+    # for the matched-accuracy claim (NumPyro IS reaches GenMLX's exact L3 log-ML).
     lines = [
         r'\begin{table}[t]',
         r'\centering',
-        r'\caption{System comparison on Apple M2: GenMLX (Metal GPU), Gen.jl (CPU), GenJAX (JIT, CPU).}',
+        r'\caption{System comparison on Apple M-series: GenMLX (Metal GPU), Gen.jl (CPU), '
+        r'GenJAX (JIT, CPU), and the out-of-family NumPyro (effect-handler, JIT CPU). '
+        r'LinReg IS uses the shared 20-point $\mathcal{N}(0,2)$ spec; GenMLX MH/IS '
+        r'timings are on its native bench and indicative, not matched-spec.}',
         r'\label{tab:system-comparison}',
-        r'\begin{tabular}{l l r r r l}',
+        r'\begin{tabular}{l l r r r r l}',
         r'\toprule',
-        r'Model & Algorithm & GenMLX & Gen.jl & GenJAX & Notes \\',
+        r'Model & Algorithm & GenMLX & Gen.jl & GenJAX & NumPyro & Notes \\',
         r'\midrule',
     ]
-    for model, algo, mlx, jl, jx, note in rows:
+    for model, algo, mlx, jl, jx, npyro, note in rows:
         lines.append(
             f'{model} & {algo} & {fmt_ms(mlx)} & {fmt_ms(jl)} '
-            f'& {fmt_ms(jx)} & {note} \\\\'
+            f'& {fmt_ms(jx)} & {fmt_ms(npyro)} & {note} \\\\'
         )
     lines += [
         r'\bottomrule',
@@ -1014,16 +1060,17 @@ def fig10_system_table():
         r'\end{table}',
     ]
 
-    outpath = os.path.join(RESULTS, 'exp4_system_comparison', 'fig10_system_table.tex')
+    outpath = os.path.join(RESULTS, 'cross-system', 'fig10_system_table.tex')
     with open(outpath, 'w') as f:
         f.write('\n'.join(lines) + '\n')
     print(f'  Wrote: {outpath}')
 
 
 def fig10_system_table_pdf():
-    genmlx = load_json('exp4_system_comparison/genmlx.json')
-    genjl = load_json('exp4_system_comparison/genjl.json')
-    genjax = load_json('exp4_system_comparison/genjax.json')
+    genmlx = load_genmlx_crosssystem()
+    genjl = load_json('cross-system/genjl.json')
+    genjax = load_json('cross-system/genjax.json')
+    numpyro = load_json('cross-system/numpyro.json')
 
     def find(data, model, algo):
         for c in data['comparisons']:
@@ -1049,34 +1096,37 @@ def fig10_system_table_pdf():
          fmt_ms(find(genmlx, 'linreg', 'IS')),
          fmt_ms(find(genjl, 'linreg', 'IS')),
          fmt_ms(find(genjax, 'linreg', 'IS')),
-         'Vec IS vs JIT'],
-        ['LinReg', 'MH (5K)',
+         fmt_ms(find(numpyro, 'linreg', 'IS')),
+         'Vec IS vs JIT vs eff-handler'],
+        ['LinReg', 'MH',
          fmt_ms(find(genmlx, 'linreg', 'MH')),
          fmt_ms(find(genjl, 'linreg', 'MH')),
-         '---',
+         '---', '---',
          'Compiled MH'],
         ['HMM', 'IS (1K)',
          fmt_ms(find(genmlx, 'hmm', 'IS')),
          fmt_ms(find(genjl, 'hmm', 'IS')),
          fmt_ms(find(genjax, 'hmm', 'IS')),
+         fmt_ms(find(numpyro, 'hmm', 'IS')),
          'Sequential'],
         ['HMM', 'SMC (100)',
          fmt_ms(find(genmlx, 'hmm', 'SMC')),
          fmt_ms(find(genjl, 'hmm', 'SMC')),
-         '---',
+         '---', '---',
          'Unfold PF'],
         ['GMM', 'IS (1K)',
          fmt_ms(find(genmlx, 'gmm', 'IS')),
          fmt_ms(find(genjl, 'gmm', 'IS')),
          fmt_ms(find(genjax, 'gmm', 'IS')),
+         fmt_ms(find(numpyro, 'gmm', 'IS')),
          'Sequential vs JIT'],
     ]
 
-    outpath = os.path.join(RESULTS, 'exp4_system_comparison', 'fig10_system_table.pdf')
+    outpath = os.path.join(RESULTS, 'cross-system', 'fig10_system_table.pdf')
     _render_table_pdf(
-        ['Model', 'Algorithm', 'GenMLX', 'Gen.jl', 'GenJAX', 'Notes'],
-        pdf_rows, 'System Comparison: Apple M2', outpath,
-        col_widths=[0.12, 0.12, 0.12, 0.12, 0.12, 0.22])
+        ['Model', 'Algorithm', 'GenMLX', 'Gen.jl', 'GenJAX', 'NumPyro', 'Notes'],
+        pdf_rows, 'System Comparison: Apple M-series', outpath,
+        col_widths=[0.10, 0.11, 0.11, 0.10, 0.10, 0.11, 0.22])
 
 
 # ---------------------------------------------------------------------------

--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -19,6 +19,7 @@
             [genmlx.compiled-ops :as cops]
             [genmlx.conjugacy :as conj]
             [genmlx.rewrite :as rewrite]
+            [genmlx.linear-gaussian :as lg]
             [genmlx.inference.auto-analytical :as auto]
             [genmlx.dispatch :as dispatch]
             [clojure.set :as set]))
@@ -361,6 +362,9 @@
                  {:choices cm/EMPTY :score SCORE-ZERO :weight SCORE-ZERO
                   :key key :selection selection
                   :old-choices (:choices trace)
+                  ;; Linear-Gaussian block regenerate handlers recover the design
+                  ;; matrix by probing the obs mean forms against the model args.
+                  :model-args (:args trace)
                   :auto-posteriors {} :auto-kalman-beliefs {} :auto-kalman-noise-vars {}
                   :old-splice-scores (::splice-scores (meta trace))
                   :old-nested-splice-scores (::nested-splice-scores (meta trace))
@@ -755,20 +759,30 @@
                  (let [augmented (conj/augment-schema-with-conjugacy schema)]
                    (if (:has-conjugate? augmented)
                      (let [plan (rewrite/build-analytical-plan augmented source)
-                           ;; v1: regenerate DECLINES linear-Gaussian blocks (and
-                           ;; declined concern-components) — exclude their addrs so
-                           ;; the latents fall through to base regenerate (sampled).
+                           ;; Keep both declined concern-components AND linear-Gaussian
+                           ;; block addrs off the SCALAR regenerate path: declined addrs
+                           ;; fall through to base regenerate (sampled), and block addrs
+                           ;; would be mis-handled by the per-prior scalar conjugate path
+                           ;; (the off-by-affine-coefficient bug). Blocks instead get
+                           ;; dedicated joint regenerate handlers merged in below
+                           ;; (genmlx-m3tn: Rao-Blackwell under MH moves).
+                           lg-blocks (:lg-blocks plan)
                            lg-excluded (into (set (:declined-addrs plan))
-                                             (mapcat :all-addrs (:lg-blocks plan)))
+                                             (mapcat :all-addrs lg-blocks))
                            regen-pairs (if (seq lg-excluded)
                                          (remove (fn [p]
                                                    (or (contains? lg-excluded (:prior-addr p))
                                                        (contains? lg-excluded (:obs-addr p))))
                                                  (:conjugate-pairs augmented))
                                          (:conjugate-pairs augmented))
-                           regen-handlers (auto/build-all-regenerate-handlers
-                                           regen-pairs
-                                           :chains (:kalman-chains plan))
+                           scalar-regen-handlers (auto/build-all-regenerate-handlers
+                                                  regen-pairs
+                                                  :chains (:kalman-chains plan))
+                           block-regen-handlers (reduce
+                                                 (fn [m blk]
+                                                   (merge m (lg/make-lg-handlers blk :regenerate)))
+                                                 {} lg-blocks)
+                           regen-handlers (merge scalar-regen-handlers block-regen-handlers)
                            ;; Opt 1: precompute dispatch transition once at construction
                            regen-transition (when (seq regen-handlers)
                                               (auto/make-address-dispatch

--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -335,7 +335,7 @@
                      h/generate-transition (:auto-handlers schema))
         result (rt/run-handler transition
                  {:choices cm/EMPTY :score SCORE-ZERO :weight SCORE-ZERO
-                  :key key :constraints constraints
+                  :key key :constraints constraints :model-args args
                   :auto-posteriors {} :auto-kalman-beliefs {} :auto-kalman-noise-vars {}
                   :executor execute-sub :param-store (param-store gf)}
                  (fn [rt] (run-body gf rt args)))
@@ -348,7 +348,7 @@
                      h/assess-transition (:auto-handlers schema))
         result (rt/run-handler transition
                  {:choices cm/EMPTY :score SCORE-ZERO :weight SCORE-ZERO
-                  :key key :constraints constraints
+                  :key key :constraints constraints :model-args args
                   :auto-posteriors {} :auto-kalman-beliefs {} :auto-kalman-noise-vars {}
                   :executor execute-sub-assess :param-store (param-store gf)}
                  (fn [rt] (run-body gf rt args)))]
@@ -754,9 +754,20 @@
         schema (if (and schema (not (:opaque-gen-escape? schema)))
                  (let [augmented (conj/augment-schema-with-conjugacy schema)]
                    (if (:has-conjugate? augmented)
-                     (let [plan (rewrite/build-analytical-plan augmented)
+                     (let [plan (rewrite/build-analytical-plan augmented source)
+                           ;; v1: regenerate DECLINES linear-Gaussian blocks (and
+                           ;; declined concern-components) — exclude their addrs so
+                           ;; the latents fall through to base regenerate (sampled).
+                           lg-excluded (into (set (:declined-addrs plan))
+                                             (mapcat :all-addrs (:lg-blocks plan)))
+                           regen-pairs (if (seq lg-excluded)
+                                         (remove (fn [p]
+                                                   (or (contains? lg-excluded (:prior-addr p))
+                                                       (contains? lg-excluded (:obs-addr p))))
+                                                 (:conjugate-pairs augmented))
+                                         (:conjugate-pairs augmented))
                            regen-handlers (auto/build-all-regenerate-handlers
-                                           (:conjugate-pairs augmented)
+                                           regen-pairs
                                            :chains (:kalman-chains plan))
                            ;; Opt 1: precompute dispatch transition once at construction
                            regen-transition (when (seq regen-handlers)
@@ -766,6 +777,7 @@
                            (assoc :auto-handlers (get-in plan [:rewrite-result :handlers]))
                            (assoc :auto-regenerate-handlers regen-handlers)
                            (assoc :auto-regenerate-transition regen-transition)
+                           (assoc :linear-gaussian-blocks (:lg-blocks plan))
                            (assoc :analytical-plan plan)))
                      augmented))
                  schema)]

--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -37,6 +37,7 @@
             [genmlx.gradients :as grad]
             [genmlx.verify :as verify]
             [genmlx.inference.mcmc :as mcmc]
+            [genmlx.inference.smc :as smc]
             [genmlx.inference.util :as u]
             [genmlx.learning :as learn]
             [genmlx.combinators :as comb]))
@@ -1494,6 +1495,52 @@
                      (recur (inc t) trace k2
                             (approx= w expected 1e-4)))))))}
 
+   {:name :pf-log-ml-convergence
+    :from "[T] Alg 7 — bootstrap PF log-ML = sum_j (logsumexp(weights_j) - log N) -> Kalman"
+    :theorem "For a bootstrap particle filter on an analytically tractable
+              Gaussian SSM (x_t ~ N(x_{t-1},1), y_t ~ N(x_t,1)), the
+              accumulated log marginal likelihood
+                log_ml = sum_j [logsumexp(weights_j) - log N]
+              converges to the exact Kalman-filter log-evidence as N grows.
+              Conjugacy is stripped so the bootstrap (prior) proposal is used:
+              the optimal proposal collapses particle diversity and biases the
+              log-ML estimate. Verified on y=[1,2,0.5], N=1000:
+              |SMC log-ML - Kalman| < 0.25 nats."
+    :tags #{:inference :smc :pf}
+    :check (fn [_]
+             (let [kernel (dyn/make-gen-fn
+                           (fn [rt]
+                             (let [trace (.-trace rt)
+                                   args (.-args rt)
+                                   prev-state (second args)
+                                   x (trace :x (dist/gaussian prev-state 1))]
+                               (trace :y (dist/gaussian x 1))
+                               x))
+                           '([t prev-state]
+                             (let [x (trace :x (dist/gaussian prev-state 1))]
+                               (trace :y (dist/gaussian x 1))
+                               x)))
+                   ;; Strip conjugacy -> force bootstrap (prior) proposal.
+                   stripped (assoc kernel :schema
+                                   (dissoc (:schema kernel)
+                                           :auto-handlers :conjugate-pairs
+                                           :has-conjugate? :analytical-plan
+                                           :auto-regenerate-transition))
+                   ys [1.0 2.0 0.5]
+                   obs-seq (mapv #(cm/choicemap :y (mx/scalar %)) ys)
+                   ;; Kalman analytical log-evidence (per-step innovation LLs):
+                   ;; step0 P_pred=1,S=2,innov=1; step1 P_pred=1.5,S=2.5,innov=1.5;
+                   ;; step2 P_pred=1.6,S=2.6,innov=-0.9.
+                   LOG-2PI (js/Math.log (* 2 js/Math.PI))
+                   ll0 (* -0.5 (+ LOG-2PI (js/Math.log 2.0) (/ 1.0 2.0)))
+                   ll1 (* -0.5 (+ LOG-2PI (js/Math.log 2.5) (/ 2.25 2.5)))
+                   ll2 (* -0.5 (+ LOG-2PI (js/Math.log 2.6) (/ 0.81 2.6)))
+                   analytical (+ ll0 ll1 ll2)
+                   result (smc/smc-unfold {:particles 1000 :key (rng/fresh-key 42)}
+                                          stripped (mx/scalar 0.0) obs-seq)
+                   smc-log-ml (ev (:log-ml result))]
+               (approx= smc-log-ml analytical 0.25)))}
+
    ;; ===================================================================
    ;; AIS DENSITY RATIO laws [T] Alg 8
    ;; ===================================================================
@@ -1538,6 +1585,58 @@
                    total (reduce + increments)]
                (and (every? #(approx= % expected-inc 1e-10) increments)
                     (approx= total lik-score 1e-10))))}
+
+   {:name :ais-weight-accumulation
+    :from "[T] Alg 8 — AIS log-Z = logsumexp(accumulated weights) - log N -> analytical"
+    :theorem "Annealed Importance Sampling accumulates log-weights across a
+              temperature schedule beta_0=0,...,beta_n=1. For the annealed
+              Normal-Normal target f_beta(x) = p_0(x) * L(x)^beta with
+              x ~ N(0,2) and L(x) = N(y | x, 1), the per-step increment is the
+              tempered-score difference (a GFI weight under a temperature
+              change):
+                z_hat_j = z_hat_{j-1} + (beta_j - beta_{j-1}) * log L(x_{j-1}),
+              with x_j resampled from the exact tempered posterior (a kernel
+              leaving f_beta invariant). The AIS estimate
+                log Z = logsumexp_i(z_hat_i) - log N
+              converges to the true marginal log-likelihood. Verified on y=3:
+              analytical log p(y) = log N(3; 0, sqrt(5)) ~ -2.6236, N=2000,
+              |AIS - analytical| < 0.1 nats."
+    :tags #{:inference :ais}
+    :check (fn [_]
+             (let [n 2000
+                   ys 3.0
+                   betas [0.0 0.25 0.5 0.75 1.0]
+                   n-steps (dec (count betas))
+                   sp2 4.0                       ; prior variance (sd 2)
+                   ;; Exact tempered posterior at beta (lik var = 1):
+                   ;;   prec = 1/sp2 + beta, var = 1/prec, mean = var*beta*y
+                   tpost (fn [b] (let [v (/ 1.0 (+ (/ 1.0 sp2) b))]
+                                   {:mean (* v b ys) :sd (js/Math.sqrt v)}))
+                   [k-init k-loop] (rng/split (rng/fresh-key 7))
+                   ;; x_0 ~ prior N(0, 2), shape [n]
+                   x0 (mx/multiply (mx/scalar 2.0) (rng/normal k-init [n]))
+                   lw (loop [j 1, x x0, acc (mx/scalar 0.0), k k-loop]
+                        (if (> j n-steps)
+                          acc
+                          (let [b   (nth betas j)
+                                db  (- b (nth betas (dec j)))
+                                ;; log L(x) = log N(y | x, 1), shape [n]
+                                logL (dist/log-prob (dist/gaussian x 1) (mx/scalar ys))
+                                acc' (mx/add acc (mx/multiply (mx/scalar db) logL))
+                                {pm :mean psd :sd} (tpost b)
+                                [k1 k2] (rng/split k)
+                                x'  (mx/add (mx/scalar pm)
+                                            (mx/multiply (mx/scalar psd)
+                                                         (rng/normal k1 [n])))]
+                            (recur (inc j) x' acc' k2))))
+                   _ (mx/materialize! lw)
+                   log-z (ev (mx/subtract (mx/logsumexp lw)
+                                          (mx/scalar (js/Math.log n))))
+                   ;; analytical log p(y) = log N(3; 0, sqrt(5))
+                   analytical (- (* -0.5 (js/Math.log (* 2 js/Math.PI)))
+                                 (* 0.5 (js/Math.log 5.0))
+                                 (* 0.5 (/ 9.0 5.0)))]
+               (approx= log-z analytical 0.1)))}
 
    ;; ===================================================================
    ;; INVOLUTIVE MCMC laws [T] §3.7, Def 3.7.1, Eq 3.15, Eq 3.17

--- a/src/genmlx/inference/diagnostics.cljs
+++ b/src/genmlx/inference/diagnostics.cljs
@@ -52,6 +52,177 @@
                 (recur (+ lag 2) (+ sum-rho pair-sum))))))))))
 
 ;; ---------------------------------------------------------------------------
+;; Rank-normalized bulk-ESS and tail-ESS (Vehtari et al. 2021,
+;; "Rank-normalization, folding, and localization: An improved R-hat")
+;;
+;; SCOPE: bulk-ess/tail-ess (and r-hat) are MULTI-CHAIN MCMC diagnostics --
+;; they take several independent chains and quantify mixing/convergence of a
+;; scalar marginal via autocorrelation. They do NOT apply to particle methods
+;; (importance sampling / SMC), which have no chains and no autocorrelation;
+;; those report weight-based ESS (u/compute-ess) instead. Hence the funnel
+;; (HMC/NUTS/MH) bench carries r-hat + bulk/tail-ESS, while the hmm/gmm/
+;; changepoint (IS/SMC) benches carry weight-based ESS -- by design, not omission.
+;; ---------------------------------------------------------------------------
+
+(defn- chain->doubles
+  "Materialize a chain (vector of MLX scalars or plain numbers) to doubles."
+  [chain]
+  (mapv (fn [s]
+          (cond
+            (number? s) s
+            (mx/array? s) (do (mx/materialize! s) (mx/item s))
+            :else s))
+        chain))
+
+(defn- quantile
+  "Type-7 (linear-interpolation) quantile of a vector of doubles."
+  [vals p]
+  (let [sorted (vec (sort vals))
+        s (count sorted)
+        h (* (dec s) p)
+        lo (int (js/Math.floor h))
+        hi (min (dec s) (inc lo))
+        frac (- h lo)]
+    (+ (nth sorted lo) (* frac (- (nth sorted hi) (nth sorted lo))))))
+
+(defn- autocovariance
+  "Biased autocovariances gamma_t = (1/n) sum_i (x_i-xbar)(x_{i+t}-xbar),
+   t = 0..n-1. Returns a vector of n doubles."
+  [xs]
+  (let [n (count xs)
+        v (vec xs)
+        xbar (/ (reduce + v) n)
+        c (mapv #(- % xbar) v)]
+    (mapv (fn [t]
+            (/ (loop [i 0 acc 0.0]
+                 (if (< i (- n t))
+                   (recur (inc i) (+ acc (* (nth c i) (nth c (+ i t)))))
+                   acc))
+               n))
+          (range n))))
+
+(defn- polyval
+  "Horner evaluation: [k0 k1 ... km] x -> k0 x^m + k1 x^(m-1) + ... + km."
+  [coeffs x]
+  (reduce (fn [acc k] (+ (* acc x) k)) 0.0 coeffs))
+
+(defn- inv-normal-cdf
+  "Inverse standard-normal CDF (Acklam's rational approximation, |err|<1.15e-9)."
+  [p]
+  (let [a [-3.969683028665376e+01 2.209460984245205e+02 -2.759285104469687e+02
+           1.383577518672690e+02 -3.066479806614716e+01 2.506628277459239e+00]
+        b [-5.447609879822406e+01 1.615858368580409e+02 -1.556989798598866e+02
+           6.680131188771972e+01 -1.328068155288572e+01 1.0]
+        c [-7.784894002430293e-03 -3.223964580411365e-01 -2.400758277161838e+00
+           -2.549732539343734e+00 4.374664141464968e+00 2.938163982698783e+00]
+        d [7.784695709041462e-03 3.224671290700398e-01 2.445134137142996e+00
+           3.754408661907416e+00 1.0]
+        plow 0.02425
+        phigh (- 1.0 plow)]
+    (cond
+      (< p plow)   (let [q (js/Math.sqrt (* -2.0 (js/Math.log p)))]
+                     (/ (polyval c q) (polyval d q)))
+      (<= p phigh) (let [q (- p 0.5) r (* q q)]
+                     (/ (* (polyval a r) q) (polyval b r)))
+      :else        (let [q (js/Math.sqrt (* -2.0 (js/Math.log (- 1.0 p))))]
+                     (- (/ (polyval c q) (polyval d q)))))))
+
+(defn- rank-normalize
+  "Average-rank-normalize a pooled vector via the Blom transform
+   z_i = Phi^{-1}((r_i - 3/8)/(S - 1/4)). Returns a vector aligned with input."
+  [pooled]
+  (let [s (count pooled)
+        order (vec (sort-by (fn [i] (nth pooled i)) (range s)))
+        ranks (double-array s)]
+    (loop [k 0]
+      (when (< k s)
+        (let [vk (nth pooled (nth order k))
+              j (loop [j (inc k)]
+                  (if (and (< j s) (= (nth pooled (nth order j)) vk))
+                    (recur (inc j)) j))
+              avg (/ (+ (inc k) j) 2.0)]   ; mean of 1-based ranks (k+1 .. j)
+          (doseq [t (range k j)] (aset ranks (nth order t) avg))
+          (recur j))))
+    (mapv (fn [i] (inv-normal-cdf (/ (- (aget ranks i) 0.375) (- s 0.25))))
+          (range s))))
+
+(defn- split-chains
+  "Split each chain into two halves, dropping the middle element if odd length."
+  [chains-vals]
+  (vec (mapcat (fn [c]
+                 (let [c (vec c) n (count c) h (quot n 2)]
+                   [(subvec c 0 h) (subvec c (- n h) n)]))
+               chains-vals)))
+
+(defn- ess-from-chains
+  "Multi-chain effective sample size (Vehtari et al. 2021 / Stan) over chains of
+   equal length given as vectors of doubles. Returns a number."
+  [chains-vals]
+  (let [m (count chains-vals)
+        n (count (first chains-vals))]
+    (if (< n 8)
+      (* m n)
+      (let [acovs (mapv autocovariance chains-vals)
+            means (mapv (fn [xs] (/ (reduce + xs) n)) chains-vals)
+            mean-var (* (/ (reduce + (map #(nth % 0) acovs)) m) (/ n (dec n)))
+            grand (/ (reduce + means) m)
+            between (if (> m 1)
+                      (/ (reduce + (map #(let [e (- % grand)] (* e e)) means)) (dec m))
+                      0.0)
+            var-plus (+ (* mean-var (/ (dec n) n)) between)]
+        (if (<= var-plus 0.0)
+          (* m n)                          ; degenerate (constant) -> nominal
+          (let [rho (fn [t]
+                      (if (zero? t) 1.0
+                          (- 1.0 (/ (- mean-var (/ (reduce + (map #(nth % t) acovs)) m))
+                                    var-plus))))
+                ;; Geyer pair-sums Gamma_k = rho(2k) + rho(2k+1)
+                gammas (loop [k 0 acc []]
+                         (let [te (* 2 k) to (inc te)]
+                           (if (> to (dec n))
+                             acc
+                             (recur (inc k) (conj acc (+ (rho te) (rho to)))))))
+                pos-gammas (vec (take-while pos? gammas))]
+            (if (empty? pos-gammas)
+              (* m n)
+              (let [mono (reductions min (first pos-gammas) (rest pos-gammas))
+                    tau (max (- (* 2.0 (reduce + mono)) 1.0)
+                             (/ 1.0 (js/Math.log10 (* m n))))]
+                (/ (* m n) tau)))))))))
+
+(defn bulk-ess
+  "Rank-normalized bulk effective sample size (Vehtari et al. 2021).
+   chains: vector of equal-length chains, each a vector of MLX scalars or
+   numbers. Captures sampling efficiency for the bulk of the distribution."
+  [chains]
+  (let [chains-d (mapv chain->doubles chains)
+        n (count (first chains-d))]
+    (if (or (zero? n) (some #(not= n (count %)) chains-d))
+      0.0
+      (let [pooled (vec (apply concat chains-d))
+            z (rank-normalize pooled)
+            z-chains (mapv (fn [ci] (subvec z (* ci n) (* (inc ci) n)))
+                           (range (count chains-d)))]
+        (ess-from-chains (split-chains z-chains))))))
+
+(defn tail-ess
+  "Tail effective sample size (Vehtari et al. 2021): the minimum of the ESS of
+   the 5%- and 95%-quantile tail indicators (pooled quantiles, split chains).
+   chains: vector of equal-length chains of MLX scalars or numbers."
+  [chains]
+  (let [chains-d (mapv chain->doubles chains)
+        n (count (first chains-d))]
+    (if (or (zero? n) (some #(not= n (count %)) chains-d))
+      0.0
+      (let [pooled (vec (apply concat chains-d))
+            q05 (quantile pooled 0.05)
+            q95 (quantile pooled 0.95)
+            indic (fn [thr] (mapv (fn [c] (mapv (fn [x] (if (<= x thr) 1.0 0.0)) c))
+                                  chains-d))]
+        (min (ess-from-chains (split-chains (indic q05)))
+             (ess-from-chains (split-chains (indic q95))))))))
+
+;; ---------------------------------------------------------------------------
 ;; R-hat (Gelman-Rubin)
 ;; ---------------------------------------------------------------------------
 

--- a/src/genmlx/linear_gaussian.cljs
+++ b/src/genmlx/linear_gaussian.cljs
@@ -28,15 +28,26 @@
    which is algebraically identical to the batch marginal/posterior (chain rule
    of the joint Gaussian density) and fits the per-address handler structure.
 
-   v1 scope: generate + assess (exact). regenerate/update DECLINE (the block is
-   excluded from regenerate handlers, so its latents fall through to sampling).
-   Blocks whose latents have non-conjugate children, latent-dependent noise,
-   non-affine means, or latents not preceding their observations are DECLINED —
+   Scope: generate + assess (exact), and regenerate (genmlx-m3tn: the block stays
+   Rao-Blackwellised under MH moves over unrelated residual latents; selecting a
+   block latent re-opens the whole block). UPDATE still declines (no analytical
+   :update path yet — genmlx-6hcu).
+
+   Partial conjugacy (genmlx-4q9d): when the obs noise depends on a RESIDUAL
+   (non-block) latent — e.g. y_j ~ N(slope·x_j+intercept, sigma) with sigma ~ Gamma
+   — the block is eliminated CONDITIONAL on the sampled residual (the marginal is
+   exact per sample; the population gives E_residual[block marginal], a strictly
+   Rao-Blackwellised IS/MH estimate).
+
+   Blocks whose latents have non-conjugate children, whose noise references a
+   BLOCK latent, with non-affine means, with residual noise latents that do not
+   precede the obs, or latents not preceding their observations are DECLINED —
    their pairs are removed so no rule claims a (wrong) exact elimination."
   (:require [clojure.set :as set]
             [genmlx.mlx :as mx]
             [genmlx.mlx.constants :refer [LOG-2PI]]
             [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
             [genmlx.compiled :as compiled]))
 
 ;; ===========================================================================
@@ -101,6 +112,14 @@
   (let [names (into #{} (map name) addrs)]
     (boolean (some #(contains? names (name %)) (form-symbols form)))))
 
+(defn- form-trace-addrs
+  "Trace-site addresses (drawn from all-addrs) referenced anywhere in a source
+   form, matched by symbol name. Used to separate an observation's MEAN deps
+   (must be block latents) from its NOISE deps (may be residual latents)."
+  [form all-addrs]
+  (let [by-name (into {} (map (fn [a] [(name a) a])) all-addrs)]
+    (into #{} (keep #(get by-name (name %))) (form-symbols form))))
+
 (defn- connected-components
   "Undirected connected components over conjugate pairs (prior-addr ↔ obs-addr).
    Returns a seq of {:nodes :latents :obs :pairs}."
@@ -144,9 +163,15 @@
    Returns {:eligible? true :block desc} or {:eligible? false}.
 
    Eligible when: priors are independent (no latent in another latent's prior),
-   obs depend only on block latents, no latent has a non-conjugate child, obs
-   noise is latent-independent, latents precede all obs in dep-order, and every
-   obs mean/sigma form compiles."
+   obs MEANS depend only on block latents, no block latent has a non-conjugate
+   child, obs noise references no block latent, block latents precede all obs in
+   dep-order, and every obs mean/sigma form compiles.
+
+   Partial conjugacy (genmlx-4q9d): obs NOISE may reference RESIDUAL (non-block)
+   latents — the block is then eliminated CONDITIONAL on those residual values
+   (read at runtime from :choices). Such residual noise latents must precede the
+   block obs in dep-order, and are recorded as :noise-latents so the obs handlers
+   inject their sampled values when evaluating the noise form."
   [comp schema binding-env site-map dep-idx all-trace-addrs]
   (let [latents (:latents comp)
         obs     (:obs comp)
@@ -158,11 +183,11 @@
         ;; (a) independent priors: a latent's prior must not reference another latent
         indep-priors? (every? (fn [s] (not (references-any? (vec (:dist-args s)) latents)))
                                latent-sites)
-        ;; (b) obs depend only on block latents (mean only references block latents)
-        obs-deps-ok? (every? (fn [s]
-                               (set/subset? (set/intersection (:deps s) all-trace-addrs)
-                                            latents))
-                             obs-sites)
+        ;; (b) obs MEAN references only block latents (noise handled separately below)
+        mean-deps-ok? (every? (fn [s]
+                                (set/subset? (form-trace-addrs (mean-form s) all-trace-addrs)
+                                             latents))
+                              obs-sites)
         ;; (c) no non-conjugate children of any block latent
         children-conjugate?
         (every? (fn [la]
@@ -170,9 +195,21 @@
                                       (contains? obs (:addr s))))
                           (:trace-sites schema)))
                 latents)
-        ;; (d) noise latent-independent: sigma form references no block latent
-        noise-ok? (every? (fn [s] (not (references-any? (sigma-form s) latents))) obs-sites)
-        ;; (e) latents precede obs in dep-order
+        ;; (d) noise references no BLOCK latent (it may reference residual latents)
+        sigma-block-free? (every? (fn [s] (not (references-any? (sigma-form s) latents))) obs-sites)
+        ;; (d') residual latents the noise depends on (genmlx-4q9d): exclude block
+        ;; latents and block obs — what remains are the residual noise latents.
+        noise-latents (reduce (fn [acc s]
+                                (set/union acc (set/difference
+                                                (form-trace-addrs (sigma-form s) all-trace-addrs)
+                                                latents obs)))
+                              #{} obs-sites)
+        ;; (d'') residual noise latents must precede all block obs in dep-order, so
+        ;; their sampled value is available in :choices when the obs handler fires.
+        noise-precede? (or (empty? noise-latents)
+                           (let [min-obs (apply min (map #(get dep-idx % 0) order-obs))]
+                             (every? #(< (get dep-idx % 0) min-obs) noise-latents)))
+        ;; (e) block latents precede obs in dep-order
         order-ok? (or (empty? order-obs)
                       (< (apply max (map #(get dep-idx % 0) latents))
                          (apply min (map #(get dep-idx % 0) obs))))
@@ -184,13 +221,15 @@
                            :sigma-fn (compiled/compile-expr (sigma-form s) binding-env #{})}))
                       order-obs)
         forms-ok? (every? #(and (:mean-fn %) (:sigma-fn %)) obs-fns)]
-    (if (and indep-priors? obs-deps-ok? children-conjugate? noise-ok? order-ok? forms-ok?)
+    (if (and indep-priors? mean-deps-ok? children-conjugate? sigma-block-free?
+             noise-precede? order-ok? forms-ok?)
       {:eligible? true
        :block {:id order-latents            ; stable id (blocks are disjoint)
                :latents order-latents
                :latent-index (into {} (map-indexed (fn [i a] [a i])) order-latents)
                :p (count order-latents)
                :obs obs-fns
+               :noise-latents noise-latents
                :latent-addrs order-latents
                :obs-addrs order-obs
                :all-addrs (set/union latents obs)}}
@@ -249,58 +288,102 @@
     {:h h :c c}))
 
 (defn make-lg-handlers
-  "Build generate-mode address handlers for a linear-Gaussian block.
+  "Build address handlers for a linear-Gaussian block, parameterized by `mode`.
 
    Latent handlers collect each prior (mean, var) and, once all are seen,
    materialise the joint belief. Observation handlers perform a vector-Kalman
    measurement update against the model args (read from :model-args in state),
-   accumulating the marginal LL into :score and :weight and writing posterior
-   means back to the latent choices. Handlers return nil (fall through) when the
-   block cannot proceed (missing args/belief, unconstrained obs)."
-  [block]
-  (let [{:keys [id latents p obs]} block
-        latent-handlers
-        (into {}
-              (map (fn [la]
-                     [la
-                      (fn [state _addr dist]
-                        (let [{:keys [mu sigma]} (:params dist)
-                              var (mx/multiply sigma sigma)
-                              st (-> state
-                                     (assoc-in [:lg-init id la] {:mean (coerce-scalar mu)
-                                                                 :var (coerce-scalar var)})
-                                     (update :choices cm/set-value la mu))
-                              inits (get-in st [:lg-init id])
-                              st (if (= (count inits) p)
-                                   (let [m0 (mx/stack (mapv #(:mean (get inits %)) latents))
-                                         s0 (mx/diag (mx/stack (mapv #(:var (get inits %)) latents)))]
-                                     (assoc-in st [:lg-belief id] {:mean m0 :cov s0}))
-                                   st)]
-                          [mu st]))]))
-              latents)
-        obs-handlers
-        (into {}
-              (map (fn [{:keys [addr mean-fn sigma-fn]}]
-                     [addr
-                      (fn [state _addr _dist]
-                        (let [belief (get-in state [:lg-belief id])
-                              args (:model-args state)
-                              constraint (cm/get-submap (:constraints state) addr)]
-                          (when (and belief args (cm/has-value? constraint))
-                            (let [y (cm/get-value constraint)
-                                  {:keys [h c]} (obs-design mean-fn latents args)
-                                  s (coerce-scalar
-                                     (sigma-fn (zipmap latents (repeat (mx/scalar 0.0))) args))
-                                  r (mx/multiply s s)
-                                  {:keys [mean cov ll]} (lg-kalman-step belief {:y y :h h :c c :r r})
-                                  st (reduce (fn [st i]
-                                               (update st :choices cm/set-value
-                                                       (nth latents i) (mx/index mean i)))
-                                             state (range p))]
-                              [y (-> st
-                                     (assoc-in [:lg-belief id] {:mean mean :cov cov})
-                                     (update :choices cm/set-value addr y)
-                                     (update :score mx/add ll)
-                                     (update :weight mx/add ll))]))))]))
-              obs)]
-    (merge latent-handlers obs-handlers)))
+   writing posterior means back to the latent choices. Handlers return nil (fall
+   through) when the block cannot proceed (missing args/belief, unconstrained obs).
+
+   :generate (default) — obs read :constraints; the marginal LL accumulates into
+     BOTH :score and :weight; latents write the prior mean (placeholder,
+     overwritten with the posterior mean by the obs handlers). Used for generate
+     AND assess.
+   :regenerate — mirrors the scalar-conjugate regenerate contract (genmlx-m3tn).
+     The block is a JOINTLY coupled unit, so if ANY block latent is selected the
+     WHOLE block re-opens: every block handler returns nil, falling through to the
+     base regenerate transition (selected latents resample from prior, others keep
+     their old value, obs scored plainly). Otherwise (no block latent selected)
+     latents seed the belief and write their OLD value; obs read :old-choices, do
+     the Kalman update, write posterior means, and accumulate the marginal LL into
+     :score ONLY (not :weight) — so an MH move over an unrelated residual sees the
+     block's Rao-Blackwellised contribution to the target without double-counting.
+
+   Partial conjugacy (genmlx-4q9d): when the block has :noise-latents, the obs
+   handlers read those residual latents' sampled values from :choices and inject
+   them into the noise (sigma) form — eliminating the block CONDITIONAL on the
+   current residual. The marginal LL is then exact per residual sample, and the
+   overall estimate is E_residual[block marginal] over the particle population."
+  ([block] (make-lg-handlers block :generate))
+  ([block mode]
+   (let [{:keys [id latents p obs noise-latents]} block
+         noise-latents (or noise-latents #{})
+         regenerate? (= mode :regenerate)
+         block-reopened?
+         (fn [state]
+           (and regenerate?
+                (:selection state)
+                (boolean (some #(sel/selected? (:selection state) %) latents))))
+         latent-handlers
+         (into {}
+               (map (fn [la]
+                      [la
+                       (fn [state _addr dist]
+                         (when-not (block-reopened? state)
+                           (let [{:keys [mu sigma]} (:params dist)
+                                 var (mx/multiply sigma sigma)
+                                 value (if regenerate?
+                                         (cm/get-value (cm/get-submap (:old-choices state) la))
+                                         mu)
+                                 st (-> state
+                                        (assoc-in [:lg-init id la] {:mean (coerce-scalar mu)
+                                                                    :var (coerce-scalar var)})
+                                        (update :choices cm/set-value la value))
+                                 inits (get-in st [:lg-init id])
+                                 st (if (= (count inits) p)
+                                      (let [m0 (mx/stack (mapv #(:mean (get inits %)) latents))
+                                            s0 (mx/diag (mx/stack (mapv #(:var (get inits %)) latents)))]
+                                        (assoc-in st [:lg-belief id] {:mean m0 :cov s0}))
+                                      st)]
+                             [value st])))]))
+               latents)
+         obs-handlers
+         (into {}
+               (map (fn [{:keys [addr mean-fn sigma-fn]}]
+                      [addr
+                       (fn [state _addr _dist]
+                         (when-not (block-reopened? state)
+                           (let [belief (get-in state [:lg-belief id])
+                                 args (:model-args state)
+                                 constraint (if regenerate?
+                                              (cm/get-submap (:old-choices state) addr)
+                                              (cm/get-submap (:constraints state) addr))
+                                 ;; Residual noise latents (genmlx-4q9d): their sampled
+                                 ;; values, read live from :choices (set before the obs by
+                                 ;; dep-order). Empty for v1 constant/block-free noise.
+                                 noise-ready? (every? #(cm/has-value? (cm/get-submap (:choices state) %))
+                                                      noise-latents)]
+                             (when (and belief args noise-ready? (cm/has-value? constraint))
+                               (let [y (cm/get-value constraint)
+                                     {:keys [h c]} (obs-design mean-fn latents args)
+                                     noise-vals (into {} (map (fn [nl]
+                                                                [nl (cm/get-value
+                                                                     (cm/get-submap (:choices state) nl))]))
+                                                      noise-latents)
+                                     sigma-env (merge (zipmap latents (repeat (mx/scalar 0.0)))
+                                                      noise-vals)
+                                     s (coerce-scalar (sigma-fn sigma-env args))
+                                     r (mx/multiply s s)
+                                     {:keys [mean cov ll]} (lg-kalman-step belief {:y y :h h :c c :r r})
+                                     st (reduce (fn [st i]
+                                                  (update st :choices cm/set-value
+                                                          (nth latents i) (mx/index mean i)))
+                                                state (range p))]
+                                 [y (cond-> (-> st
+                                                (assoc-in [:lg-belief id] {:mean mean :cov cov})
+                                                (update :choices cm/set-value addr y)
+                                                (update :score mx/add ll))
+                                      (not regenerate?) (update :weight mx/add ll))])))))]))
+               obs)]
+     (merge latent-handlers obs-handlers))))

--- a/src/genmlx/linear_gaussian.cljs
+++ b/src/genmlx/linear_gaussian.cljs
@@ -1,0 +1,306 @@
+(ns genmlx.linear-gaussian
+  "L3 joint linear-Gaussian elimination (genmlx-lwhw).
+
+   Eliminates a *block* of independent Gaussian-prior latents that jointly
+   determine Gaussian observations through affine means — i.e. Bayesian linear
+   regression. The per-prior scalar conjugate path (auto_analytical) is only
+   correct when each observation depends on a SINGLE latent through the natural
+   parameter directly; it silently drops the affine coefficient and offset, so a
+   model like `y_j ~ N(slope*x_j + intercept, σ)` collapsed to the shared-mean
+   marginal `y_j ~ N(intercept, σ)` (off by ~16 nats on the linreg benchmark).
+
+   This module detects such blocks and eliminates them JOINTLY:
+
+     latents  β ~ N(m0, S0)            (independent priors, S0 diagonal)
+     obs      y_j ~ N(h_j·β + c_j, r_j)
+     marginal y ~ N(X m0 + c, R + X S0 Xᵀ)
+     posterior β|y ~ N(m1, S1), S1 = (S0⁻¹ + Xᵀ R⁻¹ X)⁻¹
+
+   The design row h_j and offset c_j are recovered at generate time from the
+   observation's source mean form, evaluated against the model args via the
+   compiled expression evaluator (compile-expr) — no autodiff needed, since the
+   mean is affine in the latents:
+
+     c_j  = mean_j(all latents → 0, args)
+     h_jk = mean_j(latent_k → 1, others → 0, args) − c_j
+
+   Elimination is performed by a sequential vector-Kalman measurement update,
+   which is algebraically identical to the batch marginal/posterior (chain rule
+   of the joint Gaussian density) and fits the per-address handler structure.
+
+   v1 scope: generate + assess (exact). regenerate/update DECLINE (the block is
+   excluded from regenerate handlers, so its latents fall through to sampling).
+   Blocks whose latents have non-conjugate children, latent-dependent noise,
+   non-affine means, or latents not preceding their observations are DECLINED —
+   their pairs are removed so no rule claims a (wrong) exact elimination."
+  (:require [clojure.set :as set]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.constants :refer [LOG-2PI]]
+            [genmlx.choicemap :as cm]
+            [genmlx.compiled :as compiled]))
+
+;; ===========================================================================
+;; Pure math — sequential vector-Kalman elimination
+;; ===========================================================================
+
+(defn lg-kalman-step
+  "One vector-Kalman measurement update for a linear-Gaussian block.
+
+   belief: {:mean [p] :cov [p p]}  (MLX arrays)
+   obs:    {:y scalar :h [p] :c scalar :r variance-scalar}  (MLX)
+   Returns {:mean [p] :cov [p p] :ll scalar}.
+
+   S = hᵀP h + r;  K = P h / S;  innov = y − (hᵀm + c)
+   m' = m + K·innov;  P' = P − K (P h)ᵀ;  ll = −½(log2π + log S + innov²/S)"
+  [{:keys [mean cov]} {:keys [y h c r]}]
+  (let [p (first (mx/shape mean))
+        Ph    (mx/flatten (mx/matmul cov (mx/reshape h [p 1])))   ; P h, [p]
+        S     (mx/add (mx/sum (mx/multiply h Ph)) r)               ; scalar
+        K     (mx/divide Ph S)                                     ; [p]
+        pred  (mx/add (mx/sum (mx/multiply h mean)) c)             ; scalar
+        innov (mx/subtract y pred)                                 ; scalar
+        new-mean (mx/add mean (mx/multiply K innov))
+        new-cov  (mx/subtract cov (mx/outer K Ph))                 ; rank-1 downdate
+        ll (mx/multiply (mx/scalar -0.5)
+                        (mx/add (mx/scalar LOG-2PI)
+                                (mx/add (mx/log S)
+                                        (mx/divide (mx/multiply innov innov) S))))]
+    {:mean new-mean :cov new-cov :ll ll}))
+
+(defn lg-eliminate
+  "Sequentially eliminate a linear-Gaussian block.
+   m0: [p] prior mean, S0: [p p] prior covariance (diagonal),
+   obs-specs: seq of {:y :h :c :r} (r is a variance).
+   Returns {:marginal-ll scalar :post-mean [p] :post-cov [p p]}."
+  [m0 S0 obs-specs]
+  (let [final (reduce (fn [{:keys [mean cov ll]} ob]
+                        (let [r (lg-kalman-step {:mean mean :cov cov} ob)]
+                          {:mean (:mean r) :cov (:cov r)
+                           :ll (mx/add ll (:ll r))}))
+                      {:mean m0 :cov S0 :ll (mx/scalar 0.0)}
+                      obs-specs)]
+    {:marginal-ll (:ll final) :post-mean (:mean final) :post-cov (:cov final)}))
+
+;; ===========================================================================
+;; Detection
+;; ===========================================================================
+
+(defn- form-symbols
+  "Set of symbols appearing anywhere in a source form."
+  [form]
+  (cond
+    (symbol? form) #{form}
+    (seq? form)    (into #{} (mapcat form-symbols) form)
+    (vector? form) (into #{} (mapcat form-symbols) form)
+    (map? form)    (into #{} (mapcat form-symbols) (concat (keys form) (vals form)))
+    :else #{}))
+
+(defn- references-any?
+  "Does the form reference any symbol whose name matches an address in addrs?"
+  [form addrs]
+  (let [names (into #{} (map name) addrs)]
+    (boolean (some #(contains? names (name %)) (form-symbols form)))))
+
+(defn- connected-components
+  "Undirected connected components over conjugate pairs (prior-addr ↔ obs-addr).
+   Returns a seq of {:nodes :latents :obs :pairs}."
+  [pairs]
+  (let [priors (into #{} (map :prior-addr) pairs)
+        nodes  (into priors (map :obs-addr) pairs)
+        adj    (reduce (fn [m {:keys [prior-addr obs-addr]}]
+                         (-> m
+                             (update prior-addr (fnil conj #{}) obs-addr)
+                             (update obs-addr (fnil conj #{}) prior-addr)))
+                       {} pairs)]
+    (loop [unseen nodes comps []]
+      (if (empty? unseen)
+        comps
+        (let [start (first unseen)
+              comp  (loop [stack [start] seen #{}]
+                      (if (empty? stack)
+                        seen
+                        (let [x (peek stack) stack' (pop stack)]
+                          (if (contains? seen x)
+                            (recur stack' seen)
+                            (recur (into stack' (get adj x)) (conj seen x))))))]
+          (recur (set/difference unseen comp)
+                 (conj comps {:nodes comp
+                              :latents (set/intersection comp priors)
+                              :obs (set/difference comp priors)
+                              :pairs (filterv #(contains? comp (:prior-addr %)) pairs)})))))))
+
+(defn- concern?
+  "Is this component a regression-block concern (beyond the correct single-latent
+   :direct scalar path)? True when ≥2 latents, or any dependency is affine."
+  [comp]
+  (or (>= (count (:latents comp)) 2)
+      (some #(= :affine (:type (:dependency-type %))) (:pairs comp))))
+
+(defn- mean-form [site] (first (:dist-args site)))
+(defn- sigma-form [site] (second (:dist-args site)))
+
+(defn- eligible-block
+  "Validate a concern component and, if eligible, build a block descriptor.
+   Returns {:eligible? true :block desc} or {:eligible? false}.
+
+   Eligible when: priors are independent (no latent in another latent's prior),
+   obs depend only on block latents, no latent has a non-conjugate child, obs
+   noise is latent-independent, latents precede all obs in dep-order, and every
+   obs mean/sigma form compiles."
+  [comp schema binding-env site-map dep-idx all-trace-addrs]
+  (let [latents (:latents comp)
+        obs     (:obs comp)
+        latent-sites (map site-map latents)
+        obs-sites    (map site-map obs)
+        ;; latents ordered by dep-order; obs likewise
+        order-latents (vec (sort-by #(get dep-idx % 0) latents))
+        order-obs     (vec (sort-by #(get dep-idx % 0) obs))
+        ;; (a) independent priors: a latent's prior must not reference another latent
+        indep-priors? (every? (fn [s] (not (references-any? (vec (:dist-args s)) latents)))
+                               latent-sites)
+        ;; (b) obs depend only on block latents (mean only references block latents)
+        obs-deps-ok? (every? (fn [s]
+                               (set/subset? (set/intersection (:deps s) all-trace-addrs)
+                                            latents))
+                             obs-sites)
+        ;; (c) no non-conjugate children of any block latent
+        children-conjugate?
+        (every? (fn [la]
+                  (every? (fn [s] (or (not (contains? (:deps s) la))
+                                      (contains? obs (:addr s))))
+                          (:trace-sites schema)))
+                latents)
+        ;; (d) noise latent-independent: sigma form references no block latent
+        noise-ok? (every? (fn [s] (not (references-any? (sigma-form s) latents))) obs-sites)
+        ;; (e) latents precede obs in dep-order
+        order-ok? (or (empty? order-obs)
+                      (< (apply max (map #(get dep-idx % 0) latents))
+                         (apply min (map #(get dep-idx % 0) obs))))
+        ;; (f) compile mean + sigma forms
+        obs-fns (mapv (fn [a]
+                        (let [s (site-map a)]
+                          {:addr a
+                           :mean-fn (compiled/compile-expr (mean-form s) binding-env #{})
+                           :sigma-fn (compiled/compile-expr (sigma-form s) binding-env #{})}))
+                      order-obs)
+        forms-ok? (every? #(and (:mean-fn %) (:sigma-fn %)) obs-fns)]
+    (if (and indep-priors? obs-deps-ok? children-conjugate? noise-ok? order-ok? forms-ok?)
+      {:eligible? true
+       :block {:id order-latents            ; stable id (blocks are disjoint)
+               :latents order-latents
+               :latent-index (into {} (map-indexed (fn [i a] [a i])) order-latents)
+               :p (count order-latents)
+               :obs obs-fns
+               :latent-addrs order-latents
+               :obs-addrs order-obs
+               :all-addrs (set/union latents obs)}}
+      {:eligible? false})))
+
+(defn detect-lg-blocks
+  "Detect linear-Gaussian regression blocks in a schema.
+
+   schema: extracted schema with :conjugate-pairs, :trace-sites, :dep-order.
+   source: gen source form (params + body) for the binding environment.
+   exclude-addrs: addresses already claimed (e.g. by Kalman chains) — skipped.
+
+   Returns {:blocks [block-descriptor ...] :declined-addrs #{addr ...}}.
+   Declined addresses are concern-components that cannot be exactly eliminated;
+   callers should drop their conjugate pairs so no rule claims a wrong exact."
+  [schema source & {:keys [exclude-addrs] :or {exclude-addrs #{}}}]
+  (let [pairs (->> (:conjugate-pairs schema)
+                   (filter #(= :normal-normal (:family %)))
+                   (remove #(or (contains? exclude-addrs (:prior-addr %))
+                                (contains? exclude-addrs (:obs-addr %)))))
+        comps (filter concern? (connected-components pairs))]
+    (if (empty? comps)
+      {:blocks [] :declined-addrs #{}}
+      (let [binding-env (compiled/build-binding-env source)
+            site-map (into {} (map (juxt :addr identity)) (:trace-sites schema))
+            dep-order (vec (:dep-order schema))
+            dep-idx (into {} (map-indexed (fn [i a] [a i])) dep-order)
+            all-trace-addrs (set (map :addr (:trace-sites schema)))]
+        (reduce
+          (fn [acc comp]
+            (let [{:keys [eligible? block]}
+                  (eligible-block comp schema binding-env site-map dep-idx all-trace-addrs)]
+              (if eligible?
+                (update acc :blocks conj block)
+                (update acc :declined-addrs set/union (:nodes comp)))))
+          {:blocks [] :declined-addrs #{}}
+          comps)))))
+
+;; ===========================================================================
+;; Generate-mode handlers (used for generate AND assess)
+;; ===========================================================================
+
+(defn- coerce-scalar [x] (if (mx/array? x) x (mx/scalar x)))
+
+(defn- obs-design
+  "Recover the design row h [p] and offset c (scalar) for an observation, by
+   probing its compiled mean form against the model args."
+  [mean-fn latents args]
+  (let [zero-v (zipmap latents (repeat (mx/scalar 0.0)))
+        c (coerce-scalar (mean-fn zero-v args))
+        h (mx/stack (mapv (fn [a]
+                            (mx/subtract (coerce-scalar
+                                          (mean-fn (assoc zero-v a (mx/scalar 1.0)) args))
+                                         c))
+                          latents))]
+    {:h h :c c}))
+
+(defn make-lg-handlers
+  "Build generate-mode address handlers for a linear-Gaussian block.
+
+   Latent handlers collect each prior (mean, var) and, once all are seen,
+   materialise the joint belief. Observation handlers perform a vector-Kalman
+   measurement update against the model args (read from :model-args in state),
+   accumulating the marginal LL into :score and :weight and writing posterior
+   means back to the latent choices. Handlers return nil (fall through) when the
+   block cannot proceed (missing args/belief, unconstrained obs)."
+  [block]
+  (let [{:keys [id latents p obs]} block
+        latent-handlers
+        (into {}
+              (map (fn [la]
+                     [la
+                      (fn [state _addr dist]
+                        (let [{:keys [mu sigma]} (:params dist)
+                              var (mx/multiply sigma sigma)
+                              st (-> state
+                                     (assoc-in [:lg-init id la] {:mean (coerce-scalar mu)
+                                                                 :var (coerce-scalar var)})
+                                     (update :choices cm/set-value la mu))
+                              inits (get-in st [:lg-init id])
+                              st (if (= (count inits) p)
+                                   (let [m0 (mx/stack (mapv #(:mean (get inits %)) latents))
+                                         s0 (mx/diag (mx/stack (mapv #(:var (get inits %)) latents)))]
+                                     (assoc-in st [:lg-belief id] {:mean m0 :cov s0}))
+                                   st)]
+                          [mu st]))]))
+              latents)
+        obs-handlers
+        (into {}
+              (map (fn [{:keys [addr mean-fn sigma-fn]}]
+                     [addr
+                      (fn [state _addr _dist]
+                        (let [belief (get-in state [:lg-belief id])
+                              args (:model-args state)
+                              constraint (cm/get-submap (:constraints state) addr)]
+                          (when (and belief args (cm/has-value? constraint))
+                            (let [y (cm/get-value constraint)
+                                  {:keys [h c]} (obs-design mean-fn latents args)
+                                  s (coerce-scalar
+                                     (sigma-fn (zipmap latents (repeat (mx/scalar 0.0))) args))
+                                  r (mx/multiply s s)
+                                  {:keys [mean cov ll]} (lg-kalman-step belief {:y y :h h :c c :r r})
+                                  st (reduce (fn [st i]
+                                               (update st :choices cm/set-value
+                                                       (nth latents i) (mx/index mean i)))
+                                             state (range p))]
+                              [y (-> st
+                                     (assoc-in [:lg-belief id] {:mean mean :cov cov})
+                                     (update :choices cm/set-value addr y)
+                                     (update :score mx/add ll)
+                                     (update :weight mx/add ll))]))))]))
+              obs)]
+    (merge latent-handlers obs-handlers)))

--- a/src/genmlx/rewrite.cljs
+++ b/src/genmlx/rewrite.cljs
@@ -12,9 +12,11 @@
    3. Rao-Blackwellization → sample from posterior (not prior) for shared priors
 
    Level 3 — WP-5: Algebraic Graph Rewriting."
-  (:require [genmlx.dep-graph :as dep-graph]
+  (:require [clojure.set :as set]
+            [genmlx.dep-graph :as dep-graph]
             [genmlx.affine :as affine]
             [genmlx.inference.auto-analytical :as auto]
+            [genmlx.linear-gaussian :as lg]
             [genmlx.handler :as h]))
 
 ;; ---------------------------------------------------------------------------
@@ -76,6 +78,23 @@
                          (pr-str (:latent-addrs chain)))})))
 
 ;; ---------------------------------------------------------------------------
+;; RegressionRule — eliminates a coupled/affine linear-Gaussian block jointly
+;; ---------------------------------------------------------------------------
+
+(defrecord RegressionRule [block]
+  IRewriteRule
+  (-applicable? [this graph schema]
+    (every? #(contains? (:nodes graph) %) (:latent-addrs block)))
+  (-apply [this graph schema constraints]
+    (let [handlers (lg/make-lg-handlers block)
+          latents (set (:latent-addrs block))
+          graph' (prune-eliminated graph latents)]
+      {:graph' graph'
+       :handlers handlers
+       :eliminated latents
+       :description (str "Linear-Gaussian block: " (pr-str (:latent-addrs block)))})))
+
+;; ---------------------------------------------------------------------------
 ;; RaoBlackwellRule — sample from posterior instead of prior
 ;; ---------------------------------------------------------------------------
 
@@ -119,22 +138,36 @@
   "Generate rewrite rules from schema conjugacy metadata.
    Each detected conjugate pair becomes a ConjugacyRule.
    Detected Kalman chains become KalmanRules.
+   Coupled/affine linear-Gaussian blocks become RegressionRules.
    Shared priors with non-conjugate children become RaoBlackwellRules.
 
-   Priority: Kalman > Conjugacy > RaoBlackwell
-   (more structure eliminated first)"
-  [schema conjugate-pairs chains]
-  (let [kalman-rules (mapv ->KalmanRule chains)
+   Priority: Kalman > Regression > Conjugacy > RaoBlackwell
+   (more structure eliminated first).
 
-        ;; Addresses already claimed by Kalman chains
+   lg-blocks: linear-Gaussian block descriptors (jointly eliminated).
+   declined-addrs: concern-component addresses that cannot be exactly eliminated
+   — excluded so no per-prior ConjugacyRule claims a wrong exact.
+
+   Backward-compatible arities: [schema pairs] and [schema pairs chains] omit
+   linear-Gaussian blocks (no RegressionRules)."
+  ([schema conjugate-pairs] (generate-rewrite-rules schema conjugate-pairs nil nil nil))
+  ([schema conjugate-pairs chains] (generate-rewrite-rules schema conjugate-pairs chains nil nil))
+  ([schema conjugate-pairs chains lg-blocks declined-addrs]
+  (let [kalman-rules (mapv ->KalmanRule chains)
+        regression-rules (mapv ->RegressionRule lg-blocks)
+
+        ;; Addresses already claimed by Kalman chains / regression blocks, plus
+        ;; declined concern-components (kept off the scalar conjugacy path).
         kalman-latents (set (mapcat :latent-addrs chains))
         kalman-obs (set (mapcat :obs-addrs chains))
-        kalman-addrs (into kalman-latents kalman-obs)
+        claimed (set/union (into kalman-latents kalman-obs)
+                           (into #{} (mapcat :all-addrs lg-blocks))
+                           (or declined-addrs #{}))
 
-        ;; Group remaining conjugate pairs by prior (excluding Kalman-claimed)
+        ;; Group remaining conjugate pairs by prior (excluding claimed addrs)
         remaining-pairs (remove (fn [p]
-                                  (or (contains? kalman-addrs (:prior-addr p))
-                                      (contains? kalman-addrs (:obs-addr p))))
+                                  (or (contains? claimed (:prior-addr p))
+                                      (contains? claimed (:obs-addr p))))
                                 conjugate-pairs)
         grouped (group-by :prior-addr remaining-pairs)
 
@@ -152,10 +185,11 @@
                 {:conjugacy (->ConjugacyRule family prior-addr obs-addrs)})))
           grouped)]
 
-    ;; Priority ordering: Kalman first, then conjugacy, then RB
+    ;; Priority ordering: Kalman, then Regression, then conjugacy, then RB
     (vec (concat kalman-rules
+                 regression-rules
                  (keep :conjugacy classified)
-                 (keep :rb classified)))))
+                 (keep :rb classified))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Rewrite engine
@@ -194,22 +228,35 @@
 (defn build-analytical-plan
   "Analyze model and build the optimal analytical execution plan.
    schema must already have :conjugate-pairs (from augment-schema-with-conjugacy).
+   source (optional) is the gen source form — required to detect linear-Gaussian
+   regression blocks (their design matrix is recovered from the obs mean forms).
 
-   Returns {:rewrite-result :auto-transition :kalman-chains :stats}"
-  [schema]
-  (let [pairs (or (:conjugate-pairs schema) [])
-        graph (dep-graph/build-dep-graph schema)
-        chains (affine/detect-kalman-chains pairs)
-        rules (generate-rewrite-rules schema pairs chains)
-        result (apply-rewrites graph schema nil rules)
-        auto-transition (when (seq (:handlers result))
-                          (auto/make-address-dispatch
-                            h/generate-transition
-                            (:handlers result)))]
-    {:rewrite-result result
-     :auto-transition auto-transition
-     :kalman-chains chains
-     :stats {:total-sites (count (:nodes graph))
-             :eliminated (count (:eliminated result))
-             :residual (count (:nodes (:residual-graph result)))
-             :rewrites-applied (count (:rewrite-log result))}}))
+   Returns {:rewrite-result :auto-transition :kalman-chains :lg-blocks
+            :declined-addrs :stats}"
+  ([schema] (build-analytical-plan schema nil))
+  ([schema source]
+   (let [pairs (or (:conjugate-pairs schema) [])
+         graph (dep-graph/build-dep-graph schema)
+         chains (affine/detect-kalman-chains pairs)
+         kalman-addrs (into (set (mapcat :latent-addrs chains))
+                            (mapcat :obs-addrs chains))
+         lg-result (if source
+                     (lg/detect-lg-blocks schema source :exclude-addrs kalman-addrs)
+                     {:blocks [] :declined-addrs #{}})
+         lg-blocks (:blocks lg-result)
+         declined (:declined-addrs lg-result)
+         rules (generate-rewrite-rules schema pairs chains lg-blocks declined)
+         result (apply-rewrites graph schema nil rules)
+         auto-transition (when (seq (:handlers result))
+                           (auto/make-address-dispatch
+                             h/generate-transition
+                             (:handlers result)))]
+     {:rewrite-result result
+      :auto-transition auto-transition
+      :kalman-chains chains
+      :lg-blocks lg-blocks
+      :declined-addrs declined
+      :stats {:total-sites (count (:nodes graph))
+              :eliminated (count (:eliminated result))
+              :residual (count (:nodes (:residual-graph result)))
+              :rewrites-applied (count (:rewrite-log result))}})))

--- a/test/genmlx/gfi_laws_test_p8.cljs
+++ b/test/genmlx/gfi_laws_test_p8.cljs
@@ -200,6 +200,46 @@
       (t/is (close? log-z analytical 0.15)
             (str "IS log-ML=" log-z " analytical=" analytical)))))
 
+;; --- Law #20: AIS Weight Accumulation ---
+;; AIS accumulates log-weights z_hat_j = z_hat_{j-1} + (b_j - b_{j-1})*logL(x)
+;; across a temperature schedule, resampling x from the exact tempered
+;; posterior each step. The estimate logsumexp(z_hat) - log N converges to
+;; the true marginal log-ML. Model: x ~ N(0,2), y ~ N(x,1), y=3.
+
+(t/deftest law:ais-weight-accumulation
+  (t/testing "AIS accumulated log-weights converge to analytical log marginal likelihood"
+    (let [n 2000
+          ys 3.0
+          betas [0.0 0.25 0.5 0.75 1.0]
+          n-steps (dec (count betas))
+          sp2 4.0
+          ;; exact tempered posterior at beta (lik var = 1)
+          tpost (fn [b] (let [v (/ 1.0 (+ (/ 1.0 sp2) b))]
+                          {:mean (* v b ys) :sd (js/Math.sqrt v)}))
+          [k-init k-loop] (rng/split (rng/fresh-key 7))
+          x0 (mx/multiply (mx/scalar 2.0) (rng/normal k-init [n]))
+          lw (loop [j 1, x x0, acc (mx/scalar 0.0), k k-loop]
+               (if (> j n-steps)
+                 acc
+                 (let [b   (nth betas j)
+                       db  (- b (nth betas (dec j)))
+                       logL (dist/log-prob (dist/gaussian x 1) (mx/scalar ys))
+                       acc' (mx/add acc (mx/multiply (mx/scalar db) logL))
+                       {pm :mean psd :sd} (tpost b)
+                       [k1 k2] (rng/split k)
+                       x'  (mx/add (mx/scalar pm)
+                                   (mx/multiply (mx/scalar psd) (rng/normal k1 [n])))]
+                   (recur (inc j) x' acc' k2))))
+          _ (mx/materialize! lw)
+          log-z (ev (mx/subtract (mx/logsumexp lw) (mx/scalar (js/Math.log n))))
+          analytical (- (* -0.5 (js/Math.log (* 2 js/Math.PI)))
+                        (* 0.5 (js/Math.log 5.0))
+                        (* 0.5 (/ 9.0 5.0)))
+          diff (js/Math.abs (- log-z analytical))]
+      ;; AIS with exact tempered-posterior kernels, N=2000, tol = 0.1 nats.
+      (t/is (close? log-z analytical 0.1)
+            (str "AIS log-Z=" log-z " analytical=" analytical " diff=" diff)))))
+
 ;; ---------------------------------------------------------------------------
 ;; INVOLUTIVE MCMC laws [T] §3.7, Def 3.7.1, Eq 3.15, Eq 3.17
 ;; ---------------------------------------------------------------------------

--- a/test/genmlx/linear_gaussian_elim_test.cljs
+++ b/test/genmlx/linear_gaussian_elim_test.cljs
@@ -1,3 +1,4 @@
+;; @tier medium
 (ns genmlx.linear-gaussian-elim-test
   "L3 joint linear-Gaussian elimination (genmlx-lwhw).
 

--- a/test/genmlx/linear_gaussian_elim_test.cljs
+++ b/test/genmlx/linear_gaussian_elim_test.cljs
@@ -16,6 +16,8 @@
             [genmlx.dynamic :as dyn]
             [genmlx.protocols :as p]
             [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.mlx.random :as rng]
             [genmlx.method-selection :as ms]
             [genmlx.linear-gaussian :as lg])
   (:require-macros [genmlx.gen :refer [gen]]))
@@ -172,29 +174,315 @@
   (assert-close "M2 posterior mu choice" 1.112957 (choice-val trace :mu) POST-TOL))
 
 ;; ===========================================================================
-;; SECTION 3 — Honesty: declined cases are NOT claimed exact
+;; SECTION 3 — Honesty: the non-conjugate NOISE latent stays residual
 ;; ===========================================================================
+;; sigma is the obs noise and is itself a (non-conjugate) latent. Under genmlx-4q9d
+;; the affine block {mu} IS eliminated CONDITIONAL on sigma — but sigma must NEVER be
+;; swept into the block: it stays residual (it is sampled, not analytically eliminated).
 
-(println "\n== Section 3: declined cases stay honest ==")
+(println "\n== Section 3: non-conjugate noise latent stays residual ==")
 
-;; Latent-dependent noise (sigma is itself a latent) -> NOT a linear-Gaussian block
-;; (mirrors 5D's structure). Must fall through; latents stay residual.
 (def latent-noise-model
   (dyn/auto-key
     (gen []
-      (let [mu    (trace :mu (dist/gaussian 0 10))
-            sigma (trace :sigma (dist/gamma-dist 2 1))]
+      (let [sigma (trace :sigma (dist/gamma-dist 2 1))
+            mu    (trace :mu (dist/gaussian 0 10))]
         (trace :y1 (dist/gaussian (mx/add (mx/multiply mu 2) 0) sigma))
         (trace :y2 (dist/gaussian (mx/add (mx/multiply mu 2) 0) sigma))
         mu))))
 (def latent-noise-obs
   (-> cm/EMPTY (cm/set-choice [:y1] (mx/scalar 1.5)) (cm/set-choice [:y2] (mx/scalar 2.0))))
-(println "-- latent-dependent noise: sigma must remain residual")
+(println "-- non-conjugate noise: sigma residual, block mu eliminated conditional on it")
 (let [sel (ms/select-method latent-noise-model latent-noise-obs)]
-  (assert-true "latent-noise: sigma NOT eliminated" (not (contains? (set (:eliminated sel)) :sigma)))
-  (assert-true "latent-noise: method != exact OR sigma residual"
-               (or (not= :exact (:method sel))
-                   (contains? (:residual-addrs sel) :sigma))))
+  (assert-true "latent-noise: sigma NOT eliminated (honesty)"
+               (not (contains? (set (:eliminated sel)) :sigma)))
+  (assert-true "latent-noise: sigma stays residual" (contains? (:residual-addrs sel) :sigma))
+  (assert-true "latent-noise: block mu eliminated conditional on sigma (4q9d)"
+               (contains? (set (:eliminated sel)) :mu))
+  (assert-true "latent-noise: method != exact (sigma residual)" (not= :exact (:method sel))))
+
+;; ===========================================================================
+;; SECTION 4 — Regenerate: block stays Rao-Blackwellised under MH (genmlx-m3tn)
+;; ===========================================================================
+;; A model with an ELIGIBLE regression block {slope,intercept} (constant noise)
+;; PLUS an unrelated residual latent `tau` (Gamma prior, Gaussian-scale obs `w`).
+;; tau is non-conjugate w.r.t. its scale obs, so it stays residual; the block is
+;; fully eliminated and a-posteriori independent of tau (no shared data). The
+;; Rao-Blackwell win: the block latents are returned as EXACT posterior means
+;; (zero Monte-Carlo variance) while an MH chain explores tau.
+
+(println "\n== Section 4: regenerate (genmlx-m3tn) ==")
+
+(defn- strip-analytical
+  "Force the standard handler/compiled path (drop analytical auto-handlers)."
+  [gf]
+  (assoc gf :schema (dissoc (:schema gf)
+                            :auto-handlers :auto-regenerate-handlers
+                            :auto-regenerate-transition :conjugate-pairs
+                            :has-conjugate? :analytical-plan :linear-gaussian-blocks)))
+
+(def br-model
+  (dyn/auto-key
+    (gen [x1 x2 x3 x4 x5]
+      (let [slope     (trace :slope (dist/gaussian 0 10))
+            intercept (trace :intercept (dist/gaussian 0 10))
+            tau       (trace :tau (dist/gamma-dist 2 1))]
+        (trace :y1 (dist/gaussian (mx/add (mx/multiply slope x1) intercept) 1))
+        (trace :y2 (dist/gaussian (mx/add (mx/multiply slope x2) intercept) 1))
+        (trace :y3 (dist/gaussian (mx/add (mx/multiply slope x3) intercept) 1))
+        (trace :y4 (dist/gaussian (mx/add (mx/multiply slope x4) intercept) 1))
+        (trace :y5 (dist/gaussian (mx/add (mx/multiply slope x5) intercept) 1))
+        (trace :w  (dist/gaussian 0 tau))
+        slope))))
+
+(def br-xs (mapv mx/scalar [1.0 2.0 3.0 4.0 5.0]))
+(def br-w 1.5)
+(def br-obs
+  (-> cm/EMPTY
+      (cm/set-choice [:y1] (mx/scalar 2.3)) (cm/set-choice [:y2] (mx/scalar 4.7))
+      (cm/set-choice [:y3] (mx/scalar 6.1)) (cm/set-choice [:y4] (mx/scalar 8.9))
+      (cm/set-choice [:y5] (mx/scalar 10.2))
+      (cm/set-choice [:w]  (mx/scalar br-w))))
+
+;; Independent oracle for tau: p(tau|w) ∝ Gamma(tau;2,1)·N(w;0,tau)
+;;   ∝ tau·e^{-tau} · tau^{-1}·e^{-w²/(2τ²)} = e^{-tau - w²/(2τ²)}, tau>0.
+;; 1D quadrature — uses only the model densities, NOT the eliminator.
+(defn tau-posterior-mean [w]
+  (let [grid (mapv #(* 0.001 %) (range 1 30000))      ; tau in (0,30]
+        dens (mapv (fn [t] (js/Math.exp (- (- t) (/ (* w w) (* 2 t t))))) grid)
+        z    (reduce + dens)
+        num  (reduce + (mapv * grid dens))]
+    (/ num z)))
+
+;; -- method-selection honesty
+(println "-- method-selection: block eliminated, tau residual")
+(let [sel (ms/select-method br-model br-obs)]
+  (assert-true "eliminated = {slope intercept}" (= #{:slope :intercept} (set (:eliminated sel))))
+  (assert-true "tau is residual" (contains? (:residual-addrs sel) :tau))
+  (assert-true "slope NOT residual" (not (contains? (:residual-addrs sel) :slope)))
+  (assert-true "intercept NOT residual" (not (contains? (:residual-addrs sel) :intercept)))
+  (assert-true "method != exact (tau residual)" (not= :exact (:method sel))))
+
+;; -- generate: block latents = analytic conditional; tau sampled
+(println "-- generate: block posterior means = analytic conditional")
+(let [{:keys [trace]} (p/generate br-model br-xs br-obs)]
+  (assert-close "gen slope = posterior mean" 1.999324 (choice-val trace :slope) POST-TOL)
+  (assert-close "gen intercept = posterior mean" 0.441145 (choice-val trace :intercept) POST-TOL)
+  (assert-true  "tau present & positive" (pos? (choice-val trace :tau))))
+
+;; -- strip-analytical: block latents are genuinely sampled (not eliminated)
+(println "-- strip-analytical: block latents are sampled, not pinned to posterior mean")
+(let [{:keys [trace]} (p/generate (dyn/with-key (strip-analytical br-model) (rng/fresh-key 5))
+                                  br-xs br-obs)]
+  (assert-true "stripped slope != analytic posterior mean"
+               (> (js/Math.abs (- (choice-val trace :slope) 1.999324)) 1e-3)))
+
+;; -- Case B (empty selection): nothing resampled -> score unchanged, weight 0,
+;;    block stays at the exact posterior mean (mirrors l3_5_regenerate Case B).
+(println "-- Case B (empty selection): score consistency + weight 0")
+(let [{:keys [trace]} (p/generate br-model br-xs br-obs)
+      old-score (mx/item (:score trace))
+      {rtrace :trace rweight :weight} (p/regenerate br-model trace (sel/select))
+      new-score (mx/item (:score rtrace))]
+  (assert-close "regen score = generate score" old-score new-score MARG-TOL)
+  (assert-close "regen weight = 0" 0.0 (mx/item rweight) MARG-TOL)
+  (assert-close "slope still posterior mean" 1.999324 (choice-val rtrace :slope) POST-TOL)
+  (assert-close "intercept still posterior mean" 0.441145 (choice-val rtrace :intercept) POST-TOL))
+
+;; -- Case A (select a block latent): the WHOLE block re-opens (option a).
+;;    Selected latent resamples from prior; the unselected block latent is kept
+;;    at its old value (base regenerate); weight is finite & MH-valid.
+(println "-- Case A (select :slope): whole block re-opens, weight finite")
+(let [{:keys [trace]} (p/generate (dyn/with-key br-model (rng/fresh-key 7)) br-xs br-obs)
+      {rtrace :trace rweight :weight}
+      (p/regenerate (dyn/with-key br-model (rng/fresh-key 13)) trace (sel/select :slope))]
+  (assert-true  "Case A weight finite" (js/isFinite (mx/item rweight)))
+  (assert-close "intercept (unselected) kept at posterior mean"
+                0.441145 (choice-val rtrace :intercept) POST-TOL))
+
+;; -- MH over tau (analytical): converges to the oracle, AND the eliminated block
+;;    stays at the EXACT posterior mean every step (zero MC variance = Rao-Blackwell).
+(println "-- MH over tau (analytical): oracle convergence + zero-variance block")
+(let [n-steps 200 burn 50
+      oracle (tau-posterior-mean br-w)
+      init (:trace (p/generate (dyn/with-key br-model (rng/fresh-key 1)) br-xs br-obs))
+      chain (reduce
+              (fn [{:keys [trace taus slopes accepts]} i]
+                (let [{rtrace :trace w :weight}
+                      (p/regenerate (dyn/with-key br-model (rng/fresh-key (+ 2000 i)))
+                                    trace (sel/select :tau))
+                      la (mx/item w)
+                      accept? (< (js/Math.log (js/Math.random)) la)
+                      nt (if accept? rtrace trace)]
+                  {:trace nt
+                   :taus (conj taus (choice-val nt :tau))
+                   :slopes (conj slopes (choice-val nt :slope))
+                   :accepts (if accept? (inc accepts) accepts)}))
+              {:trace init :taus [] :slopes [] :accepts 0}
+              (range n-steps))
+      post-taus  (subvec (:taus chain) burn)
+      tau-mean   (/ (reduce + post-taus) (count post-taus))
+      slopes     (:slopes chain)
+      slope-mean (/ (reduce + slopes) (count slopes))
+      slope-var  (/ (reduce + (mapv #(let [d (- % slope-mean)] (* d d)) slopes)) (count slopes))]
+  (assert-true  "MH accept rate > 0" (pos? (:accepts chain)))
+  (assert-true  (str "tau chain mean ~ oracle (" (.toFixed oracle 4) ")")
+                (< (js/Math.abs (- tau-mean oracle)) 0.35))
+  (assert-close "block slope stays exact posterior mean" 1.999324 slope-mean POST-TOL)
+  (assert-true  "block slope has ~zero MC variance (Rao-Blackwell)" (< slope-var 1e-6)))
+
+;; ===========================================================================
+;; SECTION 5 — Partial conjugacy: conditional elimination over a residual (4q9d)
+;; ===========================================================================
+;; Block {slope,intercept} with NON-CONJUGATE noise: y_j ~ N(slope*x_j+intercept, sigma),
+;; sigma ~ Gamma. v1 declined this. 4q9d samples sigma from prior and eliminates the block
+;; CONDITIONAL on the sampled sigma -> per-sample exact block marginal; the population gives
+;; E_sigma[block marginal] = the true marginal (Rao-Blackwellised IS / MH).
+;;
+;; Oracle: pure float64 JS quadrature of the JOINT density — independent of the Kalman
+;; eliminator. cond-quad integrates out (slope,intercept) analytically by brute force.
+
+(println "\n== Section 5: partial conjugacy / conditional elimination (genmlx-4q9d) ==")
+
+(def br4-xs (mapv mx/scalar [1.0 2.0 3.0]))
+(def br4-obs
+  (-> cm/EMPTY (cm/set-choice [:y1] (mx/scalar 1.6))
+      (cm/set-choice [:y2] (mx/scalar 2.4)) (cm/set-choice [:y3] (mx/scalar 3.7))))
+
+;; sigma declared FIRST (precedes the block obs in dep-order — required so its sampled
+;; value is in :choices when the block obs handlers fire and read the noise).
+(def br4-model
+  (dyn/auto-key
+    (gen [x1 x2 x3]
+      (let [sigma     (trace :sigma (dist/gamma-dist 2 1))
+            slope     (trace :slope (dist/gaussian 0 3))
+            intercept (trace :intercept (dist/gaussian 0 3))]
+        (trace :y1 (dist/gaussian (mx/add (mx/multiply slope x1) intercept) sigma))
+        (trace :y2 (dist/gaussian (mx/add (mx/multiply slope x2) intercept) sigma))
+        (trace :y3 (dist/gaussian (mx/add (mx/multiply slope x3) intercept) sigma))
+        slope))))
+
+;; -- Independent quadrature oracle (float64 JS; vs the float32 eliminator) --
+;; Grids kept modest + inner loop free of log/alloc (nbb is interpreted): per-sigma
+;; constants are hoisted, residuals computed inline for the 3 obs.
+(def LOG2PI (js/Math.log (* 2 js/Math.PI)))
+(def y0 1.6) (def y1 2.4) (def y2 3.7)            ; br4-y, x = [1 2 3]
+(defn log-gamma21 [sig] (- (js/Math.log sig) sig)) ; Gamma(2,1): logpdf = log(sig) - sig
+
+(def DA 0.07) (def DB 0.07) (def DSIG 0.08)
+(def AS (mapv #(+ -1.5 (* DA %)) (range 80)))      ; slope grid [-1.5, 4.1)
+(def BS (mapv #(+ -3.0 (* DB %)) (range 100)))     ; intercept grid [-3.0, 4.0)
+(def QS (mapv #(+ 0.02 (* DSIG %)) (range 100)))   ; sigma grid [0.02, 8.02)
+;; prior log-density N(0,3), per grid value, paired with the value to avoid nth in loop
+(defn- lg03 [x] (let [d (/ x 3.0)] (- (* -0.5 d d) (js/Math.log 3.0) (* 0.5 LOG2PI))))
+(def A-PAIRS (mapv (fn [a] [a (lg03 a)]) AS))
+(def B-PAIRS (mapv (fn [b] [b (lg03 b)]) BS))
+(def LOG-DA-DB (+ (js/Math.log DA) (js/Math.log DB)))
+
+;; log p(y|sigma) via 2D quadrature over (slope,intercept) — online logsumexp, 1 pass.
+(defn cond-logm [sig]
+  (let [s2 (* sig sig)
+        cst (* -3.0 (+ (js/Math.log sig) (* 0.5 LOG2PI)))   ; 3-obs noise normaliser (per sig)
+        m (volatile! -1e30) s (volatile! 0.0)]
+    (doseq [[a la] A-PAIRS [b lb] B-PAIRS]
+      (let [r0 (- y0 (+ a b)) r1 (- y1 (+ (* 2.0 a) b)) r2 (- y2 (+ (* 3.0 a) b))
+            lp (+ la lb cst (* -0.5 (/ (+ (* r0 r0) (* r1 r1) (* r2 r2)) s2)))]
+        (if (> lp @m)
+          (do (vreset! s (+ (* @s (js/Math.exp (- @m lp))) 1.0)) (vreset! m lp))
+          (vswap! s + (js/Math.exp (- lp @m))))))
+    (+ @m (js/Math.log @s) LOG-DA-DB)))
+
+;; conditional posterior means E[slope|y,sigma], E[intercept|y,sigma] (called ≤2×).
+(defn cond-means [sig]
+  (let [s2 (* sig sig)
+        triples (vec (for [[a la] A-PAIRS [b lb] B-PAIRS]
+                       (let [r0 (- y0 (+ a b)) r1 (- y1 (+ (* 2.0 a) b)) r2 (- y2 (+ (* 3.0 a) b))]
+                         [a b (+ la lb (* -0.5 (/ (+ (* r0 r0) (* r1 r1) (* r2 r2)) s2)))])))
+        mx-lp (reduce max (mapv #(nth % 2) triples))
+        ws (mapv (fn [t] (js/Math.exp (- (nth t 2) mx-lp))) triples)
+        z  (reduce + ws)]
+    [(/ (reduce + (mapv (fn [t w] (* (nth t 0) w)) triples ws)) z)
+     (/ (reduce + (mapv (fn [t w] (* (nth t 1) w)) triples ws)) z)]))
+
+(defn logsumexp [xs]
+  (let [m (reduce max xs)] (+ m (js/Math.log (reduce + (mapv #(js/Math.exp (- % m)) xs))))))
+
+;; single pass over sigma; derive both the marginal and E[sigma|y]
+(def sigma-logw (mapv (fn [sig] [sig (+ (log-gamma21 sig) (cond-logm sig))]) QS))
+(def oracle-log-py
+  (logsumexp (mapv (fn [[_ lw]] (+ lw (js/Math.log DSIG))) sigma-logw)))
+(def oracle-sigma-mean
+  (let [m (reduce max (mapv second sigma-logw))
+        w (mapv (fn [[_ lw]] (js/Math.exp (- lw m))) sigma-logw)
+        z (reduce + w)]
+    (/ (reduce + (mapv (fn [[sig _] wi] (* sig wi)) sigma-logw w)) z)))
+
+;; -- method-selection honesty
+(println "-- method-selection: block eliminated, sigma residual")
+(let [sel (ms/select-method br4-model br4-obs)]
+  (assert-true "4q9d eliminated = {slope intercept}" (= #{:slope :intercept} (set (:eliminated sel))))
+  (assert-true "4q9d sigma residual" (contains? (:residual-addrs sel) :sigma))
+  (assert-true "4q9d slope NOT residual" (not (contains? (:residual-addrs sel) :slope)))
+  (assert-true "4q9d method != exact (sigma residual)" (not= :exact (:method sel))))
+
+;; -- per residual sample: block marginal is EXACT (matches the independent oracle)
+(println "-- per-sample: conditional posterior mean + weight = analytic block marginal")
+(let [{:keys [trace weight]} (p/generate (dyn/with-key br4-model (rng/fresh-key 3)) br4-xs br4-obs)
+      sig (choice-val trace :sigma)
+      [em-slope em-int] (cond-means sig)]
+  (assert-close "block slope = conditional posterior mean" em-slope (choice-val trace :slope) 2e-2)
+  (assert-close "block intercept = conditional posterior mean" em-int (choice-val trace :intercept) 2e-2)
+  (assert-close "generate weight = conditional log-marginal" (cond-logm sig) (mx/item weight) 5e-2))
+
+;; -- marginal (IS over sigma~prior, block eliminated) matches oracle + strictly lower
+;;    variance / higher ESS than full sampling (strip-analytical).
+(println "-- IS marginal ~ oracle + ESS(conditional) > ESS(full sampling)")
+(let [n 400
+      gen-w (fn [gf base] (mapv (fn [i]
+                                  (mx/item (:weight (p/generate (dyn/with-key gf (rng/fresh-key (+ base i)))
+                                                                br4-xs br4-obs))))
+                                (range n)))
+      cond-w  (gen-w br4-model 5000)
+      strip-w (gen-w (strip-analytical br4-model) 9000)
+      lme  (fn [ws] (- (logsumexp ws) (js/Math.log (count ws))))
+      ess  (fn [ws] (let [m (reduce max ws)
+                          e (mapv #(js/Math.exp (- % m)) ws)
+                          s (reduce + e) s2 (reduce + (mapv #(* % %) e))]
+                      (/ (* s s) s2)))
+      cond-est (lme cond-w)
+      ess-cond (ess cond-w)
+      ess-full (ess strip-w)]
+  (println (str "     oracle log p(y)=" (.toFixed oracle-log-py 4)
+                "  cond-IS=" (.toFixed cond-est 4)
+                "  ESS cond=" (.toFixed ess-cond 1) " full=" (.toFixed ess-full 1)))
+  (assert-close "conditional-elim IS marginal ~ oracle" oracle-log-py cond-est 0.2)
+  (assert-true  "ESS(conditional) > ESS(full sampling) — Rao-Blackwell" (> ess-cond ess-full)))
+
+;; -- regenerate: MH over sigma re-eliminates the block conditional on the current sigma
+(println "-- regenerate: MH over sigma; block re-eliminated conditional on current sigma")
+(let [n-steps 150 burn 40
+      init (:trace (p/generate (dyn/with-key br4-model (rng/fresh-key 11)) br4-xs br4-obs))
+      chain (reduce
+              (fn [{:keys [trace sigs accepts]} i]
+                (let [{rt :trace w :weight}
+                      (p/regenerate (dyn/with-key br4-model (rng/fresh-key (+ 7000 i)))
+                                    trace (sel/select :sigma))
+                      accept? (< (js/Math.log (js/Math.random)) (mx/item w))
+                      nt (if accept? rt trace)]
+                  {:trace nt :sigs (conj sigs (choice-val nt :sigma))
+                   :accepts (if accept? (inc accepts) accepts)}))
+              {:trace init :sigs [] :accepts 0}
+              (range n-steps))
+      post     (subvec (:sigs chain) burn)
+      sig-mean (/ (reduce + post) (count post))
+      final    (:trace chain)
+      fsig     (choice-val final :sigma)
+      [fem-slope _] (cond-means fsig)]
+  (assert-true  "MH accept rate > 0" (pos? (:accepts chain)))
+  (assert-true  (str "sigma chain mean ~ oracle (" (.toFixed oracle-sigma-mean 4) ")")
+                (< (js/Math.abs (- sig-mean oracle-sigma-mean)) 0.35))
+  (assert-close "block re-eliminated conditional on current sigma"
+                fem-slope (choice-val final :slope) 2e-2))
 
 ;; ===========================================================================
 ;; Summary

--- a/test/genmlx/linear_gaussian_elim_test.cljs
+++ b/test/genmlx/linear_gaussian_elim_test.cljs
@@ -1,0 +1,206 @@
+(ns genmlx.linear-gaussian-elim-test
+  "L3 joint linear-Gaussian elimination (genmlx-lwhw).
+
+   Coupled multi-latent / affine linear-Gaussian regression models: multiple
+   independent Gaussian-prior latents jointly determine Gaussian observations via
+   affine means. L3 must compute the JOINT marginal log-ML (and joint posterior),
+   NOT the old per-prior scalar composition (which dropped the affine coefficient
+   and gave the shared-mean-only marginal).
+
+   Ground truth is an INDEPENDENT oracle (numpy/closed-form, triple-verified
+   batch=sequential=quadrature; see genmlx-lwhw), NEVER the function under test.
+
+   Run: bun run --bun nbb test/genmlx/linear_gaussian_elim_test.cljs"
+  (:require [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.method-selection :as ms]
+            [genmlx.linear-gaussian :as lg])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+;; ---------------------------------------------------------------------------
+;; Assertion helpers
+;; ---------------------------------------------------------------------------
+
+(def ^:dynamic *pass* (volatile! 0))
+(def ^:dynamic *fail* (volatile! 0))
+
+(defn assert-true [desc pred]
+  (if pred
+    (do (vswap! *pass* inc) (println (str "  PASS: " desc)))
+    (do (vswap! *fail* inc) (println (str "  FAIL: " desc)))))
+
+(defn assert-close [desc expected actual tol]
+  (let [d (js/Math.abs (- expected actual))]
+    (if (<= d tol)
+      (do (vswap! *pass* inc)
+          (println (str "  PASS: " desc " (" (.toFixed actual 6) " ~ " (.toFixed expected 6) ", |Δ|=" (.toExponential d 2) ")")))
+      (do (vswap! *fail* inc)
+          (println (str "  FAIL: " desc " (" (.toFixed actual 6) " vs " (.toFixed expected 6) ", |Δ|=" (.toExponential d 2) " > " tol ")"))))))
+
+;; Tolerances (float32 end-to-end; see oracle note)
+(def MARG-TOL 2e-4)
+(def POST-TOL 1e-4)
+
+(defn choice-val [trace addr]
+  (mx/item (cm/get-value (cm/get-submap (:choices trace) addr))))
+
+;; ===========================================================================
+;; SECTION 1 — Pure eliminator math vs oracle (independent of GFI wiring)
+;; ===========================================================================
+;; lg/lg-eliminate takes explicit m0, S0, obs specs {:y :h :c :r(variance)}.
+
+(println "\n== Section 1: pure lg/lg-eliminate vs oracle ==")
+
+(defn sc [x] (mx/scalar (double x)))
+(defn vecarr [xs] (mx/array (mapv double xs)))
+
+(defn run-pure [m0 s0-diag obs-specs]
+  (let [m0v (vecarr m0)
+        s0  (mx/diag (vecarr s0-diag))
+        r   (lg/lg-eliminate m0v s0 obs-specs)]
+    {:marg (mx/item (:marginal-ll r))
+     :mean (mapv #(mx/item (mx/index (:post-mean r) %)) (range (count m0)))
+     :std  (mapv #(js/Math.sqrt (mx/item (mx/index (mx/diag (:post-cov r)) %)))
+                 (range (count m0)))}))
+
+;; M1 linreg: slope,intercept ~ N(0,10); y_j ~ N(slope*x_j + intercept, 1)
+(let [x [1 2 3 4 5] y [2.3 4.7 6.1 8.9 10.2]
+      obs (mapv (fn [xj yj] {:y (sc yj) :h (vecarr [xj 1.0]) :c (sc 0.0) :r (sc 1.0)}) x y)
+      {:keys [marg mean std]} (run-pure [0 0] [100 100] obs)]
+  (println "-- M1 linreg (pure)")
+  (assert-close "M1 marginal" -11.418803 marg MARG-TOL)
+  (assert-close "M1 slope mean" 1.999324 (nth mean 0) POST-TOL)
+  (assert-close "M1 intercept mean" 0.441145 (nth mean 1) POST-TOL)
+  (assert-close "M1 slope std" 0.314661 (nth std 0) POST-TOL)
+  (assert-close "M1 intercept std" 1.042666 (nth std 1) POST-TOL))
+
+;; M2 affine: mu ~ N(0,5); y_j ~ N(2*mu + 1, 1)
+(let [y [3.0 4.5 2.2]
+      obs (mapv (fn [yj] {:y (sc yj) :h (vecarr [2.0]) :c (sc 1.0) :r (sc 1.0)}) y)
+      {:keys [marg mean std]} (run-pure [0] [25] obs)]
+  (println "-- M2 affine single-latent (pure)")
+  (assert-close "M2 marginal" -6.998560 marg MARG-TOL)
+  (assert-close "M2 mu mean" 1.112957 (nth mean 0) POST-TOL)
+  (assert-close "M2 mu std" 0.288195 (nth std 0) POST-TOL))
+
+;; M3 quadratic: a,b,c ~ N(0,10); y_j ~ N(a*x^2 + b*x + c, 0.5)
+(let [x [-1 0 1 2] y [1.1 0.2 0.9 4.3]
+      obs (mapv (fn [xj yj] {:y (sc yj) :h (vecarr [(* xj xj) xj 1.0]) :c (sc 0.0) :r (sc 0.25)}) x y)
+      {:keys [marg mean std]} (run-pure [0 0 0] [100 100 100] obs)]
+  ;; Oracle (batch matrix formula + 3D quadrature, both independent, agree to 1e-6).
+  ;; NB: supersedes an erroneous earlier derivation (-12.497356); -12.209727 is
+  ;; confirmed by np.linalg batch AND brute-force quadrature.
+  (println "-- M3 quadratic (pure)")
+  (assert-close "M3 marginal" -12.209727 marg MARG-TOL)
+  (assert-close "M3 a mean" 1.074323 (nth mean 0) POST-TOL)
+  (assert-close "M3 b mean" -0.044292 (nth mean 1) POST-TOL)
+  (assert-close "M3 c mean" 0.035639 (nth mean 2) POST-TOL))
+
+;; M4 heteroscedastic: slope,intercept ~ N(0,10); sigma=[0.5,1,2]
+(let [x [1 2 3] y [2.0 3.5 8.0] s [0.5 1.0 2.0]
+      obs (mapv (fn [xj yj sj] {:y (sc yj) :h (vecarr [xj 1.0]) :c (sc 0.0) :r (sc (* sj sj))}) x y s)
+      {:keys [marg mean std]} (run-pure [0 0] [100 100] obs)]
+  (println "-- M4 heteroscedastic (pure)")
+  (assert-close "M4 marginal" -8.999312 marg MARG-TOL)
+  (assert-close "M4 slope mean" 2.300389 (nth mean 0) POST-TOL)
+  (assert-close "M4 intercept mean" -0.385480 (nth mean 1) POST-TOL))
+
+;; M5 reduces to single-latent direct (= 5A): mu ~ N(0,10); y_j ~ N(mu,1)
+(let [y [1.0 1.5 0.8 1.2 1.1]
+      obs (mapv (fn [yj] {:y (sc yj) :h (vecarr [1.0]) :c (sc 0.0) :r (sc 1.0)}) y)
+      {:keys [marg mean]} (run-pure [0] [100] obs)]
+  (println "-- M5 direct (pure)")
+  (assert-close "M5 marginal" -7.843255 marg MARG-TOL)
+  (assert-close "M5 mu mean" 1.117764 (nth mean 0) POST-TOL))
+
+;; ===========================================================================
+;; SECTION 2 — End-to-end GFI: p/generate computes joint marginal + posterior
+;; ===========================================================================
+
+(println "\n== Section 2: GFI p/generate (joint elimination) ==")
+
+;; M1 linreg as a gen model
+(def linreg
+  (dyn/auto-key
+    (gen [x1 x2 x3 x4 x5]
+      (let [slope     (trace :slope (dist/gaussian 0 10))
+            intercept (trace :intercept (dist/gaussian 0 10))]
+        (trace :y1 (dist/gaussian (mx/add (mx/multiply slope x1) intercept) 1))
+        (trace :y2 (dist/gaussian (mx/add (mx/multiply slope x2) intercept) 1))
+        (trace :y3 (dist/gaussian (mx/add (mx/multiply slope x3) intercept) 1))
+        (trace :y4 (dist/gaussian (mx/add (mx/multiply slope x4) intercept) 1))
+        (trace :y5 (dist/gaussian (mx/add (mx/multiply slope x5) intercept) 1))
+        slope))))
+
+(def linreg-xs (mapv mx/scalar [1.0 2.0 3.0 4.0 5.0]))
+(def linreg-obs
+  (-> cm/EMPTY
+      (cm/set-choice [:y1] (mx/scalar 2.3)) (cm/set-choice [:y2] (mx/scalar 4.7))
+      (cm/set-choice [:y3] (mx/scalar 6.1)) (cm/set-choice [:y4] (mx/scalar 8.9))
+      (cm/set-choice [:y5] (mx/scalar 10.2))))
+
+(println "-- M1 linreg via p/generate")
+(let [{:keys [trace weight]} (p/generate linreg linreg-xs linreg-obs)]
+  (assert-close "M1 generate marginal weight" -11.418803 (mx/item weight) MARG-TOL)
+  (assert-close "M1 posterior slope choice" 1.999324 (choice-val trace :slope) POST-TOL)
+  (assert-close "M1 posterior intercept choice" 0.441145 (choice-val trace :intercept) POST-TOL))
+
+;; method-selection must report exact (both latents eliminated)
+(let [sel (ms/select-method linreg linreg-obs)]
+  (assert-true "M1 method = exact" (= :exact (:method sel)))
+  (assert-true "M1 eliminated slope+intercept" (= #{:slope :intercept} (set (:eliminated sel))))
+  (assert-true "M1 zero residual" (zero? (:n-residual sel))))
+
+;; M2 affine single-latent via gen
+(def affine-model
+  (dyn/auto-key
+    (gen []
+      (let [mu (trace :mu (dist/gaussian 0 5))]
+        (trace :y1 (dist/gaussian (mx/add (mx/multiply 2 mu) 1) 1))
+        (trace :y2 (dist/gaussian (mx/add (mx/multiply 2 mu) 1) 1))
+        (trace :y3 (dist/gaussian (mx/add (mx/multiply 2 mu) 1) 1))
+        mu))))
+(def affine-obs
+  (-> cm/EMPTY (cm/set-choice [:y1] (mx/scalar 3.0))
+      (cm/set-choice [:y2] (mx/scalar 4.5)) (cm/set-choice [:y3] (mx/scalar 2.2))))
+(println "-- M2 affine via p/generate")
+(let [{:keys [trace weight]} (p/generate affine-model [] affine-obs)]
+  (assert-close "M2 generate marginal weight" -6.998560 (mx/item weight) MARG-TOL)
+  (assert-close "M2 posterior mu choice" 1.112957 (choice-val trace :mu) POST-TOL))
+
+;; ===========================================================================
+;; SECTION 3 — Honesty: declined cases are NOT claimed exact
+;; ===========================================================================
+
+(println "\n== Section 3: declined cases stay honest ==")
+
+;; Latent-dependent noise (sigma is itself a latent) -> NOT a linear-Gaussian block
+;; (mirrors 5D's structure). Must fall through; latents stay residual.
+(def latent-noise-model
+  (dyn/auto-key
+    (gen []
+      (let [mu    (trace :mu (dist/gaussian 0 10))
+            sigma (trace :sigma (dist/gamma-dist 2 1))]
+        (trace :y1 (dist/gaussian (mx/add (mx/multiply mu 2) 0) sigma))
+        (trace :y2 (dist/gaussian (mx/add (mx/multiply mu 2) 0) sigma))
+        mu))))
+(def latent-noise-obs
+  (-> cm/EMPTY (cm/set-choice [:y1] (mx/scalar 1.5)) (cm/set-choice [:y2] (mx/scalar 2.0))))
+(println "-- latent-dependent noise: sigma must remain residual")
+(let [sel (ms/select-method latent-noise-model latent-noise-obs)]
+  (assert-true "latent-noise: sigma NOT eliminated" (not (contains? (set (:eliminated sel)) :sigma)))
+  (assert-true "latent-noise: method != exact OR sigma residual"
+               (or (not= :exact (:method sel))
+                   (contains? (:residual-addrs sel) :sigma))))
+
+;; ===========================================================================
+;; Summary
+;; ===========================================================================
+
+(println (str "\n=========================================="))
+(println (str "  linear-gaussian-elim: " @*pass* " passed, " @*fail* " failed"))
+(println (str "=========================================="))
+(when (pos? @*fail*) (js/process.exit 1))

--- a/test/genmlx/mcmc_diagnostics_test.cljs
+++ b/test/genmlx/mcmc_diagnostics_test.cljs
@@ -264,6 +264,72 @@
           "x0 mean near posterior mean 2.475"))))
 
 ;; ---------------------------------------------------------------------------
+;; 5.3.5 Rank-normalized bulk-ESS and tail-ESS (Vehtari et al. 2021)
+;; ---------------------------------------------------------------------------
+;; Independent oracle: a stationary AR(1) x_t = phi*x_{t-1} + sqrt(1-phi^2)*eps_t
+;; has integrated autocorrelation time tau = (1+phi)/(1-phi), so the analytic
+;; ESS of N draws is N*(1-phi)/(1+phi). We validate bulk-ESS against this closed
+;; form (NOT against the function under test) and i.i.d. draws against ESS ~ N.
+
+(defn- gen-normal-vec [seed n]
+  (let [a (rng/normal (rng/fresh-key seed) [n])]
+    (mx/materialize! a)
+    (vec (mx/->clj a))))
+
+(defn- ar1-chain [phi noise]
+  (let [s (js/Math.sqrt (- 1.0 (* phi phi)))]
+    (vec (reductions (fn [prev e] (+ (* phi prev) (* s e)))
+                     (first noise) (rest noise)))))
+
+(deftest bulk-ess-iid-matches-nominal
+  (testing "bulk-ESS of i.i.d. draws ~ total sample count"
+    (let [n 500
+          chains (mapv #(gen-normal-vec % n) [11 22 33 44])
+          total (* 4 n)
+          be (diag/bulk-ess chains)]
+      (is (js/isFinite be) "bulk-ESS finite")
+      ;; i.i.d. -> ESS ~ N; estimator spread tolerated, but clearly high.
+      (is (and (> be (* 0.7 total)) (< be (* 1.15 total)))
+          (str "bulk-ESS=" be " near total=" total " for i.i.d.")))))
+
+(deftest bulk-ess-ar1-matches-analytic
+  (testing "bulk-ESS of AR(1) matches analytic N*(1-phi)/(1+phi)"
+    (let [phi 0.7
+          n 1000
+          chains (mapv (fn [seed] (ar1-chain phi (gen-normal-vec seed n)))
+                       [101 202 303 404])
+          total (* 4 n)
+          analytic (* total (/ (- 1.0 phi) (+ 1.0 phi)))  ; 4000*0.3/1.7 = 705.9
+          be (diag/bulk-ess chains)]
+      (is (js/isFinite be) "bulk-ESS finite")
+      ;; ESS estimator variance ~ +/-30% on 4000 autocorrelated draws.
+      (is (and (> be (* 0.7 analytic)) (< be (* 1.35 analytic)))
+          (str "bulk-ESS=" be " near analytic=" analytic " (phi=" phi ")"))
+      ;; bulk-ESS must DETECT the autocorrelation: well below i.i.d. nominal.
+      (is (< be (* 0.5 total))
+          (str "bulk-ESS=" be " well below nominal " total " (autocorrelated)")))))
+
+(deftest tail-ess-sane
+  (testing "tail-ESS is finite, positive, bounded, and tracks autocorrelation"
+    (let [n 500
+          iid (mapv #(gen-normal-vec % n) [5 6 7 8])
+          arc (mapv (fn [seed] (ar1-chain 0.7 (gen-normal-vec seed n))) [9 10 12 13])
+          total (* 4 n)
+          te-iid (diag/tail-ess iid)
+          te-arc (diag/tail-ess arc)]
+      (is (and (js/isFinite te-iid) (pos? te-iid)) "tail-ESS(iid) finite positive")
+      (is (< te-iid (* 1.15 total)) (str "tail-ESS(iid)=" te-iid " <= total"))
+      (is (and (js/isFinite te-arc) (pos? te-arc)) "tail-ESS(ar1) finite positive")
+      ;; autocorrelated tails mix slower than i.i.d.
+      (is (< te-arc (* 0.7 total))
+          (str "tail-ESS(ar1)=" te-arc " below nominal for autocorrelated tails")))))
+
+(deftest bulk-tail-ess-degenerate-guard
+  (testing "ragged / empty chains return 0.0"
+    (is (= 0.0 (diag/bulk-ess [[1.0 2.0 3.0] [1.0 2.0]])) "ragged -> 0")
+    (is (= 0.0 (diag/tail-ess [[] []])) "empty -> 0")))
+
+;; ---------------------------------------------------------------------------
 ;; Run
 ;; ---------------------------------------------------------------------------
 

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -204,6 +204,7 @@ fast test/genmlx/lanczos_test.cljs
 medium test/genmlx/lazy_mcmc_test.cljs
 medium test/genmlx/level0_certification_test.cljs
 medium test/genmlx/limitations_fixes_test.cljs
+medium test/genmlx/linear_gaussian_elim_test.cljs
 slow test/genmlx/llm_backend_test.cljs
 slow test/genmlx/llm_bytes_test.cljs
 bench test/genmlx/llm_cache_benchmark.cljs


### PR DESCRIPTION
M3a milestone (TOPML rigor floor). Six commits:

- **rqaa / fabd** — PF log-ML convergence + annealed-IS weight-accumulation GFI laws
- **5gww** — rank-normalized bulk/tail-ESS + 4-chain funnel diagnostics
- **lwhw** — joint linear-Gaussian elimination (coupled/affine regression)
- **anlv** — analytical elimination reframed as exactness (killed the >1000x artifact)
- **m3tn / 4q9d** — L3 regenerate parity + conditional partial-conjugacy
- **d0qx** — out-of-family NumPyro baseline (matched-accuracy-at-cost; IS within 0.13 nats of exact, NUTS recovers exact posterior)

Note: the uncommitted `results/` regeneration (generated at stale sha 5f29f7a) is intentionally left out — it belongs to 9ocx (THE GATE, results freeze).

🤖 Generated with [Claude Code](https://claude.com/claude-code)