### PR TITLE
fix(schema): close walker blind spots (genmlx-q3x2)

### DIFF
--- a/src/genmlx/schema.cljs
+++ b/src/genmlx/schema.cljs
@@ -39,6 +39,8 @@
     (symbol? form) #{form}
     (seq? form) (into #{} (mapcat find-symbols) form)
     (vector? form) (into #{} (mapcat find-symbols) form)
+    (map? form) (into #{} (mapcat find-symbols) (mapcat identity form))
+    (set? form) (into #{} (mapcat find-symbols) form)
     :else #{}))
 
 (defn- deps-of-syms
@@ -83,6 +85,12 @@
 
     (and (vector? form) (seq form))
     (some contains-gen-call? form)
+
+    (map? form)
+    (boolean (some contains-gen-call? (mapcat identity form)))
+
+    (set? form)
+    (boolean (some contains-gen-call? form))
 
     :else false))
 
@@ -130,7 +138,37 @@
     (and (vector? form) (seq form))
     (some contains-trace-call? form)
 
+    (map? form)
+    (boolean (some contains-trace-call? (mapcat identity form)))
+
+    (set? form)
+    (boolean (some contains-trace-call? form))
+
     :else false))
+
+(defn- find-all-calls
+  "Recursively find all calls matching pred in forms. Recurses into matched
+   forms as well — a match's arguments may contain further matches (e.g. a
+   trace call nested in another trace's dist-args)."
+  [forms pred]
+  (let [results (volatile! [])]
+    (letfn [(walk [form]
+              (when (pred form) (vswap! results conj form))
+              (cond
+                (seq? form) (run! walk form)
+                (vector? form) (run! walk form)
+                (map? form) (run! walk (mapcat identity form))
+                (set? form) (run! walk form)))]
+      (run! walk forms))
+    @results))
+
+(defn- trace-addrs-in
+  "Keyword addresses of all literal trace calls anywhere inside form."
+  [form]
+  (->> (find-all-calls [form] #(call-named? % "trace"))
+       (map second)
+       (filter keyword?)
+       set))
 
 (defn- gen-binding-sym?
   "True for an unqualified symbol that is one of the gen-macro runtime bindings
@@ -259,24 +297,24 @@
           ;; Process bindings sequentially, updating env
           [acc' env'] (reduce
                        (fn [[acc env] [sym val-form]]
-                         (let [acc' (walk-form acc env val-form)]
+                         (let [acc' (walk-form acc env val-form)
+                               ;; Deps flow from referenced bindings AND from
+                               ;; any trace call inside the value form — literal
+                               ;; (trace :x ...) or wrapped, e.g.
+                               ;; (mx/add (trace :x ...) 1).
+                               sym-deps (into (compute-deps env val-form)
+                                              (trace-addrs-in val-form))]
                            (if (symbol? sym)
-                              ;; Simple symbol binding — track deps in env
-                             (let [val-deps (compute-deps env val-form)
-                                    ;; If val-form is a trace call, include the trace addr
-                                   is-trace? (call-named? val-form "trace")
-                                   trace-addr (when (and is-trace?
-                                                         (keyword? (second val-form)))
-                                                (second val-form))
-                                   sym-deps (if trace-addr
-                                              (conj val-deps trace-addr)
-                                              val-deps)
-                                   env' (if (seq sym-deps)
-                                          (assoc env sym sym-deps)
-                                          env)]
-                               [acc' env'])
-                              ;; Destructuring binding — walk but don't track
-                             [acc' env])))
+                             [acc' (if (seq sym-deps)
+                                     (assoc env sym sym-deps)
+                                     env)]
+                             ;; Destructuring binding — conservatively give
+                             ;; every bound symbol the full deps of the value
+                             ;; form (over-approximation keeps dep edges).
+                             [acc' (if (seq sym-deps)
+                                     (reduce (fn [e s] (assoc e s sym-deps))
+                                             env (find-symbols sym))
+                                     env)])))
                        [acc env]
                        (or pairs []))]
       (walk-forms acc' env' body))))
@@ -407,18 +445,6 @@
 
       :else -1)))
 
-(defn- find-all-calls
-  "Recursively find all calls matching pred in forms."
-  [forms pred]
-  (let [results (volatile! [])]
-    (letfn [(walk [form]
-              (cond
-                (pred form) (vswap! results conj form)
-                (seq? form) (run! walk form)
-                (vector? form) (run! walk form)))]
-      (run! walk forms))
-    @results))
-
 (defn- contains-nested-loop?
   "Check if forms contain a nested loop construct."
   [forms]
@@ -430,6 +456,8 @@
                   (some check (rest form))))
             (seq? form) (some check form)
             (vector? form) (some check form)
+            (map? form) (some check (mapcat identity form))
+            (set? form) (some check form)
             :else false))
         forms))
 
@@ -446,6 +474,8 @@
                   (some check (rest form))))
               (seq? form) (some check form)
               (vector? form) (some check form)
+              (map? form) (some check (mapcat identity form))
+              (set? form) (some check form)
               :else false))
           forms)))
 
@@ -686,6 +716,14 @@
     (and (vector? form) (seq form))
     (walk-forms acc env form)
 
+    ;; Map literal → walk keys and values (traces can hide in either)
+    (and (map? form) (seq form))
+    (walk-forms acc env (mapcat identity form))
+
+    ;; Set literal → walk elements
+    (and (set? form) (seq form))
+    (walk-forms acc env (seq form))
+
     ;; Anything else (keyword, symbol, number, string, nil, empty colls)
     :else acc))
 
@@ -757,7 +795,12 @@
                  :return-form (last body)
                  :dep-order (topo-sort (:trace-sites result))
                  :opaque-gen-escape? opaque-escape?
+                 ;; CLAUDE.md definition: static = all keyword-literal
+                 ;; addresses, no branches, no loops, no splices. Splices
+                 ;; were previously compensated for only inside the
+                 ;; compiled.cljs builders (genmlx-q3x2).
                  :static? (and (not (:dynamic-addresses? result))
                                (not (:has-branches? result))
                                (not (:has-loops? result))
+                               (empty? (:splice-sites result))
                                (not opaque-escape?)))))))

--- a/test/genmlx/schema_test.cljs
+++ b/test/genmlx/schema_test.cljs
@@ -11,6 +11,9 @@
             [genmlx.dist :as dist]
             [genmlx.mlx :as mx]
             [genmlx.combinators :as comb]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.mlx.random :as rng]
             [clojure.set])
   (:require-macros [genmlx.gen :refer [gen]]))
 
@@ -1012,5 +1015,113 @@
           ls (first (:loop-sites s))]
       (is (= 'n (:count-form ls)) "count-form is n")
       (is (= 0 (:count-arg-idx ls)) "count-arg-idx is 0"))))
+
+;; ============================================================
+;; Tests 61-67: walker blind spots (genmlx-q3x2)
+;; Trace sites inside map/set literals, splices in :static?,
+;; dep edges for wrapped/destructured bindings, find-all-calls
+;; recursion into matched forms.
+;; ============================================================
+
+(defn- gaussian-lp
+  "Closed-form N(v | mu, sigma) log-density — independent oracle,
+   no genmlx.dist involvement."
+  [v mu sigma]
+  (- (* -0.5 (Math/pow (/ (- v mu) sigma) 2))
+     (Math/log sigma)
+     (* 0.5 (Math/log (* 2 Math/PI)))))
+
+;; Test 61: trace inside a map literal is a real site
+(deftest test-61-trace-in-map-literal
+  (testing "q3x2: trace site inside a map literal is recorded"
+    (let [model (gen []
+                  (let [m {:v (trace :x (dist/gaussian (mx/scalar 0) (mx/scalar 1)))}]
+                    (:v m)))
+          s (:schema model)]
+      (is (= 1 (count (:trace-sites s))) "map-literal site recorded")
+      (is (= :x (-> s :trace-sites first :addr)) "addr is :x")
+      (is (= :gaussian (-> s :trace-sites first :dist-type)) "dist recognized")
+      (let [tr (p/simulate (dyn/with-key model (rng/fresh-key 42)) [])]
+        (is (cm/has-value? (cm/get-submap (:choices tr) :x))
+            "simulate samples :x end to end")))))
+
+;; Test 62: trace inside a set literal is a real site
+(deftest test-62-trace-in-set-literal
+  (testing "q3x2: trace site inside a set literal is recorded"
+    (let [model (gen []
+                  (let [s #{(trace :x (dist/gaussian (mx/scalar 0) (mx/scalar 1)))}]
+                    (first s)))
+          sch (:schema model)]
+      (is (= 1 (count (:trace-sites sch))) "set-literal site recorded")
+      (is (= :x (-> sch :trace-sites first :addr)) "addr is :x"))))
+
+;; Test 63: partial blindness — visible site + map-hidden site (end to end)
+(deftest test-63-map-hidden-site-end-to-end
+  (testing "q3x2: a model with one visible and one map-hidden site traces both"
+    (let [model (gen []
+                  (let [mu (trace :mu (dist/gaussian (mx/scalar 0) (mx/scalar 1)))
+                        m {:logged (trace :x (dist/gaussian mu (mx/scalar 1)))}]
+                    mu))
+          s (:schema model)]
+      (is (= 2 (count (:trace-sites s))) "both sites recorded")
+      (is (= #{:mu :x} (set (map :addr (:trace-sites s)))) "addrs :mu and :x")
+      (let [tr (p/simulate (dyn/with-key model (rng/fresh-key 42)) [])
+            ch (:choices tr)]
+        (is (cm/has-value? (cm/get-submap ch :mu)) "simulate samples :mu")
+        (is (cm/has-value? (cm/get-submap ch :x)) "simulate samples :x"))
+      ;; Independent oracle: fully-constrained generate weight is the joint
+      ;; closed-form log-density.
+      (let [{:keys [weight]} (p/generate (dyn/with-key model (rng/fresh-key 7)) []
+                                         (cm/choicemap :mu 0.3 :x 1.5))
+            expected (+ (gaussian-lp 0.3 0 1) (gaussian-lp 1.5 0.3 1))]
+        (is (< (Math/abs (- (mx/item weight) expected)) 1e-4)
+            "constrained generate weight matches closed form")))))
+
+;; Test 64: splices disqualify model-level :static?
+(deftest test-64-splice-model-not-static
+  (testing "q3x2: a model with a splice is not static (CLAUDE.md definition)"
+    (let [inner (gen [mu] (trace :y (dist/gaussian mu (mx/scalar 1))))
+          splice-only (gen [] (splice :sub inner (mx/scalar 0)))
+          mixed (gen []
+                  (let [z (trace :z (dist/gaussian (mx/scalar 0) (mx/scalar 1)))]
+                    (splice :sub inner z)))]
+      (is (not (-> splice-only :schema :static?)) "splice-only model not static")
+      (is (not (-> mixed :schema :static?)) "trace+splice model not static")
+      (is (nil? (:compiled-simulate (:schema mixed))) "no full-compile key attached"))))
+
+;; Test 65: wrapped trace binding keeps its dep edge
+(deftest test-65-wrapped-binding-deps
+  (testing "q3x2: deps survive a wrapped (non-literal) trace binding"
+    (let [model (gen []
+                  (let [a (mx/add (trace :a (dist/gaussian (mx/scalar 0) (mx/scalar 1)))
+                                  (mx/scalar 1))]
+                    (trace :b (dist/gaussian a (mx/scalar 1)))))
+          s (:schema model)
+          b-site (first (filter #(= :b (:addr %)) (:trace-sites s)))]
+      (is (contains? (:deps b-site) :a) ":b depends on :a through the wrapper")
+      (is (= [:a :b] (:dep-order s)) "topo order :a before :b"))))
+
+;; Test 66: destructured binding conservatively inherits deps
+(deftest test-66-destructured-binding-deps
+  (testing "q3x2: destructuring a traced value keeps the dep edge"
+    (let [model (gen []
+                  (let [{:keys [v]} {:v (trace :x (dist/gaussian (mx/scalar 0) (mx/scalar 1)))}]
+                    (trace :y (dist/gaussian v (mx/scalar 1)))))
+          s (:schema model)
+          y-site (first (filter #(= :y (:addr %)) (:trace-sites s)))]
+      (is (= 2 (count (:trace-sites s))) "both sites recorded")
+      (is (contains? (:deps y-site) :x) ":y depends on :x through destructuring"))))
+
+;; Test 67: find-all-calls recurses into matched forms (loop extraction)
+(deftest test-67-nested-trace-in-loop-site
+  (testing "q3x2: a trace nested in another trace's args is seen by loop analysis"
+    (let [model (gen [xs]
+                  (doseq [i xs]
+                    (trace (keyword (str "y" i))
+                           (dist/gaussian
+                            (trace :inner (dist/gaussian (mx/scalar 0) (mx/scalar 1)))
+                            (mx/scalar 1)))))
+          ls (-> model :schema :loop-sites first)]
+      (is (= 2 (count (:trace-sites ls))) "loop analysis sees both trace sites"))))
 
 (cljs.test/run-tests)


### PR DESCRIPTION
## Summary
- Trace sites inside **map/set literals** are now seen by `walk-form` and every recursive helper (`find-symbols`, `contains-gen-call?`, `contains-trace-call?`, `contains-nested-loop?`, `contains-branch-with-trace?`, `find-all-calls`). Pre-fix, `(let [m {:v (trace :x d)}] ...)` extracted **zero** trace sites while staying `:static? true` — the compiled path silently dropped the hidden site.
- `:static?` now includes `(empty? splice-sites)`, matching the CLAUDE.md definition instead of compensating inside each compiled.cljs builder (M2/M3/M4 builders keep their own guards, so no dispatch behavior changes for compilable models).
- `handle-let` dep extraction widened: bindings keep dep edges for **wrapped** trace calls (`(mx/add (trace :a d) 1)`) and **destructured** patterns conservatively inherit the value form's full deps — fixes topo-order / conjugacy-detection blindness.
- `find-all-calls` recurses into matched forms, so traces nested in another trace's dist-args are seen by loop-site extraction.

## Verification (independent-oracle rule)
- New tests 61–67 in `schema_test.cljs`: **15 assertions fail on pre-fix walker, all green post-fix**. Test 63 demonstrates the miscompile end to end: pre-fix, `simulate` on a model with one visible + one map-hidden site never samples the hidden site, and fully-constrained `generate` weight diverges from the closed-form joint log-density (hand-computed oracle, no genmlx.dist involvement).
- Suite: 67 tests / 246 assertions, 0 failures 0 errors. Fast-core tier 33/33.
- The 5 fast-tier failures (branch_rewrite, branching_property, iid_compiled, iid, ch10) reproduce **identically on unmodified main** (verified by stash/run/pop) — tracked in genmlx-lcka / genmlx-dn56, not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)