### PR TITLE
fix(combinators): batched Switch/Mix combine heterogeneous choices and non-array retvals (genmlx-v740, final item)

### DIFF
--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -982,16 +982,26 @@
 
 (defn- where-select-choicemap
   "Combine two choicemaps using mx/where on a boolean mask.
-   Where mask is true, use cm-true; otherwise use cm-false.
-   Requires both choicemaps to have the same address structure."
+   Where mask is true, use cm-true's value; otherwise cm-false's.
+   Operates on the UNION of leaf addresses: an address present on only
+   one side keeps that side's value for all particles — every branch
+   runs once in batched mode, so a branch-only address holds that
+   branch's sampled values, and score masking already excludes the
+   particles that selected another branch (genmlx-v740)."
   [mask cm-true cm-false]
-  (let [addrs (cm/addresses cm-true)]
+  (let [addrs-t (cm/addresses cm-true)
+        union (into addrs-t (remove (set addrs-t)) (cm/addresses cm-false))]
     (reduce
      (fn [acc addr-path]
-       (let [v-t (cm/get-choice cm-true addr-path)
-             v-f (cm/get-choice cm-false addr-path)]
-         (cm/set-choice acc addr-path (mx/where mask v-t v-f))))
-     cm/EMPTY addrs)))
+       (let [node-t (reduce cm/get-submap cm-true addr-path)
+             node-f (reduce cm/get-submap cm-false addr-path)]
+         (cm/set-choice acc addr-path
+                        (cond
+                          (not (cm/has-value? node-f)) (cm/get-value node-t)
+                          (not (cm/has-value? node-t)) (cm/get-value node-f)
+                          :else (mx/where mask (cm/get-value node-t)
+                                          (cm/get-value node-f))))))
+     cm/EMPTY union)))
 
 (defn- idx-mask
   "Boolean mask selecting particles whose [N]-shaped index equals branch i."
@@ -1007,6 +1017,62 @@
    (fn [acc i r]
      (mx/where (idx-mask index i) (value-fn r) acc))
    init results))
+
+(defn- mask-combinable?
+  "Can the per-branch values vs be mask-selected into one per-particle
+   value? True for: all nil, all MLX arrays/numbers, maps with identical
+   key sets whose values are combinable, same-length vectors combinable
+   element-wise, or identical values across branches."
+  [vs]
+  (cond
+    (every? nil? vs) true
+    (every? #(or (mx/array? %) (number? %)) vs) true
+    (and (every? map? vs) (apply = (map (comp set keys) vs)))
+    (every? (fn [k] (mask-combinable? (mapv #(get % k) vs)))
+            (keys (first vs)))
+    (and (every? vector? vs) (apply = (map count vs)))
+    (every? mask-combinable? (apply mapv vector vs))
+    :else (apply = vs)))
+
+(defn- mask-combine-vals
+  "Mask-select per-branch return values into one per-particle value.
+   Arrays and numbers combine via mx/where on the [N]-shaped index; maps
+   and vectors combine recursively (mirrors vectorized merge-state-by-mask);
+   identical non-numeric values pass through. Call mask-combinable? first —
+   on uncombinable input the equal-values fallthrough is meaningless."
+  [index vs]
+  (cond
+    (every? nil? vs) nil
+    (every? #(or (mx/array? %) (number? %)) vs)
+    (where-combine index (first vs) vs identity)
+    (map? (first vs))
+    (into {} (map (fn [k] [k (mask-combine-vals index (mapv #(get % k) vs))]))
+          (keys (first vs)))
+    (vector? (first vs))
+    (mapv #(mask-combine-vals index %) (apply mapv vector vs))
+    :else (first vs)))
+
+(defn- combine-retvals
+  "Combine per-branch return values per-particle, or throw an honest
+   error when they cannot be represented in shape-batched mode. The old
+   behavior returned nil for any non-array retval — silently wrong for
+   every model that uses the splice's return value (genmlx-v740)."
+  [combinator addr index rvs]
+  (when-not (mask-combinable? rvs)
+    (throw (ex-info (str combinator " batched-splice at " addr ": branch return "
+                         "values cannot be combined per-particle in shape-batched "
+                         "mode. Branches must return MLX arrays, numbers, maps/"
+                         "vectors of those with matching structure, or identical "
+                         "values. Use scalar-mode inference for this model.")
+                    {:addr addr
+                     :retval-types (mapv #(cond (nil? %) :nil
+                                                (mx/array? %) :array
+                                                (number? %) :number
+                                                (map? %) :map
+                                                (vector? %) :vector
+                                                :else (type %))
+                                         rvs)})))
+  (mask-combine-vals index rvs))
 
 (extend-type SwitchCombinator
   p/IBatchedSplice
@@ -1049,9 +1115,7 @@
                    (where-select-choicemap (idx-mask index i) (:choices br) acc)))
                cm/EMPTY branch-results)
               combined-retval
-              (let [rvs (mapv :retval branch-results)]
-                (when (mx/array? (first rvs))
-                  (where-combine index (first rvs) rvs identity)))
+              (combine-retvals "Switch" addr index (mapv :retval branch-results))
               ;; Merge into parent state
               sub-result {:choices combined-choices
                           :score combined-score
@@ -1993,9 +2057,7 @@
                    (where-select-choicemap (idx-mask idx-vals i) (:choices cr) acc)))
                cm/EMPTY comp-results)
               combined-retval
-              (let [rvs (mapv :retval comp-results)]
-                (when (mx/array? (first rvs))
-                  (where-combine idx-vals (first rvs) rvs identity)))
+              (combine-retvals "Mix" addr idx-vals (mapv :retval comp-results))
               ;; Add component-idx to choices + add idx-score to combined score
               final-choices (cm/set-value combined-choices :component-idx idx-vals)
               final-score (mx/add combined-score idx-score)

--- a/test/genmlx/batched_switch_test.cljs
+++ b/test/genmlx/batched_switch_test.cljs
@@ -88,4 +88,188 @@
         (let [overall-mean (mx/item (mx/mean x-vals))]
           (is (< (js/Math.abs (- 5 overall-mean)) 3) "mixture mean near 5"))))))
 
+;; ---------------------------------------------------------------------------
+;; Heterogeneous branch addresses + non-array retvals (genmlx-v740 item 3)
+;; ---------------------------------------------------------------------------
+
+(def branch-a
+  (gen []
+    (trace :a (dist/gaussian (mx/scalar 0.0) (mx/scalar 1.0)))
+    nil))
+
+(def branch-b
+  (gen []
+    (trace :b (dist/gaussian (mx/scalar 5.0) (mx/scalar 2.0)))
+    nil))
+
+(def het-model
+  (gen [index]
+    (splice :sw (comb/switch-combinator branch-a branch-b) index)))
+
+(deftest batched-switch-heterogeneous-branch-addresses
+  (testing "branch-only addresses survive the mask combine; per-particle
+            score equals the selected branch's closed-form log-density"
+    ;; Pre-fix, where-select-choicemap iterated only the later branch's
+    ;; addresses: :a was dropped from the combined choices and the missing
+    ;; :b on the accumulator side hit mx/where with nil (NAPI type error).
+    (let [n 6
+          index (mx/array [0 1 0 1 0 1] mx/int32)
+          vt (dyn/vsimulate het-model [index] n (rng/fresh-key 11))
+          sw-choices (cm/get-submap (:choices vt) :sw)
+          a-vals (h/realize-vec (cm/get-value (cm/get-submap sw-choices :a)))
+          b-vals (h/realize-vec (cm/get-value (cm/get-submap sw-choices :b)))
+          scores (h/realize-vec (:score vt))]
+      (is (= n (count a-vals)) ":a present and [n]-shaped")
+      (is (= n (count b-vals)) ":b present and [n]-shaped")
+      (doseq [i (range n)]
+        (let [expected (if (even? i)
+                         (h/gaussian-lp (nth a-vals i) 0.0 1.0)
+                         (h/gaussian-lp (nth b-vals i) 5.0 2.0))]
+          (is (h/close? expected (nth scores i) 1e-4)
+              (str "particle " i " score = selected branch closed-form lp")))))))
+
+(def branch-ret-42
+  (gen []
+    (trace :x (dist/gaussian (mx/scalar 0.0) (mx/scalar 1.0)))
+    42))
+
+(def branch-ret-7
+  (gen []
+    (trace :x (dist/gaussian (mx/scalar 0.0) (mx/scalar 1.0)))
+    7))
+
+(deftest batched-switch-number-retvals
+  (testing "numeric branch retvals mask-select per particle (pre-fix: nil)"
+    (let [n 4
+          index (mx/array [0 1 1 0] mx/int32)
+          model (gen [idx]
+                  (splice :sw (comb/switch-combinator branch-ret-42 branch-ret-7) idx))
+          vt (dyn/vsimulate model [index] n (rng/fresh-key 12))]
+      (is (= [42 7 7 42] (h/realize-vec (:retval vt)))
+          "retval is the selected branch's constant per particle"))))
+
+(def branch-done-a
+  (gen []
+    (trace :x (dist/gaussian (mx/scalar 0.0) (mx/scalar 1.0)))
+    :done))
+
+(def branch-done-b
+  (gen []
+    (trace :x (dist/gaussian (mx/scalar 1.0) (mx/scalar 1.0)))
+    :done))
+
+(deftest batched-switch-identical-value-retvals
+  (testing "identical non-numeric retvals pass through (pre-fix: nil)"
+    (let [index (mx/array [0 1] mx/int32)
+          model (gen [idx]
+                  (splice :sw (comb/switch-combinator branch-done-a branch-done-b) idx))
+          vt (dyn/vsimulate model [index] 2 (rng/fresh-key 13))]
+      (is (= :done (:retval vt)) "particle-invariant retval survives"))))
+
+(def branch-map-a
+  (gen []
+    (let [x (trace :x (dist/gaussian (mx/scalar 0.0) (mx/scalar 1.0)))]
+      {:v x})))
+
+(def branch-map-b
+  (gen []
+    (let [x (trace :x (dist/gaussian (mx/scalar 5.0) (mx/scalar 1.0)))]
+      {:v x})))
+
+(deftest batched-switch-map-retvals
+  (testing "map retvals combine recursively, pairing with the combined choices"
+    (let [n 4
+          index (mx/array [0 1 0 1] mx/int32)
+          model (gen [idx]
+                  (splice :sw (comb/switch-combinator branch-map-a branch-map-b) idx))
+          vt (dyn/vsimulate model [index] n (rng/fresh-key 14))
+          x-comb (cm/get-value (cm/get-submap (cm/get-submap (:choices vt) :sw) :x))]
+      (is (map? (:retval vt)) "retval keeps its map structure")
+      (is (= (h/realize-vec x-comb) (h/realize-vec (:v (:retval vt))))
+          "retval :v mask-selects identically to the :x choices"))))
+
+(def branch-left
+  (gen []
+    (trace :x (dist/gaussian (mx/scalar 0.0) (mx/scalar 1.0)))
+    :left))
+
+(def branch-right
+  (gen []
+    (trace :x (dist/gaussian (mx/scalar 0.0) (mx/scalar 1.0)))
+    :right))
+
+(deftest batched-switch-uncombinable-retvals-throw
+  (testing "heterogeneous non-numeric retvals throw honestly (pre-fix: silent nil)"
+    (let [index (mx/array [0 1] mx/int32)
+          model (gen [idx]
+                  (splice :sw (comb/switch-combinator branch-left branch-right) idx))]
+      (is (thrown? js/Error (dyn/vsimulate model [index] 2 (rng/fresh-key 15)))
+          "uncombinable retvals are a loud contract violation"))))
+
+;; ---------------------------------------------------------------------------
+;; Batched Mix: heterogeneous components + retvals (genmlx-v740 item 3)
+;; ---------------------------------------------------------------------------
+
+(def comp-het-a
+  (gen []
+    (trace :a (dist/gaussian (mx/scalar 0.0) (mx/scalar 1.0)))
+    nil))
+
+(def comp-het-b
+  (gen []
+    (trace :b (dist/gaussian (mx/scalar 3.0) (mx/scalar 1.0)))
+    nil))
+
+(deftest batched-mix-heterogeneous-components
+  (testing "component-only addresses survive; per-particle score is the
+            selected component's closed-form lp + categorical lp; constrained
+            component-idx contributes exactly the categorical lp to weight"
+    (let [n 4
+          idx (mx/array [0 1 0 1] mx/int32)
+          log-w (mx/array [(js/Math.log 0.3) (js/Math.log 0.7)])
+          model (gen []
+                  (splice :mix (comb/mix-combinator [comp-het-a comp-het-b] log-w)))
+          obs (cm/set-choice cm/EMPTY [:mix :component-idx] idx)
+          vt (dyn/vgenerate model [] obs n (rng/fresh-key 16))
+          mix-choices (cm/get-submap (:choices vt) :mix)
+          a-vals (h/realize-vec (cm/get-value (cm/get-submap mix-choices :a)))
+          b-vals (h/realize-vec (cm/get-value (cm/get-submap mix-choices :b)))
+          scores (h/realize-vec (:score vt))
+          weights (h/realize-vec (:weight vt))
+          lw0 (js/Math.log 0.3)
+          lw1 (js/Math.log 0.7)]
+      (is (= n (count a-vals)) ":a present and [n]-shaped")
+      (is (= n (count b-vals)) ":b present and [n]-shaped")
+      (doseq [i (range n)]
+        (let [sel0? (even? i)
+              comp-lp (if sel0?
+                        (h/gaussian-lp (nth a-vals i) 0.0 1.0)
+                        (h/gaussian-lp (nth b-vals i) 3.0 1.0))
+              idx-lp (if sel0? lw0 lw1)]
+          (is (h/close? (+ comp-lp idx-lp) (nth scores i) 1e-4)
+              (str "particle " i " score = component lp + categorical lp"))
+          (is (h/close? idx-lp (nth weights i) 1e-4)
+              (str "particle " i " weight = categorical lp of constrained idx")))))))
+
+(def comp-ret-1
+  (gen []
+    (trace :x (dist/gaussian (mx/scalar 0.0) (mx/scalar 1.0)))
+    1))
+
+(def comp-ret-2
+  (gen []
+    (trace :x (dist/gaussian (mx/scalar 0.0) (mx/scalar 1.0)))
+    2))
+
+(deftest batched-mix-number-retvals
+  (testing "numeric component retvals mask-select per particle (pre-fix: nil)"
+    (let [idx (mx/array [1 0 1] mx/int32)
+          log-w (mx/array [(js/Math.log 0.5) (js/Math.log 0.5)])
+          model (gen []
+                  (splice :mix (comb/mix-combinator [comp-ret-1 comp-ret-2] log-w)))
+          obs (cm/set-choice cm/EMPTY [:mix :component-idx] idx)
+          vt (dyn/vgenerate model [] obs 3 (rng/fresh-key 17))]
+      (is (= [2 1 2] (h/realize-vec (:retval vt)))
+          "retval is the selected component's constant per particle"))))
+
 (cljs.test/run-tests)


### PR DESCRIPTION
## Summary

Closes the last open item of audit bean `genmlx-v740` (epic `genmlx-hqo2`).

- **`where-select-choicemap` operates on the union of leaf addresses.** Pre-fix it iterated only the later branch's addresses: accumulator-only addresses were silently dropped and later-branch-only addresses hit `mx/where` against a missing value (hard error via the choicemap leaf check). Heterogeneous-address Switch branches / Mix components were unusable in batched mode. A branch-only address now keeps that branch's values for all particles — every branch runs once in batched mode, and score masking already excludes the particles that selected another branch.
- **Batched Switch/Mix retvals were nil unless the first branch returned an MLX array** — silently wrong for every model using the splice's return value. `combine-retvals` now mask-selects arrays and numbers per particle, recurses through maps/vectors with matching structure (mirrors `merge-state-by-mask` in vectorized.cljs), passes identical values through, and **throws an honest contract error** for genuinely uncombinable retvals. The per-particle fallback is no rescue for Switch — its scalar path needs a host-number index for `nth` — so a loud error beats a silent nil or an obscure downstream crash.

## Verification (independent-oracle rule)

- 7 new tests in `batched_switch_test.cljs`, **all failing pre-fix (stash-verified: 3 failures, 5 errors)**. Oracles are hand-computed closed-form gaussian/categorical log-densities (`h/gaussian-lp`), never the path under test:
  - heterogeneous Switch branches: union choices present, per-particle score = selected branch's closed-form lp
  - heterogeneous Mix components with constrained `:component-idx`: score = component lp + categorical lp, weight = categorical lp exactly
  - retval classes: numbers (mask-select), identical keywords (pass through), maps-of-arrays (recursive, pairs with combined choices), heterogeneous keywords (throw)
- Suites: batched_switch 11/37, combinators 21/67, combinator_compile 26/92, combinator_regen_weight 11/25, vectorized 17/62, fast-core 34/34 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)