### PR TITLE
fix(vectorized): reindex-state passes 0-d retvals through instead of gathering (genmlx-xlng)

### DIFF
--- a/src/genmlx/vectorized.cljs
+++ b/src/genmlx/vectorized.cljs
@@ -86,7 +86,13 @@
   [state indices]
   (cond
     (mx/array? state)
-    (mx/take-idx state indices)
+    ;; 0-d arrays (e.g. a scalar constraint passed through as the model's
+    ;; return value) are particle-invariant — permutation is identity, and
+    ;; a gather on a 0-d array is an MLX shape error that aborts the
+    ;; process through NAPI.
+    (if (pos? (count (mx/shape state)))
+      (mx/take-idx state indices)
+      state)
 
     (map? state)
     (update-vals state #(reindex-state % indices))
@@ -95,8 +101,6 @@
     (mapv #(reindex-state % indices) state)
 
     :else state))
-
-(declare reindex-state)
 
 (defn resample-vtrace
   "Resample a VectorizedTrace using systematic resampling.

--- a/test/genmlx/vectorized_test.cljs
+++ b/test/genmlx/vectorized_test.cljs
@@ -153,6 +153,41 @@
         (is (h/close? 0.0 (h/realize (mx/mean w)) 0.001)
             "resampled weights are zero")))))
 
+(deftest resample-vtrace-scalar-retval-test
+  (testing "resample-vtrace with a 0-d retval (scalar constraint at the
+            returned address) must not gather the retval (genmlx-xlng)"
+    ;; Pre-fix this aborted the whole process: reindex-state called
+    ;; mx/take-idx on the shape-[] retval, an MLX C++ shape error that
+    ;; crosses NAPI as a process abort, not a catchable JS error.
+    (let [model (gen []
+                  (let [x (trace :x (dist/gaussian 0 1))]
+                    (trace :y (dist/gaussian x 1))))
+          n 20
+          key (rng/fresh-key 42)
+          [k1 k2] (rng/split key)
+          vtrace (dyn/vgenerate model [] (cm/choicemap :y (mx/scalar 1.5)) n k1)
+          resampled (vec/resample-vtrace vtrace k2)]
+      (is (= 1.5 (h/realize (:retval resampled)))
+          "0-d retval passes through resample unchanged")
+      (is (= [] (h/realize-shape (:retval resampled)))
+          "retval stays 0-d, not gathered to [n]")
+      (let [x-val (cm/get-value (cm/get-submap (:choices resampled) :x))]
+        (is (= [n] (h/realize-shape x-val)) "choices still reindexed to [n]")))))
+
+(deftest resample-vtrace-batched-retval-test
+  (testing "resample-vtrace permutes an [N]-shaped retval with the choices"
+    (let [model (gen []
+                  (trace :x (dist/gaussian 0 1)))
+          n 30
+          key (rng/fresh-key 7)
+          [k1 k2] (rng/split key)
+          vtrace (dyn/vsimulate model [] n k1)
+          resampled (vec/resample-vtrace vtrace k2)
+          x-val (cm/get-value (cm/get-submap (:choices resampled) :x))]
+      (is (= [n] (h/realize-shape (:retval resampled))) "retval shape [n]")
+      (is (= (h/realize-vec x-val) (h/realize-vec (:retval resampled)))
+          "retval permuted identically to the :x choices"))))
+
 ;; -------------------------------------------------------------------------
 ;; vectorized importance sampling
 ;; -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Process-abort regression from PR #74**: `resample-vtrace` now permutes `:retval` via `reindex-state`, which called `mx/take-idx` on ANY mx array. A gather on a **0-d array** is an MLX C++ shape error that crosses NAPI as a process abort (Bun panic → SIGTRAP), not a catchable JS error. Hit whenever the model's return value is a scalar constraint passed through (retval shape `[]`) — e.g. `vgenerate` with a scalar observation at the returned address, then resample.
- Fix mirrors `reindex-choicemap`'s existing scalar-leaf guard: 0-d retvals are particle-invariant, the ancestor permutation is the identity on them. Also removes a dead `(declare reindex-state)`.
- `merge-state-by-mask` needs no change: `mx/where` broadcasts 0-d operands correctly.

## Found by
The merged fast tier: `vectorized_property_test.cljs` (`resample-vtrace-produces-near-uniform-weights` draws scalar `:y` constraints on a model returning `y`) crashed CRASH(133) post-#74. Minimal repro confirmed: `(mx/take-idx (mx/scalar 1.0) idx)` aborts the process.

## Verification
- New `resample-vtrace-scalar-retval-test`: **aborts the process pre-fix (stash-verified)**, green post-fix; retval stays 0-d and unchanged, choices still reindex to `[n]`.
- New `resample-vtrace-batched-retval-test`: `[N]` retval permuted identically to the `:x` choices.
- `vectorized_property_test.cljs` 13/13 with clean exit; `vectorized_test.cljs` 17 tests / 62 assertions green; fast-core 34/34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)