### PR TITLE
fix(combinators): regenerate weights survive metadata loss through splices (genmlx-v740, part 1)

### DIFF
--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -27,6 +27,30 @@
           cm/EMPTY
           (map-indexed vector results)))
 
+(defn- ensure-kernel-key
+  "Give the kernel an auto-key when it carries no PRNG key, so handler-path
+   sub-calls (update/regenerate fallbacks) can run instead of throwing
+   'No PRNG key on gen-fn'. Uses the metadata literal to avoid requiring
+   genmlx.dynamic (circular) — same convention as unfold-extend."
+  [kern]
+  (if (:genmlx.dynamic/key (meta kern))
+    kern
+    (vary-meta kern assoc :genmlx.dynamic/key :genmlx.dynamic/auto-key)))
+
+(defn- assemble-indexed-discards
+  "Collect non-empty per-element discards under their ORIGINAL element
+   indices. Filtering before positional reassembly records element i's
+   discard under a compacted (wrong) index, breaking backward-request
+   reversibility (genmlx-v740)."
+  [results]
+  (reduce (fn [cm [i r]]
+            (let [d (:discard r)]
+              (if (and d (not= d cm/EMPTY))
+                (cm/set-choice cm [i] d)
+                cm)))
+          cm/EMPTY
+          (map-indexed vector results)))
+
 (defn- sum-field
   "Sum a field across results, starting from scalar 0.0."
   [results field-fn]
@@ -263,9 +287,7 @@
                               ZERO)
             weight (mx/subtract (mx/add (sum-field results :weight) constructed-old)
                                 (:score trace))
-            discard (assemble-choices
-                     (filter :discard results)
-                     :discard)
+            discard (assemble-indexed-discards results)
             element-scores (mapv (comp :score :trace) results)]
         {:trace (with-meta
                   (tr/make-trace {:gen-fn this :args args
@@ -2194,7 +2216,7 @@
         (let [changed-set (if (diff/no-change? argdiffs)
                             #{}
                             (:changed argdiffs))
-              kernel (:kernel this)
+              kernel (ensure-kernel-key (:kernel this))
               ;; Determine which elements need updating: changed args OR new constraints
               update-set (into changed-set
                                (filter #(not= (cm/get-submap constraints %) cm/EMPTY))
@@ -2223,7 +2245,7 @@
               retvals (mapv (comp :retval :trace) results)
               score (sum-field results (comp :score :trace))
               weight (mx/subtract score (:score trace))
-              discard (assemble-choices (filter #(and (:discard %) (not= (:discard %) cm/EMPTY)) results) :discard)
+              discard (assemble-indexed-discards results)
               element-scores (mapv (comp :score :trace) results)]
           {:trace (with-meta
                     (tr/make-trace {:gen-fn this :args args

--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -2096,11 +2096,17 @@
           old-idx-score (dc/dist-log-prob idx-dist (mx/scalar old-idx mx/int32))
           idx-selected? (sel/selected? selection :component-idx)]
       (if idx-selected?
-        ;; Resample component index and simulate new component
+        ;; Resample component index and simulate new component. EVERYTHING
+        ;; under the Mix is freshly drawn from the prior, so the regenerate
+        ;; MH weight is exactly 0: the score delta cancels against the
+        ;; forward/backward prior-proposal ratio (system convention
+        ;; W = dS - proposal_ratio, and proposal_ratio = dS here). The old
+        ;; scoreDelta return un-cancelled the whole subtree score at parent
+        ;; splices and skewed top-level MH acceptance (genmlx-v740).
         (let [new-idx-trace (dc/dist-simulate idx-dist)
               new-idx (int (mx/item (cm/get-value (:choices new-idx-trace))))
               new-idx-score (:score new-idx-trace)
-              new-component (nth (:components this) new-idx)
+              new-component (ensure-kernel-key (nth (:components this) new-idx))
               new-comp-trace (p/simulate new-component args)
               new-score (mx/add (:score new-comp-trace) new-idx-score)]
           {:trace (tr/make-trace {:gen-fn this :args args
@@ -2109,7 +2115,7 @@
                                                           (mx/scalar new-idx mx/int32))
                                   :retval (:retval new-comp-trace)
                                   :score new-score})
-           :weight (mx/subtract new-score (:score trace))})
+           :weight ZERO})
         ;; Same component: regenerate within the component
         (let [component (nth (:components this) old-idx)
               inner-old-score (mx/subtract (:score trace) old-idx-score)

--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -274,12 +274,19 @@
          :weight weight :discard discard})))
 
   p/IRegenerate
+  ;; Per-element old scores come from ::element-scores metadata. When that
+  ;; metadata is lost (splice-boundary trace reconstruction, serialize
+  ;; round-trip), the loop runs against ZERO olds and the summed weight is
+  ;; too high by exactly the old total — which the trace always records as
+  ;; (:score trace). Correct at the end instead of silently returning wrong
+  ;; weights (genmlx-v740). When metadata is present the path is unchanged.
   (regenerate [this trace selection]
     (if-let [cregen (cops/get-compiled-regenerate kernel)]
       ;; WP-9A: compiled regenerate path
       (let [old-choices (:choices trace)
             args (:args trace)
             n (count (first args))
+            old-element-scores (::element-scores (meta trace))
             init-key (rng/fresh-key)]
         (loop [i 0 key init-key
                choices cm/EMPTY score ZERO weight ZERO
@@ -289,15 +296,16 @@
                       (tr/make-trace {:gen-fn this :args args
                                       :choices choices :retval retvals :score score})
                       {::element-scores element-scores ::compiled-path true})
-             :weight weight}
+             :weight (if old-element-scores
+                       weight
+                       (mx/subtract weight (:score trace)))}
             (let [[k1 k2] (rng/split key)
                   elem-args (mapv #(nth % i) args)
                   old-sub-choices (cm/get-submap old-choices i)
                   result (cregen k1 (vec elem-args) old-sub-choices
                                  (sel/get-subselection selection i))
                   elem-choices (values->choices (:values result))
-                  old-elem-score (or (some-> (::element-scores (meta trace))
-                                             (nth i nil))
+                  old-elem-score (or (some-> old-element-scores (nth i nil))
                                      ZERO)
                   ;; compiled-regenerate returns proposal_ratio in :weight
                   ;; per-step weight = new_score - old_score - proposal_ratio
@@ -332,7 +340,9 @@
                   (tr/make-trace {:gen-fn this :args args
                                   :choices choices :retval retvals :score score})
                   {::element-scores element-scores})
-         :weight weight}))))
+         :weight (if old-element-scores
+                   weight
+                   (mx/subtract weight (:score trace)))}))))
 
 (defn map-combinator
   "Create a Map combinator from a kernel generative function.
@@ -624,6 +634,10 @@
                          (conj step-scores (:score new-trace)))))))))))
 
   p/IRegenerate
+  ;; Per-step old scores come from ::step-scores metadata; when it is lost
+  ;; (splice-boundary reconstruction, serialize round-trip) the loop runs
+  ;; against ZERO olds and the summed weight is too high by the old total —
+  ;; recorded on (:score trace). Correct at the end (genmlx-v740).
   (regenerate [this trace selection]
     (let [kern (:kernel this)
           cregen (cops/get-compiled-regenerate kern)
@@ -640,7 +654,9 @@
                                     :choices new-choices :retval states :score score})
                     (cond-> {::step-scores step-scores}
                       cregen (assoc ::compiled-path true)))
-           :weight weight}
+           :weight (if old-step-scores
+                     weight
+                     (mx/subtract weight (:score trace)))}
           (let [old-sub-choices (cm/get-submap choices t)
                 kernel-args (into [t state] extra)
                 old-score (if old-step-scores (nth old-step-scores t) ZERO)]
@@ -1571,6 +1587,7 @@
                          (conj step-carries new-carry))))))))))
 
   p/IRegenerate
+  ;; Same ::step-scores-loss correction as Unfold regenerate (genmlx-v740).
   (regenerate [this trace selection]
     (let [kern (:kernel this)
           cregen (cops/get-compiled-regenerate kern)
@@ -1590,7 +1607,9 @@
                                     :score score})
                     (cond-> {::step-scores step-scores ::step-carries step-carries}
                       cregen (assoc ::compiled-path true)))
-           :weight weight}
+           :weight (if old-step-scores
+                     weight
+                     (mx/subtract weight (:score trace)))}
           (let [old-sub-choices (cm/get-submap choices t)
                 kernel-args [carry (nth inputs t)]
                 old-score (if old-step-scores (nth old-step-scores t) ZERO)]

--- a/src/genmlx/vectorized.cljs
+++ b/src/genmlx/vectorized.cljs
@@ -96,11 +96,16 @@
 
     :else state))
 
+(declare reindex-state)
+
 (defn resample-vtrace
   "Resample a VectorizedTrace using systematic resampling.
-   Returns a new VectorizedTrace with reindexed choices, uniform weights."
+   Returns a new VectorizedTrace with reindexed choices, retval, and
+   uniform weights. The retval MUST follow the same ancestor permutation
+   as the choices — leaving it unpermuted silently pairs particle i's
+   choices with ancestor j's return value (genmlx-v740)."
   [vtrace key]
-  (let [{:keys [weight n-particles choices score]} vtrace
+  (let [{:keys [weight n-particles choices score retval]} vtrace
         indices (systematic-resample-indices weight n-particles key)
         new-choices (reindex-choicemap choices indices)
         new-score (mx/take-idx score indices)
@@ -109,7 +114,8 @@
     (assoc vtrace
            :choices new-choices
            :score   new-score
-           :weight  new-weight)))
+           :weight  new-weight
+           :retval  (reindex-state retval indices))))
 
 ;; ---------------------------------------------------------------------------
 ;; Diagnostics
@@ -146,11 +152,31 @@
                   (fn [k sub] (merge-choicemap-by-mask
                                 sub (cm/-get-submap proposed k) mask))))
 
+(defn- merge-state-by-mask
+  "Per-particle merge of two structured retvals by an [N] boolean mask:
+   arrays via mx/where, maps/vectors recursively, anything else keeps
+   current. Mirrors reindex-state's shape handling."
+  [cur prop mask]
+  (cond
+    (and (mx/array? cur) (mx/array? prop))
+    (mx/where mask prop cur)
+
+    (and (map? cur) (map? prop))
+    (into {} (map (fn [[k v]] [k (merge-state-by-mask v (get prop k) mask)])) cur)
+
+    (and (vector? cur) (vector? prop))
+    (mapv #(merge-state-by-mask %1 %2 mask) cur prop)
+
+    :else cur))
+
 (defn merge-vtraces-by-mask
   "Merge two VectorizedTraces per-particle using an [N] boolean mask.
    Where mask=true takes from proposed, where false keeps current.
-   Preserves the current vtrace's :weight (rejuvenation is weight-preserving)."
+   Preserves the current vtrace's :weight (rejuvenation is weight-preserving).
+   The retval merges with the same mask — leaving it unmerged silently
+   pairs accepted choices with rejected return values (genmlx-v740)."
   [current proposed mask]
   (assoc current
     :choices (merge-choicemap-by-mask (:choices current) (:choices proposed) mask)
-    :score   (mx/where mask (:score proposed) (:score current))))
+    :score   (mx/where mask (:score proposed) (:score current))
+    :retval  (merge-state-by-mask (:retval current) (:retval proposed) mask)))

--- a/src/genmlx/vmap.cljs
+++ b/src/genmlx/vmap.cljs
@@ -165,25 +165,24 @@
     :score (if element-scores (nth element-scores i) (mx/scalar 0.0))}))
 
 (defn- kernel-update
-  "Update a kernel trace. Falls back to generate if IUpdate not implemented."
+  "Update a kernel trace. Throws when the kernel does not implement IUpdate:
+   the old generate fallback RESAMPLED every unconstrained site — not update
+   semantics — and reported the score delta as the weight (genmlx-v740)."
   [kernel trace constraints]
   (if (satisfies? p/IUpdate kernel)
     (p/update kernel trace constraints)
-    ;; Fallback: generate with constraints, compute weight from score diff
-    (let [old-score (:score trace)
-          {:keys [trace weight]} (p/generate kernel (:args trace) constraints)]
-      {:trace trace :weight (mx/subtract (:score trace) old-score)
-       :discard cm/EMPTY})))
+    (throw (ex-info "vmap kernel does not implement IUpdate — no semantically honest fallback exists"
+                    {:kernel-type (type kernel)}))))
 
 (defn- kernel-regenerate
-  "Regenerate a kernel trace. Falls back to simulate if IRegenerate not implemented."
+  "Regenerate a kernel trace. Throws when the kernel does not implement
+   IRegenerate: the old simulate fallback resampled EVERY site regardless of
+   the selection (genmlx-v740)."
   [kernel trace selection]
   (if (satisfies? p/IRegenerate kernel)
     (p/regenerate kernel trace selection)
-    ;; Fallback: re-simulate, weight = new_score - old_score
-    (let [old-score (:score trace)
-          new-trace (p/simulate kernel (:args trace))]
-      {:trace new-trace :weight (mx/subtract (:score new-trace) old-score)})))
+    (throw (ex-info "vmap kernel does not implement IRegenerate — no semantically honest fallback exists"
+                    {:kernel-type (type kernel)}))))
 
 ;; ---------------------------------------------------------------------------
 ;; VmapCombinator
@@ -198,7 +197,13 @@
         (let [key (rng/fresh-key)
               result (rt/run-handler h/batched-simulate-transition
                                      {:choices cm/EMPTY :score (mx/scalar 0.0)
-                                      :key key :batch-size n :batched? true}
+                                      :key key :batch-size n :batched? true
+                                      ;; Trained params live on the kernel's
+                                      ;; metadata; omitting them made the fast
+                                      ;; path silently use param DEFAULTS
+                                      ;; (genmlx-v740).
+                                      :param-store (:genmlx.dynamic/param-store
+                                                    (meta kernel))}
                                      (fn [rt] (apply (:body-fn kernel) rt args)))
               ;; score is [N]-shaped, sum for total
               total-score (mx/sum (:score result))
@@ -233,7 +238,10 @@
                                      {:choices cm/EMPTY :score (mx/scalar 0.0)
                                       :weight (mx/scalar 0.0)
                                       :key key :constraints cm/EMPTY
-                                      :batch-size n :batched? true}
+                                      :batch-size n :batched? true
+                                      ;; See simulate fast path (genmlx-v740).
+                                      :param-store (:genmlx.dynamic/param-store
+                                                    (meta kernel))}
                                      (fn [rt] (apply (:body-fn kernel) rt args)))
               total-score (mx/sum (:score result))
               total-weight (mx/sum (:weight result))

--- a/test/genmlx/combinator_regen_weight_test.cljs
+++ b/test/genmlx/combinator_regen_weight_test.cljs
@@ -1,0 +1,149 @@
+;; @tier fast core
+(ns genmlx.combinator-regen-weight-test
+  "genmlx-v740: combinator regenerate weights must stay correct when the
+   per-step/per-element score metadata (::step-scores / ::element-scores) is
+   lost — which happens on every regenerate THROUGH a splice (execute-sub
+   reconstructs the child trace without it) and after serialize round-trips.
+
+   Oracles (independent of the code under test):
+   1. Empty selection => weight must be exactly 0 (nothing resampled, all
+      values kept, same args => identical scores, zero proposal ratio).
+      Pre-fix, metadata loss made this S_total (the entire old joint score).
+   2. Single-site selection through a splice => weight must equal the
+      hand-computed local density ratio from the trace values."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.combinators :as comb]
+            [genmlx.mlx.random :as rng])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(defn- num [x] (mx/eval! x) (mx/item x))
+
+(defn- strip-meta [trace] (with-meta trace {}))
+
+(def select-nothing (sel/select :no-such-address))
+
+;; ── Unfold ────────────────────────────────────────────────────────────────
+
+(def hmm-kernel
+  (gen [t prev]
+       (let [x (trace :x (dist/gaussian prev 1))]
+         (trace :y (dist/gaussian x 0.5))
+         x)))
+
+(def hmm-unfold (comb/unfold-combinator hmm-kernel))
+
+(deftest unfold-empty-selection-weight-zero-after-meta-loss
+  (let [tr (p/simulate (dyn/with-key hmm-unfold (rng/fresh-key 3))
+                       [3 (mx/scalar 0.0)])]
+    (testing "with metadata intact"
+      (let [{w :weight} (p/regenerate hmm-unfold tr select-nothing)]
+        (is (< (js/Math.abs (num w)) 1e-5) "empty selection => weight 0")))
+    (testing "with metadata stripped (splice/serialize loss)"
+      (let [{w :weight} (p/regenerate hmm-unfold (strip-meta tr) select-nothing)]
+        (is (< (js/Math.abs (num w)) 1e-4)
+            (str "empty selection => weight 0 even without ::step-scores, got "
+                 (num w)))))))
+
+;; ── Through a splice (the SBC unfold-hmm repro) ───────────────────────────
+
+(def spliced-model
+  (dyn/auto-key (gen []
+                     (splice :chain hmm-unfold 3 (mx/scalar 0.0)))))
+
+(defn- chain-val [choices t addr]
+  (num (cm/get-value (reduce cm/get-submap choices [:chain t addr]))))
+
+(deftest spliced-unfold-empty-selection-weight-zero
+  (let [tr0 (p/simulate spliced-model [])
+        obs (reduce (fn [o t]
+                      (cm/set-choice o [:chain t :y]
+                                     (mx/scalar (chain-val (:choices tr0) t :y))))
+                    cm/EMPTY (range 3))
+        {tr :trace} (p/generate spliced-model [] obs)
+        {w :weight} (p/regenerate spliced-model tr
+                                  (sel/hierarchical :chain select-nothing))]
+    (is (< (js/Math.abs (num w)) 1e-4)
+        (str "regenerate through splice, empty selection => weight 0, got "
+             (num w)))))
+
+(deftest spliced-unfold-single-site-weight-matches-local-ratio
+  ;; Regenerate ONLY [:chain 1 :x]. The exact MH weight for a prior-proposal
+  ;; single-site regenerate is the local density ratio:
+  ;;   logp(y1|x1') - logp(y1|x1) + logp(x2|x1') - logp(x2|x1)
+  ;; (the x1-prior terms cancel against the proposal).
+  (let [tr0 (p/simulate spliced-model [])
+        obs (reduce (fn [o t]
+                      (cm/set-choice o [:chain t :y]
+                                     (mx/scalar (chain-val (:choices tr0) t :y))))
+                    cm/EMPTY (range 3))
+        {tr :trace} (p/generate spliced-model [] obs)
+        x1 (chain-val (:choices tr) 1 :x)
+        x2 (chain-val (:choices tr) 2 :x)
+        y1 (chain-val (:choices tr) 1 :y)
+        {tr' :trace w :weight}
+        (p/regenerate spliced-model tr
+                      (sel/hierarchical :chain (sel/hierarchical 1 (sel/select :x))))
+        x1' (chain-val (:choices tr') 1 :x)
+        lp (fn [d v] (num (dist/log-prob d (mx/scalar v))))
+        expected (+ (- (lp (dist/gaussian (mx/scalar x1') 0.5) y1)
+                       (lp (dist/gaussian (mx/scalar x1) 0.5) y1))
+                    (- (lp (dist/gaussian (mx/scalar x1') 1) x2)
+                       (lp (dist/gaussian (mx/scalar x1) 1) x2)))]
+    (is (not= x1 x1') "x1 was resampled")
+    (is (< (js/Math.abs (chain-val (:choices tr') 2 :x) ) 1e9) "sanity")
+    (is (< (js/Math.abs (- (num w) expected)) 1e-3)
+        (str "spliced single-site regenerate weight " (num w)
+             " == local density ratio " expected))))
+
+;; ── Map ───────────────────────────────────────────────────────────────────
+
+(def map-kernel
+  (gen [x]
+       (let [m (trace :m (dist/gaussian x 1))]
+         (trace :o (dist/gaussian m 0.5))
+         m)))
+
+(def mapped (comb/map-combinator map-kernel))
+
+(deftest map-empty-selection-weight-zero-after-meta-loss
+  (let [tr (p/simulate (dyn/with-key mapped (rng/fresh-key 11))
+                       [[(mx/scalar 0.0) (mx/scalar 1.0) (mx/scalar 2.0)]])]
+    (testing "metadata intact"
+      (let [{w :weight} (p/regenerate mapped tr select-nothing)]
+        (is (< (js/Math.abs (num w)) 1e-5))))
+    (testing "metadata stripped"
+      (let [{w :weight} (p/regenerate mapped (strip-meta tr) select-nothing)]
+        (is (< (js/Math.abs (num w)) 1e-4)
+            (str "Map: empty selection => weight 0 without ::element-scores, got "
+                 (num w)))))))
+
+;; ── Scan ──────────────────────────────────────────────────────────────────
+
+(def scan-kernel
+  (gen [carry input]
+       (let [s (trace :s (dist/gaussian carry 1))]
+         (trace :o (dist/gaussian s 0.5))
+         [s s])))
+
+(def scanned (comb/scan-combinator scan-kernel))
+
+(deftest scan-empty-selection-weight-zero-after-meta-loss
+  (let [tr (p/simulate (dyn/with-key scanned (rng/fresh-key 17))
+                       [(mx/scalar 0.0)
+                        [(mx/scalar 0.0) (mx/scalar 1.0) (mx/scalar 2.0)]])]
+    (testing "metadata intact"
+      (let [{w :weight} (p/regenerate scanned tr select-nothing)]
+        (is (< (js/Math.abs (num w)) 1e-5))))
+    (testing "metadata stripped"
+      (let [{w :weight} (p/regenerate scanned (strip-meta tr) select-nothing)]
+        (is (< (js/Math.abs (num w)) 1e-4)
+            (str "Scan: empty selection => weight 0 without ::step-scores, got "
+                 (num w)))))))
+
+(cljs.test/run-tests)

--- a/test/genmlx/combinator_regen_weight_test.cljs
+++ b/test/genmlx/combinator_regen_weight_test.cljs
@@ -21,6 +21,7 @@
             [genmlx.combinators :as comb]
             [genmlx.diff :as diff]
             [genmlx.vectorized :as vz]
+            [genmlx.vmap :as vmap]
             [genmlx.mlx.random :as rng])
   (:require-macros [genmlx.gen :refer [gen]]))
 
@@ -219,5 +220,25 @@
         rv (mx/->clj (:retval merged))]
     (is (every? true? (mapv #(< (js/Math.abs (- %1 %2)) 1e-6) xs rv))
         "retval merged with the same mask as choices")))
+
+;; ── vmap fast path param-store (genmlx-v740 item 5) ──────────────────────
+;; The batched fast path must see the kernel's trained params; pre-fix it
+;; ran the body with param DEFAULTS.
+
+(def param-kernel
+  (gen []
+       (let [mu (param :mu 0.0)]
+         (trace :x (dist/gaussian mu 0.01)))))
+
+(deftest vmap-fast-path-sees-param-store
+  (let [store {:params {:mu (mx/scalar 50.0)} :version 0}
+        vmapped (vmap/vmap-gf
+                 (vary-meta param-kernel assoc
+                            :genmlx.dynamic/param-store store)
+                 :axis-size 4)
+        tr (p/simulate (dyn/with-key vmapped (rng/fresh-key 51)) [])
+        xs (mx/->clj (cm/get-value (cm/get-submap (:choices tr) :x)))]
+    (is (every? #(> % 40.0) xs)
+        (str "fast-path samples centered on the TRAINED mu=50, got " xs))))
 
 (cljs.test/run-tests)

--- a/test/genmlx/combinator_regen_weight_test.cljs
+++ b/test/genmlx/combinator_regen_weight_test.cljs
@@ -20,6 +20,7 @@
             [genmlx.selection :as sel]
             [genmlx.combinators :as comb]
             [genmlx.diff :as diff]
+            [genmlx.vectorized :as vz]
             [genmlx.mlx.random :as rng])
   (:require-macros [genmlx.gen :refer [gen]]))
 
@@ -183,5 +184,40 @@
       (is (< (js/Math.abs (- (num (cm/get-value (reduce cm/get-submap d [2 :m])))
                              old-m2))
              1e-6)))))
+
+;; ── Vectorized retval pairing (genmlx-v740 item 4) ───────────────────────
+;; resample-vtrace and merge-vtraces-by-mask must permute/merge :retval with
+;; the same indices/mask as the choices — otherwise particle i's choices
+;; pair with ancestor j's return value.
+
+(def identity-model
+  ;; retval IS the traced value, so retval[i] must equal choices :x [i]
+  ;; after any permutation/merge.
+  (gen []
+       (trace :x (dist/gaussian 0 1))))
+
+(deftest resample-vtrace-permutes-retval
+  (let [n 8
+        vt (dyn/vsimulate identity-model [] n (rng/fresh-key 31))
+        ;; weight mass concentrated on particle 0 => resample maps all to it
+        vt (assoc vt :weight (mx/array (into [100.0] (repeat (dec n) -100.0))))
+        rs (vz/resample-vtrace vt (rng/fresh-key 32))
+        xs (mx/->clj (cm/get-value (cm/get-submap (:choices rs) :x)))
+        rv (mx/->clj (:retval rs))]
+    (is (= (count (set (mapv #(.toFixed % 5) xs))) 1)
+        "all particles resampled to the dominant ancestor")
+    (is (every? true? (mapv #(< (js/Math.abs (- %1 %2)) 1e-6) xs rv))
+        "retval permuted with the same ancestor indices as choices")))
+
+(deftest merge-vtraces-by-mask-merges-retval
+  (let [n 4
+        cur (dyn/vsimulate identity-model [] n (rng/fresh-key 41))
+        prop (dyn/vsimulate identity-model [] n (rng/fresh-key 42))
+        mask (mx/greater (mx/array [1.0 0.0 1.0 0.0]) (mx/scalar 0.5))
+        merged (vz/merge-vtraces-by-mask cur prop mask)
+        xs (mx/->clj (cm/get-value (cm/get-submap (:choices merged) :x)))
+        rv (mx/->clj (:retval merged))]
+    (is (every? true? (mapv #(< (js/Math.abs (- %1 %2)) 1e-6) xs rv))
+        "retval merged with the same mask as choices")))
 
 (cljs.test/run-tests)

--- a/test/genmlx/combinator_regen_weight_test.cljs
+++ b/test/genmlx/combinator_regen_weight_test.cljs
@@ -19,6 +19,7 @@
             [genmlx.choicemap :as cm]
             [genmlx.selection :as sel]
             [genmlx.combinators :as comb]
+            [genmlx.diff :as diff]
             [genmlx.mlx.random :as rng])
   (:require-macros [genmlx.gen :refer [gen]]))
 
@@ -145,5 +146,42 @@
         (is (< (js/Math.abs (num w)) 1e-4)
             (str "Scan: empty selection => weight 0 without ::step-scores, got "
                  (num w)))))))
+
+;; ── Map update discard indexing (genmlx-v740 item 1) ─────────────────────
+;; Constraining ONLY element 2 must record the displaced old value under
+;; discard index [2] — positional reassembly after a filter put it at [0].
+
+(deftest map-update-discard-keeps-element-index
+  (let [tr (p/simulate (dyn/with-key mapped (rng/fresh-key 23))
+                       [[(mx/scalar 0.0) (mx/scalar 1.0) (mx/scalar 2.0)]])
+        old-m2 (num (cm/get-value (reduce cm/get-submap (:choices tr) [2 :m])))
+        {d :discard} (p/update mapped tr (cm/set-choice cm/EMPTY [2 :m]
+                                                        (mx/scalar 9.0)))]
+    (testing "discard lands under the original element index"
+      (is (cm/has-value? (reduce cm/get-submap d [2 :m]))
+          "displaced value recorded under [2]")
+      (is (= cm/EMPTY (cm/get-submap d 0))
+          "nothing recorded under [0]")
+      (is (< (js/Math.abs (- (num (cm/get-value (reduce cm/get-submap d [2 :m])))
+                             old-m2))
+             1e-6)
+          "discard holds the displaced old value"))))
+
+(deftest map-update-with-diffs-discard-keeps-element-index
+  (let [xs [(mx/scalar 0.0) (mx/scalar 1.0) (mx/scalar 2.0)]
+        tr (p/simulate (dyn/with-key mapped (rng/fresh-key 29)) [xs])
+        old-m2 (num (cm/get-value (reduce cm/get-submap (:choices tr) [2 :m])))
+        {d :discard} (p/update-with-diffs mapped tr
+                                          (cm/set-choice cm/EMPTY [2 :m]
+                                                         (mx/scalar 9.0))
+                                          diff/no-change)]
+    (testing "update-with-diffs discard lands under the original index"
+      (is (cm/has-value? (reduce cm/get-submap d [2 :m]))
+          "displaced value recorded under [2]")
+      (is (= cm/EMPTY (cm/get-submap d 0))
+          "nothing recorded under [0]")
+      (is (< (js/Math.abs (- (num (cm/get-value (reduce cm/get-submap d [2 :m])))
+                             old-m2))
+             1e-6)))))
 
 (cljs.test/run-tests)

--- a/test/genmlx/combinator_regen_weight_test.cljs
+++ b/test/genmlx/combinator_regen_weight_test.cljs
@@ -241,4 +241,23 @@
     (is (every? #(> % 40.0) xs)
         (str "fast-path samples centered on the TRAINED mu=50, got " xs))))
 
+;; ── Mix :component-idx regenerate weight (genmlx-v740 item 6) ────────────
+;; Selecting :component-idx resamples the ENTIRE Mix subtree from the
+;; prior, so the regenerate MH weight is exactly 0 (score delta cancels
+;; the prior-proposal ratio). Pre-fix it returned the raw score delta.
+
+(def mix-gf
+  (comb/mix-combinator
+   [(gen [] (trace :v (dist/gaussian -3 0.5)))
+    (gen [] (trace :v (dist/gaussian 3 0.5)))]
+   (mx/array [(js/Math.log 0.5) (js/Math.log 0.5)])))
+
+(deftest mix-idx-selected-regenerate-weight-zero
+  (let [tr (p/simulate (dyn/with-key mix-gf (rng/fresh-key 61)) [])]
+    (dotimes [i 5]
+      (let [{w :weight} (p/regenerate mix-gf tr (sel/select :component-idx))]
+        (is (< (js/Math.abs (num w)) 1e-5)
+            (str "prior-resample regenerate weight must be 0, got " (num w)
+                 " (attempt " i ")"))))))
+
 (cljs.test/run-tests)

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -59,6 +59,7 @@ fast test/genmlx/combinator_mask_test.cljs
 fast test/genmlx/combinator_mix_test2.cljs
 fast test/genmlx/combinator_property_test.cljs core
 fast test/genmlx/combinator_recurse_test2.cljs
+fast test/genmlx/combinator_regen_weight_test.cljs core
 fast test/genmlx/combinator_scan_test2.cljs
 fast test/genmlx/combinator_switch_test2.cljs
 fast test/genmlx/combinator_unfold_test2.cljs


### PR DESCRIPTION
## Summary

Audit bean `genmlx-v740`, five slices on one branch:

1. **Regenerate weights survive metadata loss** (ed2fba2). Map/Unfold/Scan regenerate silently used ZERO old scores when `::step-scores`/`::element-scores` metadata was missing — which happens on every regenerate **through a splice** and after serialize round-trips. Single-site MH through a spliced Unfold: weight ≈ −10 vs true ≈ +0.2 → acceptance 0. Fixed by correcting the final weight with `(:score trace)`; bit-identical when metadata is present; exact at splice boundaries. SBC `unfold-hmm:mh-cycle`: 0/3 (chi2 ~90) → 3/3 (chi2 1.8–7.2).
2. **Map discard indexing + update-with-diffs keying** (1252526). Element 2's displaced value landed under discard `[0]` (positional reindex after filter); `update-with-diffs` crashed on unkeyed kernels.
3. **Vectorized retval pairing** (f90838e). `resample-vtrace`/`merge-vtraces-by-mask` left `:retval` unpermuted/unmerged — stale particle pairings.
4. **vmap fast paths** (b0f053c). Batched simulate/generate ran kernels **without `:param-store`** — trained kernels silently used param defaults. Dishonest `kernel-update`→generate and `kernel-regenerate`→simulate fallbacks now throw.
5. **Mix `:component-idx` regenerate weight** (c8e042c). Was raw scoreDelta; the prior-resample weight is exactly 0 (proposal ratio cancels). Top-level MH no longer targets the wrong distribution; parent splices no longer un-cancel the subtree score. Fresh-component simulate now keyed.

## Verification

`combinator_regen_weight_test.cljs` (fast core, 11 tests / 25 assertions, each slice stash-verified failing pre-fix) with independent oracles: empty-selection ⇒ weight 0, spliced single-site weight vs hand-computed density ratio, discard under original indices, retval/choices elementwise pairing, trained-param fast path (mu=50 vs default 0), Mix prior-resample weight 0 × 5.

combinators 67/67 · wp9a 66/66 · combinator_compile 92/92 · vectorized 57/57 · vsmc_validation 12/12 · vmap 101/101 · mix 5/5 · fast-core 34/34.

Remaining on the bean: item 3 only (Switch/Mix batched-splice nil retval for non-array branch retvals + `where-select-choicemap` address handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)