### PR TITLE
fix(gfi): strip-compiled strips all alternate paths + marginal-trace conversion (genmlx-pkmx)

### DIFF
--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -529,6 +529,25 @@
    compiled-dispatcher
    handler-dispatcher])
 
+(defn- guard-marginal-trace!
+  "An analytically-scored trace (::score-type :marginal) carries a collapsed
+   score. Running a joint-scoring update/project/regenerate against it would
+   subtract a marginal old score from a joint new score — silently mixing
+   decompositions (ARCHITECTURE §3.3, genmlx-pkmx). Throw instead. Analytical
+   regenerate and custom dispatchers declaring :score-type :marginal pass."
+  [op spec opts]
+  (when (and (contains? #{:update :project :regenerate} op)
+             (= :joint (:score-type spec))
+             (= :marginal (::score-type (meta (:trace opts)))))
+    (throw (ex-info
+            (str (name op) " on an analytically-scored (:marginal) trace would "
+                 "mix score decompositions: the trace score is marginal "
+                 "(collapsed) but the resolved " (name (:label spec)) " path "
+                 "computes joint scores. Re-create the trace via a handler-path "
+                 "generate (gfi/strip-compiled), or use an op with an "
+                 "analytical path.")
+            {:op op :path (:label spec) :trace-score-type :marginal}))))
+
 (defn run-dispatched*
   "Core dispatch: walk the dispatcher stack and execute the first match.
    Public so genmlx.dev can reference it for start!/stop!."
@@ -536,6 +555,7 @@
   (let [spec (dispatch/resolve default-dispatcher-stack op (:schema gf)
                (assoc opts :gf gf))]
     (assert spec (str "No dispatcher resolved for op " op))
+    (guard-marginal-trace! op spec opts)
     ((:run spec) gf args key opts)))
 
 ;; Dispatch function atom. Defaults to run-dispatched*.

--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -529,24 +529,25 @@
    compiled-dispatcher
    handler-dispatcher])
 
-(defn- guard-marginal-trace!
+(declare run-dispatched* strip-alternate-paths)
+
+(defn- joint-rescore-marginal
   "An analytically-scored trace (::score-type :marginal) carries a collapsed
    score. Running a joint-scoring update/project/regenerate against it would
    subtract a marginal old score from a joint new score — silently mixing
-   decompositions (ARCHITECTURE §3.3, genmlx-pkmx). Throw instead. Analytical
-   regenerate and custom dispatchers declaring :score-type :marginal pass."
-  [op spec opts]
-  (when (and (contains? #{:update :project :regenerate} op)
-             (= :joint (:score-type spec))
-             (= :marginal (::score-type (meta (:trace opts)))))
-    (throw (ex-info
-            (str (name op) " on an analytically-scored (:marginal) trace would "
-                 "mix score decompositions: the trace score is marginal "
-                 "(collapsed) but the resolved " (name (:label spec)) " path "
-                 "computes joint scores. Re-create the trace via a handler-path "
-                 "generate (gfi/strip-compiled), or use an op with an "
-                 "analytical path.")
-            {:op op :path (:label spec) :trace-score-type :marginal}))))
+   decompositions (ARCHITECTURE §3.3, genmlx-pkmx). Alternate paths must stay
+   semantically invisible (a model written at L0 runs unchanged at L3), so
+   convert instead of throwing: re-generate the trace fully constrained from
+   its own choices via the handler path, yielding an identical-choices trace
+   with an exact joint score. Costs one handler generate per conversion."
+  [gf key opts]
+  (let [t (:trace opts)]
+    (if (= :marginal (::score-type (meta t)))
+      (let [stripped (strip-alternate-paths gf)
+            res (run-dispatched* stripped :generate (:args t) key
+                                 {:constraints (:choices t)})]
+        (assoc opts :trace (:trace res)))
+      opts)))
 
 (defn run-dispatched*
   "Core dispatch: walk the dispatcher stack and execute the first match.
@@ -555,8 +556,11 @@
   (let [spec (dispatch/resolve default-dispatcher-stack op (:schema gf)
                (assoc opts :gf gf))]
     (assert spec (str "No dispatcher resolved for op " op))
-    (guard-marginal-trace! op spec opts)
-    ((:run spec) gf args key opts)))
+    (let [opts (if (and (contains? #{:update :project :regenerate} op)
+                        (= :joint (:score-type spec)))
+                 (joint-rescore-marginal gf key opts)
+                 opts)]
+      ((:run spec) gf args key opts))))
 
 ;; Dispatch function atom. Defaults to run-dispatched*.
 ;; genmlx.dev/start! swaps this with a validating wrapper.
@@ -632,6 +636,33 @@
                    {:trace trace :selection selection})]
       (mx/gfi-cleanup!)
       result)))
+
+(def alternate-path-schema-keys
+  "Every schema key the dispatcher stack consults for a non-handler execution
+   path: L1-M2 full-compile keys, L1-M3 prefix keys, and the L3 analytical
+   keys. strip-alternate-paths must remove ALL of them — leaving any behind
+   lets a 'handler ground truth' comparison silently exercise a compiled or
+   analytical path (genmlx-pkmx)."
+  [:compiled-simulate :compiled-generate :compiled-update :compiled-assess
+   :compiled-project :compiled-regenerate
+   :compiled-prefix :compiled-prefix-generate :compiled-prefix-update
+   :compiled-prefix-regenerate :compiled-prefix-assess :compiled-prefix-project
+   :auto-handlers :conjugate-pairs :has-conjugate? :analytical-plan
+   :auto-regenerate-transition])
+
+(defn strip-alternate-paths
+  "Return a copy of gf with all alternate execution paths removed from its
+   schema — full-compile, prefix, and analytical — forcing the handler
+   (interpreter) path for all GFI ops. Preserves the gen-fn's metadata (the
+   PRNG ::key from with-key/auto-key lives there — genmlx-3lgy).
+   Returns gf unchanged if it has no schema."
+  [gf]
+  (if-let [schema (:schema gf)]
+    (with-meta
+      (->DynamicGF (:body-fn gf) (:source gf)
+                   (apply dissoc schema alternate-path-schema-keys))
+      (meta gf))
+    gf))
 
 (defn- propagate-meta
   "Propagate the PRNG key and param-store to a sub-gf via metadata, when present."

--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -80,33 +80,15 @@
 ;; Return all leaf address paths from a choicemap.
 (def ^:private all-leaf-addrs cm/addresses)
 
-(def ^:private alternate-path-schema-keys
-  "Every schema key the dispatcher stack consults for a non-handler execution
-   path: L1-M2 full-compile keys, L1-M3 prefix keys, and the L3 analytical
-   keys. strip-compiled must remove ALL of them — leaving any behind lets a
-   'handler ground truth' law silently compare compiled-vs-compiled or
-   analytical-vs-compiled (genmlx-pkmx)."
-  [:compiled-simulate :compiled-generate :compiled-update :compiled-assess
-   :compiled-project :compiled-regenerate
-   :compiled-prefix :compiled-prefix-generate :compiled-prefix-update
-   :compiled-prefix-regenerate :compiled-prefix-assess :compiled-prefix-project
-   :auto-handlers :conjugate-pairs :has-conjugate? :analytical-plan
-   :auto-regenerate-transition])
-
 (defn strip-compiled
   "Return a copy of model with all alternate execution paths removed from its
    schema — full-compile, prefix, and analytical — forcing the handler
    (interpreter) path for all GFI ops. Preserves the gen-fn's metadata (the
    PRNG ::key from with-key/auto-key lives there — genmlx-3lgy).
-   Returns the model unchanged if it has no schema."
+   Returns the model unchanged if it has no schema.
+   Canonical implementation: dyn/strip-alternate-paths (genmlx-pkmx)."
   [model]
-  (let [schema (:schema model)]
-    (if (nil? schema)
-      model
-      (with-meta
-        (dyn/->DynamicGF (:body-fn model) (:source model)
-                         (apply dissoc schema alternate-path-schema-keys))
-        (meta model)))))
+  (dyn/strip-alternate-paths model))
 
 ;; ---------------------------------------------------------------------------
 ;; The algebraic laws
@@ -1561,10 +1543,12 @@
     :check (fn [_]
              (let [kernel (dyn/auto-key
                            (dyn/make-gen-fn
-                            (fn [rt]
+                            ;; Handler-path body-fns receive args positionally:
+                            ;; (apply body-fn rt args). Reading (.-args rt) only
+                            ;; appears to work when a compiled path bypasses the
+                            ;; body-fn entirely (genmlx-pkmx).
+                            (fn [rt _t prev-state]
                               (let [trace (.-trace rt)
-                                    args (.-args rt)
-                                    prev-state (second args)
                                     x (trace :x (dist/gaussian prev-state 1))]
                                 (trace :y (dist/laplace x 1))
                                 x))
@@ -1606,10 +1590,10 @@
     :tags #{:inference :smc :pf}
     :check (fn [_]
              (let [kernel (dyn/make-gen-fn
-                           (fn [rt]
+                           ;; Positional args, matching the gen-macro convention
+                           ;; (see :pf-incremental-weight note — genmlx-pkmx).
+                           (fn [rt _t prev-state]
                              (let [trace (.-trace rt)
-                                   args (.-args rt)
-                                   prev-state (second args)
                                    x (trace :x (dist/gaussian prev-state 1))]
                                (trace :y (dist/gaussian x 1))
                                x))

--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -80,19 +80,33 @@
 ;; Return all leaf address paths from a choicemap.
 (def ^:private all-leaf-addrs cm/addresses)
 
+(def ^:private alternate-path-schema-keys
+  "Every schema key the dispatcher stack consults for a non-handler execution
+   path: L1-M2 full-compile keys, L1-M3 prefix keys, and the L3 analytical
+   keys. strip-compiled must remove ALL of them — leaving any behind lets a
+   'handler ground truth' law silently compare compiled-vs-compiled or
+   analytical-vs-compiled (genmlx-pkmx)."
+  [:compiled-simulate :compiled-generate :compiled-update :compiled-assess
+   :compiled-project :compiled-regenerate
+   :compiled-prefix :compiled-prefix-generate :compiled-prefix-update
+   :compiled-prefix-regenerate :compiled-prefix-assess :compiled-prefix-project
+   :auto-handlers :conjugate-pairs :has-conjugate? :analytical-plan
+   :auto-regenerate-transition])
+
 (defn strip-compiled
-  "Return a copy of model with all compiled execution paths removed from
-   its schema, forcing the handler (interpreter) path for all GFI ops.
+  "Return a copy of model with all alternate execution paths removed from its
+   schema — full-compile, prefix, and analytical — forcing the handler
+   (interpreter) path for all GFI ops. Preserves the gen-fn's metadata (the
+   PRNG ::key from with-key/auto-key lives there — genmlx-3lgy).
    Returns the model unchanged if it has no schema."
   [model]
   (let [schema (:schema model)]
     (if (nil? schema)
       model
-      (dyn/->DynamicGF (:body-fn model) (:source model)
-                        (dissoc schema
-                                :compiled-simulate :compiled-generate
-                                :compiled-update :compiled-assess
-                                :compiled-project :compiled-regenerate)))))
+      (with-meta
+        (dyn/->DynamicGF (:body-fn model) (:source model)
+                         (apply dissoc schema alternate-path-schema-keys))
+        (meta model)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The algebraic laws
@@ -1604,11 +1618,7 @@
                                (trace :y (dist/gaussian x 1))
                                x)))
                    ;; Strip conjugacy -> force bootstrap (prior) proposal.
-                   stripped (assoc kernel :schema
-                                   (dissoc (:schema kernel)
-                                           :auto-handlers :conjugate-pairs
-                                           :has-conjugate? :analytical-plan
-                                           :auto-regenerate-transition))
+                   stripped (strip-compiled kernel)
                    ys [1.0 2.0 0.5]
                    obs-seq (mapv #(cm/choicemap :y (mx/scalar %)) ys)
                    ;; Kalman analytical log-evidence (per-step innovation LLs):
@@ -1649,11 +1659,7 @@
                            '([] (let [x (trace :x (dist/gaussian 0 2))]
                                   (trace :y (dist/gaussian x 1))
                                   x))))
-                   stripped (assoc model :schema
-                                  (dissoc (:schema model)
-                                          :auto-handlers :conjugate-pairs
-                                          :has-conjugate? :analytical-plan
-                                          :auto-regenerate-transition))
+                   stripped (strip-compiled model)
                    choices (cm/choicemap :x (mx/scalar 2.0) :y (mx/scalar 3.0))
                    {:keys [trace]} (p/generate stripped [] choices)
                    _ (mx/materialize! (:score trace))

--- a/src/genmlx/inference/mcmc.cljs
+++ b/src/genmlx/inference/mcmc.cljs
@@ -79,6 +79,19 @@
 ;; Custom Proposal MH
 ;; ---------------------------------------------------------------------------
 
+(defn- ensure-joint-trace
+  "MH acceptance ratios are joint-score deltas computed via p/update. A trace
+   produced by an analytical (collapsed) generate carries a marginal score
+   (::dyn/score-type :marginal) and would mix score decompositions — the
+   dispatcher guard throws on it (genmlx-pkmx). Its choices are a perfectly
+   good chain state, so re-generate it jointly from its own choices via the
+   handler path. No-op for joint traces."
+  [model trace]
+  (if (= :marginal (::dyn/score-type (meta trace)))
+    (:trace (p/generate (dyn/strip-alternate-paths model)
+                        (:args trace) (:choices trace)))
+    trace))
+
 (defn mh-custom-step
   "One MH step with a custom proposal generative function.
    proposal-gf: generative function that takes [current-trace-choices]
@@ -94,6 +107,7 @@
    (let [model (dyn/auto-key model)
          proposal-gf (dyn/auto-key proposal-gf)
          backward-gf (when backward-gf (dyn/auto-key backward-gf))
+         current-trace (ensure-joint-trace model current-trace)
          [k1 k2 k3] (rng/split-n (rng/ensure-key key) 3)
          ;; 1. Run propose on the proposal GF → forward choices + forward score
          proposal-args [(:choices current-trace)]
@@ -134,7 +148,8 @@
     :or {burn 0 thin 1}}
    model args observations]
   (let [model (dyn/auto-key model)
-        {:keys [trace]} (p/generate model args observations)]
+        {:keys [trace]} (p/generate model args observations)
+        trace (ensure-joint-trace model trace)]
     (kern/collect-samples
      {:samples samples :burn burn :thin thin :callback callback :key key}
      (fn [state step-key]
@@ -1127,6 +1142,7 @@
   [current-trace model proposal-gf involution key]
   (let [model (dyn/auto-key model)
         proposal-gf (dyn/auto-key proposal-gf)
+        current-trace (ensure-joint-trace model current-trace)
         [k1 k2] (rng/split (rng/ensure-key key))
         ;; 1. Propose auxiliary choices
         fwd-result (p/propose proposal-gf [(:choices current-trace)])
@@ -1168,7 +1184,8 @@
     :or {burn 0 thin 1}}
    model args observations]
   (let [model (dyn/auto-key model)
-        {:keys [trace]} (p/generate model args observations)]
+        {:keys [trace]} (p/generate model args observations)
+        trace (ensure-joint-trace model trace)]
     (kern/collect-samples
      {:samples samples :burn burn :thin thin :callback callback :key key}
      (fn [state step-key]

--- a/test/genmlx/schema_test.cljs
+++ b/test/genmlx/schema_test.cljs
@@ -804,10 +804,13 @@
 ;; ============================================================
 (deftest test-48-behavior-preservation-update
   (testing "Behavior preservation — update"
+    ;; Non-affine mean keeps the model out of L3 conjugacy: an analytically
+    ;; generated (:marginal) trace now rejects joint-path update by contract
+    ;; (genmlx-pkmx, see strip_compiled_test for that behavior).
     (let [model (dyn/auto-key
                   (gen []
                     (let [x (trace :x (dist/gaussian (mx/scalar 0) (mx/scalar 1)))]
-                      (trace :y (dist/gaussian x (mx/scalar 1))))))
+                      (trace :y (dist/gaussian (mx/multiply x x) (mx/scalar 1))))))
           obs (genmlx.choicemap/set-value genmlx.choicemap/EMPTY :y (mx/scalar 3.0))
           {:keys [trace]} (genmlx.protocols/generate model [] obs)
           new-obs (genmlx.choicemap/set-value genmlx.choicemap/EMPTY :x (mx/scalar 2.0))

--- a/test/genmlx/strip_compiled_test.cljs
+++ b/test/genmlx/strip_compiled_test.cljs
@@ -1,0 +1,115 @@
+;; @tier fast core
+(ns genmlx.strip-compiled-test
+  "genmlx-pkmx: strip-compiled must remove ALL alternate-path schema keys
+   (full-compile + prefix + analytical) and preserve gen-fn metadata
+   (genmlx-3lgy); update/project/regenerate on an analytically-scored
+   (:marginal) trace must fail loudly instead of mixing decompositions."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.protocols :as p]
+            [genmlx.dynamic :as dyn]
+            [genmlx.gfi :as gfi]
+            [genmlx.dist :as dist]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(def ^:private full-compile-keys
+  [:compiled-simulate :compiled-generate :compiled-update :compiled-assess
+   :compiled-project :compiled-regenerate])
+
+(def ^:private prefix-keys
+  [:compiled-prefix :compiled-prefix-generate :compiled-prefix-update
+   :compiled-prefix-regenerate :compiled-prefix-assess :compiled-prefix-project])
+
+(def ^:private analytical-keys
+  [:auto-handlers :conjugate-pairs :has-conjugate? :analytical-plan
+   :auto-regenerate-transition])
+
+(defn- conjugate-model
+  "mu ~ N(0,1); y ~ N(mu,1). Normal-normal conjugate — L3 analytical keys."
+  []
+  (gen []
+    (let [mu (trace :mu (dist/gaussian (mx/scalar 0) (mx/scalar 1)))]
+      (trace :y (dist/gaussian mu (mx/scalar 1)))
+      mu)))
+
+(defn- prefix-model
+  "Static prefix + dynamic loop suffix — L1-M3 prefix keys."
+  []
+  (gen [n]
+    (let [mu (trace :mu (dist/gaussian (mx/scalar 0) (mx/scalar 1)))]
+      (doseq [i (range n)]
+        (trace (keyword (str "y" i)) (dist/gaussian mu (mx/scalar 1))))
+      mu)))
+
+;; ============================================================
+;; 1. strip-compiled removes every alternate-path key
+;; ============================================================
+(deftest test-strip-removes-all-alternate-paths
+  (testing "analytical keys stripped"
+    (let [model (conjugate-model)
+          sch (:schema model)
+          stripped (:schema (gfi/strip-compiled model))]
+      (is (seq (:auto-handlers sch)) "conjugate model HAS analytical keys pre-strip")
+      (is (some sch full-compile-keys) "static model HAS full-compile keys pre-strip")
+      (is (not-any? stripped (concat full-compile-keys prefix-keys analytical-keys))
+          "no alternate-path key survives strip-compiled")))
+  (testing "prefix keys stripped"
+    (let [model (prefix-model)
+          sch (:schema model)
+          stripped (:schema (gfi/strip-compiled model))]
+      (is (some sch prefix-keys) "prefix model HAS prefix keys pre-strip")
+      (is (not-any? stripped (concat full-compile-keys prefix-keys analytical-keys))
+          "no alternate-path key survives strip-compiled"))))
+
+;; ============================================================
+;; 2. Stripped model dispatches to the handler path
+;; ============================================================
+(deftest test-stripped-dispatch-is-handler
+  (testing "simulate resolves :handler after strip"
+    (let [model (conjugate-model)
+          pre (dyn/resolve-dispatch model :simulate)
+          post (dyn/resolve-dispatch (gfi/strip-compiled model) :simulate)]
+      (is (not= :handler (:label pre)) "compiled model does not resolve handler")
+      (is (= :handler (:label post)) "stripped model resolves handler"))))
+
+;; ============================================================
+;; 3. Metadata (PRNG key) survives strip-compiled (genmlx-3lgy)
+;; ============================================================
+(deftest test-strip-preserves-key-metadata
+  (testing "a keyed model can still run sampling ops after strip"
+    (let [model (dyn/with-key (conjugate-model) (rng/fresh-key 5))
+          stripped (gfi/strip-compiled model)
+          tr (p/simulate stripped [])]
+      (is (some? tr) "simulate runs without 'No PRNG key' error")
+      (is (cm/has-value? (cm/get-submap (:choices tr) :mu)) "trace has :mu"))))
+
+;; ============================================================
+;; 4. Marginal-trace guard on update/project; regenerate stays analytical
+;; ============================================================
+(deftest test-marginal-trace-guard
+  (let [model (dyn/with-key (conjugate-model) (rng/fresh-key 7))
+        obs (cm/choicemap :y 1.5)
+        {:keys [trace]} (p/generate model [] obs)]
+    (testing "precondition: analytical generate produced a marginal trace"
+      (is (= :marginal (:genmlx.dynamic/score-type (meta trace)))
+          "trace is analytically scored"))
+    (testing "update on a marginal trace throws instead of mixing scores"
+      (is (thrown-with-msg? js/Error #"mix score decompositions"
+            (p/update model trace (cm/choicemap :y 2.0)))))
+    (testing "project on a marginal trace throws instead of mixing scores"
+      (is (thrown-with-msg? js/Error #"mix score decompositions"
+            (p/project model trace (sel/select :mu)))))
+    (testing "regenerate keeps its analytical path (no throw)"
+      (let [{t' :trace} (p/regenerate model trace (sel/select :mu))]
+        (is (some? t') "analytical regenerate works on marginal traces")))
+    (testing "joint traces are unaffected by the guard"
+      (let [stripped (dyn/auto-key (gfi/strip-compiled model))
+            {jt :trace} (p/generate stripped [] obs)
+            upd (p/update stripped jt (cm/choicemap :y 2.0))]
+        (is (nil? (:genmlx.dynamic/score-type (meta jt))) "handler trace is joint")
+        (is (some? (:trace upd)) "update on joint trace works")))))
+
+(cljs.test/run-tests)

--- a/test/genmlx/strip_compiled_test.cljs
+++ b/test/genmlx/strip_compiled_test.cljs
@@ -3,7 +3,9 @@
   "genmlx-pkmx: strip-compiled must remove ALL alternate-path schema keys
    (full-compile + prefix + analytical) and preserve gen-fn metadata
    (genmlx-3lgy); update/project/regenerate on an analytically-scored
-   (:marginal) trace must fail loudly instead of mixing decompositions."
+   (:marginal) trace must convert it exactly (joint re-score via the handler
+   path) instead of mixing decompositions — alternate paths stay semantically
+   invisible."
   (:require [cljs.test :refer [deftest is testing]]
             [genmlx.protocols :as p]
             [genmlx.dynamic :as dyn]
@@ -87,28 +89,42 @@
       (is (cm/has-value? (cm/get-submap (:choices tr) :mu)) "trace has :mu"))))
 
 ;; ============================================================
-;; 4. Marginal-trace guard on update/project; regenerate stays analytical
+;; 4. Marginal-trace conversion on update/project; regenerate stays analytical
 ;; ============================================================
-(deftest test-marginal-trace-guard
+;; Oracle: the same choices re-generated on the handler path (a joint trace)
+;; and pushed through the same op. The marginal trace must give the SAME
+;; numbers — the L3 analytical path is an optimization, not a semantic change.
+(deftest test-marginal-trace-conversion
   (let [model (dyn/with-key (conjugate-model) (rng/fresh-key 7))
         obs (cm/choicemap :y 1.5)
-        {:keys [trace]} (p/generate model [] obs)]
+        {:keys [trace]} (p/generate model [] obs)
+        stripped (dyn/auto-key (gfi/strip-compiled model))
+        {jt :trace} (p/generate stripped [] (:choices trace))]
     (testing "precondition: analytical generate produced a marginal trace"
       (is (= :marginal (:genmlx.dynamic/score-type (meta trace)))
           "trace is analytically scored"))
-    (testing "update on a marginal trace throws instead of mixing scores"
-      (is (thrown-with-msg? js/Error #"mix score decompositions"
-            (p/update model trace (cm/choicemap :y 2.0)))))
-    (testing "project on a marginal trace throws instead of mixing scores"
-      (is (thrown-with-msg? js/Error #"mix score decompositions"
-            (p/project model trace (sel/select :mu)))))
-    (testing "regenerate keeps its analytical path (no throw)"
+    (testing "update on a marginal trace = update on the joint-rescored trace"
+      (let [u-marg (p/update model trace (cm/choicemap :y 2.0))
+            u-joint (p/update stripped jt (cm/choicemap :y 2.0))
+            _ (mx/materialize! (:weight u-marg) (:weight u-joint))
+            w-marg (mx/item (:weight u-marg))
+            w-joint (mx/item (:weight u-joint))]
+        (is (< (js/Math.abs (- w-marg w-joint)) 1e-4)
+            (str "update weights match: marginal-path " w-marg
+                 " vs handler baseline " w-joint))
+        (is (nil? (:genmlx.dynamic/score-type (meta (:trace u-marg))))
+            "result trace is joint-scored")))
+    (testing "project on a marginal trace = project on the joint-rescored trace"
+      (let [p-marg (p/project model trace (sel/select :mu))
+            p-joint (p/project stripped jt (sel/select :mu))
+            _ (mx/materialize! p-marg p-joint)]
+        (is (< (js/Math.abs (- (mx/item p-marg) (mx/item p-joint))) 1e-4)
+            "project values match")))
+    (testing "regenerate keeps its analytical path (no conversion needed)"
       (let [{t' :trace} (p/regenerate model trace (sel/select :mu))]
         (is (some? t') "analytical regenerate works on marginal traces")))
-    (testing "joint traces are unaffected by the guard"
-      (let [stripped (dyn/auto-key (gfi/strip-compiled model))
-            {jt :trace} (p/generate stripped [] obs)
-            upd (p/update stripped jt (cm/choicemap :y 2.0))]
+    (testing "joint traces are passed through untouched"
+      (let [upd (p/update stripped jt (cm/choicemap :y 2.0))]
         (is (nil? (:genmlx.dynamic/score-type (meta jt))) "handler trace is joint")
         (is (some? (:trace upd)) "update on joint trace works")))))
 


### PR DESCRIPTION
## Summary

Closes the law-suite soundness gap from bean `genmlx-pkmx` (audit epic `genmlx-hqo2`).

- **`strip-compiled` strips ALL alternate-path schema keys** — 6 full-compile + 6 prefix + 5 analytical — and preserves gen-fn metadata (PRNG key, also fixes draft `genmlx-3lgy`). Canonical implementation now lives in `dynamic.cljs` as `strip-alternate-paths`; `gfi/strip-compiled` delegates. Previously, "handler ground truth" laws could silently compare compiled-vs-compiled or analytical-vs-compiled.
- **Marginal-trace conversion at dispatch**: a joint-scoring `update`/`project`/`regenerate` on an analytically-scored (`::score-type :marginal`) trace now re-generates it fully constrained via the handler path and proceeds — exact joint score, identical choices. Previously these ops silently subtracted a marginal old score from a joint new score (ARCHITECTURE §3.3's unenforced convention). A guard-that-throws was tried first but broke the ladder principle (L0-correct code throwing under L3 detection — caught by `error_message_test` and `vupdate_test`).
- **MH steps convert upfront**: `mh-custom-step`/`involutive-mh-step` (+ drivers) convert marginal traces once via `ensure-joint-trace` instead of per-step at dispatch.
- **Two law kernels were never handler-executable**: `pf-incremental-weight` and `pf-log-ml-convergence` read `(.-args rt)` — always nil on the handler path; they only appeared to work because the compiled path bypasses the body-fn. The pf-log-ml 0/5 failure after widening strip-compiled was this, not a compiled-vs-handler discrepancy: with positional args the handler path matches the Kalman oracle.
- `schema_test` test-48 moved to a non-conjugate model (it codified the silently-mixed update surface). New `strip_compiled_test.cljs` asserts numeric equality of marginal-trace ops against an independent handler-path baseline.

## Verification

- `strip_compiled_test` 16/16 (5 fail + 1 error on pre-fix code, verified by stash)
- `gfi_laws_test` 82 tests / 196 assertions — only the known pre-existing `vgenerate` flake (`genmlx-v4mz`)
- fast-all: 131 passed; the 5 not-passed are pre-existing on main (re-verified identical at `a53acef` in a clean worktree; tracked in `genmlx-lcka`, `genmlx-dn56`)
- level0 68/68, L4 41/41, gen_clj_compat 356/356, genjax_compat 73/73, schema 227/227, limitations_fixes/pmcmc/untested_features green

🤖 Generated with [Claude Code](https://claude.com/claude-code)