### PR TITLE
fix(dynamic): correct regenerate and update weight composition (splices, batched, combinators)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -566,7 +566,7 @@ src/genmlx/
   method_selection.cljs, fit.cljs
 
   ;; Layer 10: Verification
-  gfi.cljs                     ;; 53 algebraic laws from the Cusumano-Towner thesis
+  gfi.cljs                     ;; 68 algebraic laws from the Cusumano-Towner thesis
   verify.cljs                  ;; static validator (validate-gen-fn)
 
   ;; Support

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,7 @@ direct import of dynamic.cljs).
 6. **Compose, don't duplicate.** Compiled paths compose on existing handlers and
    infrastructure — no parallel implementations. The handler is ground truth.
 
-7. **53 algebraic laws.** The GFI algebraic theory (`gfi.cljs`) encodes 53 laws
+7. **68 algebraic laws.** The GFI algebraic theory (`gfi.cljs`) encodes 68 laws
    from the thesis covering all operations, compositionality, gradients, and
    compiled path equivalence. `strip-compiled` forces handler path for testing.
 

--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -253,7 +253,16 @@
             choices (assemble-choices results (comp :choices :trace))
             retvals (mapv (comp :retval :trace) results)
             score (sum-field results (comp :score :trace))
-            weight (mx/subtract score (:score trace))
+            ;; Thesis update weights are additive across elements, but each
+            ;; element weight was computed against the constructed old score
+            ;; (recorded element score, or 0 without metadata). Re-base
+            ;; against the true total old score so both cases stay exact:
+            ;; W = Σ w_i + Σ constructed_old_i - old_total.
+            constructed-old (if old-element-scores
+                              (reduce mx/add ZERO old-element-scores)
+                              ZERO)
+            weight (mx/subtract (mx/add (sum-field results :weight) constructed-old)
+                                (:score trace))
             discard (assemble-choices
                      (filter :discard results)
                      :discard)
@@ -554,9 +563,16 @@
                             (nth (:retval trace) (dec first-changed))
                             init-state)
               init-key (when cupd (rng/fresh-key))]
-          ;; Execute steps first-changed..n-1
+          ;; Execute steps first-changed..n-1. `nf` accumulates the non-fresh
+          ;; score: prefix steps are retained verbatim (their non-fresh score
+          ;; is the recorded prefix score); compiled steps never sample fresh
+          ;; (full new score counts); fallback steps recover it from the
+          ;; child's thesis weight, nonfresh_t = w_t + constructed_old_t.
+          ;; Final thesis weight = nf - old_total, exact with or without
+          ;; step-score metadata (the constructed old scores cancel).
           (loop [t first-changed state start-state key init-key
                  new-choices prefix-choices score prefix-score
+                 nf prefix-score
                  discard cm/EMPTY
                  states prefix-states step-scores prefix-step-scores]
             (if (>= t n)
@@ -565,7 +581,7 @@
                                         :choices new-choices :retval states :score score})
                         (cond-> {::step-scores step-scores}
                           cupd (assoc ::compiled-path true)))
-               :weight (mx/subtract score (:score trace)) :discard discard}
+               :weight (mx/subtract nf (:score trace)) :discard discard}
               (if cupd
                 ;; WP-8: compiled update path
                 (let [[k1 k2] (rng/split key)
@@ -579,6 +595,7 @@
                   (recur (inc t) new-state k2
                          (cm/set-choice new-choices [t] step-choices)
                          (mx/add score (:score result))
+                         (mx/add nf (:score result))
                          (if (seq (:discard result))
                            (cm/set-choice discard [t] step-discard)
                            discard)
@@ -587,10 +604,11 @@
                 ;; Fallback: handler path
                 (let [old-sub-choices (cm/get-submap choices t)
                       kernel-args (into [t state] extra)
+                      constructed-old (if old-step-scores (nth old-step-scores t) ZERO)
                       old-trace (tr/make-trace
                                  {:gen-fn kern :args kernel-args
                                   :choices old-sub-choices
-                                  :retval nil :score (if old-step-scores (nth old-step-scores t) ZERO)})
+                                  :retval nil :score constructed-old})
                       result (p/update kern old-trace (cm/get-submap constraints t))
                       new-trace (:trace result)
                       new-state (:retval new-trace)]
@@ -598,6 +616,7 @@
                          new-state nil
                          (cm/set-choice new-choices [t] (:choices new-trace))
                          (mx/add score (:score new-trace))
+                         (mx/add nf (mx/add (:weight result) constructed-old))
                          (if (:discard result)
                            (cm/set-choice discard [t] (:discard result))
                            discard)
@@ -858,7 +877,10 @@
                                         :score (:score new-branch-trace)})
                         {::switch-idx new-idx})
                :weight (:weight result) :discard (:discard result)})))
-        ;; Different branch: generate new branch from scratch
+        ;; Different branch: generate new branch from scratch.
+        ;; Thesis weight: the generate weight counts only constrained sites
+        ;; (fresh ones cancel against the internal proposal); the removed old
+        ;; branch is charged via its recorded score.
         (let [new-branch (nth (:branches this) new-idx)
               gen-result (p/generate new-branch (vec branch-args) constraints)
               new-branch-trace (:trace gen-result)
@@ -869,7 +891,7 @@
                                     :retval (:retval new-branch-trace)
                                     :score new-score})
                     {::switch-idx new-idx})
-           :weight (mx/subtract new-score (:score trace))
+           :weight (mx/subtract (:weight gen-result) (:score trace))
            :discard (:choices trace)}))))
 
   p/IRegenerate
@@ -1489,9 +1511,12 @@
                             (nth old-step-carries (dec first-changed))
                             init-carry)
               init-key (when cupd (rng/fresh-key))]
-          ;; Execute steps first-changed..n-1
+          ;; Execute steps first-changed..n-1. `nf` accumulates the non-fresh
+          ;; score (see Unfold update for the convention); final thesis
+          ;; weight = nf - old_total.
           (loop [t first-changed carry start-carry key init-key
                  new-choices prefix-choices score prefix-score
+                 nf prefix-score
                  discard cm/EMPTY
                  outputs prefix-outputs
                  step-scores prefix-step-scores step-carries prefix-step-carries]
@@ -1503,7 +1528,7 @@
                                         :score score})
                         (cond-> {::step-scores step-scores ::step-carries step-carries}
                           cupd (assoc ::compiled-path true)))
-               :weight (mx/subtract score (:score trace)) :discard discard}
+               :weight (mx/subtract nf (:score trace)) :discard discard}
               (if cupd
                 ;; WP-8: compiled update path
                 (let [[k1 k2] (rng/split key)
@@ -1516,6 +1541,7 @@
                   (recur (inc t) new-carry k2
                          (cm/set-choice new-choices [t] step-choices)
                          (mx/add score (:score result))
+                         (mx/add nf (:score result))
                          (if (seq (:discard result))
                            (cm/set-choice discard [t] step-discard)
                            discard)
@@ -1524,10 +1550,11 @@
                          (conj step-carries new-carry)))
                 ;; Fallback: handler path
                 (let [old-sub-choices (cm/get-submap choices t)
+                      constructed-old (if old-step-scores (nth old-step-scores t) ZERO)
                       old-trace (tr/make-trace
                                  {:gen-fn kern :args [carry (nth inputs t)]
                                   :choices old-sub-choices
-                                  :retval nil :score (if old-step-scores (nth old-step-scores t) ZERO)})
+                                  :retval nil :score constructed-old})
                       result (p/update kern old-trace (cm/get-submap constraints t))
                       new-trace (:trace result)
                       [new-carry output] (:retval new-trace)]
@@ -1535,6 +1562,7 @@
                          new-carry nil
                          (cm/set-choice new-choices [t] (:choices new-trace))
                          (mx/add score (:score new-trace))
+                         (mx/add nf (mx/add (:weight result) constructed-old))
                          (if (:discard result)
                            (cm/set-choice discard [t] (:discard result))
                            discard)

--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -624,14 +624,24 @@
         [trace result] (cond
                          ;; Regenerate mode
                          selection
-                         (let [old-trace (-> (tr/make-trace {:gen-fn gf :args args
+                         (let [old-sub-score (or old-splice-score SCORE-ZERO)
+                               old-trace (-> (tr/make-trace {:gen-fn gf :args args
                                                              :choices (or old-choices cm/EMPTY)
-                                                             :retval nil :score (or old-splice-score SCORE-ZERO)})
+                                                             :retval nil :score old-sub-score})
                                              (attach-old-splice-meta old-sub-splice-scores
                                                                      old-sub-nested-splice-scores))
                                {:keys [trace weight]} (p/regenerate gf old-trace selection)]
+                           ;; The child returns its final MH weight
+                           ;; w = ΔS_child - pr_child, but the parent regenerate
+                           ;; state accumulates proposal ratios (make-regen-result
+                           ;; computes W = ΔS_total - accumulator). Convert back:
+                           ;; pr_child = ΔS_child - w. The constructed old score
+                           ;; cancels, so a missing old-splice-score stays exact.
                            [trace {:choices (:choices trace) :retval (:retval trace)
-                                   :score (:score trace) :weight weight}])
+                                   :score (:score trace)
+                                   :weight (mx/subtract
+                                            (mx/subtract (:score trace) old-sub-score)
+                                            weight)}])
 
                          ;; Update mode: has old-choices (possibly with new constraints)
                          (and old-choices (not= old-choices cm/EMPTY))

--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -162,8 +162,11 @@
                   :executor execute-sub :param-store (param-store gf)}
                  (fn [rt] (run-body gf rt (:args trace))))
         new-trace (make-result-trace gf (:args trace) result)]
+    ;; Thesis update weight: non-fresh score (handler :weight) minus the
+    ;; recorded old score. Freshly sampled new addresses are drawn from the
+    ;; internal proposal and cancel — score-delta would wrongly include them.
     (make-update-result new-trace
-      (mx/subtract (:score result) (:score trace))
+      (mx/subtract (:weight result) (:score trace))
       (:discard result) constraints (:choices result) result)))
 
 (defn- run-regen [transition gf _args key {:keys [trace selection]}]
@@ -279,16 +282,19 @@
   (let [pfx (:compiled-prefix-update (:schema gf))
         result (pfx key (vec (:args trace)) constraints (:choices trace))
         replay (cops/make-replay-update-transition (:values result))
+        ;; Prefix sites never sample fresh (values come from constraints or
+        ;; old choices), so the prefix score seeds the non-fresh :weight
+        ;; accumulator as well as :score.
         handler-result (rt/run-handler replay
                          {:choices cm/EMPTY :score (:score result)
-                          :weight SCORE-ZERO :key key :constraints constraints
+                          :weight (:score result) :key key :constraints constraints
                           :old-choices (:choices trace) :discard (cm/from-flat-map (:discard result))
                           :old-nested-splice-scores (::nested-splice-scores (meta trace))
                           :executor execute-sub :param-store (param-store gf)}
                          (fn [rt] (run-body gf rt (:args trace))))
         new-trace (make-result-trace gf (:args trace) handler-result)]
     (make-update-result new-trace
-      (mx/subtract (:score handler-result) (:score trace))
+      (mx/subtract (:weight handler-result) (:score trace))
       (:discard handler-result) constraints (:choices handler-result) handler-result)))
 
 (defn- run-regen-prefix [gf _args key {:keys [trace selection]}]
@@ -645,15 +651,26 @@
 
                          ;; Update mode: has old-choices (possibly with new constraints)
                          (and old-choices (not= old-choices cm/EMPTY))
-                         (let [old-trace (-> (tr/make-trace {:gen-fn gf :args args
+                         (let [old-sub-score (or old-splice-score SCORE-ZERO)
+                               old-trace (-> (tr/make-trace {:gen-fn gf :args args
                                                              :choices old-choices
-                                                             :retval nil :score (or old-splice-score SCORE-ZERO)})
+                                                             :retval nil :score old-sub-score})
                                              (attach-old-splice-meta old-sub-splice-scores
                                                                      old-sub-nested-splice-scores))
                                {:keys [trace weight discard]} (p/update gf old-trace
                                                                         (or constraints cm/EMPTY))]
+                           ;; The child returns its thesis update weight
+                           ;; w = nonfresh_child - old_child, but the parent's
+                           ;; update accumulator holds non-fresh scores (the
+                           ;; final weight subtracts the parent's recorded old
+                           ;; score, which already includes the child's old
+                           ;; score). Convert back: nonfresh_child = w + old.
+                           ;; The constructed old score cancels, so a missing
+                           ;; old-splice-score stays exact.
                            [trace {:choices (:choices trace) :retval (:retval trace)
-                                   :score (:score trace) :weight weight :discard discard}])
+                                   :score (:score trace)
+                                   :weight (mx/add weight old-sub-score)
+                                   :discard discard}])
 
                          ;; Generate with constraints
                          (and constraints (not= constraints cm/EMPTY))
@@ -886,11 +903,14 @@
                                 :batch-size n :batched? true
                                 :executor execute-sub
                                 :param-store (param-store gf)}
-                               (fn [rt] (run-body gf rt (:args vtrace))))]
+                               (fn [rt] (run-body gf rt (:args vtrace))))
+        ;; Thesis update weight: non-fresh score minus old [N]-shaped score —
+        ;; the same convention as the scalar run-update path.
+        weight (mx/subtract (:weight result) (:score vtrace))]
     {:vtrace (vec/->VectorizedTrace gf (:args vtrace) (:choices result)
-                                    (:score result) (:weight result)
+                                    (:score result) weight
                                     n (:retval result))
-     :weight (:weight result)
+     :weight weight
      :discard (:discard result)}))
 
 (defn vregenerate

--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -221,7 +221,10 @@
 
    {:name :update-density-ratio
     :from "[T] §2.3.1 UPDATE weight = log(p(tau';x')/p(tau;x))"
-    :theorem "update(t, sigma).weight = new_score - old_score"
+    :theorem "update(t, sigma).weight = new_score - old_score for updates
+              that introduce no fresh addresses (fully constrained or fixed
+              structure). See :update-fresh-cancellation for the general
+              form when the internal proposal samples new addresses."
     :tags #{:update :core}
     :check (fn [{:keys [model args]}]
              (let [t1 (p/simulate model args)
@@ -231,6 +234,39 @@
                    new-score (ev (:score trace))
                    w (ev weight)]
                (approx= w (- new-score old-score) 0.1)))}
+
+   {:name :update-fresh-cancellation
+    :from "[T] §2.3.1 UPDATE internal proposal q; Gen.jl/GenJAX update spec"
+    :theorem "update(t, sigma).weight = (new_score - old_score)
+              - project(t', F), where F = the addresses of t' that are in
+              neither t nor sigma (fresh-sampled by the internal proposal).
+              Fresh choices are drawn from the prior and cancel out of the
+              weight; for fixed-structure updates F = {} and this reduces
+              to :update-density-ratio. Checked with a partial constraint
+              (only the first address) so retained sites with changed
+              parents and fresh sites are both exercised when present."
+    :tags #{:update :core}
+    :check (fn [{:keys [model args]}]
+             (let [t1 (p/simulate model args)
+                   t2 (p/simulate model args)
+                   t2-paths (all-leaf-addrs (:choices t2))]
+               (if (empty? t2-paths)
+                 true
+                 (let [sigma-path (first t2-paths)
+                       sigma-val (cm/get-choice (:choices t2) sigma-path)
+                       sigma (cm/set-choice cm/EMPTY sigma-path sigma-val)
+                       {:keys [trace weight]} (p/update model t1 sigma)
+                       old-paths (set (all-leaf-addrs (:choices t1)))
+                       fresh (remove #(or (old-paths %) (= % sigma-path))
+                                     (all-leaf-addrs (:choices trace)))
+                       fresh-lp (reduce
+                                 (fn [acc path]
+                                   (+ acc (ev (p/project model trace
+                                                         (path->selection path)))))
+                                 0.0 fresh)
+                       expected (- (- (ev (:score trace)) (ev (:score t1)))
+                                   fresh-lp)]
+                   (approx= (ev weight) expected 0.05)))))}
 
    {:name :update-round-trip
     :from "[T] Proposition 2.3.1"

--- a/src/genmlx/handler.cljs
+++ b/src/genmlx/handler.cljs
@@ -309,20 +309,15 @@
                                   (assoc :nested-splice-scores (:nested-splice-scores sub-result)))]
                     (assoc (or nss {}) addr sub-meta)))))))
 
-(defn- mlx-array-like?
-  "Duck-typing probe: does x look like an MLX array (has .shape and .item)?"
-  [x]
-  (and (some? x) (some? (.-shape x)) (some? (.-item x))))
-
 (defn- mlx-arr-batched?
   "Check if x is an MLX array with at least 1 dimension."
   [x]
-  (and (mlx-array-like? x) (pos? (count (mx/shape x)))))
+  (and (mx/array? x) (pos? (count (mx/shape x)))))
 
 (defn- scalar-leaf-val?
   "Check if a value is scalar (0-d or not an MLX array)."
   [v]
-  (or (not (mlx-array-like? v))
+  (or (not (mx/array? v))
       (= [] (mx/shape v))))
 
 (defn- run-batched-particle
@@ -339,8 +334,12 @@
                        :choices old-choices :retval nil
                        :score (mx/scalar 0.0)})
           {:keys [trace weight]} (p/regenerate gf elem-trace sub-selection)]
+      ;; The child returns its final MH weight w = ΔS - pr, computed against
+      ;; the constructed old score of 0. The parent's batched regenerate
+      ;; accumulator holds proposal ratios (its final weight is
+      ;; ΔS_total - accumulator), so convert back: pr = S'_child - w.
       {:choices (:choices trace) :score (:score trace)
-       :weight weight :retval (:retval trace)})
+       :weight (mx/subtract (:score trace) weight) :retval (:retval trace)})
 
     ;; Update mode
     (and old-i (not= old-i cm/EMPTY))

--- a/src/genmlx/handler.cljs
+++ b/src/genmlx/handler.cljs
@@ -88,7 +88,15 @@
                       {:addr addr})))))
 
 (defn update-transition
-  "Pure: use new constraint, keep old, or sample fresh."
+  "Pure: use new constraint, keep old, or sample fresh.
+
+   :weight accumulates the NON-FRESH score: the log-prob of every
+   constrained or retained site under the new parameters. Freshly
+   sampled sites (new addresses) contribute only to :score. The caller
+   computes the thesis update weight as non-fresh-score minus the
+   recorded old trace score: fresh choices are drawn from the internal
+   proposal and cancel; removed and overwritten old choices are charged
+   via the old score."
   [state addr dist]
   (let [constraint (cm/get-submap (:constraints state) addr)
         old-choice (cm/get-submap (:old-choices state) addr)]
@@ -97,12 +105,11 @@
       (cm/has-value? constraint)
       (let [new-val (cm/get-value constraint)
             new-lp (dc/dist-log-prob dist new-val)
-            old-val (when (cm/has-value? old-choice) (cm/get-value old-choice))
-            old-lp (if old-val (dc/dist-log-prob dist old-val) ZERO)]
+            old-val (when (cm/has-value? old-choice) (cm/get-value old-choice))]
         [new-val (-> state
                      (update :choices cm/set-value addr new-val)
                      (update :score mx/add new-lp)
-                     (update :weight mx/add (mx/subtract new-lp old-lp))
+                     (update :weight mx/add new-lp)
                      (cond->
                       old-val (update :discard cm/set-value addr old-val)))])
 
@@ -112,7 +119,8 @@
             lp (dc/dist-log-prob dist val)]
         [val (-> state
                  (update :choices cm/set-value addr val)
-                 (update :score mx/add lp))])
+                 (update :score mx/add lp)
+                 (update :weight mx/add lp))])
 
       ;; New address: sample fresh
       :else (simulate-transition state addr dist))))
@@ -222,23 +230,25 @@
       (batched-simulate-transition state addr dist))))
 
 (defn batched-update-transition
-  "Pure: batched update with [N]-shaped old values and scalar/[N]-shaped new constraints."
+  "Pure: batched update with [N]-shaped old values and scalar/[N]-shaped new
+   constraints. Same :weight convention as update-transition: accumulate the
+   non-fresh score (constrained + retained site log-probs); the caller
+   subtracts the old [N]-shaped score to obtain the thesis update weight."
   [state addr dist]
   (let [n (:batch-size state)
         constraint (cm/get-submap (:constraints state) addr)
         old-choice (cm/get-submap (:old-choices state) addr)]
     (cond
-      ;; New constraint provided — score difference against old values
+      ;; New constraint provided
       (cm/has-value? constraint)
       (let [new-val (cm/get-value constraint)
             new-lp (dc/dist-log-prob dist new-val)
-            old-val (when (cm/has-value? old-choice) (cm/get-value old-choice))
-            old-lp (if old-val (dc/dist-log-prob dist old-val) ZERO)]
+            old-val (when (cm/has-value? old-choice) (cm/get-value old-choice))]
         (check-batched-lp! addr n new-lp)
         [new-val (-> state
                      (update :choices cm/set-value addr new-val)
                      (update :score mx/add new-lp)
-                     (update :weight mx/add (mx/subtract new-lp old-lp))
+                     (update :weight mx/add new-lp)
                      (cond->
                       old-val (update :discard cm/set-value addr old-val)))])
 
@@ -249,7 +259,8 @@
         (check-batched-lp! addr n lp)
         [val (-> state
                  (update :choices cm/set-value addr val)
-                 (update :score mx/add lp))])
+                 (update :score mx/add lp)
+                 (update :weight mx/add lp))])
 
       ;; New address: sample [N] fresh values
       :else (batched-simulate-transition state addr dist))))
@@ -349,6 +360,9 @@
                        :choices old-i :retval nil
                        :score (mx/scalar 0.0)})
           {:keys [trace weight discard]} (p/update gf elem-trace c)]
+      ;; The child update weight is non-fresh-score minus its constructed
+      ;; old score of 0, i.e. exactly the non-fresh-score contribution the
+      ;; parent's batched update accumulator expects — merge as-is.
       {:choices (:choices trace) :score (:score trace)
        :weight weight :discard discard :retval (:retval trace)})
 

--- a/src/genmlx/vmap.cljs
+++ b/src/genmlx/vmap.cljs
@@ -313,7 +313,16 @@
           choices (stack-choices (mapv (comp :choices :trace) results))
           retvals (stack-retvals (mapv (comp :retval :trace) results))
           score (mx-sum-by (comp :score :trace) results)
-          weight (mx/subtract score (:score trace))
+          ;; Regenerate weights are additive across independent elements, but
+          ;; each element weight was computed against the constructed old score
+          ;; (recorded element score, or 0 without metadata). Re-base against
+          ;; the true total old score so both cases stay exact:
+          ;; W = Σ w_i + Σ constructed_old_i - old_total.
+          constructed-old (if old-element-scores
+                            (reduce mx/add (mx/scalar 0.0) old-element-scores)
+                            (mx/scalar 0.0))
+          weight (mx/subtract (mx/add (mx-sum-by :weight results) constructed-old)
+                              (:score trace))
           element-scores (mapv (comp :score :trace) results)]
       {:trace (with-meta
                 (tr/make-trace {:gen-fn this :args (:args trace)

--- a/src/genmlx/vmap.cljs
+++ b/src/genmlx/vmap.cljs
@@ -282,7 +282,16 @@
           choices (stack-choices (mapv (comp :choices :trace) results))
           retvals (stack-retvals (mapv (comp :retval :trace) results))
           score (mx-sum-by (comp :score :trace) results)
-          weight (mx/subtract score (:score trace))
+          ;; Thesis update weights are additive across elements, but each
+          ;; element weight was computed against the constructed old score
+          ;; (recorded element score, or 0 without metadata). Re-base against
+          ;; the true total old score so both cases stay exact:
+          ;; W = Σ w_i + Σ constructed_old_i - old_total.
+          constructed-old (if old-element-scores
+                            (reduce mx/add (mx/scalar 0.0) old-element-scores)
+                            (mx/scalar 0.0))
+          weight (mx/subtract (mx/add (mx-sum-by :weight results) constructed-old)
+                              (:score trace))
           discard (let [discards (mapv :discard results)]
                     (if (every? #(= % cm/EMPTY) discards)
                       cm/EMPTY

--- a/test/genmlx/splice_weight_test.cljs
+++ b/test/genmlx/splice_weight_test.cljs
@@ -1,0 +1,182 @@
+;; @tier fast core
+(ns genmlx.splice-weight-test
+  "Weight composition through splices and combinator descent (genmlx-ovop).
+
+   Thesis/Gen.jl semantics: a child GFI call returns its FINAL weight
+   (for regenerate, the MH weight w_child = dS_child - pr_child). The
+   parent regenerate handler accumulates a proposal-ratio correction in
+   :weight and computes W = (S' - S) - correction at the end. Merging a
+   child's final weight directly into the correction accumulator is a
+   convention mix-up; the correct contribution is dS_child - w_child.
+
+   Canonical counterexample: x ~ N(0,10) at :x, spliced child
+   z ~ N(x,1). Regenerating :z draws from its conditional prior with
+   unchanged parents, so the exact weight is 0 — same as the flat
+   (handler-derived) equivalent model."
+  (:require-macros [genmlx.gen :refer [gen]])
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.test-helpers :as h]
+            [genmlx.protocols :as p]
+            [genmlx.dynamic :as dyn]
+            [genmlx.dist :as dist]
+            [genmlx.dist.core :as dc]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.combinators :as comb]
+            [genmlx.vmap :as vmap]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]))
+
+(def sub-gf
+  (gen [mu] (trace :z (dist/gaussian mu 1))))
+
+(def spliced-model
+  (gen []
+    (let [x (trace :x (dist/gaussian 0 10))]
+      (splice :sub sub-gf x))))
+
+(def flat-model
+  (gen []
+    (let [x (trace :x (dist/gaussian 0 10))]
+      (trace :z (dist/gaussian x 1)))))
+
+(defn- regen-weight [model seed selection]
+  (let [t (p/simulate (dyn/with-key model (rng/fresh-key seed)) [])
+        {:keys [weight]} (p/regenerate (dyn/with-key model (rng/fresh-key (inc seed)))
+                                       t selection)]
+    (h/realize weight)))
+
+(deftest regen-through-splice-prior-resample-weight-zero
+  (testing "flat reference: regenerating a leaf from its conditional prior => weight 0"
+    (is (h/close? 0.0 (regen-weight flat-model 11 (sel/select :z)) 1e-3)))
+  (testing "spliced: same model through a splice must also give weight 0"
+    (is (h/close? 0.0 (regen-weight spliced-model 11
+                                    (sel/hierarchical :sub (sel/select :z)))
+                  1e-3))))
+
+(def nested-sub-gf
+  (gen [mu] (splice :inner sub-gf mu)))
+
+(def nested-spliced-model
+  (gen []
+    (let [x (trace :x (dist/gaussian 0 10))]
+      (splice :sub nested-sub-gf x))))
+
+(deftest regen-through-nested-splice-weight-zero
+  (testing "two-level splice: prior resample of leaf => weight 0"
+    (is (h/close? 0.0 (regen-weight nested-spliced-model 17
+                                    (sel/hierarchical
+                                     :sub (sel/hierarchical
+                                           :inner (sel/select :z))))
+                  1e-3))))
+
+(def spliced-model-downstream
+  (gen []
+    (let [x (trace :x (dist/gaussian 0 10))
+          z (splice :sub sub-gf x)]
+      (trace :y (dist/gaussian z 1)))))
+
+(deftest regen-through-splice-downstream-dependency
+  (testing "downstream :y depends on spliced :z => weight = lp_y(y;z') - lp_y(y;z)"
+    (let [t (p/simulate (dyn/with-key spliced-model-downstream (rng/fresh-key 33)) [])
+          old-z (cm/get-choice (:choices t) [:sub :z])
+          y (cm/get-choice (:choices t) [:y])
+          {:keys [trace weight]} (p/regenerate
+                                  (dyn/with-key spliced-model-downstream (rng/fresh-key 34))
+                                  t (sel/hierarchical :sub (sel/select :z)))
+          new-z (cm/get-choice (:choices trace) [:sub :z])
+          expected (- (h/realize (dc/dist-log-prob (dist/gaussian new-z 1) y))
+                      (h/realize (dc/dist-log-prob (dist/gaussian old-z 1) y)))]
+      (is (h/close? expected (h/realize weight) 1e-3)
+          "weight captures only the retained downstream lp change"))))
+
+(deftest project-through-splice-convention
+  (testing "project through a splice = lp of the selected child site"
+    (let [t (p/simulate (dyn/with-key spliced-model (rng/fresh-key 55)) [])
+          x (cm/get-choice (:choices t) [:x])
+          z (cm/get-choice (:choices t) [:sub :z])
+          proj (p/project (dyn/with-key spliced-model (rng/fresh-key 56))
+                          t (sel/hierarchical :sub (sel/select :z)))
+          expected (h/realize (dc/dist-log-prob (dist/gaussian x 1) z))]
+      (is (h/close? expected (h/realize proj) 1e-3)))))
+
+(deftest update-through-splice-fixed-structure
+  (testing "constraining the spliced child :z: weight = full lp delta (no fresh choices)"
+    (let [t (p/simulate (dyn/with-key spliced-model-downstream (rng/fresh-key 77)) [])
+          x (cm/get-choice (:choices t) [:x])
+          old-z (cm/get-choice (:choices t) [:sub :z])
+          y (cm/get-choice (:choices t) [:y])
+          new-z (mx/scalar 0.25)
+          constraints (cm/set-choice cm/EMPTY [:sub :z] new-z)
+          {:keys [weight]} (p/update (dyn/with-key spliced-model-downstream (rng/fresh-key 78))
+                                     t constraints)
+          lp (fn [d v] (h/realize (dc/dist-log-prob d v)))
+          expected (+ (- (lp (dist/gaussian x 1) new-z)
+                         (lp (dist/gaussian x 1) old-z))
+                      (- (lp (dist/gaussian new-z 1) y)
+                         (lp (dist/gaussian old-z 1) y)))]
+      (is (h/close? expected (h/realize weight) 1e-3)))))
+
+;; ---------------------------------------------------------------------------
+;; Vmap combinator regenerate (same convention-mix class)
+;; ---------------------------------------------------------------------------
+
+(def two-site-kernel
+  (gen []
+    (let [a (trace :a (dist/gaussian 0 1))]
+      (trace :b (dist/gaussian a 1)))))
+
+(deftest vmap-regenerate-weight-composition
+  (testing "vmap regenerate: weight = sum of per-element MH weights"
+    (let [vgf (vmap/vmap-gf (dyn/auto-key two-site-kernel) :axis-size 3)
+          t (p/simulate vgf [])
+          {:keys [trace weight]} (p/regenerate vgf t (sel/select :a))
+          lp (fn [mu v] (h/realize (dc/dist-log-prob (dist/gaussian mu 1) v)))
+          ;; vmap traces hold stacked [N]-shaped leaves at the kernel addresses
+          old-as (cm/get-choice (:choices t) [:a])
+          new-as (cm/get-choice (:choices trace) [:a])
+          bs (cm/get-choice (:choices t) [:b])
+          ;; expected: per element, retained :b re-scored under resampled :a
+          expected (reduce + (for [i (range 3)]
+                               (let [old-a (mx/index old-as i)
+                                     new-a (mx/index new-as i)
+                                     b (mx/index bs i)]
+                                 (- (lp new-a b) (lp old-a b)))))]
+      (is (h/close? expected (h/realize weight) 1e-3)))))
+
+;; ---------------------------------------------------------------------------
+;; Batched (vectorized) splice paths
+;; ---------------------------------------------------------------------------
+
+(deftest vregenerate-through-spliced-dynamic-gf
+  (testing "batched regen through spliced DynamicGF: prior resample => all-zero weights"
+    (let [n 8
+          vt (dyn/vsimulate spliced-model [] n (rng/fresh-key 101))
+          {:keys [weight]} (dyn/vregenerate spliced-model vt
+                                            (sel/hierarchical :sub (sel/select :z))
+                                            (rng/fresh-key 102))]
+      (mx/eval! weight)
+      (is (= [n] (mx/shape weight)))
+      (is (h/close? 0.0 (mx/realize (mx/amax (mx/abs weight))) 1e-3)
+          "every particle weight is 0"))))
+
+(def map-spliced-model
+  ;; Splices a Map combinator (non-DynamicGF) so batched execution takes
+  ;; the combinator-batched-fallback path.
+  (let [mgf (comb/map-combinator (dyn/auto-key sub-gf))]
+    (gen []
+      (splice :m mgf [(mx/scalar 0.0) (mx/scalar 0.0)]))))
+
+(deftest vregenerate-through-spliced-combinator-fallback
+  (testing "combinator-batched-fallback regen: prior resample => all-zero weights"
+    (let [n 4
+          vt (dyn/vsimulate map-spliced-model [] n (rng/fresh-key 111))
+          {:keys [weight]} (dyn/vregenerate map-spliced-model vt
+                                            (sel/hierarchical :m sel/all)
+                                            (rng/fresh-key 112))]
+      (mx/eval! weight)
+      (is (= [n] (mx/shape weight)))
+      (is (h/close? 0.0 (mx/realize (mx/amax (mx/abs weight))) 1e-3)
+          "every particle weight is 0"))))
+
+(cljs.test/run-tests)

--- a/test/genmlx/update_weight_test.cljs
+++ b/test/genmlx/update_weight_test.cljs
@@ -1,0 +1,271 @@
+;; @tier fast core
+(ns genmlx.update-weight-test
+  "Thesis/Gen.jl update-weight convention (genmlx-8l8j).
+
+   update(t, sigma).weight = (non-fresh score of t') - score(t), where the
+   non-fresh score counts every constrained or retained site under the new
+   parameters. Freshly sampled addresses (drawn from the internal proposal)
+   cancel out of the weight; removed and overwritten old choices are charged
+   via the recorded old score. Equivalently:
+
+       weight = (score' - score) - project(t', fresh-addresses)
+
+   The previous convention returned the raw score delta, which wrongly
+   included the log-probs of freshly sampled latents — biasing SMC whenever
+   an update extends a model's structure. The batched vupdate path used a
+   third convention (constrained sums only), which missed retained sites
+   whose parents changed. All paths now agree on the thesis convention."
+  (:require-macros [genmlx.gen :refer [gen]])
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.test-helpers :as h]
+            [genmlx.protocols :as p]
+            [genmlx.dynamic :as dyn]
+            [genmlx.dist :as dist]
+            [genmlx.dist.core :as dc]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.combinators :as comb]
+            [genmlx.vmap :as vmap]
+            [genmlx.gfi :as gfi]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]))
+
+(defn- lp [d v] (h/realize (dc/dist-log-prob d v)))
+
+;; ---------------------------------------------------------------------------
+;; Structure change: branch flip removes one address and freshly samples another
+;; ---------------------------------------------------------------------------
+
+(def gate-model
+  (gen []
+    (let [b (trace :b (dist/bernoulli 0.5))]
+      (if (pos? (mx/item b))
+        (trace :w (dist/gaussian 0 1))
+        (trace :y (dist/gaussian 2 1))))))
+
+(deftest branch-flip-update-weight
+  (testing "flipping :b removes :y (charged via old score) and freshly samples :w (cancels)"
+    (let [obs (cm/choicemap :b (mx/scalar 0.0) :y (mx/scalar 1.5))
+          {t0 :trace} (p/generate (dyn/with-key gate-model (rng/fresh-key 7)) [] obs)
+          {:keys [trace weight]} (p/update (dyn/with-key gate-model (rng/fresh-key 8))
+                                           t0 (cm/choicemap :b (mx/scalar 1.0)))
+          ;; lp_b(1) - (lp_b(0) + lp_y(1.5)) = -lp_y(1.5)
+          expected (- (lp (dist/gaussian 2 1) (mx/scalar 1.5)))]
+      (is (cm/has-value? (cm/get-submap (:choices trace) :w)) "new branch sampled :w")
+      (is (h/close? expected (h/realize weight) 1e-3)
+          "weight excludes the fresh :w log-prob"))))
+
+(deftest branch-flip-round-trip
+  (testing "forward + backward weights cancel up to the fresh forward sample"
+    (let [obs (cm/choicemap :b (mx/scalar 0.0) :y (mx/scalar 1.5))
+          {t0 :trace} (p/generate (dyn/with-key gate-model (rng/fresh-key 17)) [] obs)
+          {t1 :trace w-fwd :weight discard :discard}
+          (p/update (dyn/with-key gate-model (rng/fresh-key 18))
+                    t0 (cm/choicemap :b (mx/scalar 1.0)))
+          fresh-lp (h/realize (p/project (dyn/with-key gate-model (rng/fresh-key 19))
+                                         t1 (sel/select :w)))
+          {t2 :trace w-bwd :weight}
+          (p/update (dyn/with-key gate-model (rng/fresh-key 20)) t1 discard)]
+      (is (h/close? (h/realize (:score t0)) (h/realize (:score t2)) 1e-3)
+          "backward update with the discard restores the original score")
+      (is (h/close? (- fresh-lp)
+                    (+ (h/realize w-fwd) (h/realize w-bwd))
+                    1e-3)
+          "w_fwd + w_bwd = -project(t', fresh)"))))
+
+;; ---------------------------------------------------------------------------
+;; Structure extension: a flipped gate brings a fresh latent into existence
+;; ---------------------------------------------------------------------------
+
+(def extend-model
+  (gen []
+    (let [more (trace :more (dist/bernoulli 0.3))]
+      (when (pos? (mx/item more))
+        (trace :extra (dist/gaussian 0 1)))
+      (trace :obs (dist/gaussian 0 1)))))
+
+(deftest extension-update-weight-excludes-fresh-latent
+  (testing "SMC-style extension: fresh latent cancels, weight = gate lp delta"
+    (let [obs (cm/choicemap :more (mx/scalar 0.0) :obs (mx/scalar 0.7))
+          {t0 :trace} (p/generate (dyn/with-key extend-model (rng/fresh-key 27)) [] obs)
+          {:keys [trace weight]} (p/update (dyn/with-key extend-model (rng/fresh-key 28))
+                                           t0 (cm/choicemap :more (mx/scalar 1.0)))
+          expected (- (js/Math.log 0.3) (js/Math.log 0.7))]
+      (is (cm/has-value? (cm/get-submap (:choices trace) :extra)) "fresh :extra sampled")
+      (is (h/close? expected (h/realize weight) 1e-3)
+          "weight is independent of the fresh :extra value"))))
+
+;; ---------------------------------------------------------------------------
+;; Fixed structure: constrained site feeds a retained downstream site
+;; ---------------------------------------------------------------------------
+
+(def dep-model
+  (gen []
+    (let [x (trace :x (dist/gaussian 0 1))]
+      (trace :y (dist/gaussian x 1)))))
+
+(deftest dependent-retained-scalar-and-batched-agree
+  (testing "scalar update: weight = full lp delta including retained :y under new :x"
+    (let [t (p/simulate (dyn/with-key dep-model (rng/fresh-key 37)) [])
+          x-old (cm/get-choice (:choices t) [:x])
+          y (cm/get-choice (:choices t) [:y])
+          new-x (mx/scalar 0.5)
+          {:keys [weight]} (p/update (dyn/with-key dep-model (rng/fresh-key 38))
+                                     t (cm/choicemap :x new-x))
+          expected (- (+ (lp (dist/gaussian 0 1) new-x)
+                         (lp (dist/gaussian new-x 1) y))
+                      (+ (lp (dist/gaussian 0 1) x-old)
+                         (lp (dist/gaussian x-old 1) y)))]
+      (is (h/close? expected (h/realize weight) 1e-3))))
+  (testing "batched vupdate: same convention per particle"
+    (let [n 4
+          vt (dyn/vsimulate dep-model [] n (rng/fresh-key 47))
+          new-x (mx/scalar 0.5)
+          {:keys [weight]} (dyn/vupdate dep-model vt (cm/choicemap :x new-x)
+                                        (rng/fresh-key 48))
+          xs (cm/get-choice (:choices vt) [:x])
+          ys (cm/get-choice (:choices vt) [:y])]
+      (mx/eval! weight)
+      (is (= [n] (mx/shape weight)) "vupdate weight is [N]-shaped")
+      (doseq [i (range n)]
+        (let [x-i (mx/index xs i)
+              y-i (mx/index ys i)
+              expected (- (+ (lp (dist/gaussian 0 1) new-x)
+                             (lp (dist/gaussian new-x 1) y-i))
+                          (+ (lp (dist/gaussian 0 1) x-i)
+                             (lp (dist/gaussian x-i 1) y-i)))]
+          (is (h/close? expected (mx/realize (mx/index weight i)) 1e-3)
+              (str "particle " i " matches the scalar convention")))))))
+
+;; ---------------------------------------------------------------------------
+;; Update through a splice with a fresh child site
+;; ---------------------------------------------------------------------------
+
+(def gated-sub
+  (gen [mu]
+    (let [g (trace :g (dist/bernoulli 0.25))]
+      (if (pos? (mx/item g))
+        (trace :z (dist/gaussian mu 1))
+        mu))))
+
+(def splice-gate-model
+  (gen []
+    (let [x (trace :x (dist/gaussian 0 10))]
+      (splice :sub gated-sub x))))
+
+(deftest update-through-splice-fresh-and-removed
+  (testing "flipping the child gate on: fresh child :z cancels"
+    (let [obs (-> cm/EMPTY
+                  (cm/set-choice [:x] (mx/scalar 1.0))
+                  (cm/set-choice [:sub :g] (mx/scalar 0.0)))
+          {t0 :trace} (p/generate (dyn/with-key splice-gate-model (rng/fresh-key 57)) [] obs)
+          {:keys [trace weight]} (p/update (dyn/with-key splice-gate-model (rng/fresh-key 58))
+                                           t0 (cm/set-choice cm/EMPTY [:sub :g] (mx/scalar 1.0)))
+          expected (- (js/Math.log 0.25) (js/Math.log 0.75))]
+      (is (some? (cm/get-choice (:choices trace) [:sub :z])) "fresh child :z sampled")
+      (is (h/close? expected (h/realize weight) 1e-3))))
+  (testing "flipping the child gate off: removed child :z charged via old score"
+    (let [obs (-> cm/EMPTY
+                  (cm/set-choice [:x] (mx/scalar 1.0))
+                  (cm/set-choice [:sub :g] (mx/scalar 1.0))
+                  (cm/set-choice [:sub :z] (mx/scalar 0.4)))
+          {t0 :trace} (p/generate (dyn/with-key splice-gate-model (rng/fresh-key 67)) [] obs)
+          {:keys [weight]} (p/update (dyn/with-key splice-gate-model (rng/fresh-key 68))
+                                     t0 (cm/set-choice cm/EMPTY [:sub :g] (mx/scalar 0.0)))
+          expected (- (js/Math.log 0.75)
+                      (+ (js/Math.log 0.25)
+                         (lp (dist/gaussian (mx/scalar 1.0) 1) (mx/scalar 0.4))))]
+      (is (h/close? expected (h/realize weight) 1e-3)))))
+
+;; ---------------------------------------------------------------------------
+;; Combinators: Map, Unfold (dynamic kernels => handler fallback paths), Switch
+;; ---------------------------------------------------------------------------
+
+(def map-kernel
+  (gen [mu]
+    (let [g (trace :g (dist/bernoulli 0.25))]
+      (if (pos? (mx/item g))
+        (trace :z (dist/gaussian mu 1))
+        mu))))
+
+(deftest map-update-weight-dynamic-kernel
+  (testing "Map update: element 0's gate flips on, fresh :z cancels; element 1 untouched"
+    (let [mgf (comb/map-combinator (dyn/auto-key map-kernel))
+          obs (-> cm/EMPTY
+                  (cm/set-choice [0 :g] (mx/scalar 0.0))
+                  (cm/set-choice [1 :g] (mx/scalar 0.0)))
+          {t0 :trace} (p/generate mgf [[(mx/scalar 0.0) (mx/scalar 0.0)]] obs)
+          {:keys [weight]} (p/update mgf t0
+                                     (cm/set-choice cm/EMPTY [0 :g] (mx/scalar 1.0)))
+          expected (- (js/Math.log 0.25) (js/Math.log 0.75))]
+      (is (h/close? expected (h/realize weight) 1e-3)))))
+
+(def unfold-kernel
+  (gen [t state]
+    (let [g (trace :g (dist/bernoulli 0.25))]
+      (when (pos? (mx/item g))
+        (trace :z (dist/gaussian state 1)))
+      state)))
+
+(deftest unfold-update-weight-dynamic-kernel
+  (testing "Unfold update: step 0 prefix-skipped, step 1 gate flips (fresh :z cancels), step 2 retained"
+    (let [ugf (comb/unfold-combinator (dyn/auto-key unfold-kernel))
+          obs (-> cm/EMPTY
+                  (cm/set-choice [0 :g] (mx/scalar 0.0))
+                  (cm/set-choice [1 :g] (mx/scalar 0.0))
+                  (cm/set-choice [2 :g] (mx/scalar 0.0)))
+          {t0 :trace} (p/generate ugf [3 (mx/scalar 0.0)] obs)
+          {:keys [weight]} (p/update ugf t0
+                                     (cm/set-choice cm/EMPTY [1 :g] (mx/scalar 1.0)))
+          expected (- (js/Math.log 0.25) (js/Math.log 0.75))]
+      (is (h/close? expected (h/realize weight) 1e-3)))))
+
+(deftest switch-branch-flip-update-weight
+  (testing "Switch flip: generate weight of constrained new branch minus old branch score"
+    (let [b0 (dyn/auto-key (gen [] (trace :u (dist/gaussian 0 1))))
+          b1 (dyn/auto-key (gen [] (trace :v (dist/gaussian 5 1))))
+          sgf (comb/switch-combinator b0 b1)
+          t (p/simulate sgf [0])
+          u-old (cm/get-choice (:choices t) [:u])
+          flipped (assoc t :args [1])
+          {:keys [trace weight]} (p/update sgf flipped
+                                           (cm/choicemap :v (mx/scalar 4.5)))
+          expected (- (lp (dist/gaussian 5 1) (mx/scalar 4.5))
+                      (lp (dist/gaussian 0 1) u-old))]
+      (is (cm/has-value? (cm/get-submap (:choices trace) :v)) "new branch active")
+      (is (h/close? expected (h/realize weight) 1e-3)))))
+
+(deftest vmap-update-weight
+  (testing "vmap update: per-element thesis weights, retained :b re-scored under new :a"
+    (let [kernel (gen []
+                   (let [a (trace :a (dist/gaussian 0 1))]
+                     (trace :b (dist/gaussian a 1))))
+          vgf (vmap/vmap-gf (dyn/auto-key kernel) :axis-size 3)
+          t (p/simulate vgf [])
+          new-a (mx/scalar 0.5)
+          {:keys [weight]} (p/update vgf t (cm/choicemap :a new-a))
+          old-as (cm/get-choice (:choices t) [:a])
+          bs (cm/get-choice (:choices t) [:b])
+          expected (reduce + (for [i (range 3)]
+                               (let [a-i (mx/index old-as i)
+                                     b-i (mx/index bs i)]
+                                 (- (+ (lp (dist/gaussian 0 1) new-a)
+                                       (lp (dist/gaussian new-a 1) b-i))
+                                    (+ (lp (dist/gaussian 0 1) a-i)
+                                       (lp (dist/gaussian a-i 1) b-i))))))]
+      (is (h/close? expected (h/realize weight) 1e-3)))))
+
+;; ---------------------------------------------------------------------------
+;; GFI law: update-fresh-cancellation
+;; ---------------------------------------------------------------------------
+
+(deftest update-fresh-cancellation-law
+  (testing "law holds on fixed-structure and structure-changing models"
+    (is (true? (:pass? (gfi/check-law :update-fresh-cancellation
+                                      (dyn/auto-key dep-model) [])))
+        "fixed structure: reduces to density ratio")
+    (is (true? (:pass? (gfi/check-law :update-fresh-cancellation
+                                      (dyn/auto-key gate-model) [])))
+        "branch model: fresh project term exercised")))
+
+(cljs.test/run-tests)


### PR DESCRIPTION
## Summary

Two weight-convention bugs in the GFI implementation, fixed across all execution paths.

### Regenerate through splices (commit 1)

A child `p/regenerate` returns its **final MH weight** (ΔS_child − pr_child), but the parent handler accumulates **proposal ratios** and computes `W = ΔS_total − accumulator` at the end. Merging the child's final weight directly into the accumulator yielded `W = ΔS_own − pr_own + pr_child` instead of `w_own + w_child`.

Counterexample: `x ~ N(0,10)` with spliced child `z ~ N(x,1)`. Regenerating `:z` draws from its conditional prior with unchanged parents, so the exact weight is **0** (the flat equivalent model gives exactly that) — the spliced model returned a random nonzero value.

Same-class fixes: the batched combinator-fallback regen path, Vmap regenerate (ignored per-element weights entirely), and a latent membrane bug — the MxArray duck-typing probe (`.item` as instance property) never matched, so the combinator fallback never unstacked `[N]`-shaped old choices.

### Thesis update-weight convention (commit 2)

`update(t, σ).weight` is now the Gen.jl/thesis weight on every path:

```
weight = (non-fresh score of t') − score(t)
       = (score' − score) − project(t', fresh addresses)
```

Fresh choices drawn from the internal proposal cancel; removed/overwritten old choices are charged via the recorded old score. Previously the scalar path returned the raw score delta (including fresh latents' log-probs — biasing SMC whenever an update extends model structure), while batched `vupdate` used a third convention (constrained sums only — missing retained sites whose parents changed). On a branch-flip update the old code returned `lp(fresh w') − lp(removed y)`; the correct weight is `−lp(removed y)`.

Aligned: scalar handler, prefix-compiled, batched `vupdate`, splice executor, and Map/Unfold/Scan/Switch/Vmap combinator updates. Compiled static paths are untouched (score delta = thesis weight when no fresh/removed sites exist). New GFI law `:update-fresh-cancellation` pins the convention with `project` as the independent oracle.

## Tests

- New `splice_weight_test.cljs` (8 tests) and `update_weight_test.cljs` (10 tests / 22 assertions) — all fail on the previous conventions, pass now.
- Regression: fast-core 31/31, level0 68/68, gen_clj 356/356, genjax 73/73, schema 227/227, compiled-simulate 82/82, partial-compile 92/92, combinator-compile 92/92, L4 41/41, all SMC suites, pmcmc, smcp3, edit suites, combinator suites, vectorized — all green.
- `gfi_laws_test` has one **pre-existing** seed-dependent failure (`law:vgenerate-shape-and-finiteness` — scalar score when a single-site model is fully constrained), verified present on pristine HEAD and tracked separately.

Beans: genmlx-ovop, genmlx-8l8j (both completed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)