### PR TITLE
fix(l3,compiled): close analytical false positives and compiled-parity holes

### DIFF
--- a/src/genmlx/compiled.cljs
+++ b/src/genmlx/compiled.cljs
@@ -405,10 +405,88 @@
        (= "trace" (name (first form)))
        (keyword? (second form))))
 
+(defn- pattern-symbols
+  "Name strings of all symbols appearing anywhere in a binding pattern
+   (a plain symbol or a destructuring form). Over-approximates on purpose:
+   poisoning a name that was not really bound only declines compilation."
+  [pattern]
+  (cond
+    (symbol? pattern) (if (= "&" (name pattern)) #{} #{(name pattern)})
+    (or (vector? pattern) (seq? pattern))
+    (into #{} (mapcat pattern-symbols) pattern)
+    (map? pattern)
+    (into #{} (mapcat pattern-symbols) (concat (keys pattern) (vals pattern)))
+    :else #{}))
+
+(def ^:private binder-heads
+  "Heads of forms that bind locals through mechanisms this walker does not
+   model with proper scoping. Their binding targets are poisoned so
+   compile-expr declines instead of silently falling through to a same-named
+   namespace var (genmlx-b210)."
+  #{"fn" "fn*" "loop" "loop*" "for" "doseq" "dotimes" "letfn" "letfn*"
+    "if-let" "when-let" "if-some" "when-some" "when-first" "binding"
+    "with-redefs" "as->"})
+
+(defn- binding-vector-targets
+  "Names bound by a let-like binding vector [target init target init ...].
+   Handles for/doseq modifiers: :let vectors recurse, :when/:while skip."
+  [bvec]
+  (loop [xs (seq bvec) acc #{}]
+    (if (or (nil? xs) (nil? (next xs)))
+      acc
+      (let [t (first xs) v (second xs)]
+        (recur (nnext xs)
+               (cond
+                 (= :let t) (into acc (binding-vector-targets v))
+                 (keyword? t) acc
+                 :else (into acc (pattern-symbols t))))))))
+
+(defn- binder-target-names
+  "Names bound by a non-let binder form (see binder-heads)."
+  [form]
+  (let [head (name (first form))]
+    (cond
+      (#{"fn" "fn*"} head)
+      (into #{} (mapcat (fn [x]
+                          (cond
+                            (vector? x) (pattern-symbols x)        ; params
+                            (symbol? x) #{(name x)}                ; fn name
+                            (seq? x) (let [params (first x)]       ; arity form
+                                       (when (vector? params)
+                                         (pattern-symbols params)))
+                            :else nil)))
+            (rest form))
+
+      (#{"letfn" "letfn*"} head)
+      ;; Over-approximate: every symbol in the letfn binding vector (names,
+      ;; params, and body references). Safe — only declines compilation.
+      (pattern-symbols (second form))
+
+      (= "as->" head)
+      (let [n (nth form 2 nil)]
+        (if (symbol? n) #{(name n)} #{}))
+
+      (vector? (second form))
+      (binding-vector-targets (second form))
+
+      :else #{})))
+
+(defn- poison-names [env names]
+  (reduce (fn [e n] (assoc e n {:kind :poisoned})) env names))
+
 (declare walk-binding-forms)
 
 (defn- walk-binding-form
-  "Walk a single form, collecting let/do bindings into env."
+  "Walk a single form, collecting let/do bindings into env.
+
+   The env is FLAT — it cannot represent lexical scopes. Any name that would
+   need scoping to resolve correctly is poisoned ({:kind :poisoned}) instead
+   of bound, and compile-expr declines on poisoned names (genmlx-b210):
+   - a let target that rebinds an existing name (last-wins would retroactively
+     change how earlier sites resolve the name)
+   - destructuring targets (invisible to compile-expr, which would otherwise
+     fall through to a same-named namespace var)
+   - targets of fn/loop/for/doseq/... binders (same fallthrough hazard)."
   [env form]
   (cond
     ;; let form: process bindings sequentially, then walk body
@@ -418,12 +496,14 @@
     (let [pairs (partition 2 (second form))
           env' (reduce
                 (fn [env [sym val-form]]
-                  (if (symbol? sym)
+                  (if (and (symbol? sym) (not (contains? env (name sym))))
                     (assoc env (name sym)
                            (if (trace-call? val-form)
                              {:kind :trace :addr (second val-form)}
                              {:kind :expr :form val-form}))
-                    env))
+                    (poison-names env (if (symbol? sym)
+                                        [(name sym)]
+                                        (pattern-symbols sym)))))
                 env pairs)]
       (walk-binding-forms env' (drop 2 form)))
 
@@ -431,6 +511,12 @@
     (and (seq? form) (seq form) (symbol? (first form))
          (= "do" (name (first form))))
     (walk-binding-forms env (rest form))
+
+    ;; Binder forms with unmodeled scoping: poison targets, walk children
+    (and (seq? form) (seq form) (symbol? (first form))
+         (contains? binder-heads (name (first form))))
+    (walk-binding-forms (poison-names env (binder-target-names form))
+                        (rest form))
 
     ;; Other sequences: walk children for nested lets
     (seq? form) (walk-binding-forms env form)
@@ -477,9 +563,15 @@
         :expr (when-not (contains? visited (name form))
                 (compile-expr (:form info) binding-env
                               (conj visited (name form))))
-        ;; Not in binding-env: try to resolve as a closed-over var (captured constant)
-        (when-let [resolved (try (deref (resolve form)) (catch :default _ nil))]
-          (fn [_v _a] resolved))))
+        ;; Shadowed / unscopeable local (genmlx-b210): decline compilation
+        ;; rather than mis-resolve to a namespace var.
+        :poisoned nil
+        ;; Not in binding-env: resolve as a closed-over var. The var is
+        ;; captured once but deref'd PER CALL, so later redefinition is
+        ;; honored instead of baking a stale value (genmlx-b210).
+        (when-let [vr (try (resolve form) (catch :default _ nil))]
+          (when (some? (try (deref vr) (catch :default _ nil)))
+            (fn [_v _a] (deref vr))))))
 
     ;; Keyword-as-function: (:key arg) → (get arg :key) — common map access pattern
     (and (seq? form) (seq form) (keyword? (first form)))
@@ -586,18 +678,26 @@
    {:noise-fn (fn [key] (rng/uniform key []))
     :transform (fn [noise p]
                  (mx/where (mx/less noise p) ONE ZERO))
+    ;; xlogy guards ported from dist.cljs (genmlx-b210): without them p=0,v=0
+    ;; gives 0 * -Inf = NaN where the handler gives 0.
     :log-prob (fn [v p]
-                (mx/add (mx/multiply v (mx/log p))
-                        (mx/multiply (mx/subtract ONE v)
-                                     (mx/log (mx/subtract ONE p)))))}
+                (let [log-p (mx/log p)
+                      log-1-p (mx/log (mx/subtract ONE p))]
+                  (mx/add (mx/where (mx/equal v ZERO) ZERO (mx/multiply v log-p))
+                          (mx/where (mx/equal v ONE) ZERO
+                                    (mx/multiply (mx/subtract ONE v) log-1-p)))))}
 
    :exponential
    {:noise-fn (fn [key] (rng/uniform key []))
     :transform (fn [noise rate]
                  (mx/divide (mx/negative (mx/log (mx/subtract ONE noise)))
                             rate))
+    ;; Support guard ported from dist.cljs (genmlx-b210): v<0 must score -Inf,
+    ;; not the finite extrapolation log(rate) - rate*v.
     :log-prob (fn [v rate]
-                (mx/subtract (mx/log rate) (mx/multiply rate v)))}
+                (mx/where (mx/greater-equal v ZERO)
+                          (mx/subtract (mx/log rate) (mx/multiply rate v))
+                          NEG-INF))}
 
    :log-normal
    {:noise-fn (fn [key] (rng/normal key []))
@@ -712,16 +812,19 @@
   "Build the reduce step function for one trace site using noise transforms.
    Noise is pre-generated OUTSIDE mx/compile-fn and passed in via noise-array.
    Returns (fn [{:keys [values score]} site-idx noise-array args-vec] -> state)
-   or nil if the site can't use noise transforms."
+   or nil if the site can't use noise transforms.
+
+   :args-noise-fn sites (iid-gaussian) are DECLINED: their noise shape depends
+   on dist args that may reference traced values, so it cannot be pre-generated
+   here — the old path crashed at runtime (genmlx-b210). Simulate falls back to
+   the handler; compiled generate/regenerate draw such noise inline and keep
+   working."
   [site-spec]
   (let [{:keys [addr compiled-args dist-type]} site-spec
         nt (get noise-transforms-full dist-type)]
     (when nt
       (cond
-        ;; Noise-driven sites: :noise-fn pre-generates standard noise,
-        ;; :args-noise-fn pre-generates dynamic-shape noise. Both transform the
-        ;; pre-generated noise and score it identically inside the compiled fn.
-        (or (:noise-fn nt) (:args-noise-fn nt))
+        (:noise-fn nt)
         (let [transform-fn (:transform nt)
               log-prob-fn (:log-prob nt)]
           (fn [{:keys [values score]} site-idx noise-array args-vec]
@@ -732,13 +835,17 @@
               {:values (assoc values addr value)
                :score (mx/add score lp)})))
 
-        :else
-        ;; Delta: no noise, value = first arg, lp = 0
+        ;; Delta ONLY when the dist-type really is delta — a transform entry
+        ;; without noise fns must not silently degrade to value=first-arg,
+        ;; score=0 (genmlx-b210).
+        (= dist-type :delta)
         (fn [{:keys [values score]} _site-idx _noise-array args-vec]
           (let [eval-args (mapv #(% values args-vec) compiled-args)
                 value (first eval-args)]
             {:values (assoc values addr value)
-             :score score}))))))
+             :score score}))
+
+        :else nil))))
 
 (defn prepare-static-sites
   "Common pipeline for static model compilation (M2).
@@ -761,11 +868,13 @@
            :binding-env binding-env})))))
 
 (defn- site-noise-fn
-  "Return the noise-generation function for a site-spec, or nil for delta."
+  "Return the noise-generation function for a site-spec, or nil for delta.
+   Only :noise-fn — :args-noise-fn sites never reach noise pre-generation
+   (build-site-step declines them, genmlx-b210)."
   [site-spec]
   (let [nt (get noise-transforms-full (:dist-type site-spec))]
     (when nt
-      (or (:noise-fn nt) (:args-noise-fn nt)))))
+      (:noise-fn nt))))
 
 (defn- generate-site-noise
   "Pre-generate noise for all sites OUTSIDE mx/compile-fn.
@@ -783,15 +892,18 @@
 (defn- run-site-steps
   "Run the noise-transform step-fns and return a flat JS array
    [v0 v1 ... vN score], values ordered by `addrs`. Shared inner-fn body for
-   the M2/M3/M4 compiled simulate paths."
-  [step-fns addrs noise-array args-vec]
-  (let [result (reduce-kv
-                (fn [state idx step-fn]
-                  (step-fn state idx noise-array args-vec))
-                {:values {} :score (mx/scalar 0.0)}
-                step-fns)
-        vals (mapv #(get (:values result) %) addrs)]
-    (to-array (conj vals (:score result)))))
+   the M2/M3/M4 compiled simulate paths. init-values seeds the values map
+   (M4 branch conditions, resolved host-side per call)."
+  ([step-fns addrs noise-array args-vec]
+   (run-site-steps step-fns addrs noise-array args-vec {}))
+  ([step-fns addrs noise-array args-vec init-values]
+   (let [result (reduce-kv
+                 (fn [state idx step-fn]
+                   (step-fn state idx noise-array args-vec))
+                 {:values init-values :score (mx/scalar 0.0)}
+                 step-fns)
+         vals (mapv #(get (:values result) %) addrs)]
+     (to-array (conj vals (:score result))))))
 
 (defn- unpack-result
   "Unpack a flat [v0 ... vN score] JS array (from run-site-steps) into
@@ -826,33 +938,25 @@
               (fn [noise-array args-vec]
                 (run-site-steps step-fns addrs noise-array args-vec))
               ;; Build arity-specific wrapper for mx/compile-fn.
-              ;; Skip mx/compile-fn when any site uses :args-noise-fn
-              ;; (dynamic noise shape breaks Metal graph caching).
+              ;; (:args-noise-fn sites never get here — build-site-step
+              ;; declines them, genmlx-b210.)
               n-params (count (first source))
-              has-dynamic-noise?
-              (some (fn [ss]
-                      (let [nt (get noise-transforms-full (:dist-type ss))]
-                        (and nt (:args-noise-fn nt))))
-                    site-specs)
               compiled-inner
-              (if has-dynamic-noise?
-                ;; Raw noise transforms — still faster than multimethod dispatch
-                (fn [noise args] (inner-fn noise args))
-                (case n-params
-                  0 (let [f (fn [noise] (inner-fn noise []))
-                          cf (mx/compile-fn f)]
-                      (fn [noise _args] (cf noise)))
-                  1 (let [f (fn [noise a0] (inner-fn noise [a0]))
-                          cf (mx/compile-fn f)]
-                      (fn [noise args] (cf noise (nth args 0))))
-                  2 (let [f (fn [noise a0 a1] (inner-fn noise [a0 a1]))
-                          cf (mx/compile-fn f)]
-                      (fn [noise args] (cf noise (nth args 0) (nth args 1))))
-                  3 (let [f (fn [noise a0 a1 a2] (inner-fn noise [a0 a1 a2]))
-                          cf (mx/compile-fn f)]
-                      (fn [noise args] (cf noise (nth args 0) (nth args 1) (nth args 2))))
-                  ;; >3 params: no mx/compile-fn, use raw noise transforms
-                  (fn [noise args] (inner-fn noise args))))]
+              (case n-params
+                0 (let [f (fn [noise] (inner-fn noise []))
+                        cf (mx/compile-fn f)]
+                    (fn [noise _args] (cf noise)))
+                1 (let [f (fn [noise a0] (inner-fn noise [a0]))
+                        cf (mx/compile-fn f)]
+                    (fn [noise args] (cf noise (nth args 0))))
+                2 (let [f (fn [noise a0 a1] (inner-fn noise [a0 a1]))
+                        cf (mx/compile-fn f)]
+                    (fn [noise args] (cf noise (nth args 0) (nth args 1))))
+                3 (let [f (fn [noise a0 a1 a2] (inner-fn noise [a0 a1 a2]))
+                        cf (mx/compile-fn f)]
+                    (fn [noise args] (cf noise (nth args 0) (nth args 1) (nth args 2))))
+                ;; >3 params: no mx/compile-fn, use raw noise transforms
+                (fn [noise args] (inner-fn noise args)))]
           ;; Outer wrapper: GenMLX interface
           ;; Noise generated OUTSIDE compile-fn — fresh per call
           (fn compiled-simulate [key args-vec]
@@ -1274,36 +1378,50 @@
                env)
              env))
          base-env base-env)
-        ;; Compile each site's args (standard or where-wrapped)
+        ;; Compile each site's args (standard or host-branched)
         site-specs
         (mapv
          (fn [site]
            (if (:cond-form site)
-              ;; Rewritten branch: wrap dist args in mx/where.
-              ;; Safety: condition must be a JS value (parameter or literal),
-              ;; not an MLX array. MLX arrays are always truthy in CLJS's if,
-              ;; so mx/where would disagree with the handler path.
+              ;; Rewritten branch (genmlx-b210): the condition is resolved
+              ;; HOST-side with ClojureScript truthiness, exactly matching the
+              ;; handler path's `if`. Conditions are restricted to literals and
+              ;; params so truthiness is computable from the RAW call args
+              ;; (before ensure-mlx-args, which collapses 0 and false): number
+              ;; literals — including 0 — are truthy; params read raw, where
+              ;; only false/nil are falsy (an MLX-array param is truthy, as in
+              ;; the handler). The boolean is seeded per call into the values
+              ;; map under a reserved key by :seed-conds. mx/where is NOT used
+              ;; — it disagrees with CLJS truthiness at numeric 0.
              (let [cf (:cond-form site)
-                   safe-cond? (or (boolean? cf) (number? cf)
-                                  (and (symbol? cf)
-                                       (= :param (:kind (get binding-env (name cf))))))]
-               (when safe-cond?
-                 (let [cond-fn (compile-expr cf binding-env #{})
+                   param-info (when (symbol? cf) (get binding-env (name cf)))
+                   cond-resolver
+                   (cond
+                     (boolean? cf) (constantly cf)
+                     (number? cf) (constantly true)
+                     (= :param (:kind param-info))
+                     (let [i (:index param-info)]
+                       (fn [raw-args] (boolean (nth raw-args i nil))))
+                     :else nil)]
+               (when cond-resolver
+                 (let [cond-key (keyword "genmlx.compiled"
+                                         (str "branch-cond-" (name (:addr site))))
                        true-fns (mapv #(compile-expr % binding-env #{}) (:true-dist-args site))
                        false-fns (mapv #(compile-expr % binding-env #{}) (:false-dist-args site))
                        flipped? (:flipped? site)]
-                   (when (and cond-fn (every? some? true-fns) (every? some? false-fns))
+                   (when (and (every? some? true-fns) (every? some? false-fns))
                      (let [[sel-t sel-f] (if flipped? [false-fns true-fns] [true-fns false-fns])
                            compiled-args
                            (mapv (fn [tf ff]
                                    (fn [values args-vec]
-                                     (mx/where (mx/ensure-array (cond-fn values args-vec))
-                                               (mx/ensure-array (tf values args-vec))
-                                               (mx/ensure-array (ff values args-vec)))))
+                                     (if (get values cond-key)
+                                       (tf values args-vec)
+                                       (ff values args-vec))))
                                  sel-t sel-f)]
                        {:addr (:addr site)
                         :compiled-args compiled-args
-                        :dist-type (:dist-type site)})))))
+                        :dist-type (:dist-type site)
+                        :cond-seed {:key cond-key :resolver cond-resolver}})))))
               ;; Standard site
              (let [cargs (mapv #(compile-expr % binding-env #{}) (:dist-args site))]
                (when (every? some? cargs)
@@ -1320,10 +1438,19 @@
                (when-let [branch (analyze-rewritable-branch return-expr)]
                  (let [addr (:addr branch)]
                    (fn [v _a] (get v addr)))))
-             (compile-expr return-expr binding-env #{}))]
-        {:site-specs site-specs
-         :retval-fn retval-fn
-         :addrs (mapv :addr site-specs)}))))
+             (compile-expr return-expr binding-env #{}))
+            cond-seeds (vec (keep :cond-seed site-specs))
+            seed-conds (fn [raw-args]
+                         (reduce (fn [m {:keys [key resolver]}]
+                                   (assoc m key (resolver raw-args)))
+                                 {} cond-seeds))]
+        ;; retval-fn is REQUIRED (genmlx-b210): without it the M4 paths would
+        ;; emit traces with retval nil — decline so the handler path runs.
+        (when retval-fn
+          {:site-specs site-specs
+           :retval-fn retval-fn
+           :seed-conds seed-conds
+           :addrs (mapv :addr site-specs)})))))
 
 (defn prepare-branch-sites
   "Common pipeline for branch-rewritten compilation (M4).
@@ -1349,25 +1476,22 @@
    Reuses M2 infrastructure: build-binding-env, compile-expr, build-site-step,
    noise-transforms, mx/compile-fn."
   [schema source]
-  (when-let [{:keys [site-specs retval-fn addrs]}
+  (when-let [{:keys [site-specs retval-fn addrs seed-conds]}
              (prepare-branch-sites schema source)]
     (let [step-fns (mapv build-site-step site-specs)]
       (when (every? some? step-fns)
-        (let [n-sites (count site-specs)
-              inner-fn
-              (fn [noise-array args-vec]
-                (run-site-steps step-fns addrs noise-array args-vec))
-              ;; Skip mx/compile-fn for M4 — mx/where args vary per call.
-              ;; Noise generated outside for consistency with M2/M3.
-              compiled-inner
-              (fn [noise args] (inner-fn noise args))]
+        (let [n-sites (count site-specs)]
+          ;; No mx/compile-fn for M4 — branch conditions vary per call.
+          ;; Noise generated outside for consistency with M2/M3.
           (fn compiled-branch-simulate [key args-vec]
             (let [mlx-args (ensure-mlx-args args-vec)
+                  ;; Conditions resolve against the RAW args (genmlx-b210)
+                  init-values (seed-conds args-vec)
                   noise (generate-site-noise site-specs key)
-                  result (compiled-inner noise mlx-args)
+                  result (run-site-steps step-fns addrs noise mlx-args init-values)
                   {:keys [values score]} (unpack-result result addrs n-sites)]
               {:values values
                :score score
-               :retval (when retval-fn
-                         (retval-fn values args-vec))})))))))
+               ;; retval-fn proven truthy by prepare-branch-sites
+               :retval (retval-fn values args-vec)})))))))
 

--- a/src/genmlx/compiled_ops.cljs
+++ b/src/genmlx/compiled_ops.cljs
@@ -86,8 +86,8 @@
                      :weight weight
                      :key k1})))))
 
-          :else
-          ;; Delta distribution: no noise transform
+          ;; Delta ONLY when the dist-type really is delta (genmlx-b210)
+          (= dist-type :delta)
           (fn [{:keys [values score weight key] :as state} args-vec constraints]
             (let [constraint (cm/get-submap constraints addr)]
               (if (cm/has-value? constraint)
@@ -138,7 +138,8 @@
   "Build a compiled generate for models with rewritable branches (L1-M4).
    Returns (fn [key args-vec constraints] -> {:values :score :weight :retval}) or nil."
   [schema source]
-  (when-let [{:keys [site-specs retval-fn]} (compiled/prepare-branch-sites schema source)]
+  (when-let [{:keys [site-specs retval-fn seed-conds]}
+             (compiled/prepare-branch-sites schema source)]
     (let [step-fns (mapv build-generate-site-step site-specs)]
       (when (every? some? step-fns)
         (fn compiled-branch-generate [key args-vec constraints]
@@ -147,13 +148,15 @@
                 (reduce
                  (fn [state step-fn]
                    (step-fn state mlx-args constraints))
-                 {:values {} :score (mx/scalar 0.0) :weight (mx/scalar 0.0) :key key}
+                 ;; Branch conditions resolve against the RAW args (genmlx-b210)
+                 {:values (seed-conds args-vec)
+                  :score (mx/scalar 0.0) :weight (mx/scalar 0.0) :key key}
                  step-fns)]
             {:values (:values result)
              :score (:score result)
              :weight (:weight result)
-             :retval (when retval-fn
-                       (retval-fn (:values result) mlx-args))}))))))
+             ;; retval-fn proven truthy by prepare-branch-sites
+             :retval (retval-fn (:values result) mlx-args)}))))))
 
 (defn make-compiled-prefix-generate
   "Build a compiled prefix generate function from a gen schema and source.
@@ -254,7 +257,8 @@
    Returns (fn [key args-vec constraints old-choices]
              -> {:values :score :discard :retval}) or nil."
   [schema source]
-  (when-let [{:keys [site-specs retval-fn]} (compiled/prepare-branch-sites schema source)]
+  (when-let [{:keys [site-specs retval-fn seed-conds]}
+             (compiled/prepare-branch-sites schema source)]
     (let [step-fns (mapv build-update-site-step site-specs)]
       (when (every? some? step-fns)
         (fn compiled-branch-update [key args-vec constraints old-choices]
@@ -263,13 +267,13 @@
                 (reduce
                  (fn [state step-fn]
                    (step-fn state mlx-args constraints old-choices))
-                 {:values {} :score (mx/scalar 0.0) :discard {} :key key}
+                 {:values (seed-conds args-vec)
+                  :score (mx/scalar 0.0) :discard {} :key key}
                  step-fns)]
             {:values (:values result)
              :score (:score result)
              :discard (:discard result)
-             :retval (when retval-fn
-                       (retval-fn (:values result) mlx-args))}))))))
+             :retval (retval-fn (:values result) mlx-args)}))))))
 
 (defn make-compiled-prefix-update
   "Build a compiled prefix update function.
@@ -350,7 +354,8 @@
   "Build a compiled assess for branch-rewritten models (L1-M4).
    Returns (fn [args-vec choices] -> {:score :retval}) or nil."
   [schema source]
-  (when-let [{:keys [site-specs retval-fn]} (compiled/prepare-branch-sites schema source)]
+  (when-let [{:keys [site-specs retval-fn seed-conds]}
+             (compiled/prepare-branch-sites schema source)]
     (let [step-fns (mapv build-assess-site-step site-specs)]
       (when (every? some? step-fns)
         (fn compiled-branch-assess [args-vec choices]
@@ -359,11 +364,10 @@
                 (reduce
                  (fn [state step-fn]
                    (step-fn state mlx-args choices))
-                 {:values {} :score (mx/scalar 0.0)}
+                 {:values (seed-conds args-vec) :score (mx/scalar 0.0)}
                  step-fns)]
             {:score (:score result)
-             :retval (when retval-fn
-                       (retval-fn (:values result) mlx-args))}))))))
+             :retval (retval-fn (:values result) mlx-args)}))))))
 
 (defn make-compiled-prefix-assess
   "Build a compiled prefix assess function.
@@ -463,7 +467,7 @@
              (not (:dynamic-addresses? schema)))
     (when-let [raw-sites (compiled/extract-rewritable-sites source)]
       (when (seq raw-sites)
-        (when-let [{:keys [site-specs retval-fn addrs]}
+        (when-let [{:keys [site-specs seed-conds]}
                    (compiled/compile-branch-rewritten-site-specs schema source raw-sites)]
           (let [step-fns (mapv build-project-site-step site-specs)]
             (when (every? some? step-fns)
@@ -473,7 +477,8 @@
                       (reduce
                        (fn [state step-fn]
                          (step-fn state mlx-args old-choices selection))
-                       {:values {} :score (mx/scalar 0.0) :weight (mx/scalar 0.0)}
+                       {:values (seed-conds args-vec)
+                        :score (mx/scalar 0.0) :weight (mx/scalar 0.0)}
                        step-fns)]
                   (:weight result))))))))))
 
@@ -533,33 +538,45 @@
   (let [{:keys [addr compiled-args dist-type]} site-spec
         nt (get compiled/noise-transforms-full dist-type)]
     (when nt
-      (let [log-prob-fn (:log-prob nt)]
-        (if (:noise-fn nt)
-          ;; Standard distribution with noise transform
-          (let [noise-fn (:noise-fn nt)
-                transform-fn (:transform nt)]
-            (fn [{:keys [values score weight key]} args-vec old-choices selection]
-              (let [eval-args (mapv #(% values args-vec) compiled-args)]
-                (if (sel/selected? selection addr)
-                  ;; Selected: resample via noise transform
-                  (let [[k1 k2] (rng/split key)
-                        noise (noise-fn k2)
-                        new-val (apply transform-fn noise eval-args)
-                        new-lp (apply log-prob-fn new-val eval-args)
-                        old-val (cm/get-value (cm/get-submap old-choices addr))
-                        old-lp (apply log-prob-fn old-val eval-args)]
-                    {:values (assoc values addr new-val)
-                     :score (mx/add score new-lp)
-                     :weight (mx/add weight (mx/subtract new-lp old-lp))
-                     :key k1})
-                  ;; Not selected: keep old value, no key split
-                  (let [val (cm/get-value (cm/get-submap old-choices addr))
-                        lp (apply log-prob-fn val eval-args)]
-                    {:values (assoc values addr val)
-                     :score (mx/add score lp)
-                     :weight weight
-                     :key key})))))
-          ;; Delta distribution: no noise, value = first arg
+      (let [log-prob-fn (:log-prob nt)
+            ;; Shared resample logic for both noise sources (genmlx-b210: the
+            ;; old code treated :args-noise-fn sites as Delta — a selected
+            ;; iid-gaussian was never resampled and contributed weight 0).
+            make-noise-step
+            (fn [draw-noise]
+              (let [transform-fn (:transform nt)]
+                (fn [{:keys [values score weight key]} args-vec old-choices selection]
+                  (let [eval-args (mapv #(% values args-vec) compiled-args)]
+                    (if (sel/selected? selection addr)
+                      ;; Selected: resample via noise transform
+                      (let [[k1 k2] (rng/split key)
+                            noise (draw-noise eval-args k2)
+                            new-val (apply transform-fn noise eval-args)
+                            new-lp (apply log-prob-fn new-val eval-args)
+                            old-val (cm/get-value (cm/get-submap old-choices addr))
+                            old-lp (apply log-prob-fn old-val eval-args)]
+                        {:values (assoc values addr new-val)
+                         :score (mx/add score new-lp)
+                         :weight (mx/add weight (mx/subtract new-lp old-lp))
+                         :key k1})
+                      ;; Not selected: keep old value, no key split
+                      (let [val (cm/get-value (cm/get-submap old-choices addr))
+                            lp (apply log-prob-fn val eval-args)]
+                        {:values (assoc values addr val)
+                         :score (mx/add score lp)
+                         :weight weight
+                         :key key}))))))]
+        (cond
+          (:noise-fn nt)
+          (let [noise-fn (:noise-fn nt)]
+            (make-noise-step (fn [_eval-args k] (noise-fn k))))
+
+          (:args-noise-fn nt)
+          (let [args-noise-fn (:args-noise-fn nt)]
+            (make-noise-step (fn [eval-args k] (args-noise-fn eval-args k))))
+
+          ;; Delta ONLY when the dist-type really is delta (genmlx-b210)
+          (= dist-type :delta)
           (fn [{:keys [values score weight key]} args-vec old-choices selection]
             (let [eval-args (mapv #(% values args-vec) compiled-args)]
               (if (sel/selected? selection addr)
@@ -577,7 +594,9 @@
                   {:values (assoc values addr val)
                    :score score
                    :weight weight
-                   :key key})))))))))
+                   :key key}))))
+
+          :else nil)))))
 
 (defn make-compiled-regenerate
   "Build a compiled regenerate function from a gen schema and source.
@@ -624,7 +643,7 @@
              (not (:dynamic-addresses? schema)))
     (when-let [raw-sites (compiled/extract-rewritable-sites source)]
       (when (seq raw-sites)
-        (when-let [{:keys [site-specs retval-fn addrs]}
+        (when-let [{:keys [site-specs retval-fn seed-conds]}
                    (compiled/compile-branch-rewritten-site-specs schema source raw-sites)]
           (let [step-fns (mapv build-regenerate-site-step site-specs)]
             (when (every? some? step-fns)
@@ -634,13 +653,13 @@
                       (reduce
                        (fn [state step-fn]
                          (step-fn state mlx-args old-choices selection))
-                       {:values {} :score (mx/scalar 0.0) :weight (mx/scalar 0.0) :key key}
+                       {:values (seed-conds args-vec)
+                        :score (mx/scalar 0.0) :weight (mx/scalar 0.0) :key key}
                        step-fns)]
                   {:values (:values result)
                    :score (:score result)
                    :weight (:weight result)
-                   :retval (when retval-fn
-                             (retval-fn (:values result) mlx-args))})))))))))
+                   :retval (retval-fn (:values result) mlx-args)})))))))))
 
 (defn make-compiled-prefix-regenerate
   "Build a compiled prefix regenerate function.
@@ -718,13 +737,20 @@
   "Build a site step that reads noise from noise-row[noise-index]
    instead of generating from a PRNG key.
    Returns (fn [{:keys [values score]} args-vec noise-row] -> {:values :score})
-   or nil if the dist-type has no noise transform.
-   For delta sites, noise-index is ignored (no noise consumed)."
+   or nil if the dist-type cannot be fused.
+   For delta sites, noise-index is ignored (no noise consumed).
+
+   Only :noise-fn distributions and true :delta sites are fusable. A transform
+   entry with :args-noise-fn (iid-gaussian — noise shape depends on dist args)
+   must return nil: the previous fallback treated it as Delta, so fused
+   Map/Unfold/Scan kernels gave value=mu with ZERO score contribution,
+   silently (genmlx-b210)."
   [site-spec noise-index]
   (let [{:keys [addr compiled-args dist-type]} site-spec
         nt (get compiled/noise-transforms-full dist-type)]
     (when nt
-      (if (:noise-fn nt)
+      (cond
+        (:noise-fn nt)
         ;; Standard distribution: extract noise from row at noise-index
         (let [transform-fn (:transform nt)
               log-prob-fn (:log-prob nt)]
@@ -735,12 +761,16 @@
                   lp (apply log-prob-fn value eval-args)]
               {:values (assoc values addr value)
                :score (mx/add score lp)})))
+
+        (= dist-type :delta)
         ;; Delta: no noise needed
         (fn [{:keys [values score]} args-vec _noise-row]
           (let [eval-args (mapv #(% values args-vec) compiled-args)
                 value (first eval-args)]
             {:values (assoc values addr value)
-             :score score}))))))
+             :score score}))
+
+        :else nil))))
 
 (defn- assign-noise-indices
   "Assign sequential noise indices to site-specs that have noise-fns.
@@ -941,8 +971,11 @@
 
 (defn fusable-kernel?
   "Check if a kernel can be fused into a single Metal dispatch.
-   Returns true if the kernel has a static schema with noise transforms
-   for all non-delta trace sites."
+   Returns true if the kernel has a static schema where every trace site is
+   either a :noise-fn distribution or a true delta, with at least one
+   noise-driven site. Sites with :args-noise-fn (iid-gaussian) are NOT
+   fusable — they must decline here, mirroring build-fused-site-step
+   (genmlx-b210)."
   [gf]
   (let [schema (:schema gf)]
     (and schema
@@ -950,9 +983,12 @@
          (seq (:trace-sites schema))
          (empty? (:splice-sites schema))
          (empty? (:param-sites schema))
-         (let [nts (mapv #(get compiled/noise-transforms-full (:dist-type %))
-                         (filterv :static? (:trace-sites schema)))]
+         (let [sites (filterv :static? (:trace-sites schema))
+               nts (mapv #(get compiled/noise-transforms-full (:dist-type %)) sites)]
            (and (every? some? nts)
+                (every? (fn [[site nt]]
+                          (or (:noise-fn nt) (= :delta (:dist-type site))))
+                        (map vector sites nts))
                 (some :noise-fn nts))))))
 
 (defn make-fused-map-simulate
@@ -1127,7 +1163,16 @@
     (let [binding-env (compiled/build-binding-env source)
           static-sites (filterv :static? (:trace-sites schema))
           site-specs (compiled/build-fused-site-specs static-sites binding-env)]
-      (when (every? some? site-specs)
+      (when (and (every? some? site-specs)
+                 ;; Every site must be a :noise-fn distribution or a true
+                 ;; delta. The latent/observed split is only known at runtime,
+                 ;; and a latent :args-noise-fn site (iid-gaussian) would
+                 ;; silently degrade to value=first-arg (genmlx-b210) —
+                 ;; decline at build time instead.
+                 (every? (fn [ss]
+                           (let [nt (get compiled/noise-transforms-full (:dist-type ss))]
+                             (or (:noise-fn nt) (= :delta (:dist-type ss)))))
+                         site-specs))
         (let [dep-order (:dep-order schema)
               all-addrs (mapv :addr static-sites)
               addr-index (into {} (map-indexed (fn [i a] [a i]) all-addrs))
@@ -1170,7 +1215,9 @@
                             (let [eval-args (mapv #(% vm mlx-args) (:compiled-args site-spec))
                                   proposed (apply (:transform nt) noise-col eval-args)]
                               (assoc vm addr proposed))
-                            ;; Delta: value = first dist arg
+                            ;; Delta: value = first dist arg (only true deltas
+                            ;; reach here — the build-time gate above declines
+                            ;; every other no-noise-fn transform)
                             (let [eval-args (mapv #(% vm mlx-args) (:compiled-args site-spec))]
                               (assoc vm addr (first eval-args)))))
                         ;; Observed: bake in constant

--- a/src/genmlx/conjugacy.cljs
+++ b/src/genmlx/conjugacy.cljs
@@ -121,6 +121,16 @@
 ;; Conjugate pair detection
 ;; ---------------------------------------------------------------------------
 
+(def ^:private affine-capable-families
+  "Families whose downstream paths honor an affine coefficient/offset on the
+   natural parameter. Only normal-normal qualifies: affine NN pairs are routed
+   to Kalman chains or joint linear-Gaussian blocks, which recover the design
+   coefficients. Every other family's handlers use the obs value directly
+   against the prior's natural parameter — accepting :affine there silently
+   DROPS the coefficient (genmlx-b470), e.g. gamma-poisson with rate 2*lambda
+   scored as if rate were lambda."
+  #{:normal-normal})
+
 (defn detect-conjugate-pairs
   "Scan schema trace sites for conjugate pairs.
 
@@ -128,7 +138,8 @@
    1. Both sites are static (keyword addresses)
    2. obs depends on prior (prior-addr is in obs's :deps)
    3. [prior-dist-type, obs-dist-type] is in conjugacy-table with non-nil value
-   4. The dependency is through the natural parameter position (:direct)
+   4. The dependency is through the natural parameter position: :direct for
+      any family, :affine only for affine-capable families (normal-normal)
 
    Returns vector of {:prior-addr :obs-addr :family :prior-site :obs-site
                        :dependency-type :family-info}"
@@ -146,8 +157,12 @@
             ;; Must be in table AND non-nil (nil = explicitly not conjugate)
             :when (and (not= family-info ::not-found) (some? family-info))
             :let [dep-type (classify-dependency prior-addr obs-site family-info)]
-            ;; :direct and :affine dependencies are conjugate
-            :when (#{:direct :affine} (:type dep-type))]
+            ;; :direct for all families; :affine only where a path exists that
+            ;; recovers the coefficients (see affine-capable-families)
+            :when (or (= :direct (:type dep-type))
+                      (and (= :affine (:type dep-type))
+                           (contains? affine-capable-families
+                                      (:family family-info))))]
         {:prior-addr prior-addr
          :obs-addr (:addr obs-site)
          :family (:family family-info)
@@ -166,6 +181,26 @@
    Returns {prior-addr [pair1 pair2 ...]}."
   [pairs]
   (group-by :prior-addr pairs))
+
+(defn drop-multi-parent-pairs
+  "Remove all pairs whose obs address is claimed by MORE THAN ONE prior.
+
+   An obs with two conjugate parents (e.g. a Poisson whose rate is bound to
+   one Gamma latent while another Gamma latent also appears in its deps) gets
+   one handler per parent group; merging the handler maps is last-wins, so one
+   parent silently marginalizes against an obs the other parent also claims
+   (genmlx-b470). Normal-normal multi-parent obs are handled JOINTLY by the
+   linear-Gaussian block path and never reach this filter; for every other
+   family there is no joint path, so the only correct move is to decline."
+  [pairs]
+  (let [multi (into #{}
+                    (keep (fn [[obs-addr ps]]
+                            (when (> (count (distinct (map :prior-addr ps))) 1)
+                              obs-addr)))
+                    (group-by :obs-addr pairs))]
+    (if (empty? multi)
+      pairs
+      (vec (remove #(contains? multi (:obs-addr %)) pairs)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Schema augmentation

--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -336,6 +336,16 @@
 
 ;; -- L3: Analytical path --
 
+(defn- analytical-fired?
+  "Did any analytical handler actually marginalize during this run? When every
+   handler fell through (constrained priors, partially-constrained obs,
+   probe-declined blocks — genmlx-b470), the result is plain joint scoring and
+   must NOT be labeled :marginal."
+  [result]
+  (boolean (or (seq (:auto-posteriors result))
+               (seq (:auto-kalman-beliefs result))
+               (seq (:lg-belief result)))))
+
 (defn- run-generate-analytical [gf args key {:keys [constraints]}]
   (let [schema (:schema gf)
         transition (auto/make-address-dispatch
@@ -346,7 +356,9 @@
                   :auto-posteriors {} :auto-kalman-beliefs {} :auto-kalman-noise-vars {}
                   :executor execute-sub :param-store (param-store gf)}
                  (fn [rt] (run-body gf rt args)))
-        trace (vary-meta (make-result-trace gf args result) assoc ::score-type :marginal)]
+        trace (cond-> (make-result-trace gf args result)
+                (analytical-fired? result)
+                (vary-meta assoc ::score-type :marginal))]
     (make-generate-result trace (:weight result) constraints (:choices result) result)))
 
 (defn- run-assess-analytical [gf args key {:keys [constraints]}]
@@ -377,7 +389,9 @@
                   :executor execute-sub :param-store (param-store gf)}
                  (fn [rt] (run-body gf rt (:args trace))))
         regen-result (make-regen-result gf trace result old-score)]
-    (clojure.core/update regen-result :trace vary-meta assoc ::score-type :marginal)))
+    (if (analytical-fired? result)
+      (clojure.core/update regen-result :trace vary-meta assoc ::score-type :marginal)
+      regen-result)))
 
 ;; -- Utility --
 
@@ -478,8 +492,11 @@
       (when-let [run-fn (get analytical-table op)]
         (case op
           (:generate :assess)
+          ;; seq, not truthiness: an empty handler map (all rules declined,
+          ;; e.g. family without a runtime factory) must not claim the
+          ;; analytical path (genmlx-b470).
           (when (and (not (mx/in-grad?))
-                     (:auto-handlers schema)
+                     (seq (:auto-handlers schema))
                      (auto/some-conjugate-obs-constrained?
                        (:conjugate-pairs schema) (:constraints opts)))
             {:run run-fn :score-type :marginal :label :analytical})

--- a/src/genmlx/inference/auto_analytical.cljs
+++ b/src/genmlx/inference/auto_analytical.cljs
@@ -170,23 +170,36 @@
   (let [regenerate? (= mode :regenerate)
         prior-handler
         (fn [state addr dist]
-          (when-not (and regenerate? (:selection state)
-                         (sel/selected? (:selection state) addr))
-            (let [posterior (init-posterior (:params dist))
-                  value (if regenerate?
-                          (cm/get-value (cm/get-submap (:old-choices state) addr))
-                          (posterior-mean posterior))]
-              ;; Return point estimate / old value; don't add to score (marginalized out)
-              [value (-> state
-                         (assoc-in [:auto-posteriors prior-addr] posterior)
-                         (update :choices cm/set-value addr value))])))
+          (let [proceed?
+                (if regenerate?
+                  (not (and (:selection state)
+                            (sel/selected? (:selection state) addr)))
+                  ;; Generate/assess (genmlx-b470): the pair group marginalizes
+                  ;; only when the prior itself is UNCONSTRAINED and EVERY obs
+                  ;; is constrained. A constrained prior must keep its value
+                  ;; (the base transition scores it); a partially-constrained
+                  ;; obs set would otherwise produce a score that is neither
+                  ;; joint nor marginal. Declining here leaves no posterior in
+                  ;; state, so the obs handlers below fall through too.
+                  (let [cs (:constraints state)]
+                    (and (not (cm/has-value? (cm/get-submap cs prior-addr)))
+                         (every? #(cm/has-value? (cm/get-submap cs %)) obs-addrs))))]
+            (when proceed?
+              (let [posterior (init-posterior (:params dist))
+                    value (if regenerate?
+                            (cm/get-value (cm/get-submap (:old-choices state) addr))
+                            (posterior-mean posterior))]
+                ;; Return point estimate / old value; don't add to score (marginalized out)
+                [value (-> state
+                           (assoc-in [:auto-posteriors prior-addr] posterior)
+                           (update :choices cm/set-value addr value))]))))
 
         obs-handler
         (fn [state addr dist]
-          ;; Regenerate: fall through if the prior was selected (no posterior).
-          (when-let [current-posterior (if regenerate?
-                                         (get-in state [:auto-posteriors prior-addr])
-                                         ::generate)]
+          ;; Requires an initialized posterior — absent whenever the prior
+          ;; handler fell through (selected under regenerate; constrained prior
+          ;; or partially-constrained obs under generate) → base transition.
+          (when-let [current-posterior (get-in state [:auto-posteriors prior-addr])]
             ;; Regenerate: skip obs that are themselves being resampled.
             (when-not (and regenerate? (:selection state)
                            (sel/selected? (:selection state) addr))
@@ -195,10 +208,7 @@
                                  (cm/get-submap (:constraints state) addr))]
                 (when (cm/has-value? constraint)
                   (let [obs-value (cm/get-value constraint)
-                        cur-post (if regenerate?
-                                   current-posterior
-                                   (get-in state [:auto-posteriors prior-addr]))
-                        {:keys [posterior ll]} (update-step cur-post obs-value (:params dist))
+                        {:keys [posterior ll]} (update-step current-posterior obs-value (:params dist))
                         post-mean (posterior-mean posterior)]
                     [obs-value (cond-> state
                                  true (assoc-in [:auto-posteriors prior-addr] posterior)
@@ -368,6 +378,26 @@
                                            (:obs-dep-types step)))
                                     steps))
         regenerate? (= mode :regenerate)
+        chain-latents (mapv :latent steps)
+        chain-obs (vec (mapcat :observations steps))
+        chain-key (first chain-latents)
+        ;; Generate/assess gate (genmlx-b470): the chain marginalizes only when
+        ;; no chain latent is constrained and every chain obs is constrained.
+        ;; A constrained latent must keep its value (base transition scores it);
+        ;; a partially-constrained obs set would leave the remaining latents at
+        ;; predicted means with no score — neither joint nor marginal. The
+        ;; result is cached in state under [:auto-kalman-ok chain-key] once a
+        ;; latent handler commits (the gate can only be consulted again on the
+        ;; decline path, where handlers consistently fall through).
+        chain-ok?
+        (fn [state]
+          (if regenerate?
+            true
+            (if-some [cached (get-in state [:auto-kalman-ok chain-key])]
+              cached
+              (let [cs (:constraints state)]
+                (and (not-any? #(cm/has-value? (cm/get-submap cs %)) chain-latents)
+                     (every? #(cm/has-value? (cm/get-submap cs %)) chain-obs))))))
 
         latent-handlers
         (into {}
@@ -377,16 +407,18 @@
                   (fn [state addr dist]
                     (when-not (and regenerate? (:selection state)
                                    (sel/selected? (:selection state) addr))
-                      (let [params (:params dist)
-                            new-belief (kalman-init-belief i steps state params)
-                            value (if regenerate?
-                                    (cm/get-value (cm/get-submap (:old-choices state) addr))
-                                    (:mean new-belief))
-                            noise-var (mx/multiply (:sigma params) (:sigma params))]
-                        [value (-> state
-                                   (assoc-in [:auto-kalman-beliefs addr] new-belief)
-                                   (assoc-in [:auto-kalman-noise-vars i] noise-var)
-                                   (update :choices cm/set-value addr value))])))])
+                      (when (chain-ok? state)
+                        (let [params (:params dist)
+                              new-belief (kalman-init-belief i steps state params)
+                              value (if regenerate?
+                                      (cm/get-value (cm/get-submap (:old-choices state) addr))
+                                      (:mean new-belief))
+                              noise-var (mx/multiply (:sigma params) (:sigma params))]
+                          [value (-> state
+                                     (assoc-in [:auto-kalman-ok chain-key] true)
+                                     (assoc-in [:auto-kalman-beliefs addr] new-belief)
+                                     (assoc-in [:auto-kalman-noise-vars i] noise-var)
+                                     (update :choices cm/set-value addr value))]))))])
                steps))
 
         obs-handlers
@@ -449,11 +481,20 @@
 
 (defn- mvn-well-conditioned?
   "Check if a covariance matrix is well-conditioned (min diag > threshold).
-   Returns false if any diagonal element is below 1e-6."
+   Returns false if any diagonal element is below 1e-6, is non-finite, or the
+   check itself fails (nil/malformed matrix).
+
+   NOTE: the mx/item here forces a GPU eval inside a handler transition — a
+   deliberate exception to the eval-at-boundaries rule. It is safe because the
+   analytical path is scalar-only (never batched) and the dispatcher excludes
+   mx/in-grad?; declining (false) on any anomaly falls through to the base
+   transition, which is always correct."
   [cov-matrix]
-  (let [diag-vals (mx/diag cov-matrix)
-        min-diag (mx/item (mx/amin diag-vals))]
-    (> min-diag 1e-6)))
+  (try
+    (let [diag-vals (mx/diag cov-matrix)
+          min-diag (mx/item (mx/amin diag-vals))]
+      (and (js/isFinite min-diag) (> min-diag 1e-6)))
+    (catch :default _ false)))
 
 (defn mvn-update-step
   "MVN-MVN conjugate update.
@@ -503,23 +544,32 @@
   (let [regenerate? (= mode :regenerate)
         prior-handler
         (fn [state addr dist]
-          (when-not (and regenerate? (:selection state)
-                         (sel/selected? (:selection state) addr))
-            (let [{{:keys [mean-vec cov-matrix]} :params} dist
-                  posterior {:mean-vec mean-vec :cov-matrix cov-matrix}
-                  value (if regenerate?
-                          (cm/get-value (cm/get-submap (:old-choices state) addr))
-                          mean-vec)]
-              ;; Return prior mean / old value; don't add to score (marginalized out)
-              [value (-> state
-                         (assoc-in [:auto-posteriors prior-addr] posterior)
-                         (update :choices cm/set-value addr value))])))
+          (let [proceed?
+                (if regenerate?
+                  (not (and (:selection state)
+                            (sel/selected? (:selection state) addr)))
+                  ;; Generate/assess (genmlx-b470): marginalize only when the
+                  ;; prior is unconstrained and every obs is constrained —
+                  ;; mirrors make-conjugate-handlers-core.
+                  (let [cs (:constraints state)]
+                    (and (not (cm/has-value? (cm/get-submap cs prior-addr)))
+                         (every? #(cm/has-value? (cm/get-submap cs %)) obs-addrs))))]
+            (when proceed?
+              (let [{{:keys [mean-vec cov-matrix]} :params} dist
+                    posterior {:mean-vec mean-vec :cov-matrix cov-matrix}
+                    value (if regenerate?
+                            (cm/get-value (cm/get-submap (:old-choices state) addr))
+                            mean-vec)]
+                ;; Return prior mean / old value; don't add to score (marginalized out)
+                [value (-> state
+                           (assoc-in [:auto-posteriors prior-addr] posterior)
+                           (update :choices cm/set-value addr value))]))))
 
         obs-handler
         (fn [state addr dist]
-          (when-let [posterior (if regenerate?
-                                 (get-in state [:auto-posteriors prior-addr])
-                                 ::generate)]
+          ;; Requires an initialized posterior — absent whenever the prior
+          ;; handler fell through → base transition.
+          (when-let [cur-post (get-in state [:auto-posteriors prior-addr])]
             (when-not (and regenerate? (:selection state)
                            (sel/selected? (:selection state) addr))
               (let [constraint (if regenerate?
@@ -527,9 +577,6 @@
                                  (cm/get-submap (:constraints state) addr))]
                 (when (cm/has-value? constraint)
                   (let [obs-value (cm/get-value constraint)
-                        cur-post (if regenerate?
-                                   posterior
-                                   (get-in state [:auto-posteriors prior-addr]))
                         {{obs-cov :cov-matrix} :params} dist
                         result (mvn-update-step cur-post obs-value obs-cov)]
                     ;; Fallthrough if ill-conditioned
@@ -566,9 +613,11 @@
 
 (defn build-auto-handlers
   "Build address-based handlers from detected conjugate pairs.
+   Multi-parent obs pairs are dropped first (handler-map merge is last-wins,
+   so two priors claiming one obs would silently mis-marginalize, genmlx-b470).
    Returns a merged map of {addr handler-fn} for all conjugate sites."
   [conjugate-pairs]
-  (let [grouped (conj/group-by-prior conjugate-pairs)]
+  (let [grouped (conj/group-by-prior (conj/drop-multi-parent-pairs conjugate-pairs))]
     (reduce
      (fn [handlers [prior-addr pairs]]
        (let [family (:family (first pairs))
@@ -613,9 +662,10 @@
 
 (defn build-regenerate-handlers
   "Build regenerate-specific address-based handlers from detected conjugate pairs.
+   Multi-parent obs pairs are dropped first (see build-auto-handlers).
    Returns a merged map of {addr handler-fn}."
   [conjugate-pairs]
-  (let [grouped (conj/group-by-prior conjugate-pairs)]
+  (let [grouped (conj/group-by-prior (conj/drop-multi-parent-pairs conjugate-pairs))]
     (reduce
      (fn [handlers [prior-addr pairs]]
        (let [family (:family (first pairs))

--- a/src/genmlx/inference/compiled_gradient.cljs
+++ b/src/genmlx/inference/compiled_gradient.cljs
@@ -140,7 +140,9 @@
         gumbel-noise (dr/generate-gumbel-noise gk T particles)
         _ (mx/materialize! extend-noise gumbel-noise)
         tau-arr (mx/scalar tau)
-        extend-fn (cops/make-smc-extend-step schema source)
+        extend-fn (or (cops/make-smc-extend-step schema source)
+                      (throw (ex-info "Kernel cannot be compiled for gradient SMC"
+                                      {:kernel kernel})))
         ;; Objective: log-ML as function of model-params
         ;; For now, model-params modulate the init-state
         ;; (full parameterization requires make-parameterized-extend)

--- a/src/genmlx/inference/ekf.cljs
+++ b/src/genmlx/inference/ekf.cljs
@@ -156,15 +156,18 @@
    (fn [state addr dist]
      (let [{:keys [obs-fn noise-std mask]} (:params dist)
            belief (:ekf-belief state)
-           constraint (cm/get-submap (:constraints state) addr)
-           obs (cm/get-value constraint)
-           {:keys [belief ll]} (ekf-update belief obs obs-fn noise-std mask)
-           n (:ekf-n state)]
-       [obs (-> state
-                (assoc :ekf-belief belief)
-                (update :choices cm/set-value addr obs)
-                (update :ekf-ll
-                  #(mx/add (or % (mx/zeros [n])) ll)))]))})
+           constraint (cm/get-submap (:constraints state) addr)]
+       ;; Guards (genmlx-b470): unconstrained obs or missing belief → fall
+       ;; through to the base transition instead of updating against nil.
+       (when (and belief (cm/has-value? constraint))
+         (let [obs (cm/get-value constraint)
+               {:keys [belief ll]} (ekf-update belief obs obs-fn noise-std mask)
+               n (:ekf-n state)]
+           [obs (-> state
+                    (assoc :ekf-belief belief)
+                    (update :choices cm/set-value addr obs)
+                    (update :ekf-ll
+                      #(mx/add (or % (mx/zeros [n])) ll)))]))))})
 
 (defn make-ekf-transition
   "Handler middleware: wraps generate-transition for EKF.

--- a/src/genmlx/inference/ekf_nd.cljs
+++ b/src/genmlx/inference/ekf_nd.cljs
@@ -266,15 +266,18 @@
     (let [n (:ekf-nd-n state)
           means (:ekf-nd-means state)
           covs (:ekf-nd-covs state)
-          constraint (cm/get-submap (:constraints state) addr)
-          obs (cm/get-value constraint)
-          result (update-fn latent-addrs means covs obs dist)]
-      [obs (-> state
-               (assoc :ekf-nd-means (:means result)
-                      :ekf-nd-covs (:covs result))
-               (update :choices cm/set-value addr obs)
-               (update :ekf-nd-ll
-                 #(mx/add (or % (mx/zeros [n])) (:ll result))))])))
+          constraint (cm/get-submap (:constraints state) addr)]
+      ;; Guards (genmlx-b470): unconstrained obs or missing belief → fall
+      ;; through to the base transition instead of updating against nil.
+      (when (and means covs (cm/has-value? constraint))
+        (let [obs (cm/get-value constraint)
+              result (update-fn latent-addrs means covs obs dist)]
+          [obs (-> state
+                   (assoc :ekf-nd-means (:means result)
+                          :ekf-nd-covs (:covs result))
+                   (update :choices cm/set-value addr obs)
+                   (update :ekf-nd-ll
+                     #(mx/add (or % (mx/zeros [n])) (:ll result))))])))))
 
 (defn make-multi-ekf-dispatch
   "Create multi-dim EKF dispatch map for use with wrap-analytical.

--- a/src/genmlx/inference/kalman.cljs
+++ b/src/genmlx/inference/kalman.cljs
@@ -186,15 +186,19 @@
    (fn [state addr dist]
      (let [{:keys [base-mean loading noise-std mask]} (:params dist)
            belief (:kalman-belief state)
-           constraint (cm/get-submap (:constraints state) addr)
-           obs (cm/get-value constraint)
-           {:keys [belief ll]} (kalman-update belief obs base-mean loading noise-std mask)
-           n (:kalman-n state)]
-       [obs (-> state
-                (assoc :kalman-belief belief)
-                (update :choices cm/set-value addr obs)
-                (update :kalman-ll
-                  #(mx/add (or % (mx/zeros [n])) ll)))]))})
+           constraint (cm/get-submap (:constraints state) addr)]
+       ;; Guards (genmlx-b470): an unconstrained obs or an obs reached before
+       ;; any latent (no belief) must fall through to the base transition —
+       ;; updating against nil silently produces garbage LL.
+       (when (and belief (cm/has-value? constraint))
+         (let [obs (cm/get-value constraint)
+               {:keys [belief ll]} (kalman-update belief obs base-mean loading noise-std mask)
+               n (:kalman-n state)]
+           [obs (-> state
+                    (assoc :kalman-belief belief)
+                    (update :choices cm/set-value addr obs)
+                    (update :kalman-ll
+                      #(mx/add (or % (mx/zeros [n])) ll)))]))))})
 
 (defn make-kalman-transition
   "Handler middleware: wraps generate-transition for Kalman filtering.

--- a/src/genmlx/linear_gaussian.cljs
+++ b/src/genmlx/linear_gaussian.cljs
@@ -158,6 +158,41 @@
 (defn- mean-form [site] (first (:dist-args site)))
 (defn- sigma-form [site] (second (:dist-args site)))
 
+(defn- expand-expr-symbols
+  "Recursively replace symbols bound to :expr forms in the binding env with
+   their defining forms, so INDIRECT trace dependencies become visible to the
+   dependency analysis (genmlx-b470): a let-bound `noise-std` referencing a
+   traced `noise-prec` made noise-latents come out empty, and the obs handler
+   then evaluated the sigma form with the residual latent missing from its
+   env — a hard NAPI error at generate time."
+  [form binding-env seen]
+  (cond
+    (symbol? form)
+    (let [info (get binding-env (name form))]
+      (if (and (= :expr (:kind info)) (not (contains? seen (name form))))
+        (expand-expr-symbols (:form info) binding-env (conj seen (name form)))
+        form))
+    (seq? form) (doall (map #(expand-expr-symbols % binding-env seen) form))
+    (vector? form) (mapv #(expand-expr-symbols % binding-env seen) form)
+    :else form))
+
+(defn- latent-interaction?
+  "Does the form multiply/divide two (sub)expressions that BOTH reference block
+   latents? Static complement to the runtime joint-affinity probe
+   (genmlx-b470): a bilinear mean like (mx/multiply slope intercept) is affine
+   PER-PAIR (each latent looks constant while the other is analyzed) but not
+   JOINTLY affine, so 0/1 probing would fabricate h=0."
+  [form latents]
+  (cond
+    (seq? form)
+    (or (and (symbol? (first form))
+             (contains? #{"multiply" "divide" "matmul" "outer"}
+                        (name (first form)))
+             (>= (count (filter #(references-any? % latents) (rest form))) 2))
+        (boolean (some #(latent-interaction? % latents) (rest form))))
+    (vector? form) (boolean (some #(latent-interaction? % latents) form))
+    :else false))
+
 (defn- eligible-block
   "Validate a concern component and, if eligible, build a block descriptor.
    Returns {:eligible? true :block desc} or {:eligible? false}.
@@ -183,11 +218,21 @@
         ;; (a) independent priors: a latent's prior must not reference another latent
         indep-priors? (every? (fn [s] (not (references-any? (vec (:dist-args s)) latents)))
                                latent-sites)
+        ;; Dependency analysis runs on EXPANDED forms (let-bound :expr symbols
+        ;; replaced by their definitions) so indirect trace references are
+        ;; visible (genmlx-b470). Compilation below still uses the original
+        ;; forms — compile-expr resolves :expr bindings itself.
+        x-mean (fn [s] (expand-expr-symbols (mean-form s) binding-env #{}))
+        x-sigma (fn [s] (expand-expr-symbols (sigma-form s) binding-env #{}))
         ;; (b) obs MEAN references only block latents (noise handled separately below)
         mean-deps-ok? (every? (fn [s]
-                                (set/subset? (form-trace-addrs (mean-form s) all-trace-addrs)
+                                (set/subset? (form-trace-addrs (x-mean s) all-trace-addrs)
                                              latents))
                               obs-sites)
+        ;; (b') obs MEAN has no multiplicative interaction between block
+        ;; latents — bilinear means are not jointly affine (genmlx-b470)
+        no-interaction? (every? (fn [s] (not (latent-interaction? (x-mean s) latents)))
+                                obs-sites)
         ;; (c) no non-conjugate children of any block latent
         children-conjugate?
         (every? (fn [la]
@@ -196,12 +241,12 @@
                           (:trace-sites schema)))
                 latents)
         ;; (d) noise references no BLOCK latent (it may reference residual latents)
-        sigma-block-free? (every? (fn [s] (not (references-any? (sigma-form s) latents))) obs-sites)
+        sigma-block-free? (every? (fn [s] (not (references-any? (x-sigma s) latents))) obs-sites)
         ;; (d') residual latents the noise depends on (genmlx-4q9d): exclude block
         ;; latents and block obs — what remains are the residual noise latents.
         noise-latents (reduce (fn [acc s]
                                 (set/union acc (set/difference
-                                                (form-trace-addrs (sigma-form s) all-trace-addrs)
+                                                (form-trace-addrs (x-sigma s) all-trace-addrs)
                                                 latents obs)))
                               #{} obs-sites)
         ;; (d'') residual noise latents must precede all block obs in dep-order, so
@@ -221,8 +266,8 @@
                            :sigma-fn (compiled/compile-expr (sigma-form s) binding-env #{})}))
                       order-obs)
         forms-ok? (every? #(and (:mean-fn %) (:sigma-fn %)) obs-fns)]
-    (if (and indep-priors? mean-deps-ok? children-conjugate? sigma-block-free?
-             noise-precede? order-ok? forms-ok?)
+    (if (and indep-priors? mean-deps-ok? no-interaction? children-conjugate?
+             sigma-block-free? noise-precede? order-ok? forms-ok?)
       {:eligible? true
        :block {:id order-latents            ; stable id (blocks are disjoint)
                :latents order-latents
@@ -287,6 +332,39 @@
                           latents))]
     {:h h :c c}))
 
+(defn- probe-jointly-affine?
+  "Runtime backstop for the static affine classification (genmlx-b470).
+
+   The 0/1 probing in obs-design recovers h and c correctly ONLY when the mean
+   form is JOINTLY affine in the block latents. Bilinear means like
+   (mx/multiply slope intercept) classify affine PER-PAIR (each latent looks
+   constant while the other is analyzed) yet probe to h=0, c=0 — a silently
+   wrong exact LL. Verify the recovered design reproduces the mean form at two
+   joint probe points:  mean(s,...,s) ?= c + s·Σh  for s ∈ {1, 2}
+   (s=2 additionally catches pure-power forms like β² that pass s=1).
+   Tolerance is relative, float32-scaled. Any evaluation failure declines.
+
+   The mx/item here forces a GPU eval inside a handler transition — acceptable
+   for the same reason as mvn-well-conditioned?: the analytical path is
+   scalar-only and dispatcher-gated against mx/in-grad?.
+
+   The design recovery itself (obs-design) runs INSIDE the try: a mean form
+   whose evaluation fails (e.g. a hidden non-latent trace reference leaving
+   nil in the env) declines the block instead of crashing generate."
+  [mean-fn latents args]
+  (try
+    (let [{:keys [h c]} (obs-design mean-fn latents args)
+          sum-h (mx/sum h)
+          check (fn [s]
+                  (let [probe-env (zipmap latents (repeat (mx/scalar s)))
+                        lhs (mx/item (coerce-scalar (mean-fn probe-env args)))
+                        rhs (mx/item (mx/add c (mx/multiply (mx/scalar s) sum-h)))]
+                    (and (js/isFinite lhs) (js/isFinite rhs)
+                         (<= (js/Math.abs (- lhs rhs))
+                             (* 1e-4 (max 1.0 (js/Math.abs lhs) (js/Math.abs rhs)))))))]
+      (and (check 1.0) (check 2.0)))
+    (catch :default _ false)))
+
 (defn make-lg-handlers
   "Build address handlers for a linear-Gaussian block, parameterized by `mode`.
 
@@ -317,43 +395,76 @@
    overall estimate is E_residual[block marginal] over the particle population."
   ([block] (make-lg-handlers block :generate))
   ([block mode]
-   (let [{:keys [id latents p obs noise-latents]} block
+   (let [{:keys [id latents p obs noise-latents obs-addrs]} block
          noise-latents (or noise-latents #{})
+         obs-addrs (or obs-addrs (mapv :addr obs))
          regenerate? (= mode :regenerate)
          block-reopened?
          (fn [state]
+           ;; Selecting ANY block address — latent OR obs — re-opens the whole
+           ;; block (genmlx-b470: a selected obs must be resampled by the base
+           ;; transition, not Kalman-conditioned on its old value).
            (and regenerate?
                 (:selection state)
-                (boolean (some #(sel/selected? (:selection state) %) latents))))
+                (boolean (some #(sel/selected? (:selection state) %)
+                               (concat latents obs-addrs)))))
+         block-ok?
+         ;; Runtime eligibility gate (genmlx-b470), consulted by EVERY block
+         ;; handler before committing and cached under [:lg-ok id] once a
+         ;; latent commits (on the decline path nothing is committed, so the
+         ;; recomputation cost is only paid by declined blocks):
+         ;; - generate/assess: no block latent constrained, every block obs
+         ;;   constrained (otherwise latents would be left at placeholder
+         ;;   means with no score — neither joint nor marginal);
+         ;; - both modes: every obs mean form passes the joint-affinity probe
+         ;;   (bilinear means classify affine per-pair but probe to h=0).
+         ;; When false, all block handlers fall through to the base transition.
+         (fn [state]
+           (if-some [cached (get-in state [:lg-ok id])]
+             cached
+             (let [args (:model-args state)
+                   cs (:constraints state)
+                   constraints-ok?
+                   (or regenerate?
+                       (and (not-any? #(cm/has-value? (cm/get-submap cs %)) latents)
+                            (every? #(cm/has-value? (cm/get-submap cs %)) obs-addrs)))]
+               (boolean
+                (and args constraints-ok?
+                     (every? (fn [{:keys [mean-fn]}]
+                               (probe-jointly-affine? mean-fn latents args))
+                             obs))))))
          latent-handlers
          (into {}
                (map (fn [la]
                       [la
                        (fn [state _addr dist]
                          (when-not (block-reopened? state)
-                           (let [{:keys [mu sigma]} (:params dist)
-                                 var (mx/multiply sigma sigma)
-                                 value (if regenerate?
-                                         (cm/get-value (cm/get-submap (:old-choices state) la))
-                                         mu)
-                                 st (-> state
-                                        (assoc-in [:lg-init id la] {:mean (coerce-scalar mu)
-                                                                    :var (coerce-scalar var)})
-                                        (update :choices cm/set-value la value))
-                                 inits (get-in st [:lg-init id])
-                                 st (if (= (count inits) p)
-                                      (let [m0 (mx/stack (mapv #(:mean (get inits %)) latents))
-                                            s0 (mx/diag (mx/stack (mapv #(:var (get inits %)) latents)))]
-                                        (assoc-in st [:lg-belief id] {:mean m0 :cov s0}))
-                                      st)]
-                             [value st])))]))
+                           (when (block-ok? state)
+                             (let [{:keys [mu sigma]} (:params dist)
+                                   var (mx/multiply sigma sigma)
+                                   value (if regenerate?
+                                           (cm/get-value (cm/get-submap (:old-choices state) la))
+                                           mu)
+                                   st (-> state
+                                          (assoc-in [:lg-ok id] true)
+                                          (assoc-in [:lg-init id la] {:mean (coerce-scalar mu)
+                                                                      :var (coerce-scalar var)})
+                                          (update :choices cm/set-value la value))
+                                   inits (get-in st [:lg-init id])
+                                   st (if (= (count inits) p)
+                                        (let [m0 (mx/stack (mapv #(:mean (get inits %)) latents))
+                                              s0 (mx/diag (mx/stack (mapv #(:var (get inits %)) latents)))]
+                                          (assoc-in st [:lg-belief id] {:mean m0 :cov s0}))
+                                        st)]
+                               [value st]))))]))
                latents)
          obs-handlers
          (into {}
                (map (fn [{:keys [addr mean-fn sigma-fn]}]
                       [addr
                        (fn [state _addr _dist]
-                         (when-not (block-reopened? state)
+                         (when (and (not (block-reopened? state))
+                                    (block-ok? state))
                            (let [belief (get-in state [:lg-belief id])
                                  args (:model-args state)
                                  constraint (if regenerate?

--- a/src/genmlx/rewrite.cljs
+++ b/src/genmlx/rewrite.cljs
@@ -15,6 +15,7 @@
   (:require [clojure.set :as set]
             [genmlx.dep-graph :as dep-graph]
             [genmlx.affine :as affine]
+            [genmlx.conjugacy :as conj-detect]
             [genmlx.inference.auto-analytical :as auto]
             [genmlx.linear-gaussian :as lg]
             [genmlx.handler :as h]))
@@ -46,14 +47,19 @@
 (defrecord ConjugacyRule [family prior-addr obs-addrs]
   IRewriteRule
   (-applicable? [this graph schema]
-    (and (contains? (:nodes graph) prior-addr)
+    ;; A family present in the conjugacy table but absent from the handler
+    ;; factory map (e.g. dirichlet-categorical) has NO runtime elimination —
+    ;; applying the rule anyway would prune a still-stochastic latent from the
+    ;; graph and let method-selection claim an exact marginal (genmlx-b470).
+    (and (some? (get auto/family->handler-factory family))
+         (contains? (:nodes graph) prior-addr)
          (every? #(contains? (:nodes graph) %) obs-addrs)))
   (-apply [this graph schema constraints]
     (let [factory (get auto/family->handler-factory family)
-          handlers (when factory (factory prior-addr obs-addrs))
+          handlers (factory prior-addr obs-addrs)
           graph' (prune-eliminated graph #{prior-addr})]
       {:graph' graph'
-       :handlers (or handlers {})
+       :handlers handlers
        :eliminated #{prior-addr}
        :description (str "Marginalized " (name prior-addr)
                          " via " (name family))})))
@@ -101,7 +107,8 @@
 (defrecord RaoBlackwellRule [prior-addr conjugate-obs-addrs non-conjugate-children family]
   IRewriteRule
   (-applicable? [this graph schema]
-    (and (contains? (:nodes graph) prior-addr)
+    (and (some? (get auto/family->handler-factory family))
+         (contains? (:nodes graph) prior-addr)
          (seq conjugate-obs-addrs)
          (seq non-conjugate-children)))
   (-apply [this graph schema constraints]
@@ -113,9 +120,9 @@
     ;; requires deferred execution (Level 4 enhancement).
     (let [factory (get auto/family->handler-factory family)
           ;; Build handlers for the conjugate obs subset
-          handlers (when factory (factory prior-addr conjugate-obs-addrs))]
+          handlers (factory prior-addr conjugate-obs-addrs)]
       {:graph' graph  ;; Graph unchanged (prior still sampled)
-       :handlers (or handlers {})
+       :handlers handlers
        :eliminated #{}  ;; Nothing eliminated, but variance reduced
        :description (str "Rao-Blackwellized " (name prior-addr))})))
 
@@ -164,11 +171,14 @@
                            (into #{} (mapcat :all-addrs lg-blocks))
                            (or declined-addrs #{}))
 
-        ;; Group remaining conjugate pairs by prior (excluding claimed addrs)
-        remaining-pairs (remove (fn [p]
-                                  (or (contains? claimed (:prior-addr p))
-                                      (contains? claimed (:obs-addr p))))
-                                conjugate-pairs)
+        ;; Group remaining conjugate pairs by prior (excluding claimed addrs).
+        ;; Multi-parent obs (one obs claimed by several priors) have no correct
+        ;; scalar elimination — drop those pairs entirely (genmlx-b470).
+        remaining-pairs (conj-detect/drop-multi-parent-pairs
+                         (vec (remove (fn [p]
+                                        (or (contains? claimed (:prior-addr p))
+                                            (contains? claimed (:obs-addr p))))
+                                      conjugate-pairs)))
         grouped (group-by :prior-addr remaining-pairs)
 
         ;; One pass over grouped priors: compute non-conjugate children once and

--- a/test/genmlx/compiled_parity_test.cljs
+++ b/test/genmlx/compiled_parity_test.cljs
@@ -1,0 +1,394 @@
+;; @tier medium
+(ns genmlx.compiled-parity-test
+  "Compiled-path parity (genmlx-b210).
+
+   Compiled execution must produce the same traces, scores, and weights as
+   the handler path — or decline compilation. Covers:
+   1. fused M5 kernels: iid-gaussian must NOT silently score as Delta
+   2. compiled SMC extend step declines iid-gaussian kernels
+   3. bernoulli/exponential log-prob boundary guards (NaN / support)
+   4. M4 branch conditions: ClojureScript truthiness (numeric 0 is truthy)
+   5. binding-env shadowing/destructuring declines instead of mis-resolving
+   6. M4 requires a compilable return expression (no retval-nil traces)
+   7. compiled regenerate resamples iid-gaussian (was: Delta, zero weight)
+   8. closed-over vars deref per call (no stale baked values)
+
+   Handler path (strip-compiled / stripped schema) is ground truth; numeric
+   oracles are computed host-side.
+
+   Run: bun run --bun nbb test/genmlx/compiled_parity_test.cljs"
+  (:require [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.dist.core :as dc]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.mlx.random :as rng]
+            [genmlx.combinators :as comb]
+            [genmlx.compiled :as compiled]
+            [genmlx.compiled-ops :as cops]
+            [genmlx.gfi :as gfi])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+;; ---------------------------------------------------------------------------
+;; Assertion helpers
+;; ---------------------------------------------------------------------------
+
+(def ^:dynamic *pass* (volatile! 0))
+(def ^:dynamic *fail* (volatile! 0))
+
+(defn assert-true [desc pred]
+  (if pred
+    (do (vswap! *pass* inc) (println (str "  PASS: " desc)))
+    (do (vswap! *fail* inc) (println (str "  FAIL: " desc)))))
+
+(defn assert-close [desc expected actual tol]
+  (let [d (js/Math.abs (- expected actual))]
+    (if (<= d tol)
+      (do (vswap! *pass* inc)
+          (println (str "  PASS: " desc " (" (.toFixed actual 6) " ~ " (.toFixed expected 6) ", |Δ|=" (.toExponential d 2) ")")))
+      (do (vswap! *fail* inc)
+          (println (str "  FAIL: " desc " (" (.toFixed actual 6) " vs " (.toFixed expected 6) ", |Δ|=" (.toExponential d 2) " > " tol ")"))))))
+
+(def TOL 2e-4)
+(def LOG2PI (js/Math.log (* 2 js/Math.PI)))
+
+(defn norm-lpdf [x mu variance]
+  (* -0.5 (+ LOG2PI (js/Math.log variance)
+             (/ (* (- x mu) (- x mu)) variance))))
+
+(defn cmv [m] (reduce-kv (fn [c k v] (cm/set-value c k (mx/scalar v))) cm/EMPTY m))
+
+;; ===========================================================================
+;; SECTION 1 — fused M5: iid-gaussian must not score as Delta
+;; ===========================================================================
+
+(println "\n== Section 1: fused M5 iid-gaussian gates ==")
+
+(def iid-map-kernel
+  (dyn/auto-key (gen [mu]
+    (let [x (trace :x (dist/iid-gaussian mu 1.0 3))]
+      x))))
+
+(def iid-unfold-kernel
+  (dyn/auto-key (gen [t state]
+    (let [x (trace :x (dist/iid-gaussian state 1.0 2))]
+      (mx/sum x)))))
+
+(def mixed-kernel
+  (dyn/auto-key (gen [t state]
+    (let [z (trace :z (dist/gaussian state 1.0))
+          x (trace :x (dist/iid-gaussian z 1.0 2))]
+      z))))
+
+(def gauss-kernel
+  (dyn/auto-key (gen [t state]
+    (let [next (trace :x (dist/gaussian state 0.1))]
+      next))))
+
+(assert-true "fusable-kernel?: iid-gaussian kernel NOT fusable"
+             (not (cops/fusable-kernel? iid-map-kernel)))
+(assert-true "fusable-kernel?: mixed gaussian+iid kernel NOT fusable"
+             (not (cops/fusable-kernel? mixed-kernel)))
+(assert-true "fusable-kernel?: pure gaussian kernel fusable (no regression)"
+             (cops/fusable-kernel? gauss-kernel))
+
+;; Map with iid-gaussian kernel: falls back, score = sum of element log-probs
+(let [mapped (comb/map-combinator iid-map-kernel)
+      trace (p/simulate mapped [[(mx/scalar 1.0) (mx/scalar -2.0)]])
+      mus [1.0 -2.0]
+      oracle (reduce +
+                     (for [i (range 2)
+                           :let [xs (mx/->clj (cm/get-value
+                                               (cm/get-submap
+                                                (cm/get-submap (:choices trace) i) :x)))]
+                           xj xs]
+                       (norm-lpdf xj (nth mus i) 1.0)))
+      score (mx/item (:score trace))]
+  (assert-true "Map iid: fused path NOT used"
+               (not (:genmlx.combinators/compiled-path (meta trace))))
+  (assert-true "Map iid: score is non-zero (was silently 0)"
+               (> (js/Math.abs score) 1e-6))
+  (assert-close "Map iid: score = sum of per-element iid log-probs"
+                oracle score TOL)
+  (assert-true "Map iid: x values are sampled, not value=mu"
+               (let [xs (mx/->clj (cm/get-value
+                                   (cm/get-submap (cm/get-submap (:choices trace) 0) :x)))]
+                 (some #(> (js/Math.abs (- % 1.0)) 1e-6) xs))))
+
+;; Unfold with iid-gaussian kernel: falls back, score reconstructable
+(let [unfold (comb/unfold-combinator iid-unfold-kernel)
+      trace (p/simulate unfold [3 (mx/scalar 0.0)])
+      retvals (mapv mx/item (:retval trace))
+      states (into [0.0] (butlast retvals))
+      oracle (reduce +
+                     (for [t (range 3)
+                           :let [xs (mx/->clj (cm/get-value
+                                               (cm/get-submap
+                                                (cm/get-submap (:choices trace) t) :x)))]
+                           xj xs]
+                       (norm-lpdf xj (nth states t) 1.0)))
+      score (mx/item (:score trace))]
+  (assert-true "Unfold iid: fused path NOT used"
+               (not (:genmlx.combinators/compiled-path (meta trace))))
+  (assert-true "Unfold iid: score is non-zero" (> (js/Math.abs score) 1e-6))
+  (assert-close "Unfold iid: score = sum of step iid log-probs" oracle score TOL))
+
+;; ===========================================================================
+;; SECTION 2 — compiled SMC extend step gate
+;; ===========================================================================
+
+(println "\n== Section 2: compiled SMC extend gate ==")
+
+(assert-true "smc-extend: iid-gaussian kernel declines (nil)"
+             (nil? (cops/make-smc-extend-step (:schema iid-unfold-kernel)
+                                              (:source iid-unfold-kernel))))
+(assert-true "smc-extend: mixed kernel declines (nil)"
+             (nil? (cops/make-smc-extend-step (:schema mixed-kernel)
+                                              (:source mixed-kernel))))
+(assert-true "smc-extend: gaussian kernel still compiles"
+             (some? (cops/make-smc-extend-step (:schema gauss-kernel)
+                                               (:source gauss-kernel))))
+
+;; ===========================================================================
+;; SECTION 3 — bernoulli / exponential log-prob boundaries
+;; ===========================================================================
+
+(println "\n== Section 3: log-prob boundary guards ==")
+
+(let [lp (:log-prob (get compiled/noise-transforms-full :bernoulli))
+      handler-lp (fn [pv v] (mx/item (dc/dist-log-prob (dist/bernoulli (mx/scalar pv))
+                                                       (mx/scalar v))))
+      compiled-lp (fn [pv v] (mx/item (lp (mx/scalar v) (mx/scalar pv))))]
+  (assert-close "bernoulli lp: p=0, v=0 → 0 (was NaN)"
+                0.0 (compiled-lp 0.0 0.0) 1e-9)
+  (assert-close "bernoulli lp: p=1, v=1 → 0 (was NaN)"
+                0.0 (compiled-lp 1.0 1.0) 1e-9)
+  (assert-true "bernoulli lp: p=0, v=1 → -Inf, matches handler"
+               (and (= (- js/Infinity) (compiled-lp 0.0 1.0))
+                    (= (handler-lp 0.0 1.0) (compiled-lp 0.0 1.0))))
+  (assert-close "bernoulli lp: interior point matches handler"
+                (handler-lp 0.3 1.0) (compiled-lp 0.3 1.0) 1e-6)
+  (assert-close "bernoulli lp: p=0, v=0 matches handler"
+                (handler-lp 0.0 0.0) (compiled-lp 0.0 0.0) 1e-9))
+
+(let [lp (:log-prob (get compiled/noise-transforms-full :exponential))
+      handler-lp (fn [rv v] (mx/item (dc/dist-log-prob (dist/exponential (mx/scalar rv))
+                                                       (mx/scalar v))))
+      compiled-lp (fn [rv v] (mx/item (lp (mx/scalar v) (mx/scalar rv))))]
+  (assert-true "exponential lp: v<0 → -Inf (was finite)"
+               (= (- js/Infinity) (compiled-lp 2.0 -1.0)))
+  (assert-true "exponential lp: v<0 matches handler"
+               (= (handler-lp 2.0 -1.0) (compiled-lp 2.0 -1.0)))
+  (assert-close "exponential lp: interior point matches handler"
+                (handler-lp 2.0 1.5) (compiled-lp 2.0 1.5) 1e-6))
+
+;; Model-level assess parity at the boundary
+(def bern-model (dyn/auto-key (gen [p] (trace :b (dist/bernoulli p)))))
+
+(let [choices (cmv {:b 0.0})
+      w-compiled (mx/item (:weight (p/assess bern-model [0.0] choices)))
+      w-handler (mx/item (:weight (p/assess (dyn/auto-key (gfi/strip-compiled bern-model))
+                                            [0.0] choices)))]
+  (assert-true "bern model: compiled-assess attached"
+               (some? (:compiled-assess (:schema bern-model))))
+  (assert-close "bern model assess: p=0, b=0 → 0 on compiled path"
+                0.0 w-compiled 1e-9)
+  (assert-close "bern model assess: compiled = handler" w-handler w-compiled 1e-9))
+
+;; ===========================================================================
+;; SECTION 4 — M4 branch conditions: CLJS truthiness
+;; ===========================================================================
+
+(println "\n== Section 4: M4 zero-truthiness ==")
+
+(def m4-model
+  (dyn/auto-key (gen [flag]
+    (if flag
+      (trace :x (dist/gaussian 5.0 1.0))
+      (trace :x (dist/gaussian -5.0 1.0))))))
+
+(assert-true "M4 model: compiled-simulate attached"
+             (some? (:compiled-simulate (:schema m4-model))))
+
+(let [k (rng/fresh-key 100)
+      x-c (mx/item (cm/get-value (cm/get-submap
+                                  (:choices (p/simulate (dyn/with-key m4-model k) [0]))
+                                  :x)))
+      x-h (mx/item (cm/get-value (cm/get-submap
+                                  (:choices (p/simulate
+                                             (dyn/with-key (gfi/strip-compiled m4-model) k)
+                                             [0]))
+                                  :x)))]
+  (assert-true "M4 flag=0: numeric 0 is TRUTHY → true branch (x near +5)"
+               (< (js/Math.abs (- x-c 5.0)) 5.0))
+  (assert-close "M4 flag=0: compiled = handler (same key)" x-h x-c 1e-6))
+
+(let [k (rng/fresh-key 101)
+      x-c (mx/item (cm/get-value (cm/get-submap
+                                  (:choices (p/simulate (dyn/with-key m4-model k) [false]))
+                                  :x)))
+      x-h (mx/item (cm/get-value (cm/get-submap
+                                  (:choices (p/simulate
+                                             (dyn/with-key (gfi/strip-compiled m4-model) k)
+                                             [false]))
+                                  :x)))]
+  (assert-true "M4 flag=false: false branch (x near -5)"
+               (< (js/Math.abs (- x-c -5.0)) 5.0))
+  (assert-close "M4 flag=false: compiled = handler (same key)" x-h x-c 1e-6))
+
+(let [k (rng/fresh-key 102)
+      x-c (mx/item (cm/get-value (cm/get-submap
+                                  (:choices (p/simulate (dyn/with-key m4-model k) [true]))
+                                  :x)))]
+  (assert-true "M4 flag=true: true branch (x near +5)"
+               (< (js/Math.abs (- x-c 5.0)) 5.0)))
+
+;; Assess parity with numeric-0 condition
+(let [choices (cmv {:x 0.0})
+      w-c (mx/item (:weight (p/assess m4-model [0] choices)))
+      w-h (mx/item (:weight (p/assess (dyn/auto-key (gfi/strip-compiled m4-model))
+                                      [0] choices)))]
+  (assert-close "M4 assess flag=0: score = true-branch lpdf"
+                (norm-lpdf 0.0 5.0 1.0) w-c TOL)
+  (assert-close "M4 assess flag=0: compiled = handler" w-h w-c 1e-6))
+
+;; ===========================================================================
+;; SECTION 5 — binding-env shadowing / destructuring
+;; ===========================================================================
+
+(println "\n== Section 5: shadowing declines compilation ==")
+
+(def shadow-model
+  (dyn/auto-key (gen []
+    (let [m 1.0]
+      (trace :a (dist/gaussian m 1.0)))
+    (let [m 5.0]
+      (trace :b (dist/gaussian m 1.0))))))
+
+(assert-true "shadow: rebound let name declines compilation"
+             (nil? (:compiled-simulate (:schema shadow-model))))
+
+(let [n 20
+      sums (reduce (fn [[sa sb] _]
+                     (let [tr (p/simulate shadow-model [])]
+                       [(+ sa (mx/item (cm/get-value (cm/get-submap (:choices tr) :a))))
+                        (+ sb (mx/item (cm/get-value (cm/get-submap (:choices tr) :b))))]))
+                   [0.0 0.0] (range n))
+      mean-a (/ (first sums) n)
+      mean-b (/ (second sums) n)]
+  (assert-true "shadow: :a samples from FIRST binding (mean ~1, not ~5)"
+               (< (js/Math.abs (- mean-a 1.0)) 1.0))
+  (assert-true "shadow: :b samples from SECOND binding (mean ~5)"
+               (< (js/Math.abs (- mean-b 5.0)) 1.0)))
+
+;; Destructured local must not fall through to a same-named namespace var
+(def bait-mu 9.0)
+
+(def destructure-model
+  (dyn/auto-key (gen []
+    (let [[bait-mu] [2.0]]
+      (trace :a (dist/gaussian bait-mu 1.0))))))
+
+(assert-true "destructure: declines compilation (poisoned target)"
+             (nil? (:compiled-simulate (:schema destructure-model))))
+
+(let [n 20
+      mean-a (/ (reduce (fn [s _]
+                          (+ s (mx/item (cm/get-value
+                                         (cm/get-submap
+                                          (:choices (p/simulate destructure-model [])) :a)))))
+                        0.0 (range n))
+                n)]
+  (assert-true "destructure: :a uses the LOCAL (mean ~2), not ns var 9.0"
+               (< (js/Math.abs (- mean-a 2.0)) 1.0)))
+
+;; ===========================================================================
+;; SECTION 6 — M4 requires compilable retval
+;; ===========================================================================
+
+(println "\n== Section 6: M4 retval required ==")
+
+(def m4-noretval
+  (dyn/auto-key (gen [flag]
+    (if flag
+      (trace :x (dist/gaussian 0.0 1.0))
+      (trace :x (dist/gaussian 1.0 1.0)))
+    (str "done"))))
+
+(assert-true "M4 no-retval: declines compilation"
+             (nil? (:compiled-simulate (:schema m4-noretval))))
+(assert-true "M4 no-retval: handler path returns the actual retval"
+             (= "done" (:retval (p/simulate m4-noretval [true]))))
+
+;; ===========================================================================
+;; SECTION 7 — compiled regenerate resamples iid-gaussian
+;; ===========================================================================
+
+(println "\n== Section 7: compiled regenerate iid-gaussian ==")
+
+(def iid-model
+  (gen []
+    (let [mu (trace :mu (dist/gaussian 0.0 1.0))
+          x (trace :x (dist/iid-gaussian mu 1.0 3))]
+      x)))
+
+(assert-true "iid model: compiled-regenerate attached"
+             (some? (:compiled-regenerate (:schema iid-model))))
+
+(let [k1 (rng/fresh-key 200)
+      k2 (rng/fresh-key 201)
+      tr (p/simulate (dyn/with-key iid-model k1) [])
+      old-x (mx/->clj (cm/get-value (cm/get-submap (:choices tr) :x)))
+      r-c (p/regenerate (dyn/with-key iid-model k2) tr (sel/select :x))
+      r-h (p/regenerate (dyn/with-key (gfi/strip-compiled iid-model) k2)
+                        tr (sel/select :x))
+      new-x-c (mx/->clj (cm/get-value (cm/get-submap (:choices (:trace r-c)) :x)))
+      new-x-h (mx/->clj (cm/get-value (cm/get-submap (:choices (:trace r-h)) :x)))]
+  (assert-true "iid regen: :x has shape [3] (was scalar mu under Delta bug)"
+               (= 3 (count new-x-c)))
+  (assert-true "iid regen: :x actually resampled"
+               (some true? (map #(> (js/Math.abs (- %1 %2)) 1e-6) new-x-c old-x)))
+  (assert-true "iid regen: compiled values = handler values (same key)"
+               (every? true? (map #(< (js/Math.abs (- %1 %2)) 1e-5) new-x-c new-x-h)))
+  (assert-close "iid regen: compiled weight = handler weight"
+                (mx/item (:weight r-h)) (mx/item (:weight r-c)) 1e-5))
+
+;; Unselected iid site: kept and re-scored identically on both paths
+(let [k1 (rng/fresh-key 202)
+      k2 (rng/fresh-key 203)
+      tr (p/simulate (dyn/with-key iid-model k1) [])
+      r-c (p/regenerate (dyn/with-key iid-model k2) tr (sel/select :mu))
+      r-h (p/regenerate (dyn/with-key (gfi/strip-compiled iid-model) k2)
+                        tr (sel/select :mu))]
+  (assert-close "iid regen (mu selected): compiled weight = handler weight"
+                (mx/item (:weight r-h)) (mx/item (:weight r-c)) 1e-5))
+
+;; ===========================================================================
+;; SECTION 8 — closed-over vars deref per call
+;; ===========================================================================
+
+(println "\n== Section 8: closed-over var freshness ==")
+
+(def drift-mu 0.0)
+(def drift-model (dyn/auto-key (gen [] (trace :x (dist/gaussian drift-mu 0.1)))))
+
+(assert-true "drift: model compiled (var resolved through fallback)"
+             (some? (:compiled-simulate (:schema drift-model))))
+
+(let [x0 (mx/item (cm/get-value (cm/get-submap
+                                 (:choices (p/simulate drift-model [])) :x)))]
+  (assert-true "drift: initial value of var honored (x ~ 0)"
+               (< (js/Math.abs x0) 1.0))
+  (def drift-mu 5.0)
+  (let [x1 (mx/item (cm/get-value (cm/get-submap
+                                   (:choices (p/simulate drift-model [])) :x)))]
+    (assert-true "drift: re-def'd var honored on next call (x ~ 5, was stale 0)"
+                 (< (js/Math.abs (- x1 5.0)) 1.0))))
+
+;; ===========================================================================
+(println "\n==========================================")
+(println (str "  compiled-parity: " @*pass* " passed, " @*fail* " failed"))
+(println "==========================================")
+(when (pos? @*fail*) (js/process.exit 1))

--- a/test/genmlx/iid_compiled_test.cljs
+++ b/test/genmlx/iid_compiled_test.cljs
@@ -64,24 +64,23 @@
       mu)))
 
 (deftest compiled-simulate-literal-t
-  (testing "compiled simulate (literal T)"
+  (testing "compiled simulate declines (genmlx-b210: args-noise-fn shape cannot
+            be pre-generated; the old path crashed at runtime)"
     (let [schema (:schema iid-const)]
       (is (:static? schema) "model is static")
-      (is (some? (:compiled-simulate schema)) "has compiled-simulate"))))
+      (is (nil? (:compiled-simulate schema))
+          "no compiled-simulate — declined, falls back to handler"))))
 
 ;; ---------------------------------------------------------------------------
-;; 4. Compiled simulate matches handler simulate
+;; 4. Simulate works via handler fallback (was: documented crash)
 ;; ---------------------------------------------------------------------------
-
-;; NOTE: Tests 4-8 trigger the compiled simulate path which has a
-;; pre-existing bug with iid-gaussian ("nth not supported on MLX array").
-;; Tests document the known error.
 
 (deftest compiled-vs-handler-equivalence
-  (testing "compiled vs handler equivalence (pre-existing compiled path issue)"
-    (is (thrown? js/Error
-          (p/simulate (dyn/auto-key iid-const) []))
-        "compiled simulate crashes on iid-gaussian (pre-existing)")))
+  (testing "simulate falls back to handler and produces a valid trace"
+    (let [trace (p/simulate (dyn/auto-key iid-const) [])]
+      (is (= [3] (mx/shape (cm/get-value (cm/get-submap (:choices trace) :ys))))
+          "ys shape [3]")
+      (is (js/isFinite (mx/item (:score trace))) "score finite"))))
 
 (def iid-dyn
   (gen [t]
@@ -90,12 +89,13 @@
       mu)))
 
 (deftest compiled-prefix-dynamic-t
-  (testing "compiled prefix (dynamic T)"
+  (testing "dynamic T simulate works via fallback"
     (let [schema (:schema iid-dyn)]
       (is (some? schema) "schema exists"))
-    (is (thrown? js/Error
-          (p/simulate (dyn/auto-key iid-dyn) [5]))
-        "compiled simulate crashes on iid-gaussian dynamic T (pre-existing)")))
+    (let [trace (p/simulate (dyn/auto-key iid-dyn) [5])]
+      (is (= [5] (mx/shape (cm/get-value (cm/get-submap (:choices trace) :ys))))
+          "ys shape [5]")
+      (is (js/isFinite (mx/item (:score trace))) "score finite"))))
 
 ;; ---------------------------------------------------------------------------
 ;; 6. Compiled generate (literal T)

--- a/test/genmlx/l3_false_positive_test.cljs
+++ b/test/genmlx/l3_false_positive_test.cljs
@@ -1,0 +1,545 @@
+;; @tier medium
+(ns genmlx.l3-false-positive-test
+  "L3 analytical false positives (genmlx-b470).
+
+   The analytical eliminator must NEVER fire on a model it does not actually
+   handle — same 'silently wrong number' class as the fixed ke9i/lwhw scars:
+   1. bilinear obs means pass joint-affinity per-pair (h probes to 0)
+   2. affine deps accepted for families that drop the coefficient
+   3. families without a runtime handler factory counted as eliminated
+   4. constrained priors / partially-constrained obs silently marginalized
+   plus kalman/ekf obs-handler guards and lg regenerate obs selection.
+
+   Ground truth per family is an INDEPENDENT closed-form oracle computed
+   host-side in this file (never the function under test); fallthrough cases
+   are verified by same-key parity against the stripped handler path.
+
+   Run: bun run --bun nbb test/genmlx/l3_false_positive_test.cljs"
+  (:require [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.mlx.random :as rng]
+            [genmlx.method-selection :as ms]
+            [genmlx.conjugacy :as conj]
+            [genmlx.linear-gaussian :as lg]
+            [genmlx.inference.kalman :as kal]
+            [genmlx.inference.ekf :as ekf]
+            [genmlx.inference.ekf-nd :as ekfnd])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+;; ---------------------------------------------------------------------------
+;; Assertion helpers
+;; ---------------------------------------------------------------------------
+
+(def ^:dynamic *pass* (volatile! 0))
+(def ^:dynamic *fail* (volatile! 0))
+
+(defn assert-true [desc pred]
+  (if pred
+    (do (vswap! *pass* inc) (println (str "  PASS: " desc)))
+    (do (vswap! *fail* inc) (println (str "  FAIL: " desc)))))
+
+(defn assert-close [desc expected actual tol]
+  (let [d (js/Math.abs (- expected actual))]
+    (if (<= d tol)
+      (do (vswap! *pass* inc)
+          (println (str "  PASS: " desc " (" (.toFixed actual 6) " ~ " (.toFixed expected 6) ", |Δ|=" (.toExponential d 2) ")")))
+      (do (vswap! *fail* inc)
+          (println (str "  FAIL: " desc " (" (.toFixed actual 6) " vs " (.toFixed expected 6) ", |Δ|=" (.toExponential d 2) " > " tol ")"))))))
+
+(def TOL 2e-4)
+
+;; ---------------------------------------------------------------------------
+;; Host-side oracles (independent of genmlx math)
+;; ---------------------------------------------------------------------------
+
+(def LOG2PI (js/Math.log (* 2 js/Math.PI)))
+
+(defn norm-lpdf [x mu variance]
+  (* -0.5 (+ LOG2PI (js/Math.log variance)
+             (/ (* (- x mu) (- x mu)) variance))))
+
+(defn mvn2-lpdf [[x0 x1] [m0 m1] [[a b] [c d]]]
+  (let [det (- (* a d) (* b c))
+        dx0 (- x0 m0) dx1 (- x1 m1)
+        q (/ (+ (* dx0 (- (* d dx0) (* b dx1)))
+                (* dx1 (- (* a dx1) (* c dx0))))
+             det)]
+    (* -0.5 (+ (* 2 LOG2PI) (js/Math.log det) q))))
+
+(defn iid-shared-mu-lpdf
+  "log N(y; m0*1, s2*I + t2*11') via the matrix-determinant lemma
+   (verified against numpy in the ke9i referee work)."
+  [ys m0 t2 s2]
+  (let [T (count ys)
+        ds (mapv #(- % m0) ys)
+        sum-d (reduce + ds)
+        sum-d2 (reduce + (map #(* % %) ds))
+        denom (+ s2 (* T t2))
+        logdet (+ (* (dec T) (js/Math.log s2)) (js/Math.log denom))
+        quad (/ (- sum-d2 (* (/ t2 denom) (* sum-d sum-d))) s2)]
+    (* -0.5 (+ (* T LOG2PI) logdet quad))))
+
+;; ---------------------------------------------------------------------------
+;; Utilities
+;; ---------------------------------------------------------------------------
+
+(defn strip-l3
+  "Force the pure handler path: remove analytical AND compiled schema keys."
+  [model]
+  (dyn/->DynamicGF (:body-fn model) (:source model)
+                   (dissoc (:schema model)
+                           :auto-handlers :auto-regenerate-transition
+                           :auto-regenerate-handlers :analytical-plan
+                           :linear-gaussian-blocks :conjugate-pairs
+                           :has-conjugate?
+                           :compiled-simulate :compiled-generate
+                           :compiled-update :compiled-assess
+                           :compiled-project :compiled-regenerate
+                           :compiled-prefix :compiled-prefix-generate
+                           :compiled-prefix-update :compiled-prefix-regenerate
+                           :compiled-prefix-assess :compiled-prefix-project)))
+
+(defn gen-weight [model constraints key]
+  (mx/item (:weight (p/generate (dyn/with-key model key) [] constraints))))
+
+(defn gen-trace [model constraints key]
+  (:trace (p/generate (dyn/with-key model key) [] constraints)))
+
+(defn marginal-trace? [trace]
+  (= :marginal (:genmlx.dynamic/score-type (meta trace))))
+
+(defn cmv [m] (reduce-kv (fn [c k v] (cm/set-value c k (mx/scalar v))) cm/EMPTY m))
+
+(defn choice-val [trace addr]
+  (mx/item (cm/get-value (cm/get-submap (:choices trace) addr))))
+
+;; ===========================================================================
+;; SECTION 1 — Bilinear obs mean: block must decline, not fabricate h=0
+;; ===========================================================================
+
+(println "\n== Section 1: bilinear mean declines ==")
+
+(def bilinear-model
+  (gen []
+    (let [a (trace :a (dist/gaussian 1.0 1.0))
+          b (trace :b (dist/gaussian 2.0 1.0))]
+      (trace :y (dist/gaussian (mx/multiply a b) 1.0))
+      a)))
+
+(let [schema (:schema bilinear-model)]
+  (assert-true "bilinear: no linear-Gaussian block claimed (static interaction check)"
+               (empty? (:linear-gaussian-blocks schema)))
+  (assert-true "bilinear: no analytical handlers installed"
+               (empty? (:auto-handlers schema))))
+
+(let [k (rng/fresh-key 42)
+      obs (cmv {:y 2.0})
+      r (p/generate (dyn/with-key bilinear-model k) [] obs)
+      w (mx/item (:weight r))
+      tr (:trace r)
+      a (choice-val tr :a)
+      b (choice-val tr :b)
+      w-handler (gen-weight (strip-l3 bilinear-model) obs k)
+      wrong-marginal (norm-lpdf 2.0 0.0 1.0)]   ; what h=[0,0],c=0 would produce
+  (assert-true "bilinear: trace NOT labeled :marginal" (not (marginal-trace? tr)))
+  (assert-close "bilinear: weight = joint p(y|a,b) from trace values"
+                (norm-lpdf 2.0 (* a b) 1.0) w TOL)
+  (assert-close "bilinear: weight matches handler path (same key)" w-handler w TOL)
+  (assert-true "bilinear: weight is NOT the fabricated h=0 marginal"
+               (> (js/Math.abs (- w wrong-marginal)) 1e-3)))
+
+;; Runtime probe backstop, exercised directly through make-lg-handlers with a
+;; synthetic block whose static detection hypothetically passed.
+(println "\n-- runtime joint-affinity probe (backstop) --")
+(let [mk-state (fn [] {:model-args [] :constraints (cmv {:y 2.0})
+                       :choices cm/EMPTY :score (mx/scalar 0.0)
+                       :weight (mx/scalar 0.0)})
+      fake-dist {:params {:mu (mx/scalar 0.0) :sigma (mx/scalar 1.0)}}
+      bilinear-block {:id [:a :b] :latents [:a :b] :p 2
+                      :latent-index {:a 0 :b 1}
+                      :obs [{:addr :y
+                             :mean-fn (fn [env _] (mx/multiply (get env :a) (get env :b)))
+                             :sigma-fn (fn [_ _] (mx/scalar 1.0))}]
+                      :obs-addrs [:y] :latent-addrs [:a :b]
+                      :noise-latents #{} :all-addrs #{:a :b :y}}
+      affine-block (assoc bilinear-block :obs
+                          [{:addr :y
+                            :mean-fn (fn [env _] (mx/add (get env :a)
+                                                         (mx/multiply (mx/scalar 2.0) (get env :b))))
+                            :sigma-fn (fn [_ _] (mx/scalar 1.0))}])
+      h-bad (get (lg/make-lg-handlers bilinear-block) :a)
+      h-good (get (lg/make-lg-handlers affine-block) :a)]
+  (assert-true "probe: bilinear mean-fn → latent handler falls through"
+               (nil? (h-bad (mk-state) :a fake-dist)))
+  (assert-true "probe: affine mean-fn → latent handler proceeds"
+               (some? (h-good (mk-state) :a fake-dist))))
+
+;; ===========================================================================
+;; SECTION 2 — Per-family closed-form oracle (still-eliminated cases stay exact)
+;; ===========================================================================
+
+(println "\n== Section 2: per-family marginal oracle ==")
+
+;; normal-normal, two obs (sequential updates must equal the joint marginal)
+(def nn-model
+  (gen []
+    (let [mu (trace :mu (dist/gaussian 1.0 2.0))]
+      (trace :y1 (dist/gaussian mu 0.5))
+      (trace :y2 (dist/gaussian mu 0.5))
+      mu)))
+
+(let [k (rng/fresh-key 1)
+      obs (cmv {:y1 2.5 :y2 0.5})
+      r (p/generate (dyn/with-key nn-model k) [] obs)
+      oracle (mvn2-lpdf [2.5 0.5] [1.0 1.0] [[4.25 4.0] [4.0 4.25]])]
+  (assert-true "NN: trace labeled :marginal" (marginal-trace? (:trace r)))
+  (assert-close "NN: generate weight = joint marginal oracle"
+                oracle (mx/item (:weight r)) TOL)
+  (assert-close "NN: assess weight = joint marginal oracle"
+                oracle (mx/item (:weight (p/assess (dyn/with-key nn-model k) [] obs))) TOL))
+
+;; normal-iid-normal
+(def nn-iid-model
+  (gen []
+    (let [mu (trace :mu (dist/gaussian 0.0 1.0))]
+      (trace :x (dist/iid-gaussian mu 1.0 3))
+      mu)))
+
+(let [k (rng/fresh-key 2)
+      obs (cm/set-value cm/EMPTY :x (mx/array [0.5 -0.3 1.2]))
+      r (p/generate (dyn/with-key nn-iid-model k) [] obs)
+      oracle (iid-shared-mu-lpdf [0.5 -0.3 1.2] 0.0 1.0 1.0)]
+  (assert-true "NN-iid: trace labeled :marginal" (marginal-trace? (:trace r)))
+  (assert-close "NN-iid: generate weight = shared-mu joint marginal"
+                oracle (mx/item (:weight r)) TOL))
+
+;; beta-bernoulli, two obs (Polya urn)
+(def bb-model
+  (gen []
+    (let [th (trace :th (dist/beta-dist 2.0 3.0))]
+      (trace :b1 (dist/bernoulli th))
+      (trace :b2 (dist/bernoulli th))
+      th)))
+
+(let [k (rng/fresh-key 3)
+      obs (cmv {:b1 1.0 :b2 0.0})
+      r (p/generate (dyn/with-key bb-model k) [] obs)
+      oracle (js/Math.log (* (/ 2.0 5.0) (/ 3.0 6.0)))]
+  (assert-close "BB: generate weight = Polya-urn marginal"
+                oracle (mx/item (:weight r)) TOL))
+
+;; gamma-poisson (negative-binomial marginal, shape=2 rate=1 k=3 → 0.125)
+(def gp-model
+  (gen []
+    (let [lam (trace :lam (dist/gamma-dist 2.0 1.0))]
+      (trace :k (dist/poisson lam))
+      lam)))
+
+(let [k (rng/fresh-key 4)
+      obs (cmv {:k 3.0})
+      r (p/generate (dyn/with-key gp-model k) [] obs)]
+  (assert-close "GP: generate weight = negative-binomial marginal"
+                (js/Math.log 0.125) (mx/item (:weight r)) TOL))
+
+;; gamma-exponential (Lomax marginal)
+(def ge-model
+  (gen []
+    (let [lam (trace :lam (dist/gamma-dist 2.0 1.0))]
+      (trace :x (dist/exponential lam))
+      lam)))
+
+(let [k (rng/fresh-key 5)
+      obs (cmv {:x 0.7})
+      r (p/generate (dyn/with-key ge-model k) [] obs)
+      oracle (- (js/Math.log 2.0) (* 3.0 (js/Math.log 1.7)))]
+  (assert-close "GE: generate weight = Lomax marginal"
+                oracle (mx/item (:weight r)) TOL))
+
+;; mvn-normal (2-d, diagonal: marginal N(m0, S0+R))
+(def mvn-model
+  (gen []
+    (let [mu (trace :mu (dist/multivariate-normal
+                         (mx/array [0.0 0.0])
+                         (mx/array [[1.0 0.0] [0.0 1.0]])))]
+      (trace :y (dist/multivariate-normal mu (mx/array [[0.5 0.0] [0.0 0.5]])))
+      mu)))
+
+(let [k (rng/fresh-key 6)
+      obs (cm/set-value cm/EMPTY :y (mx/array [1.0 -1.0]))
+      r (p/generate (dyn/with-key mvn-model k) [] obs)
+      oracle (mvn2-lpdf [1.0 -1.0] [0.0 0.0] [[1.5 0.0] [0.0 1.5]])]
+  (assert-close "MVN: generate weight = N(m0, S0+R) marginal"
+                oracle (mx/item (:weight r)) TOL))
+
+;; Kalman chain (full obs): joint MVN oracle over (y0, y1)
+(def chain-model
+  (gen []
+    (let [z0 (trace :z0 (dist/gaussian 0.0 1.0))
+          z1 (trace :z1 (dist/gaussian z0 1.0))]
+      (trace :y0 (dist/gaussian z0 0.5))
+      (trace :y1 (dist/gaussian z1 0.5))
+      z1)))
+
+(let [k (rng/fresh-key 7)
+      obs (cmv {:y0 0.8 :y1 -0.4})
+      r (p/generate (dyn/with-key chain-model k) [] obs)
+      oracle (mvn2-lpdf [0.8 -0.4] [0.0 0.0] [[1.25 1.0] [1.0 2.25]])]
+  (assert-true "chain: trace labeled :marginal" (marginal-trace? (:trace r)))
+  (assert-close "chain: generate weight = joint MVN oracle"
+                oracle (mx/item (:weight r)) TOL))
+
+;; Linear-Gaussian block (full obs): joint MVN oracle, regression for the gates
+(def linreg2
+  (gen []
+    (let [s (trace :s (dist/gaussian 0.0 1.0))
+          i (trace :i (dist/gaussian 0.0 1.0))]
+      (trace :y0 (dist/gaussian (mx/add (mx/multiply s (mx/scalar 1.0)) i) 0.5))
+      (trace :y1 (dist/gaussian (mx/add (mx/multiply s (mx/scalar 2.0)) i) 0.5))
+      s)))
+
+(let [k (rng/fresh-key 8)
+      obs (cmv {:y0 0.6 :y1 1.4})
+      r (p/generate (dyn/with-key linreg2 k) [] obs)
+      oracle (mvn2-lpdf [0.6 1.4] [0.0 0.0] [[2.25 3.0] [3.0 5.25]])]
+  (assert-true "LG block: trace labeled :marginal" (marginal-trace? (:trace r)))
+  (assert-close "LG block: generate weight = joint MVN oracle"
+                oracle (mx/item (:weight r)) TOL))
+
+;; ===========================================================================
+;; SECTION 3 — Affine deps on non-NN families are declined
+;; ===========================================================================
+
+(println "\n== Section 3: non-NN affine deps decline ==")
+
+(def gp-affine-model
+  (gen []
+    (let [lam (trace :lam (dist/gamma-dist 2.0 1.0))]
+      (trace :k (dist/poisson (mx/multiply (mx/scalar 2.0) lam)))
+      lam)))
+
+(let [schema (:schema gp-affine-model)]
+  (assert-true "GP affine: no conjugate pair detected"
+               (empty? (:conjugate-pairs schema)))
+  (assert-true "GP affine: no analytical handlers"
+               (empty? (:auto-handlers schema))))
+
+(let [k (rng/fresh-key 9)
+      obs (cmv {:k 3.0})
+      w (gen-weight gp-affine-model obs k)
+      w-handler (gen-weight (strip-l3 gp-affine-model) obs k)
+      ;; what the scalar path would produce by DROPPING the coefficient
+      wrong (js/Math.log 0.125)]
+  (assert-close "GP affine: weight matches handler path (same key)" w-handler w TOL)
+  (assert-true "GP affine: weight is NOT the coefficient-dropping marginal"
+               (> (js/Math.abs (- w wrong)) 1e-3)))
+
+;; NN affine pairs must STILL be detected (kalman/LG paths handle them)
+(let [schema (:schema linreg2)]
+  (assert-true "NN affine: pairs still detected for normal-normal"
+               (pos? (count (:conjugate-pairs schema)))))
+
+;; ===========================================================================
+;; SECTION 4 — Family without runtime factory: not eliminated, no :exact claim
+;; ===========================================================================
+
+(println "\n== Section 4: dirichlet-categorical has no factory ==")
+
+(def dc-model
+  (gen []
+    (let [th (trace :th (dist/dirichlet (mx/array [1.0 1.0 1.0])))]
+      (trace :c (dist/categorical th))
+      th)))
+
+(let [schema (:schema dc-model)
+      eliminated (get-in schema [:analytical-plan :rewrite-result :eliminated])
+      sel-result (ms/select-method dc-model (cmv {:c 1.0}))]
+  (assert-true "DC: pair detected (in conjugacy table)"
+               (pos? (count (:conjugate-pairs schema))))
+  (assert-true "DC: prior NOT counted as eliminated"
+               (not (contains? (or eliminated #{}) :th)))
+  (assert-true "DC: no analytical handlers installed"
+               (empty? (:auto-handlers schema)))
+  (assert-true "DC: method selection does NOT claim :exact"
+               (not= :exact (:method sel-result))))
+
+(let [k (rng/fresh-key 10)
+      obs (cmv {:c 1.0})
+      w (gen-weight dc-model obs k)
+      w-handler (gen-weight (strip-l3 dc-model) obs k)
+      tr (gen-trace dc-model obs k)]
+  (assert-true "DC: trace NOT labeled :marginal" (not (marginal-trace? tr)))
+  (assert-close "DC: weight matches handler path (same key)" w-handler w TOL))
+
+;; ===========================================================================
+;; SECTION 5 — Constraint checks: constrained prior, partial obs
+;; ===========================================================================
+
+(println "\n== Section 5: constraint gates ==")
+
+;; Two independent NN pairs; constrain pair-1's PRIOR and both obs.
+(def two-pair-model
+  (gen []
+    (let [m1 (trace :m1 (dist/gaussian 0.0 1.0))
+          m2 (trace :m2 (dist/gaussian 0.0 2.0))]
+      (trace :y1 (dist/gaussian m1 0.5))
+      (trace :y2 (dist/gaussian m2 0.5))
+      m1)))
+
+(let [k (rng/fresh-key 11)
+      obs (cmv {:m1 0.7 :y1 1.0 :y2 -0.5})
+      r (p/generate (dyn/with-key two-pair-model k) [] obs)
+      w (mx/item (:weight r))
+      tr (:trace r)
+      ;; pair 1 joint (prior constrained) + pair 2 marginal
+      oracle (+ (norm-lpdf 0.7 0.0 1.0)
+                (norm-lpdf 1.0 0.7 0.25)
+                (norm-lpdf -0.5 0.0 4.25))]
+  (assert-close "constrained prior: weight = joint(pair1) + marginal(pair2)"
+                oracle w TOL)
+  (assert-close "constrained prior: :m1 keeps its constrained value (not posterior mean)"
+                0.7 (choice-val tr :m1) 1e-6))
+
+;; One prior, two obs, only one constrained → pair must decline entirely.
+(let [k (rng/fresh-key 12)
+      obs (cmv {:y1 1.0})
+      w (gen-weight nn-model obs k)
+      w-handler (gen-weight (strip-l3 nn-model) obs k)
+      tr (gen-trace nn-model obs k)]
+  (assert-true "partial obs: trace NOT labeled :marginal" (not (marginal-trace? tr)))
+  (assert-close "partial obs: weight matches handler path (same key)" w-handler w TOL)
+  (assert-close "partial obs: weight = p(y1 | sampled mu) from trace"
+                (norm-lpdf 1.0 (choice-val tr :mu) 0.25) w TOL))
+
+;; Kalman chain with partial obs → chain declines.
+(let [k (rng/fresh-key 13)
+      obs (cmv {:y0 0.8})
+      w (gen-weight chain-model obs k)
+      w-handler (gen-weight (strip-l3 chain-model) obs k)
+      tr (gen-trace chain-model obs k)]
+  (assert-true "chain partial obs: trace NOT labeled :marginal" (not (marginal-trace? tr)))
+  (assert-close "chain partial obs: weight matches handler path (same key)" w-handler w TOL))
+
+;; Kalman chain with a constrained LATENT → chain declines.
+(let [k (rng/fresh-key 14)
+      obs (cmv {:z0 0.3 :y0 0.8 :y1 -0.4})
+      w (gen-weight chain-model obs k)
+      w-handler (gen-weight (strip-l3 chain-model) obs k)
+      tr (gen-trace chain-model obs k)]
+  (assert-true "chain constrained latent: NOT :marginal" (not (marginal-trace? tr)))
+  (assert-close "chain constrained latent: weight matches handler (same key)" w-handler w TOL)
+  (assert-close "chain constrained latent: :z0 keeps constrained value"
+                0.3 (choice-val tr :z0) 1e-6))
+
+;; LG block with partial obs → block declines.
+(let [k (rng/fresh-key 15)
+      obs (cmv {:y0 0.6})
+      w (gen-weight linreg2 obs k)
+      w-handler (gen-weight (strip-l3 linreg2) obs k)
+      tr (gen-trace linreg2 obs k)]
+  (assert-true "LG partial obs: NOT :marginal" (not (marginal-trace? tr)))
+  (assert-close "LG partial obs: weight matches handler (same key)" w-handler w TOL))
+
+;; LG block with a constrained latent → block declines.
+(let [k (rng/fresh-key 16)
+      obs (cmv {:s 0.5 :y0 0.6 :y1 1.4})
+      w (gen-weight linreg2 obs k)
+      w-handler (gen-weight (strip-l3 linreg2) obs k)
+      tr (gen-trace linreg2 obs k)]
+  (assert-true "LG constrained latent: NOT :marginal" (not (marginal-trace? tr)))
+  (assert-close "LG constrained latent: weight matches handler (same key)" w-handler w TOL)
+  (assert-close "LG constrained latent: :s keeps constrained value"
+                0.5 (choice-val tr :s) 1e-6))
+
+;; ===========================================================================
+;; SECTION 6 — Multi-parent obs filter (unit)
+;; ===========================================================================
+
+(println "\n== Section 6: multi-parent pair filter ==")
+
+(let [pairs [{:prior-addr :a :obs-addr :y :family :gamma-poisson}
+             {:prior-addr :b :obs-addr :y :family :gamma-poisson}
+             {:prior-addr :c :obs-addr :z :family :gamma-poisson}]
+      kept (conj/drop-multi-parent-pairs pairs)]
+  (assert-true "multi-parent: both pairs claiming :y dropped"
+               (= [:z] (mapv :obs-addr kept)))
+  (assert-true "multi-parent: single-parent pair kept"
+               (= [:c] (mapv :prior-addr kept)))
+  (assert-true "multi-parent: no-op when all single-parent"
+               (= 1 (count (conj/drop-multi-parent-pairs
+                            [{:prior-addr :c :obs-addr :z}])))))
+
+;; ===========================================================================
+;; SECTION 7 — Kalman/EKF obs-handler guards (unit)
+;; ===========================================================================
+
+(println "\n== Section 7: kalman/ekf obs guards ==")
+
+(let [h (:kalman-obs (kal/make-kalman-dispatch :z))
+      params {:base-mean (mx/zeros [1]) :loading (mx/ones [1])
+              :noise-std (mx/ones [1]) :mask (mx/ones [1])}
+      fake-dist {:params params}
+      belief {:mean (mx/zeros [1]) :var (mx/ones [1])}
+      with-obs (cm/set-value cm/EMPTY :o (mx/ones [1]))]
+  (assert-true "kalman obs: nil belief → fall through"
+               (nil? (h {:constraints with-obs :kalman-n 1} :o fake-dist)))
+  (assert-true "kalman obs: unconstrained → fall through"
+               (nil? (h {:constraints cm/EMPTY :kalman-belief belief :kalman-n 1}
+                        :o fake-dist)))
+  (assert-true "kalman obs: belief + constraint → handled"
+               (some? (h {:constraints with-obs :kalman-belief belief :kalman-n 1}
+                         :o fake-dist))))
+
+(let [h (:ekf-obs (ekf/make-ekf-dispatch :z))
+      fake-dist {:params {:obs-fn identity :noise-std (mx/ones [1]) :mask (mx/ones [1])}}
+      with-obs (cm/set-value cm/EMPTY :o (mx/ones [1]))]
+  (assert-true "ekf obs: nil belief → fall through"
+               (nil? (h {:constraints with-obs :ekf-n 1} :o fake-dist)))
+  (assert-true "ekf obs: unconstrained → fall through"
+               (nil? (h {:constraints cm/EMPTY
+                         :ekf-belief {:mean (mx/zeros [1]) :var (mx/ones [1])}
+                         :ekf-n 1}
+                        :o fake-dist))))
+
+(let [h (:ekf-nd-obs (ekfnd/make-multi-ekf-dispatch [:z0]))
+      fake-dist {:params {:obs-fn identity :noise-std (mx/ones [1]) :mask (mx/ones [1])}}
+      with-obs (cm/set-value cm/EMPTY :o (mx/ones [1]))]
+  (assert-true "ekf-nd obs: nil means/covs → fall through"
+               (nil? (h {:constraints with-obs :ekf-nd-n 1} :o fake-dist))))
+
+;; ===========================================================================
+;; SECTION 8 — LG regenerate: selected obs re-opens the block
+;; ===========================================================================
+
+(println "\n== Section 8: lg regenerate obs selection ==")
+
+(let [k (rng/fresh-key 17)
+      obs (cmv {:y0 0.6 :y1 1.4})
+      tr (gen-trace linreg2 obs k)
+      _ (assert-true "regen setup: generate trace is :marginal" (marginal-trace? tr))
+      r (p/regenerate (dyn/with-key linreg2 (rng/fresh-key 18)) tr (sel/select :y0))
+      new-tr (:trace r)]
+  (assert-true "regen obs-selected: returns a trace" (some? new-tr))
+  (assert-true "regen obs-selected: weight finite"
+               (js/isFinite (mx/item (:weight r))))
+  (assert-true "regen obs-selected: y0 actually resampled"
+               (> (js/Math.abs (- (choice-val new-tr :y0) 0.6)) 1e-6))
+  (assert-true "regen obs-selected: re-opened trace NOT labeled :marginal"
+               (not (marginal-trace? new-tr))))
+
+;; Unselected regenerate on a marginal trace still works (no over-decline).
+(let [k (rng/fresh-key 19)
+      obs (cmv {:y0 0.6 :y1 1.4})
+      tr (gen-trace linreg2 obs k)
+      r (p/regenerate (dyn/with-key linreg2 (rng/fresh-key 20)) tr (sel/select :none))]
+  (assert-true "regen no-block-selection: stays :marginal"
+               (marginal-trace? (:trace r))))
+
+;; ===========================================================================
+(println "\n==========================================")
+(println (str "  l3-false-positive: " @*pass* " passed, " @*fail* " failed"))
+(println "==========================================")
+(when (pos? @*fail*) (js/process.exit 1))

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -72,6 +72,7 @@ fast test/genmlx/compiled_generate_test.cljs
 medium test/genmlx/compiled_gradient_test.cljs
 medium test/genmlx/compiled_loss_grad_test.cljs
 medium test/genmlx/compiled_optimizer_test.cljs
+medium test/genmlx/compiled_parity_test.cljs
 medium test/genmlx/compiled_path_equivalence_test.cljs
 medium test/genmlx/compiled_pf_test.cljs
 fast test/genmlx/compiled_schema_test2.cljs
@@ -199,6 +200,7 @@ medium test/genmlx/l3_5_multivariate_test.cljs
 medium test/genmlx/l3_5_regenerate_test.cljs
 medium test/genmlx/l3_5_score_fn_test.cljs
 bench test/genmlx/l3_evaluation_benchmark.cljs
+medium test/genmlx/l3_false_positive_test.cljs
 medium test/genmlx/l4_certification_test.cljs
 fast test/genmlx/lanczos_test.cljs
 medium test/genmlx/lazy_mcmc_test.cljs
@@ -295,6 +297,7 @@ medium test/genmlx/smc_scoring_test.cljs
 slow test/genmlx/smc_stress_test.cljs
 medium test/genmlx/smcp3_kernel_test.cljs
 fast test/genmlx/splice_property_test.cljs
+fast test/genmlx/splice_weight_test.cljs core
 fast test/genmlx/stack_unstack_property_test.cljs
 slow test/genmlx/stress_test.cljs
 medium test/genmlx/support_property_test.cljs
@@ -319,6 +322,7 @@ fast test/genmlx/tutorial/ch10_test.cljs
 fast test/genmlx/unfold_splice_test.cljs
 medium test/genmlx/untested_features_test.cljs
 fast test/genmlx/update_discard_branch_test.cljs
+fast test/genmlx/update_weight_test.cljs core
 fast test/genmlx/validation_test.cljs
 bench test/genmlx/vectorized_benchmark.cljs
 fast test/genmlx/vectorized_equivalence_test.cljs


### PR DESCRIPTION
## Summary

Two high-priority correctness fixes in the "silently wrong number" class (genmlx-b470, genmlx-b210).

### L3 analytical eliminator (genmlx-b470)

The eliminator must never fire on a model it does not actually handle:

- **Bilinear obs means** (`slope * intercept`) classified affine per-pair but probe to `h=0` — now declined by a static latent-interaction check in `eligible-block` plus a runtime joint-affinity probe (`mean(s·1) ?= c + s·Σh` at s=1,2) as backstop.
- **`:affine` deps** are accepted only for normal-normal — the one family whose downstream paths (Kalman chains, LG blocks) recover the coefficients. Other families silently dropped them.
- **Families without a runtime handler factory** (dirichlet-categorical) can no longer be counted as eliminated or route method selection to `:exact`.
- **Constrained priors / partially-constrained obs** now fall through to correct joint scoring in every handler family (scalar, MVN, Kalman chain, LG block); multi-parent obs pairs are dropped; traces are labeled `:marginal` only when marginalization actually fired.
- kalman/ekf/ekf-nd obs handlers guard nil belief and unconstrained obs; LG regenerate re-opens the block when an obs is selected; dependency analysis expands let-bound `:expr` symbols — this also fixes a pre-existing crash on main (`gamma_batch_test`: a residual noise latent hidden behind `noise-std = 1/sqrt(noise-prec)` left the sigma env incomplete).

### Compiled paths (genmlx-b210)

Compiled execution must match the handler or decline:

- **Fused M5 / compiled SMC** treated any transform without `:noise-fn` as Delta — iid-gaussian kernels got `value=mu` with **zero score contribution**, silently. Fusion now declines `:args-noise-fn` sites; compiled regenerate properly resamples them.
- **Bernoulli/exponential compiled log-probs** ported the handler's xlogy and support guards (compiled gave NaN / finite where the handler gives 0 / -Inf).
- **M4 branch conditions** are resolved host-side with exact ClojureScript truthiness from the raw call args (numeric 0 is truthy; `mx/where` removed — it disagreed at 0).
- **Binding env is scope-aware**: rebound let names, destructuring targets, and fn/loop/for/doseq binder targets are poisoned so compilation declines instead of mis-resolving to same-named namespace vars; closed-over vars deref per call instead of baking stale values; M4 requires a compilable return expression (no more retval-nil traces).
- Bonus: the *documented* pre-existing M2 crash on iid-gaussian simulate is fixed by decline-and-fallback (`iid_compiled_test` updated from crash-documenting to behavior-asserting).

## Tests

- New `test/genmlx/l3_false_positive_test.cljs` — **62 assertions**, independent host-side closed-form oracle per conjugate family (NN, NN-iid, beta-bernoulli, gamma-poisson, gamma-exponential, MVN, Kalman chain, LG block); every decline path verified by same-key parity against the stripped handler path.
- New `test/genmlx/compiled_parity_test.cljs` — **48 assertions**, handler-parity at every compiled boundary.
- Regression: fast-core tier 33/33 files; full medium tier run triaged — the remaining 7 not-passed files fail identically on clean main (baselined one by one; tracked in draft beans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)