### PR TITLE
fix(selection): get-subselection resamples only selected addresses (genmlx-yey5)

### DIFF
--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -395,6 +395,53 @@
                         (= (set (all-leaf-addrs (:choices t)))
                            (set (all-leaf-addrs (:choices rev-trace)))))))))}
 
+   {:name :flat-selection-at-splice
+    :from "[T] §3.4, Gen.jl selection semantics (genmlx-yey5)"
+    :theorem "A FLAT selection descends correctly through a splice:
+              (select :a) where :a is NOT the splice address leaves the
+              entire splice subtree untouched, while (select :sub) where
+              :sub IS the splice address resamples the WHOLE subtree under
+              it. I.e. get-subselection returns `all` iff the address is
+              selected, else `none` — never `all` unconditionally.
+              Self-contained: builds a leaf :x + splice :sub{:z,:w} model."
+    :tags #{:regenerate :selection :core :compositionality}
+    :check (fn [_]
+             (let [sub (dyn/auto-key
+                        (dyn/make-gen-fn
+                         (fn [rt mu]
+                           (let [trace (.-trace rt)]
+                             (mx/add (trace :z (dist/gaussian mu 1))
+                                     (trace :w (dist/gaussian mu 1)))))
+                         '([mu] (mx/add (trace :z (dist/gaussian mu 1))
+                                        (trace :w (dist/gaussian mu 1))))))
+                   model (dyn/auto-key
+                          (dyn/make-gen-fn
+                           (fn [rt]
+                             (let [trace  (.-trace rt)
+                                   splice (.-splice rt)
+                                   x (trace :x (dist/gaussian 0 10))]
+                               (splice :sub sub x)
+                               x))
+                           '([] (let [x (trace :x (dist/gaussian 0 10))]
+                                  (splice :sub sub x)
+                                  x))))
+                   t  (p/simulate model [])
+                   z0 (ev (cm/get-choice (:choices t) [:sub :z]))
+                   w0 (ev (cm/get-choice (:choices t) [:sub :w]))
+                   x0 (choice-num (:choices t) :x)
+                   ;; (1) flat select of a NON-splice address: subtree untouched
+                   t1 (:trace (p/regenerate model t (sel/select :x)))
+                   ;; (2) flat select of the SPLICE address: whole subtree resampled
+                   t2 (:trace (p/regenerate model t (sel/select :sub)))]
+               (and
+                ;; (1) :sub subtree fully preserved
+                (approx= z0 (ev (cm/get-choice (:choices t1) [:sub :z])) 1e-6)
+                (approx= w0 (ev (cm/get-choice (:choices t1) [:sub :w])) 1e-6)
+                ;; (2) :x preserved, both :sub sites resampled
+                (approx= x0 (choice-num (:choices t2) :x) 1e-6)
+                (not (approx= z0 (ev (cm/get-choice (:choices t2) [:sub :z])) 1e-9))
+                (not (approx= w0 (ev (cm/get-choice (:choices t2) [:sub :w])) 1e-9)))))}
+
    ;; ===================================================================
    ;; PROJECT laws
    ;; ===================================================================

--- a/src/genmlx/selection.cljs
+++ b/src/genmlx/selection.cljs
@@ -22,7 +22,12 @@
 (defrecord SelectAddrs [addrs]
   ISelection
   (selected? [_ addr] (contains? addrs addr))
-  (get-subselection [_ _] all))
+  ;; Gen.jl semantics: selecting a flat address selects EVERYTHING under it,
+  ;; but ONLY that address. So the subselection is `all` iff the address is
+  ;; selected, otherwise `none`. Returning `all` unconditionally (the prior
+  ;; bug) made every splice/combinator-element descent resample its whole
+  ;; subtree regardless of which address was actually selected.
+  (get-subselection [_ addr] (if (contains? addrs addr) all none)))
 
 (defn select
   "Create a flat selection of specific addresses.
@@ -38,7 +43,14 @@
 ;; Hierarchical selection: address -> sub-selection
 (defrecord Hierarchical [m]
   ISelection
-  (selected? [_ addr] (contains? m addr))
+  ;; A leaf at `addr` is selected iff its subselection selects everything,
+  ;; i.e. the entry maps to the canonical `all` selection. Mapping `addr` to a
+  ;; PARTIAL subselection (e.g. (hierarchical :sub (select :z))) means "descend
+  ;; into :sub and select :z" — it does NOT select the leaf :sub itself. The
+  ;; prior `(contains? m addr)` conflated partial-descent with full-leaf
+  ;; selection. Descent into sub-structures uses get-subselection, not
+  ;; selected?, so this only affects genuine leaf checks.
+  (selected? [_ addr] (identical? all (get m addr none)))
   (get-subselection [_ addr] (get m addr none)))
 
 (defn hierarchical

--- a/test/genmlx/selection_algebra_test2.cljs
+++ b/test/genmlx/selection_algebra_test2.cljs
@@ -99,9 +99,11 @@
 
 (deftest hierarchical-selects-registered-addresses
   (let [h (sel/hierarchical :a (sel/select :x :y) :b sel/all)]
-    (is (sel/selected? h :a))
-    (is (sel/selected? h :b))
-    (is (not (sel/selected? h :c)))))
+    ;; :a maps to a PARTIAL subselection => :a is a descent point, not a
+    ;; selected leaf. :b maps to `all` => :b is selected as a leaf.
+    (is (not (sel/selected? h :a)) "partial-subsel key is not leaf-selected")
+    (is (sel/selected? h :b) "all-subsel key is leaf-selected")
+    (is (not (sel/selected? h :c)) "unregistered key is not selected")))
 
 (deftest hierarchical-subselection-propagates
   (let [h (sel/hierarchical :a (sel/select :x :y) :b sel/all)]
@@ -120,12 +122,15 @@
 (deftest nested-hierarchical-selection
   (let [inner (sel/hierarchical :p (sel/select :q))
         outer (sel/hierarchical :a inner)]
-    (is (sel/selected? outer :a))
+    ;; Path [:a :p :q]: :a and :p are descent points (partial subselections),
+    ;; not selected leaves; only :q at the bottom of the path is selected. The
+    ;; descent itself is verified via get-subselection.
+    (is (not (sel/selected? outer :a)) ":a is a descent point, not leaf-selected")
     (let [sub-a (sel/get-subselection outer :a)]
-      (is (sel/selected? sub-a :p))
-      (is (not (sel/selected? sub-a :z)))
+      (is (not (sel/selected? sub-a :p)) ":p is a descent point, not leaf-selected")
+      (is (not (sel/selected? sub-a :z)) ":z is not under :a")
       (let [sub-a-p (sel/get-subselection sub-a :p)]
-        (is (sel/selected? sub-a-p :q))))))
+        (is (sel/selected? sub-a-p :q) ":q is selected at the bottom of the path")))))
 
 ;; ---------------------------------------------------------------------------
 ;; Complement distributes through hierarchy
@@ -134,9 +139,11 @@
 (deftest complement-of-hierarchical-subselection
   (let [h (sel/hierarchical :a (sel/select :x :y))
         c (sel/complement-sel h)]
-    (testing "complement flips top-level"
-      (is (not (sel/selected? c :a)))
-      (is (sel/selected? c :z)))
+    (testing "complement flips top-level leaf membership"
+      ;; h leaf-selects nothing at the top level (:a is a descent point with a
+      ;; partial subselection), so the complement leaf-selects both :a and :z.
+      (is (sel/selected? c :a) "complement: :a leaf-selected (h does not leaf-select :a)")
+      (is (sel/selected? c :z) "complement: :z leaf-selected"))
     (testing "complement propagates into subselections"
       (let [c-sub-a (sel/get-subselection c :a)]
         (is (not (sel/selected? c-sub-a :x))

--- a/test/genmlx/selection_property_test.cljs
+++ b/test/genmlx/selection_property_test.cljs
@@ -91,4 +91,49 @@
           leaf-addrs (cm/addresses cm)]
       (not-any? (fn [[a]] (sel/selected? sel/none a)) leaf-addrs))))
 
+;; ---------------------------------------------------------------------------
+;; get-subselection descent semantics (genmlx-yey5)
+;;
+;; These pin the property that descent (used by splice/combinator-element
+;; recursion) resamples a subtree iff its address is selected. The prior bug
+;; was SelectAddrs.get-subselection returning `all` unconditionally, so EVERY
+;; unselected subtree was resampled.
+;; ---------------------------------------------------------------------------
+
+(defspec select-subselection-all-iff-selected 100
+  ;; A selected address descends with `all`; an unselected one with `none`.
+  (prop/for-all [s gen-addr-set
+                 k gen-addr]
+    (let [sel (sel/from-set s)
+          sub (sel/get-subselection sel k)]
+      (if (contains? s k)
+        (sel/selected? sub :anything)         ;; selected => everything under k selected
+        (not (sel/selected? sub :anything)))))) ;; unselected => nothing under k selected
+
+(defspec select-descent-consistent-with-leaf 100
+  ;; The leaf check and the descent agree: descending into k selects a leaf
+  ;; iff k itself is selected as a leaf.
+  (prop/for-all [s gen-addr-set
+                 k gen-addr]
+    (let [sel (sel/from-set s)]
+      (= (sel/selected? sel k)
+         (sel/selected? (sel/get-subselection sel k) :anything)))))
+
+(defspec complement-descent-consistent-with-leaf 100
+  ;; Complement mirror-bug regression: selected?(comp, k) agrees with whether
+  ;; everything under k is selected via the descended subselection.
+  (prop/for-all [s gen-addr-set
+                 k gen-addr]
+    (let [comp (sel/complement-sel (sel/from-set s))]
+      (= (sel/selected? comp k)
+         (sel/selected? (sel/get-subselection comp k) :anything)))))
+
+(defspec hierarchical-partial-subsel-not-leaf-selected 100
+  ;; Hierarchical conflation regression: an address mapped to a PARTIAL
+  ;; subselection is NOT selected as a leaf; mapped to `all` it IS.
+  (prop/for-all [k     gen-addr
+                 inner gen-addr]
+    (and (not (sel/selected? (sel/hierarchical k (sel/select inner)) k))
+         (sel/selected? (sel/hierarchical k sel/all) k))))
+
 (t/run-tests)

--- a/test/genmlx/selection_regenerate_test.cljs
+++ b/test/genmlx/selection_regenerate_test.cljs
@@ -1,0 +1,158 @@
+;; @tier fast core
+(ns genmlx.selection-regenerate-test
+  "End-to-end counterexample/regression tests for genmlx-yey5: selection
+   descent must resample ONLY selected addresses, keeping unselected splice
+   subtrees and combinator elements byte-for-byte unchanged.
+
+   Oracle: value preservation. An UNSELECTED address must retain its exact
+   prior value after regenerate; a SELECTED continuous address must change.
+   This is an independent invariant (not the function under test) that directly
+   falsifies the old bug, where get-subselection returned `all` unconditionally
+   and resampled entire unselected subtrees / every combinator element."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.test-helpers :as h]
+            [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.gfi :as gfi]
+            [genmlx.combinators :as comb])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(defn- leaf
+  "Realized numeric value at a path in a trace's choices."
+  [trace path]
+  (h/realize (cm/get-choice (:choices trace) path)))
+
+;; ---------------------------------------------------------------------------
+;; Splice case (scalar executor descent — runtime.cljs splice-fn)
+;; ---------------------------------------------------------------------------
+
+(def sub-model
+  (dyn/auto-key
+    (gen [mu]
+      (let [z (trace :z (dist/gaussian mu 1))
+            w (trace :w (dist/gaussian mu 1))]
+        (mx/add z w)))))
+
+(def splice-model
+  (dyn/auto-key
+    (gen []
+      (let [x (trace :x (dist/gaussian 0 10))]
+        (splice :sub sub-model x)
+        x))))
+
+(deftest splice-unselected-subtree-preserved
+  (testing "regenerate (select :x) must NOT resample the unselected :sub subtree"
+    (let [t0   (p/simulate splice-model [])
+          x0   (leaf t0 [:x])
+          z0   (leaf t0 [:sub :z])
+          w0   (leaf t0 [:sub :w])
+          t1   (:trace (p/regenerate splice-model t0 (sel/select :x)))
+          x1   (leaf t1 [:x])
+          z1   (leaf t1 [:sub :z])
+          w1   (leaf t1 [:sub :w])]
+      ;; THE FIX: unselected splice subtree is preserved exactly.
+      (is (h/close? z0 z1 0.0) ":sub/:z preserved (was resampled before the fix)")
+      (is (h/close? w0 w1 0.0) ":sub/:w preserved (was resampled before the fix)")
+      ;; The selected continuous address is resampled (changes w.p. 1).
+      (is (not (h/close? x0 x1 1e-9)) ":x resampled"))))
+
+(deftest splice-descend-partial-select
+  (testing "regenerate (hierarchical :sub (select :z)) resamples only :sub/:z"
+    (let [t0   (p/simulate splice-model [])
+          x0   (leaf t0 [:x])
+          z0   (leaf t0 [:sub :z])
+          w0   (leaf t0 [:sub :w])
+          t1   (:trace (p/regenerate splice-model t0
+                                     (sel/hierarchical :sub (sel/select :z))))
+          x1   (leaf t1 [:x])
+          z1   (leaf t1 [:sub :z])
+          w1   (leaf t1 [:sub :w])]
+      (is (h/close? x0 x1 0.0) ":x preserved (not selected)")
+      (is (h/close? w0 w1 0.0) ":sub/:w preserved (sibling not selected)")
+      (is (not (h/close? z0 z1 1e-9)) ":sub/:z resampled (selected via descent)"))))
+
+(deftest splice-empty-selection-preserves-all
+  (testing "regenerate (select :nonexistent) preserves the whole trace"
+    (let [t0 (p/simulate splice-model [])
+          t1 (:trace (p/regenerate splice-model t0 (sel/select :nonexistent)))]
+      (is (h/close? (leaf t0 [:x])      (leaf t1 [:x])      0.0) ":x preserved")
+      (is (h/close? (leaf t0 [:sub :z]) (leaf t1 [:sub :z]) 0.0) ":sub/:z preserved")
+      (is (h/close? (leaf t0 [:sub :w]) (leaf t1 [:sub :w]) 0.0) ":sub/:w preserved"))))
+
+;; ---------------------------------------------------------------------------
+;; Map combinator case (element descent — combinators.cljs)
+;; ---------------------------------------------------------------------------
+
+;; Two-site kernel so we can test partial selection WITHIN an element.
+(def kernel2
+  (dyn/auto-key
+    (gen [x]
+      (let [a (trace :a (dist/gaussian x 1))
+            b (trace :b (dist/gaussian x 1))]
+        (mx/add a b)))))
+
+(defn- map-trace [kernel inputs]
+  (p/simulate (comb/map-combinator kernel) [inputs]))
+
+(deftest map-select-one-element
+  (testing "regenerate (select 1) resamples only element 1; others preserved"
+    (let [inputs [0.0 1.0 2.0 3.0]
+          mapped (comb/map-combinator kernel2)
+          t0     (p/simulate mapped [inputs])
+          olds   (mapv (fn [i] [(leaf t0 [i :a]) (leaf t0 [i :b])]) (range 4))
+          t1     (:trace (p/regenerate mapped t0 (sel/select 1)))
+          news   (mapv (fn [i] [(leaf t1 [i :a]) (leaf t1 [i :b])]) (range 4))]
+      ;; THE FIX: only element 1 changes; before the fix EVERY element was
+      ;; resampled because get-subselection handed `all` to every index.
+      (doseq [i [0 2 3]]
+        (is (h/close? (first (olds i)) (first (news i)) 0.0)
+            (str "element " i " :a preserved"))
+        (is (h/close? (second (olds i)) (second (news i)) 0.0)
+            (str "element " i " :b preserved")))
+      (is (not (h/close? (first (olds 1)) (first (news 1)) 1e-9)) "element 1 :a resampled")
+      (is (not (h/close? (second (olds 1)) (second (news 1)) 1e-9)) "element 1 :b resampled"))))
+
+(deftest map-descend-into-element
+  (testing "regenerate (hierarchical 1 (select :a)) resamples only element 1's :a"
+    (let [inputs [0.0 1.0 2.0 3.0]
+          mapped (comb/map-combinator kernel2)
+          t0     (p/simulate mapped [inputs])
+          olds   (mapv (fn [i] [(leaf t0 [i :a]) (leaf t0 [i :b])]) (range 4))
+          t1     (:trace (p/regenerate mapped t0
+                                       (sel/hierarchical 1 (sel/select :a))))
+          news   (mapv (fn [i] [(leaf t1 [i :a]) (leaf t1 [i :b])]) (range 4))]
+      (doseq [i [0 2 3]]
+        (is (h/close? (first (olds i)) (first (news i)) 0.0)
+            (str "element " i " :a preserved"))
+        (is (h/close? (second (olds i)) (second (news i)) 0.0)
+            (str "element " i " :b preserved")))
+      (is (not (h/close? (first (olds 1)) (first (news 1)) 1e-9)) "element 1 :a resampled")
+      (is (h/close? (second (olds 1)) (second (news 1)) 0.0) "element 1 :b preserved"))))
+
+;; ---------------------------------------------------------------------------
+;; Compiled-vs-handler parity: the fix must behave identically on both paths.
+;; strip-compiled forces the handler (interpreter) regenerate for the kernel.
+;; ---------------------------------------------------------------------------
+
+(deftest map-compiled-handler-parity
+  (testing "select-one-element preservation holds on the stripped (handler) path too"
+    (let [inputs  [0.0 1.0 2.0 3.0]
+          stripped (dyn/auto-key (gfi/strip-compiled kernel2))
+          mapped  (comb/map-combinator stripped)
+          t0      (p/simulate mapped [inputs])
+          olds    (mapv (fn [i] [(leaf t0 [i :a]) (leaf t0 [i :b])]) (range 4))
+          t1      (:trace (p/regenerate mapped t0 (sel/select 2)))
+          news    (mapv (fn [i] [(leaf t1 [i :a]) (leaf t1 [i :b])]) (range 4))]
+      (doseq [i [0 1 3]]
+        (is (h/close? (first (olds i)) (first (news i)) 0.0)
+            (str "[handler] element " i " :a preserved"))
+        (is (h/close? (second (olds i)) (second (news i)) 0.0)
+            (str "[handler] element " i " :b preserved")))
+      (is (not (h/close? (first (olds 2)) (first (news 2)) 1e-9)) "[handler] element 2 :a resampled")
+      (is (not (h/close? (second (olds 2)) (second (news 2)) 1e-9)) "[handler] element 2 :b resampled"))))
+
+(cljs.test/run-tests)

--- a/test/genmlx/selection_test.cljs
+++ b/test/genmlx/selection_test.cljs
@@ -30,16 +30,56 @@
 (deftest hierarchical-test
   (testing "hierarchical"
     (let [s (sel/hierarchical :sub (sel/select :x :y))]
-      (is (sel/selected? s :sub) "hierarchical includes :sub")
+      ;; A PARTIAL subselection at :sub means "descend into :sub and select
+      ;; :x/:y" — it does NOT select the leaf :sub itself. (Gen.jl semantics.)
+      (is (not (sel/selected? s :sub)) "hierarchical with partial subsel does NOT select :sub as a leaf")
       (is (not (sel/selected? s :other)) "hierarchical excludes :other")
       (let [sub (sel/get-subselection s :sub)]
         (is (sel/selected? sub :x) "subselection includes :x")
-        (is (not (sel/selected? sub :z)) "subselection excludes :z")))))
+        (is (not (sel/selected? sub :z)) "subselection excludes :z"))))
+  (testing "an entry mapped to `all` selects its address as a leaf"
+    (let [s (sel/hierarchical :a sel/all :sub (sel/select :z))]
+      (is (sel/selected? s :a) "hierarchical with `all` subsel selects :a as a leaf")
+      (is (not (sel/selected? s :sub)) "partial subsel does not select :sub as a leaf")
+      (is (identical? sel/all (sel/get-subselection s :a)) "get-subselection :a => all")
+      (is (not (sel/selected? (sel/get-subselection s :other) :anything))
+          "unmapped address => none subselection"))))
+
+(deftest get-subselection-select-test
+  (testing "SelectAddrs.get-subselection: all iff selected, else none (genmlx-yey5)"
+    (let [s (sel/select :x :y)]
+      ;; Selected address => descend with `all` (select the whole subtree).
+      (is (identical? sel/all (sel/get-subselection s :x)) ":x subselection is `all`")
+      (is (identical? sel/all (sel/get-subselection s :y)) ":y subselection is `all`")
+      ;; UNselected address => descend with `none` (resample nothing). This is
+      ;; the fix: it previously returned `all` unconditionally, so
+      ;; (regenerate (select :x)) resampled entire unselected splice subtrees.
+      (is (identical? sel/none (sel/get-subselection s :z)) ":z subselection is `none`")
+      (is (not (sel/selected? (sel/get-subselection s :z) :anything))
+          "nothing under an unselected address is selected"))))
+
+(deftest get-subselection-all-none-test
+  (testing "all/none subselections are themselves"
+    (is (identical? sel/all (sel/get-subselection sel/all :anything)))
+    (is (identical? sel/none (sel/get-subselection sel/none :anything)))))
 
 (deftest complement-test
-  (testing "complement"
+  (testing "complement selected?"
     (let [s (sel/complement-sel (sel/select :x :y))]
       (is (not (sel/selected? s :x)) "complement excludes :x")
-      (is (sel/selected? s :z) "complement includes :z"))))
+      (is (sel/selected? s :z) "complement includes :z")))
+  (testing "complement get-subselection is consistent with selected? (mirror-bug regression)"
+    ;; The Complement was a "mirror" of the SelectAddrs bug: selected? said an
+    ;; address was selected while the descended subselection resampled nothing
+    ;; (or vice versa). With the inner subselections fixed, the two now agree.
+    (let [s (sel/complement-sel (sel/select :x))]
+      ;; :x is excluded by the complement => nothing under :x is selected.
+      (is (not (sel/selected? s :x)) "complement: :x excluded as leaf")
+      (is (not (sel/selected? (sel/get-subselection s :x) :anything))
+          "complement: nothing under excluded :x is selected")
+      ;; :y is included by the complement => everything under :y is selected.
+      (is (sel/selected? s :y) "complement: :y included as leaf")
+      (is (sel/selected? (sel/get-subselection s :y) :anything)
+          "complement: everything under included :y is selected"))))
 
 (cljs.test/run-tests)

--- a/test/genmlx/tutorial/ch04_test.cljs
+++ b/test/genmlx/tutorial/ch04_test.cljs
@@ -232,12 +232,23 @@
 (println "\n== Listing 4.12: hierarchical ==")
 
 (let [s (sel/hierarchical :params (sel/select :slope))]
-  (assert-true ":params is selected" (sel/selected? s :params))
+  ;; :params maps to a PARTIAL subselection (just :slope), so :params is a
+  ;; DESCENT POINT, not a selected leaf: selected? is false. You reach the
+  ;; selected address by descending with get-subselection.
+  (assert-true ":params is a descent point, not leaf-selected"
+               (not (sel/selected? s :params)))
   (assert-true ":other is not selected" (not (sel/selected? s :other)))
   ;; Sub-selection under :params
   (let [sub (sel/get-subselection s :params)]
     (assert-true "sub selects :slope" (sel/selected? sub :slope))
     (assert-true "sub does not select :intercept" (not (sel/selected? sub :intercept)))))
+
+;; To select an address itself (as a leaf, or its whole subtree), map it to
+;; `all` — then selected? is true and the entire subtree is selected.
+(let [s (sel/hierarchical :params sel/all)]
+  (assert-true ":params mapped to all IS selected" (sel/selected? s :params))
+  (assert-true "everything under :params is selected"
+               (sel/selected? (sel/get-subselection s :params) :anything)))
 
 ;; ============================================================
 ;; Listing 4.13: Selections as Boolean algebra


### PR DESCRIPTION
## Summary

`SelectAddrs.get-subselection` returned `all` **unconditionally**, ignoring the address. Because splice and Map/Unfold/Scan element descent recurse via `get-subselection`, a flat selection like `(regenerate t (select :x))` handed `all` down **every unselected splice subtree / combinator element** and resampled it — silently corrupting `regenerate`/MCMC on any model with splices or combinators. `Complement` was a downstream mirror; `Hierarchical.selected?` conflated partial-descent keys with full-leaf selection.

## Fix (`src/genmlx/selection.cljs`)

- `SelectAddrs.get-subselection` → `(if (contains? addrs addr) all none)` — `all` iff the address is selected, else `none`.
- `Hierarchical.selected?` → `(identical? all (get m addr none))` — a leaf is selected only if its subselection is the canonical `all`; a partial subselection (e.g. `(hierarchical :sub (select :z))`) marks a **descent point**, not a leaf selection (Gen.jl semantics). Descent uses `get-subselection`, not `selected?`, so only genuine leaf checks change.
- `Complement` needs no code change — it composes correctly once the inner subselections are right.

Both the handler and compiled regenerate paths gate leaves on `selected?`, and `none.selected?` is uniformly false, so `none` flows through correctly on both paths.

## Tests / laws

- **NEW** `selection_regenerate_test.cljs` — end-to-end counterexamples (oracle = value preservation) on splice + Map, including compiled-vs-handler parity. **Proven to fail on the reverted bug.**
- `selection_property_test.cljs` — +4 `defspec`s (all/none descent, descent consistent with leaf, complement consistency, hierarchical partial ≠ full).
- `gfi.cljs` — NEW law `:flat-selection-at-splice` (self-contained splice model).
- Updated `selection_test`, `selection_algebra_test2`, and `tutorial/ch04` (Listing 4.12) to the corrected Gen.jl semantics.

## Verification

- fast-core **30/30**; fast-all **132/133** (the 1 failure is a pre-existing, unrelated `ch10` die-roll bug, tracked separately).
- Targeted gates all **pass**: level0/l4 certifications, `gen_clj_compat` (356), `genjax_compat` (73), `wp9a_combinator_regenerate`, `wp6_regenerate`, `l3_5_regenerate`, `mcmc_detailed_balance`, `mcmc_stationary`, `inference_mh`/`smc`, `pmcmc`, `project`, `gfi_project`, `inference`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)