### PR TITLE
fix(smc): adaptive-resampling log-ML increments, csmc reference scale, smcp3 stripping + observations

### DIFF
--- a/src/genmlx/inference/smc.cljs
+++ b/src/genmlx/inference/smc.cljs
@@ -2,6 +2,7 @@
   "Sequential Monte Carlo (particle filtering) inference."
   (:require [genmlx.protocols :as p]
             [genmlx.selection :as sel]
+            [genmlx.choicemap :as cm]
             [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
             [genmlx.inference.util :as u]
@@ -12,10 +13,28 @@
 
 (defn log-ml-increment
   "Marginal-likelihood increment for one SMC step: logsumexp(weights) - log N.
-   `w-arr` is a materialized [N]-shaped MLX weight array; `n` is the particle count."
+   `w-arr` is a materialized [N]-shaped MLX weight array; `n` is the particle count.
+
+   This is the increment for a step whose INCOMING weights are uniform — the
+   init step, or any step immediately after a resample (which resets weights
+   to 0, whose logsumexp is log N). When weights carry over from a skipped
+   resample, the increment must instead subtract logsumexp of the carried
+   weights (see `log-ml-increment-from`), otherwise the previously counted
+   mass is counted again every step."
   [w-arr n]
   (mx/subtract (mx/logsumexp w-arr)
                (mx/scalar (js/Math.log n))))
+
+(defn log-ml-increment-from
+  "Marginal-likelihood increment with adaptive resampling:
+   logsumexp(W_t) - logsumexp(W'_{t-1}), where `prev-arr` holds the
+   post-resample weights the step started from (all-zero after a resample,
+   so its logsumexp is log N and this reduces to `log-ml-increment`).
+   Telescoping across steps gives total = logsumexp(W_T) - log N when no
+   resample ever fires."
+  [w-arr prev-arr]
+  (mx/subtract (mx/logsumexp w-arr)
+               (mx/logsumexp prev-arr)))
 
 (defn break-particle-graph!
   "Break the lazy graph for a per-particle generate/update result, preventing
@@ -36,16 +55,37 @@
               (if (u/accept-mh? (mx/realize weight) rk) trace t)))
           trace step-keys))
 
-(defn- strip-analytical
+(defn strip-analytical
   "Strip analytical handlers from a model for particle-based inference.
    The analytical path returns deterministic posterior means, eliminating
-   particle diversity. Particle methods need stochastic prior sampling."
+   particle diversity. Particle methods need stochastic prior sampling.
+   Public so every particle method (smc, csmc, smcp3) shares ONE stripping
+   — mixed stripped/un-stripped scoring puts particles on different weight
+   scales."
   [model]
   (assoc model :schema
          (dissoc (:schema model)
                  :auto-handlers :conjugate-pairs
                  :has-conjugate? :analytical-plan
                  :auto-regenerate-transition)))
+
+(defn- obs-selection
+  "Selection covering exactly the addresses present in an observation
+   choicemap (hierarchical when the choicemap nests). Used to put the cSMC
+   reference particle's weight on the same obs-only scale as the other
+   particles: project of the obs sites = the generate weight the particle
+   would have received had only the observations been constrained."
+  [obs]
+  (letfn [(paths->sel [paths]
+            (sel/->Hierarchical
+              (into {}
+                    (map (fn [[head ps]]
+                           (let [tails (map rest ps)]
+                             [head (if (some empty? tails)
+                                     sel/all
+                                     (paths->sel (map vec tails)))])))
+                    (group-by first paths))))]
+    (paths->sel (cm/addresses obs))))
 
 (defn- residual-resample
   "Residual resampling: deterministically allocate floor(N * w_i) copies,
@@ -166,9 +206,13 @@
         ;; Rejuvenation
         final-traces  (smc-rejuvenate new-traces rejuvenation-steps
                                        rejuvenation-selection rejuv-key)
-        ;; log ml increment
+        ;; log-ML increment: measured against the post-resample weights the
+        ;; step started from. After a resample those are uniform (lse = log N);
+        ;; when the resample is skipped they carry the already-counted mass,
+        ;; which must be subtracted or it is double-counted every step.
         w-arr         (u/materialize-weights new-weights)
-        ml-inc        (log-ml-increment w-arr particles)]
+        prev-arr      (u/materialize-weights weights')
+        ml-inc        (log-ml-increment-from w-arr prev-arr)]
     {:traces final-traces :log-weights new-weights :log-ml-increment ml-inc
      :ess ess :resampled? resample?}))
 
@@ -283,9 +327,22 @@
                                         (break-particle-graph!
                                          (p/generate particle-model args obs-t) i))
                                       (range (dec particles)))
-                  ;; Use reference trace at index 0 (the core of cSMC)
+                  ;; Reference trace at index 0 (the core of cSMC). Its
+                  ;; trajectory is reproduced by constraining ALL its choices,
+                  ;; but that puts the generate weight on the full-joint scale
+                  ;; (prior densities of the retained latents included) while
+                  ;; the other particles carry obs-only weights. Re-score it
+                  ;; via project over the step's observation addresses — the
+                  ;; weight it would have received had only the observations
+                  ;; been constrained — so resampling and the final weighted
+                  ;; draw (pmcmc) compare like with like. Same stripped model
+                  ;; as the other particles: one score semantics for all.
+                  ref-gen (p/generate particle-model args (:choices reference-trace))
                   ref-result (break-particle-graph!
-                              (p/generate model args (:choices reference-trace)) 0)
+                              {:trace (:trace ref-gen)
+                               :weight (p/project particle-model (:trace ref-gen)
+                                                  (obs-selection obs-t))}
+                              0)
                   traces (into [(:trace ref-result)] (mapv :trace other-results))
                   log-weights (into [(:weight ref-result)] (mapv :weight other-results))
                   w-arr (u/materialize-weights log-weights)
@@ -307,10 +364,21 @@
                                          [(mapv #(nth traces %) indices')
                                           (vec (repeat particles (mx/scalar 0.0)))])
                                        [traces log-weights])
-                  ;; Update all particles
+                  ;; Update all particles. The reference particle keeps its
+                  ;; retained trajectory (the update constrains values it
+                  ;; already holds) but its incremental weight is re-scored
+                  ;; via project over the step's observation addresses —
+                  ;; log p(y_t | x_ref) — the same obs-only scale as the
+                  ;; freshly updated particles.
+                  obs-sel (obs-selection obs-t)
                   results (mapv (fn [i trace]
-                                  (break-particle-graph!
-                                   (p/update (:gen-fn trace) trace obs-t) i))
+                                  (let [r (p/update (:gen-fn trace) trace obs-t)
+                                        r (if (= i ref-idx)
+                                            (assoc r :weight
+                                                   (p/project particle-model (:trace r)
+                                                              obs-sel))
+                                            r)]
+                                    (break-particle-graph! r i)))
                                 (range particles) traces')
                   new-traces (mapv :trace results)
                   update-weights (mapv :weight results)
@@ -329,8 +397,11 @@
                                                      (repeat rejuvenation-steps nil)))))
                                          (range particles) new-traces keys))
                                  new-traces)
+                  ;; Same adaptive-resampling increment as smc-step: subtract
+                  ;; the carried mass when the resample was skipped.
                   w-arr (u/materialize-weights new-weights)
-                  ml-inc (log-ml-increment w-arr particles)]
+                  prev-arr (u/materialize-weights weights')
+                  ml-inc (log-ml-increment-from w-arr prev-arr)]
               (when callback
                 (callback {:step t :ess ess :resampled? resample?}))
               (recur (inc t) final-traces new-weights
@@ -534,8 +605,12 @@
               ;; Break lazy graph — weights carried across timesteps
               _ (mx/materialize! cumul-weights)
               vtrace (assoc updated-vtrace :weight cumul-weights)
-              ;; 4. Log-ML increment
-              log-ml-inc (vz/vtrace-log-ml-estimate vtrace)
+              ;; 4. Log-ML increment, measured against the post-resample
+              ;; weights the step started from (uniform after a resample,
+              ;; lse = log N; the carried mass otherwise — subtracting it
+              ;; prevents double-counting when the resample is skipped).
+              log-ml-inc (mx/subtract (mx/logsumexp cumul-weights)
+                                      (mx/logsumexp prev-weights))
               ;; 5. Rejuvenation
               vtrace (vsmc-rejuvenate vtrace rejuvenation-steps
                                        rejuvenation-selection rejuv-key)]

--- a/src/genmlx/inference/smcp3.cljs
+++ b/src/genmlx/inference/smcp3.cljs
@@ -31,7 +31,7 @@
 
    Returns {:traces :log-weights :log-ml-increment}"
   [model args observations proposal-gf particles key]
-  (let [model (dyn/auto-key model)
+  (let [model (-> model dyn/auto-key smc/strip-analytical)
         proposal-gf (when proposal-gf (dyn/auto-key proposal-gf))
         results (mapv
                   (fn [_]
@@ -74,9 +74,13 @@
                     If nil, falls back to constraint-based update (plain p/update)
                     — the forward-kernel is NOT used in this case.
                     Weight semantics change:
-                      with backward:    weight = update + backward_score - forward_score
+                      with backward:    weight = obs_update + update + backward_score - forward_score
                       without backward: weight = update_weight only (no proposal correction)
                     Pass nil for both kernels for standard SMC.
+                    With both kernels, the step's observations are applied via
+                    p/update BEFORE the proposal edit (so the forward kernel
+                    sees them in the trace it conditions on) and their update
+                    weight is included — previously they were silently dropped.
    particles: number of particles
    ess-threshold: resample when ESS < threshold * N
    rejuvenation-fn: (optional) fn [trace key] -> trace for MCMC rejuvenation
@@ -95,20 +99,37 @@
                                [(mapv #(nth traces %) indices)
                                 (vec (repeat particles (mx/scalar 0.0)))])
                              [traces log-weights])
+        obs-empty? (empty? (cm/addresses observations))
         ;; Apply forward kernel to each particle via edit
         results (mapv
                   (fn [trace]
                     (if forward-kernel
                       ;; Use proposal edit
-                      (let [edit-req (if backward-kernel
-                                      (edit/proposal-edit forward-kernel backward-kernel)
-                                      ;; Without backward kernel, fall back to constraint update.
-                                      ;; This changes weight semantics: no backward/forward proposal
-                                      ;; correction is applied — weight is pure update weight only.
-                                      (edit/constraint-edit observations))
-                            {:keys [trace weight]} (edit/edit (:gen-fn trace) trace edit-req)]
-                        (mx/materialize! weight)
-                        {:trace trace :weight weight})
+                      (if backward-kernel
+                        ;; Apply the observations first — the proposal edit
+                        ;; only applies the forward kernel's choices, so
+                        ;; without this step the observations never reach the
+                        ;; trace. Doing it before the edit lets the forward
+                        ;; kernel condition on them (locally-optimal
+                        ;; proposals). Weights compose additively.
+                        (let [obs-result (when-not obs-empty?
+                                           (p/update (:gen-fn trace) trace observations))
+                              trace1 (if obs-result (:trace obs-result) trace)
+                              edit-req (edit/proposal-edit forward-kernel backward-kernel)
+                              {:keys [trace weight]} (edit/edit (:gen-fn trace1) trace1 edit-req)
+                              weight (if obs-result
+                                       (mx/add (:weight obs-result) weight)
+                                       weight)]
+                          (mx/materialize! weight)
+                          {:trace trace :weight weight})
+                        ;; Without backward kernel, fall back to constraint update.
+                        ;; This changes weight semantics: no backward/forward proposal
+                        ;; correction is applied — weight is pure update weight only.
+                        (let [{:keys [trace weight]}
+                              (edit/edit (:gen-fn trace) trace
+                                         (edit/constraint-edit observations))]
+                          (mx/materialize! weight)
+                          {:trace trace :weight weight}))
                       ;; Standard update
                       (let [{:keys [trace weight]} (p/update (:gen-fn trace) trace observations)]
                         (mx/materialize! weight)
@@ -122,9 +143,12 @@
                        (let [rkeys (rng/split-n-or-nils rejuv-key particles)]
                          (mapv (fn [t rk] (rejuvenation-fn t rk)) new-traces rkeys))
                        new-traces)
-        ;; log-ML increment
+        ;; log-ML increment: against the post-resample weights the step
+        ;; started from (see smc/log-ml-increment-from — subtracting the
+        ;; carried mass prevents double-counting when the resample is skipped).
         w-arr (u/materialize-weights new-weights)
-        ml-inc (smc/log-ml-increment w-arr particles)]
+        prev-arr (u/materialize-weights weights')
+        ml-inc (smc/log-ml-increment-from w-arr prev-arr)]
     {:traces final-traces :log-weights new-weights :log-ml-increment ml-inc
      :ess ess :resampled? resample?}))
 
@@ -154,7 +178,10 @@
   (let [{:keys [particles ess-threshold forward-kernel backward-kernel
                 init-proposal rejuvenation-fn callback key]
          :or {particles 100 ess-threshold 0.5}} opts
-        model (dyn/auto-key model)
+        ;; Strip analytical handlers (as smc/csmc do): the analytical path
+        ;; returns deterministic posterior means, collapsing particle
+        ;; diversity to N identical particles on L3 models.
+        model (-> model dyn/auto-key smc/strip-analytical)
         forward-kernel (when forward-kernel (dyn/auto-key forward-kernel))
         backward-kernel (when backward-kernel (dyn/auto-key backward-kernel))
         init-proposal (when init-proposal (dyn/auto-key init-proposal))

--- a/test/genmlx/smc_evidence_test.cljs
+++ b/test/genmlx/smc_evidence_test.cljs
@@ -1,0 +1,253 @@
+;; @tier medium
+;; SMC evidence bookkeeping tests (bean genmlx-vdpx).
+;;
+;; Verifies, against INDEPENDENT host-math oracles (closed-form normal-normal
+;; marginal, host Gaussian log-pdf, telescoping identities — never the code
+;; under test):
+;;   1. smc/csmc/smcp3/vsmc log-ML increments do NOT double-count when
+;;      resampling is skipped: with ess-threshold 0 the total telescopes to
+;;      logsumexp(final weights) - log N exactly.
+;;   2. smc log-ML converges to the analytic linear-Gaussian evidence when the
+;;      per-step weights are proper (all observations at init, empty later
+;;      steps), with and without resampling enabled.
+;;   3. csmc's reference particle carries an obs-only weight (project of the
+;;      observation addresses) on the same scale as the other particles, its
+;;      trajectory is retained, and unified stripping keeps particle diversity.
+;;   4. smcp3 strips analytical handlers (particle diversity on L3 models) and
+;;      applies the step observations in the proposal-edit branch.
+;;
+;; Run: bun run --bun nbb test/genmlx/smc_evidence_test.cljs
+
+(ns genmlx.smc-evidence-test
+  (:require [genmlx.protocols :as p]
+            [genmlx.dist :as dist]
+            [genmlx.choicemap :as cm]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.dynamic :as dyn]
+            [genmlx.inference.smc :as smc]
+            [genmlx.inference.smcp3 :as smcp3])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-close [msg expected actual tol]
+  (if (<= (Math/abs (- expected actual)) tol)
+    (do (vswap! passed inc) (println " PASS" msg "  =" actual))
+    (do (vswap! failed inc) (println " FAIL" msg "  expected:" expected "  got:" actual))))
+
+(defn realize [x] (mx/eval! x) (mx/item x))
+
+;; ---------------------------------------------------------------------------
+;; Independent host-math oracles
+;; ---------------------------------------------------------------------------
+
+(def LOG-2PI (js/Math.log (* 2 js/Math.PI)))
+
+(defn gaussian-logpdf [x mu sigma]
+  (let [z (/ (- x mu) sigma)]
+    (- (* -0.5 (+ LOG-2PI (* z z))) (js/Math.log sigma))))
+
+(defn nn-shared-marginal
+  "Closed-form log p(y) for mu ~ N(m0, prior-var); y_i ~ N(mu, obs-var):
+   y ~ N(m0*1, obs-var*I + prior-var*1·1ᵀ). Derived independently of any
+   GenMLX path (matrix-determinant lemma on the rank-1 covariance)."
+  [ys m0 prior-var obs-var]
+  (let [n (count ys)
+        ds (map #(- % m0) ys)
+        sum-d (reduce + ds)
+        sum-d2 (reduce + (map #(* % %) ds))
+        denom (+ obs-var (* n prior-var))
+        logdet (+ (* (dec n) (js/Math.log obs-var)) (js/Math.log denom))
+        quad (/ (- sum-d2 (* (/ prior-var denom) sum-d sum-d)) obs-var)]
+    (* -0.5 (+ (* n LOG-2PI) logdet quad))))
+
+(defn host-lse
+  "logsumexp of realized log-weights, host-side."
+  [ws]
+  (let [m (apply max ws)]
+    (+ m (js/Math.log (reduce + (map #(js/Math.exp (- % m)) ws))))))
+
+;; ---------------------------------------------------------------------------
+;; Model: normal-normal, conjugate (exercises stripping) — 3 observations
+;; ---------------------------------------------------------------------------
+
+(def model
+  (dyn/auto-key
+    (gen []
+      (let [mu (trace :mu (dist/gaussian 0 10))]
+        (trace :y0 (dist/gaussian mu 1))
+        (trace :y1 (dist/gaussian mu 1))
+        (trace :y2 (dist/gaussian mu 1))
+        mu))))
+
+(def ys [2.8 3.1 2.9])
+(def closed-form (nn-shared-marginal ys 0.0 100.0 1.0))
+
+(def full-obs
+  (cm/choicemap :y0 (mx/scalar 2.8) :y1 (mx/scalar 3.1) :y2 (mx/scalar 2.9)))
+
+(def incremental-obs
+  (mapv (fn [[i y]] (cm/choicemap (keyword (str "y" i)) (mx/scalar y)))
+        (map-indexed vector ys)))
+
+(defn mu-of [trace] (realize (cm/get-choice (:choices trace) [:mu])))
+
+(println (str "closed-form log p(y) = " closed-form))
+
+;; ===========================================================================
+(println "\n== Section 1: smc increment bookkeeping — telescoping identity ==")
+;; With ess-threshold 0 resampling never fires, so the increments must
+;; telescope: total log-ML == logsumexp(final weights) - log N, EXACTLY,
+;; regardless of the per-step weight semantics. The pre-fix code summed
+;; lse(W_t) - log N every step, re-counting the carried mass.
+(let [n 100
+      {:keys [log-weights log-ml-estimate]}
+      (smc/smc {:particles n :ess-threshold 0 :key (rng/fresh-key 11)}
+               model [] incremental-obs)
+      ws (mapv realize log-weights)
+      expected (- (host-lse ws) (js/Math.log n))]
+  (assert-close "smc no-resample: log-ML == lse(final W) - log N"
+                expected (realize log-ml-estimate) 1e-3))
+
+;; ===========================================================================
+(println "\n== Section 2: smc log-ML vs analytic linear-Gaussian oracle ==")
+;; All observations constrained at init (proper IS weights), then two EMPTY
+;; steps. The empty steps must contribute exactly 0 to the evidence — under
+;; the pre-fix bookkeeping each empty step re-added the full IS estimate.
+(let [n 2000
+      empty-steps [full-obs cm/EMPTY cm/EMPTY]
+      r0 (smc/smc {:particles n :ess-threshold 0 :key (rng/fresh-key 7)}
+                  model [] empty-steps)
+      ws (mapv realize (:log-weights r0))
+      ident (- (host-lse ws) (js/Math.log n))
+      r5 (smc/smc {:particles n :ess-threshold 0.5 :key (rng/fresh-key 7)}
+                  model [] empty-steps)]
+  (assert-close "smc (never resample): log-ML ≈ closed form"
+                closed-form (realize (:log-ml-estimate r0)) 0.30)
+  (assert-close "smc (never resample): identity lse(final)-logN"
+                ident (realize (:log-ml-estimate r0)) 1e-3)
+  (assert-close "smc (adaptive resample): log-ML ≈ closed form"
+                closed-form (realize (:log-ml-estimate r5)) 0.30))
+
+;; ===========================================================================
+(println "\n== Section 3: csmc reference particle scale + retention + diversity ==")
+(let [stripped (smc/strip-analytical model)
+      ref-mu 2.5
+      ref-cm (cm/set-choice full-obs [:mu] (mx/scalar ref-mu))
+      ref-trace (:trace (p/generate stripped [] ref-cm))
+      n 30
+      {:keys [traces log-weights]}
+      (smc/csmc {:particles n :key (rng/fresh-key 21)}
+                model [] [full-obs] ref-trace)
+      ws (mapv realize log-weights)
+      ;; obs-only oracle: sum of host Gaussian log-pdfs of the observations
+      obs-ll (fn [mu] (reduce + (map #(gaussian-logpdf % mu 1.0) ys)))
+      mus (mapv mu-of traces)]
+  (assert-close "csmc ref trajectory retained (mu at index 0)"
+                ref-mu (nth mus 0) 1e-6)
+  (assert-close "csmc ref weight = obs-only scale: sum_i log p(y_i | mu_ref)"
+                (obs-ll ref-mu) (nth ws 0) 1e-3)
+  (assert-close "csmc particle 1 weight on the SAME obs-only scale"
+                (obs-ll (nth mus 1)) (nth ws 1) 1e-3)
+  (assert-close "csmc particle 2 weight on the SAME obs-only scale"
+                (obs-ll (nth mus 2)) (nth ws 2) 1e-3)
+  (assert-true "csmc non-ref particles diverse (stripping fires on conjugate model)"
+               (> (count (distinct (rest mus))) 1)))
+
+;; csmc telescoping identity across incremental steps (no resampling)
+(let [stripped (smc/strip-analytical model)
+      ref-cm (cm/set-choice full-obs [:mu] (mx/scalar 2.5))
+      ref-trace (:trace (p/generate stripped [] ref-cm))
+      n 30
+      {:keys [log-weights log-ml-estimate]}
+      (smc/csmc {:particles n :ess-threshold 0 :key (rng/fresh-key 22)}
+                model [] incremental-obs ref-trace)
+      ws (mapv realize log-weights)
+      expected (- (host-lse ws) (js/Math.log n))]
+  (assert-close "csmc no-resample: log-ML == lse(final W) - log N"
+                expected (realize log-ml-estimate) 1e-3))
+
+;; ===========================================================================
+(println "\n== Section 4: smcp3 — stripping + observations in the proposal branch ==")
+;; 4a. Standard path (no kernels) on the conjugate model: stripping must keep
+;; particle diversity (the analytical path would emit N identical posterior
+;; means — and an exactly-correct log-ML that silently tests L3, not SMC).
+(let [n 1000
+      {:keys [traces log-ml-estimate]}
+      (smcp3/smcp3 {:particles n :key (rng/fresh-key 31)}
+                   model [] [full-obs])
+      mus (mapv mu-of traces)]
+  (assert-true "smcp3 particles diverse on conjugate model (analytical stripped)"
+               (> (count (distinct mus)) 1))
+  (assert-close "smcp3 (single step = IS): log-ML ≈ closed form"
+                closed-form (realize log-ml-estimate) 0.40))
+
+;; 4b. Proposal-edit branch must apply the step's observations. The forward
+;; and backward kernels propose a fresh :mu; before the fix obs-t never
+;; reached the trace, so :y1 kept its prior-sampled value.
+(let [fwd (dyn/auto-key
+            (gen [prev-choices]
+              (trace :mu (dist/gaussian 0 10))))
+      bwd (dyn/auto-key
+            (gen [prev-choices]
+              (trace :mu (dist/gaussian 0 10))))
+      two-step-model (dyn/auto-key
+                       (gen []
+                         (let [mu (trace :mu (dist/gaussian 0 10))]
+                           (trace :y0 (dist/gaussian mu 1))
+                           (trace :y1 (dist/gaussian mu 1))
+                           mu)))
+      obs-seq [(cm/choicemap :y0 (mx/scalar 2.8))
+               (cm/choicemap :y1 (mx/scalar 3.1))]
+      n 30
+      {:keys [traces log-weights log-ml-estimate]}
+      (smcp3/smcp3 {:particles n :forward-kernel fwd :backward-kernel bwd
+                    :key (rng/fresh-key 41)}
+                   two-step-model [] obs-seq)
+      y1-vals (mapv (fn [tr] (realize (cm/get-choice (:choices tr) [:y1]))) traces)
+      ws (mapv realize log-weights)]
+  (assert-true "smcp3 proposal branch: observed :y1 applied to EVERY particle"
+               (every? #(< (Math/abs (- % 3.1)) 1e-6) y1-vals))
+  (assert-true "smcp3 proposal branch: all weights finite"
+               (every? js/isFinite ws))
+  (assert-true "smcp3 proposal branch: log-ML finite"
+               (js/isFinite (realize log-ml-estimate))))
+
+;; 4c. smcp3 telescoping identity (proposal branch, never resample)
+(let [fwd (dyn/auto-key (gen [prev-choices] (trace :mu (dist/gaussian 0 10))))
+      bwd (dyn/auto-key (gen [prev-choices] (trace :mu (dist/gaussian 0 10))))
+      two-step-model (dyn/auto-key
+                       (gen []
+                         (let [mu (trace :mu (dist/gaussian 0 10))]
+                           (trace :y0 (dist/gaussian mu 1))
+                           (trace :y1 (dist/gaussian mu 1))
+                           mu)))
+      obs-seq [(cm/choicemap :y0 (mx/scalar 2.8))
+               (cm/choicemap :y1 (mx/scalar 3.1))]
+      n 30
+      {:keys [log-weights log-ml-estimate]}
+      (smcp3/smcp3 {:particles n :forward-kernel fwd :backward-kernel bwd
+                    :ess-threshold 0 :key (rng/fresh-key 43)}
+                   two-step-model [] obs-seq)
+      ws (mapv realize log-weights)
+      expected (- (host-lse ws) (js/Math.log n))]
+  (assert-close "smcp3 no-resample: log-ML == lse(final W) - log N"
+                expected (realize log-ml-estimate) 1e-3))
+
+;; ===========================================================================
+(println "\n== Section 5: vsmc telescoping identity ==")
+(let [n 100
+      {:keys [vtrace log-ml-estimate]}
+      (smc/vsmc {:particles n :ess-threshold 0 :key (rng/fresh-key 51)}
+                model [] incremental-obs)
+      expected (- (realize (mx/logsumexp (:weight vtrace))) (js/Math.log n))]
+  (assert-close "vsmc no-resample: log-ML == lse(final W) - log N"
+                expected (realize log-ml-estimate) 1e-3))
+
+;; ===========================================================================
+(println (str "\n" @passed " passed, " @failed " failed"))
+(when (pos? @failed) (js/process.exit 1))

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -283,11 +283,13 @@ fast test/genmlx/score_monotonicity_property_test.cljs
 fast test/genmlx/searchsorted_test.cljs
 fast test/genmlx/selection_algebra_test2.cljs core
 fast test/genmlx/selection_property_test.cljs
+fast test/genmlx/selection_regenerate_test.cljs core
 fast test/genmlx/selection_test.cljs core
 fast test/genmlx/sensorimotor_test.cljs
 slow test/genmlx/sequential_convergence_test.cljs
 fast test/genmlx/serialize_property_test.cljs
 fast test/genmlx/serialize_test.cljs
+medium test/genmlx/smc_evidence_test.cljs
 medium test/genmlx/smc_property_test.cljs
 medium test/genmlx/smc_scoring_test.cljs
 slow test/genmlx/smc_stress_test.cljs


### PR DESCRIPTION
Fixes bean genmlx-vdpx (2026-06-09 audit, parent genmlx-hqo2). Each finding was independently re-verified from source and against host-math oracles before fixing — the new `test/genmlx/smc_evidence_test.cljs` **fails 9/17 on the pre-fix code** and passes 17/17 after.

## 1. log-ML double-count when resampling is skipped

`smc-step`, `csmc`, `vsmc`, and `smcp3-step` added `lse(W_t) − log N` every step while weights carry over across skipped resamples — re-counting already-counted mass once per skipped step. With the default `ess-threshold 0.5`, skips are routine → systematically inflated evidence.

The increment is now `lse(W_t) − lse(W'_{t−1})` against the post-resample weights the step started from (new `log-ml-increment-from`; reduces to the old formula right after a resample, telescopes to `lse(final W) − log N` when no resample fires).

**Oracle**: linear-Gaussian normal-normal with all observations at init + two empty steps. Pre-fix: −17.31 (true −5.68 — one full re-count per empty step). Post-fix: −5.55 / −5.57 (never-resample and adaptive both within 0.30 of the closed form, which is implemented independently in the test).

## 2. csmc reference particle on the wrong weight scale

The reference was generated from the **un-stripped** model constrained at **all** its choices → full-joint weight (latent priors included), while other particles carried obs-only weights from the stripped model. Mixed scales bias conditional resampling and pmcmc's `sample-weighted-trace`.

Now: the reference is reproduced from the same stripped `particle-model` and re-scored via `p/project` over the step's observation addresses — `log p(y_t | x_ref)`, exactly the other particles' scale — at init and at every subsequent step. Trajectory retention verified (mu at index 0 unchanged); ref and non-ref weights both match the host Gaussian log-pdf oracle to 1e-3.

## 3. smcp3: no stripping, observations dropped in the proposal branch

- `smcp3` never stripped analytical handlers: on L3 models every particle was the same deterministic posterior mean — and the log-ML was *exactly* right because it silently tested the analytical path, not SMC (diversity assertion is the discriminator). Now strips like smc/csmc; `strip-analytical` made public so all particle methods share one stripping.
- The proposal-edit branch never applied `observations` (ProposalEdit only applies the forward kernel's choices). Now applies them via `p/update` **before** the edit — so locally-optimal forward kernels can condition on them — with the obs update weight composed into the step weight. Verified: every particle's `:y1` equals the observed value (pre-fix: prior samples).

## Regressions

gfi_laws_test_p8 (the genmlx-rqaa PF laws, 60 assertions), inference_smc, smcp3_kernel, smc_property, pmcmc, vsmc_validation, bugfix, sequential_convergence, fast-core 30/30 — all green. `gfi_laws_test.cljs` has a pre-existing time-seeded flake in two vgenerate/gradient laws unrelated to smc (2 failures on main, 1 on this branch, different laws per run) — filed as draft bean genmlx-v4mz.

Out of scope (tracked separately): scalar update-weight conventions on flat models (genmlx-8l8j); `compiled_smc` checked and unaffected (always-resample convention, per-step weights fresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)