### PR TITLE
fix(mcmc): latent-only default selection, array-aware score layout, honest acceptance rate (genmlx-7ca0)

### DIFF
--- a/src/genmlx/inference/diagnostics.cljs
+++ b/src/genmlx/inference/diagnostics.cljs
@@ -23,6 +23,8 @@
 (defn ess
   "Compute ESS from a vector of parameter samples (MLX arrays).
    Uses the autocorrelation-based estimator.
+   Array-valued samples: only element 0 is diagnosed (see flatten-samples) —
+   pass a single component explicitly for other marginals.
    Returns a number."
   [samples]
   (let [n (count samples)
@@ -229,7 +231,13 @@
 (defn r-hat
   "Compute R-hat from multiple chains of parameter samples.
    chains: vector of vectors of MLX arrays.
-   Returns a number; values close to 1.0 indicate convergence."
+   Returns a number; values close to 1.0 indicate convergence.
+
+   This is the CLASSIC Gelman-Rubin potential scale reduction factor: no
+   chain splitting, no rank normalization. It can miss non-stationarity
+   within chains and heavy-tail pathologies that the rank-normalized
+   split-R-hat of Vehtari et al. 2021 detects; bulk-ess/tail-ess in this
+   namespace ARE the Vehtari diagnostics. Documented as-is (genmlx-7ca0)."
   [chains]
   (let [m (count chains)
         n (count (first chains))
@@ -275,6 +283,7 @@
 
 (defn sample-quantiles
   "Compute quantiles of samples.
+   Array-valued samples: only element 0 is summarized (see flatten-samples).
    Returns {:median :q025 :q975}."
   [samples]
   (let [n (count samples)

--- a/src/genmlx/inference/kernel.cljs
+++ b/src/genmlx/inference/kernel.cljs
@@ -200,23 +200,26 @@
    step-fn extract-fn init-state]
   (mx/with-resource-guard
     (fn []
-      (let [total-iters (+ burn (* samples thin))]
-        (loop [i 0, state init-state, acc (transient []), n 0, n-accepted 0, rk key]
-          (if (>= n samples)
-            (with-meta (persistent! acc)
-              {:acceptance-rate (if (pos? total-iters) (/ n-accepted total-iters) 0)})
-            (let [[step-key next-key] (rng/split-or-nils rk)
-                  {:keys [state accepted?]} (u/tidy-step step-fn state step-key)
-                  _  (mx/clear-cache!)
-                  past-burn? (>= i burn)
-                  keep? (and past-burn? (zero? (mod (- i burn) thin)))]
-              (when (and callback keep?)
-                (callback {:iter n :value (extract-fn state) :accepted? accepted?}))
-              (recur (inc i) state
-                     (if keep? (conj! acc (extract-fn state)) acc)
-                     (if keep? (inc n) n)
-                     (if accepted? (inc n-accepted) n-accepted)
-                     next-key))))))))
+      ;; Acceptance rate divides by the steps actually RUN (i at exit =
+      ;; burn + (samples-1)*thin + 1), not burn + samples*thin — the loop
+      ;; stops at the last kept sample, so the old denominator overcounted
+      ;; by thin-1 steps and biased the rate low (genmlx-7ca0).
+      (loop [i 0, state init-state, acc (transient []), n 0, n-accepted 0, rk key]
+        (if (>= n samples)
+          (with-meta (persistent! acc)
+            {:acceptance-rate (if (pos? i) (/ n-accepted i) 0)})
+          (let [[step-key next-key] (rng/split-or-nils rk)
+                {:keys [state accepted?]} (u/tidy-step step-fn state step-key)
+                _  (mx/clear-cache!)
+                past-burn? (>= i burn)
+                keep? (and past-burn? (zero? (mod (- i burn) thin)))]
+            (when (and callback keep?)
+              (callback {:iter n :value (extract-fn state) :accepted? accepted?}))
+            (recur (inc i) state
+                   (if keep? (conj! acc (extract-fn state)) acc)
+                   (if keep? (inc n) n)
+                   (if accepted? (inc n-accepted) n-accepted)
+                   next-key)))))))
 
 (defn run-kernel
   "Run a kernel for n-samples iterations with burn-in and thinning.

--- a/src/genmlx/inference/mcmc.cljs
+++ b/src/genmlx/inference/mcmc.cljs
@@ -61,11 +61,17 @@
    opts: {:samples N :burn B :thin T :selection sel :callback fn :key prng-key}
    model: generative function
    args: model arguments
-   observations: choice map of observed values"
+   observations: choice map of observed values
+
+   :selection defaults to the complement of the observed addresses (all
+   latents). The old default sel/all also resampled the OBSERVATIONS via
+   regenerate — silently targeting the prior (genmlx-7ca0)."
   [{:keys [samples burn thin selection callback key]
-    :or {burn 0 thin 1 selection sel/all}}
+    :or {burn 0 thin 1}}
    model args observations]
-  (let [[init-key chain-key] (rng/split (rng/ensure-key key))
+  (let [selection (or selection
+                      (sel/complement-sel (sel/from-choicemap observations)))
+        [init-key chain-key] (rng/split (rng/ensure-key key))
         {:keys [trace]} (p/generate (dyn/with-key model init-key) args observations)]
     (kern/collect-samples
      {:samples samples :burn burn :thin thin :callback callback :key chain-key}
@@ -775,12 +781,16 @@
                                 (range n-chains)))
              param-shape (mx/shape init-params)
              std (mx/scalar proposal-std)
-             total-iters (+ burn (* samples thin))
              d (count addresses)]
+         ;; Denominator: steps actually run (i at exit) × chains — the loop
+         ;; stops at the last kept sample, burn+(samples-1)*thin+1 steps,
+         ;; not burn+samples*thin (genmlx-7ca0).
          (loop [i 0, state init-params, acc (transient []), n 0, total-accepted 0, rk key]
            (if (>= n samples)
              (with-meta (persistent! acc)
-               {:acceptance-rate (/ total-accepted (* total-iters n-chains))})
+               {:acceptance-rate (if (pos? i)
+                                   (/ total-accepted (* i n-chains))
+                                   0)})
              (let [[step-key next-key] (rng/split-or-nils rk)
                    {:keys [state n-accepted]} (vectorized-mh-step
                                                state score-fn std param-shape n-chains step-key)
@@ -1739,12 +1749,15 @@
              init-params (u/init-vectorized-params model args observations addresses n-chains)
              eps (mx/scalar step-size)
              half-eps2 (mx/scalar (* 0.5 step-size step-size))
-             two-eps-sq (mx/scalar (* 2.0 step-size step-size))
-             total-iters (+ burn (* samples thin))]
+             two-eps-sq (mx/scalar (* 2.0 step-size step-size))]
+         ;; Denominator: steps actually run (i at exit), not burn+samples*thin
+         ;; (genmlx-7ca0, see collect-samples).
          (loop [i 0, state init-params, acc (transient []), n 0, total-accepted 0, rk key]
            (if (>= n samples)
              (with-meta (persistent! acc)
-               {:acceptance-rate (/ total-accepted (* total-iters n-chains))})
+               {:acceptance-rate (if (pos? i)
+                                   (/ total-accepted (* i n-chains))
+                                   0)})
              (let [[step-key next-key] (rng/split-or-nils rk)
                    {:keys [state n-accepted]}
                    (vectorized-mala-step state score-fn grad-fn eps half-eps2 two-eps-sq
@@ -2413,12 +2426,15 @@
              init-params (u/init-vectorized-params model args observations addresses n-chains)
              eps (mx/scalar step-size)
              half-eps (mx/scalar (* 0.5 step-size))
-             half (mx/scalar 0.5)
-             total-iters (+ burn (* samples thin))]
+             half (mx/scalar 0.5)]
+         ;; Denominator: steps actually run (i at exit), not burn+samples*thin
+         ;; (genmlx-7ca0, see collect-samples).
          (loop [i 0, state init-params, acc (transient []), n 0, total-accepted 0, rk key]
            (if (>= n samples)
              (with-meta (persistent! acc)
-               {:acceptance-rate (/ total-accepted (* total-iters n-chains))})
+               {:acceptance-rate (if (pos? i)
+                                   (/ total-accepted (* i n-chains))
+                                   0)})
              (let [[step-key next-key] (rng/split-or-nils rk)
                    {:keys [state n-accepted]}
                    (vectorized-hmc-step state neg-U-fn grad-fn eps half-eps half

--- a/src/genmlx/inference/smc.cljs
+++ b/src/genmlx/inference/smc.cljs
@@ -239,11 +239,15 @@
             :log-ml-estimate MLX-scalar}"
   [{:keys [particles ess-threshold rejuvenation-steps rejuvenation-selection
            resample-method callback key]
-    :or {particles 100 ess-threshold 0.5 rejuvenation-steps 0
-         rejuvenation-selection sel/all}}
+    :or {particles 100 ess-threshold 0.5 rejuvenation-steps 0}}
    model args observations-seq]
   (let [model (-> model dyn/auto-key strip-analytical)
         obs-vec (vec observations-seq)
+        ;; Default: rejuvenate only the latents. sel/all also resampled the
+        ;; observed addresses — targeting the prior (genmlx-7ca0).
+        rejuvenation-selection
+        (or rejuvenation-selection
+            (sel/complement-sel (sel/from-paths (mapcat cm/addresses obs-vec))))
         n-steps (count obs-vec)]
     (loop [t 0
            traces nil
@@ -300,12 +304,15 @@
    Returns {:traces :log-weights :log-ml-estimate}"
   [{:keys [particles ess-threshold rejuvenation-steps rejuvenation-selection
            resample-method callback key]
-    :or {particles 100 ess-threshold 0.5 rejuvenation-steps 0
-         rejuvenation-selection sel/all}}
+    :or {particles 100 ess-threshold 0.5 rejuvenation-steps 0}}
    model args observations-seq reference-trace]
   (let [model (dyn/auto-key model)
         particle-model (strip-analytical model)
         obs-vec (vec observations-seq)
+        ;; Default: rejuvenate only the latents (genmlx-7ca0, see smc).
+        rejuvenation-selection
+        (or rejuvenation-selection
+            (sel/complement-sel (sel/from-paths (mapcat cm/addresses obs-vec))))
         n-steps (count obs-vec)
         ref-idx 0]  ;; reference particle is always at index 0
     (loop [t 0
@@ -573,11 +580,14 @@
 
    Returns {:vtrace VectorizedTrace :log-ml-estimate MLX-scalar}"
   [{:keys [particles ess-threshold rejuvenation-steps rejuvenation-selection callback key]
-    :or {particles 100 ess-threshold 0.5 rejuvenation-steps 0
-         rejuvenation-selection sel/all}}
+    :or {particles 100 ess-threshold 0.5 rejuvenation-steps 0}}
    model args observations-seq]
   (let [model (dyn/auto-key model)
         obs-vec (vec observations-seq)
+        ;; Default: rejuvenate only the latents (genmlx-7ca0, see smc).
+        rejuvenation-selection
+        (or rejuvenation-selection
+            (sel/complement-sel (sel/from-paths (mapcat cm/addresses obs-vec))))
         n-steps (count obs-vec)
         [init-key next-key] (rng/split-or-nils key)
         ;; Step 0: batched init

--- a/src/genmlx/inference/util.cljs
+++ b/src/genmlx/inference/util.cljs
@@ -425,19 +425,33 @@
   (let [;; L3.5: filter out conjugate prior addresses
         eliminated (get-eliminated-addresses model)
         addresses (filter-addresses addresses eliminated)
-        {:keys [score-fn latent-index tensor-native?]}
-        (make-tensor-score-fn model args observations addresses)]
-    (if tensor-native?
-      ;; Tensor-native: params packed in dep-order (latent-index)
-      {:score-fn score-fn
-       :init-params (extract-params-by-index trace latent-index)
-       :n-params (count latent-index)
-       :tensor-native? true
-       :latent-index latent-index}
-      ;; GFI fallback: use existing layout machinery
-      (let [layout (compute-param-layout trace addresses)]
-        {:score-fn score-fn
-         :init-params (extract-params trace addresses layout)
-         :n-params (:total-size layout)
-         :tensor-native? false
-         :latent-index latent-index}))))
+        layout (compute-param-layout trace addresses)]
+    (if (:array-valued? layout)
+      ;; Array-valued latents: only the layout-aware GFI score-fn packs and
+      ;; unpacks flat offsets correctly. The tensor-native and
+      ;; compiled-generate score-fns index one SCALAR per address, so their
+      ;; scores would silently mismatch the array-aware init-params built
+      ;; below (genmlx-7ca0). :latent-index is nil — addr→slot indexing is
+      ;; meaningless under flat offsets; consumers use :layout instead.
+      {:score-fn (make-score-fn model args observations addresses layout)
+       :init-params (extract-params trace addresses layout)
+       :n-params (:total-size layout)
+       :tensor-native? false
+       :layout layout
+       :latent-index nil}
+      (let [{:keys [score-fn latent-index tensor-native?]}
+            (make-tensor-score-fn model args observations addresses)]
+        (if tensor-native?
+          ;; Tensor-native: params packed in dep-order (latent-index)
+          {:score-fn score-fn
+           :init-params (extract-params-by-index trace latent-index)
+           :n-params (count latent-index)
+           :tensor-native? true
+           :latent-index latent-index}
+          ;; GFI/compiled-generate fallback: scalar-per-address layout
+          {:score-fn score-fn
+           :init-params (extract-params trace addresses layout)
+           :n-params (:total-size layout)
+           :tensor-native? false
+           :layout layout
+           :latent-index latent-index})))))

--- a/src/genmlx/selection.cljs
+++ b/src/genmlx/selection.cljs
@@ -1,7 +1,8 @@
 (ns genmlx.selection
   "Composable address selection algebra for GenMLX.
    Selections identify subsets of addresses in a choice map
-   for operations like regenerate.")
+   for operations like regenerate."
+  (:require [genmlx.choicemap :as cm]))
 
 (defprotocol ISelection
   (selected?        [s addr] "Is this address selected?")
@@ -69,3 +70,23 @@
   "Create the complement of a selection."
   [s]
   (->Complement s))
+
+(defn from-paths
+  "Build a selection from a collection of leaf address paths (vectors), e.g.
+   [[:x] [:sub :y]]. An empty path means 'this node itself' → all."
+  [paths]
+  (if (some empty? paths)
+    all
+    (->Hierarchical
+     (into {}
+           (map (fn [[addr subpaths]]
+                  [addr (from-paths (map rest subpaths))]))
+           (group-by first paths)))))
+
+(defn from-choicemap
+  "Selection of exactly the leaf addresses present in a choice map (each with
+   everything under it). (complement-sel (from-choicemap observations)) is
+   'all latents' — every address except the observed sites — the safe default
+   selection for MCMC moves (genmlx-7ca0)."
+  [chm]
+  (from-paths (cm/addresses chm)))

--- a/test/genmlx/mcmc_defaults_test.cljs
+++ b/test/genmlx/mcmc_defaults_test.cljs
@@ -1,0 +1,122 @@
+;; @tier fast core
+(ns genmlx.mcmc-defaults-test
+  "genmlx-7ca0: mcmc default selection, tensor-score layout, acceptance-rate
+   denominator.
+
+   Independent oracles only: closed-form Gaussian posteriors / joint
+   log-densities computed with host Math, observation-invariance checks, and
+   exact step counting — never the code path under test."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.protocols :as p]
+            [genmlx.dynamic :as dyn]
+            [genmlx.dist :as dist]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.inference.mcmc :as mcmc]
+            [genmlx.inference.kernel :as kern]
+            [genmlx.inference.util :as u])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(defn- ->num
+  "Realize an MLX scalar or pass a plain number through (constraint values
+   are stored as plain numbers in choicemaps)."
+  [v]
+  (if (number? v) v (mx/realize v)))
+
+(defn- gaussian-lp
+  "Closed-form N(v | mu, sigma) log-density (host Math — independent oracle)."
+  [v mu sigma]
+  (- (* -0.5 (Math/pow (/ (- v mu) sigma) 2))
+     (Math/log sigma)
+     (* 0.5 (Math/log (* 2 Math/PI)))))
+
+;; ============================================================
+;; 1. sel/from-choicemap + complement (pure selection algebra)
+;; ============================================================
+(deftest test-from-choicemap-selection
+  (testing "from-choicemap selects observed leaves; complement is the latents"
+    (let [obs (cm/choicemap :y 2.0 :sub {:z 1.0})
+          obs-sel (sel/from-choicemap obs)
+          latents (sel/complement-sel obs-sel)]
+      (is (sel/selected? obs-sel :y) "observed leaf selected")
+      (is (not (sel/selected? obs-sel :mu)) "unobserved addr not selected")
+      (is (sel/selected? (sel/get-subselection obs-sel :sub) :z)
+          "nested observed leaf selected")
+      (is (not (sel/selected? latents :y)) "complement excludes observation")
+      (is (sel/selected? latents :mu) "complement includes latent")
+      (is (not (sel/selected? (sel/get-subselection latents :sub) :z))
+          "complement excludes nested observation")
+      (is (sel/selected? (sel/get-subselection latents :sub) :other)
+          "complement includes nested latent"))))
+
+;; ============================================================
+;; 2. mh default selection: observations stay fixed, posterior targeted
+;; ============================================================
+(deftest test-mh-default-selection-targets-posterior
+  (testing "mh without :selection must not resample observations"
+    ;; mu ~ N(0,1), y ~ N(mu,1), observe y=2.0.
+    ;; Closed form: mu | y=2 is N(1.0, 1/2) — posterior mean 1.0, prior mean 0.
+    (let [model (gen []
+                  (let [mu (trace :mu (dist/gaussian (mx/scalar 0) (mx/scalar 1)))]
+                    (trace :y (dist/gaussian mu (mx/scalar 1)))
+                    mu))
+          obs (cm/choicemap :y 2.0)
+          traces (mcmc/mh {:samples 300 :burn 200 :key (rng/fresh-key 11)}
+                          model [] obs)
+          y-vals (mapv (fn [tr]
+                         (->num (cm/get-value (cm/get-submap (:choices tr) :y))))
+                       traces)
+          mu-vals (mapv (fn [tr]
+                          (->num (cm/get-value (cm/get-submap (:choices tr) :mu))))
+                        traces)
+          mu-mean (/ (reduce + mu-vals) (count mu-vals))]
+      (is (every? #(< (Math/abs (- % 2.0)) 1e-6) y-vals)
+          "observation :y stays exactly 2.0 in every kept trace")
+      (is (< (Math/abs (- mu-mean 1.0)) 0.35)
+          (str "posterior mean near 1.0 (closed form), got " mu-mean)))))
+
+;; ============================================================
+;; 3. Acceptance-rate denominator counts executed steps
+;; ============================================================
+(deftest test-acceptance-rate-denominator
+  (testing "always-accepting kernel reports acceptance-rate exactly 1"
+    ;; burn 2, samples 3, thin 4 → executed steps = 2 + (3-1)*4 + 1 = 11,
+    ;; NOT burn + samples*thin = 14. An always-accept step-fn must yield 1.
+    (let [out (kern/collect-samples
+               {:samples 3 :burn 2 :thin 4 :key (rng/fresh-key 1)}
+               (fn [state _k] {:state (inc state) :accepted? true})
+               identity
+               0)]
+      (is (= 3 (count out)) "3 samples kept")
+      (is (= 1 (:acceptance-rate (meta out)))
+          "acceptance-rate is exactly 1 for an always-accepting kernel"))))
+
+;; ============================================================
+;; 4. Array-valued latent: score-fn matches closed-form joint
+;; ============================================================
+(deftest test-array-latent-score-layout
+  (testing "prepare-mcmc-score scores array-valued latents correctly"
+    ;; v ~ iid-gaussian [2] (array latent), y ~ N(mean(v), 1) observed.
+    ;; Fully constrained score = lp(v0;0,1) + lp(v1;0,1) + lp(y; mean(v), 1).
+    (let [model (gen []
+                  (let [v (trace :v (dist/iid-gaussian (mx/scalar 0) (mx/scalar 1) 2))]
+                    (trace :y (dist/gaussian (mx/mean v) (mx/scalar 1)))
+                    v))
+          obs (cm/choicemap :y 0.5)
+          {:keys [trace]} (p/generate (dyn/with-key model (rng/fresh-key 3)) [] obs)
+          {:keys [score-fn init-params n-params tensor-native?]}
+          (u/prepare-mcmc-score model [] obs [:v] trace)
+          v-arr (cm/get-value (cm/get-submap (:choices trace) :v))
+          [v0 v1] (mx/->clj v-arr)
+          expected (+ (gaussian-lp v0 0 1)
+                      (gaussian-lp v1 0 1)
+                      (gaussian-lp 0.5 (/ (+ v0 v1) 2) 1))
+          got (->num (score-fn init-params))]
+      (is (= 2 n-params) "array latent occupies 2 flat slots")
+      (is (= [2] (vec (mx/shape init-params))) "init-params is the flattened latent")
+      (is (< (Math/abs (- got expected)) 1e-3)
+          (str "score matches closed-form joint: got " got " expected " expected)))))
+
+(cljs.test/run-tests)


### PR DESCRIPTION
## Summary
- **Default selection no longer resamples observations.** `mh` and `smc`/`csmc`/`vsmc` defaulted to `sel/all`; regenerate has no notion of 'observed', so omitting `:selection` silently targeted the **prior**. The default is now the complement of the observed addresses, via new `sel/from-paths` / `sel/from-choicemap`. With no observations this reduces to the old behavior.
- **Array-valued latents score correctly.** `prepare-mcmc-score` routes array-valued layouts to the layout-aware GFI score-fn up front — the tensor-native / compiled-generate score fns index one scalar per address and silently mismatched the array-aware `init-params` (affects compiled-mh/mala/hmc/nuts/map-optimize). Also un-deadens `map-optimize`'s layout-aware unpack branch (`:latent-index` was returned unconditionally).
- **Acceptance rates divide by steps actually run** — the loops stop at the last kept sample (`burn+(samples-1)*thin+1`), not `burn+samples*thin`. Fixed in `kern/collect-samples` and the vectorized compiled mh/mala/hmc; pmcmc and fused chains already counted correctly.
- **Diagnostics documented honestly**: `r-hat` is classic Gelman-Rubin (no split/rank-normalization — `bulk-ess`/`tail-ess` are the Vehtari 2021 diagnostics); element-0 behavior for array samples stated on `ess`/`sample-quantiles`.

## Verification (independent-oracle rule)
New `mcmc_defaults_test.cljs` — oracles are closed-form posteriors, observation invariance, exact step counting, and hand-computed joint log-densities, never the path under test. **5 assertions fail pre-fix** (incl. the smoking gun: observed `:y` drifting from its constrained value under default-selection mh, posterior mean ≈ prior), all green post-fix (4 tests / 14 assertions).

Regression: fast-core 33/33; selection_test, selection_regenerate, selection_algebra2, inference_test, inference_smc_test, smc_evidence_test, vectorized_test, pmcmc_test all green. `fused_mcmc_test` SIGTRAP reproduces identically on unmodified main (medium-tier, pre-existing — noted in genmlx-06xw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)