### PR TITLE
fix(vi,learning): real REINFORCE, keyed ADVI, honest fit/wake-sleep labels, true soft-resampling (genmlx-7sqe)

### DIFF
--- a/src/genmlx/fit.cljs
+++ b/src/genmlx/fit.cljs
@@ -119,7 +119,11 @@
        :log-ml nil
        :samples traces})
 
-    ;; --- VI (skip — not safe in all processes due to vmap segfault) ---
+    ;; --- :vi — currently MAP point estimation via co/learn, NOT
+    ;; variational inference (true VI is avoided here: vmap is not safe in
+    ;; all processes). The optimized joint log-density is reported as
+    ;; :log-joint; it is NOT a marginal likelihood, so :log-ml stays nil
+    ;; (genmlx-7sqe). ---
     :vi
     (let [residual (or (:residual-addrs opts) [])
           addrs (vec residual)
@@ -130,8 +134,9 @@
       {:trace nil
        :posterior {:params (:params result)
                    :latent-index (:latent-index result)}
-       :log-ml (when (seq (:loss-history result))
-                 (- (last (:loss-history result))))
+       :log-ml nil
+       :log-joint (when (seq (:loss-history result))
+                    (- (last (:loss-history result))))
        :loss-history (:loss-history result)})
 
     ;; --- SMC (no temporal structure → fall back to IS) and handler-based
@@ -199,7 +204,9 @@
      {:method       keyword — which method was used
       :trace        Trace   — best/final trace (or nil for VI/HMC)
       :posterior    map     — per-latent summary or distribution params
-      :log-ml      number  — log marginal likelihood estimate (when available)
+      :log-ml      number  — log marginal likelihood estimate (when available;
+                              nil for :vi, which is currently MAP point
+                              estimation and reports :log-joint instead)
       :loss-history [nums] — optimization loss per iteration (if :learn)
       :params      MLX     — learned parameter values (if :learn)
       :diagnostics map     — method-specific diagnostics

--- a/src/genmlx/inference/amortized.cljs
+++ b/src/genmlx/inference/amortized.cljs
@@ -96,15 +96,16 @@
      :observations-fn  (fn [data] -> choicemap), default returns EMPTY
      :posterior-family  posterior family spec (default gaussian-posterior)
      :log-joint-fn     (fn [latent-values data] -> scalar log p(z, x))
-                       Pure MxArray function for computing the model log-joint.
-                       REQUIRED for gradient-based training via nn/value-and-grad.
+                       Optional pure MxArray function for the model log-joint.
 
-                       Why: MLX autograd (MxArray.valueAndGrad) traces MxArray
-                       operations to build a computation graph. The GFI handler
-                       system uses a volatile! cell for state threading — this is
-                       opaque to MLX's tracer, so gradients through p/generate
-                       are always zero. The log-joint-fn must express the same
-                       math as the model using only mx/* operations.
+                       Gradients DO flow through the p/generate fallback: the
+                       handler's volatile! threads host-side state only, while
+                       the weight remains one connected lazy MLX graph in the
+                       constraint values (verified analytically in
+                       vi_learning_honesty_test.cljs; cf. score_gradient_test,
+                       gradients.cljs). Provide log-joint-fn when you want to
+                       skip handler execution per training step or express
+                       the joint more cheaply than the full model.
 
                        Example for z ~ N(0,1), x|z ~ N(z, 0.5):
                          (fn [latent-values data]
@@ -113,8 +114,9 @@
                              (mx/add (gaussian-log-prob z 0 1)
                                      (gaussian-log-prob x z 0.5))))
 
-                       If omitted, falls back to p/generate (works for evaluation
-                       and scoring, but NOT for gradient computation).
+                       If omitted, p/generate computes the joint — gradients
+                       flow either way; the handler path just runs the model
+                       per training step.
 
    Returns (fn [forward-fn data] -> scalar loss) for use with nn/value-and-grad."
   [encoder model latent-addrs & {:keys [model-args-fn observations-fn posterior-family
@@ -130,9 +132,10 @@
             {:keys [values log-prob]} (sample-fn out (rng/fresh-key) d)
             log-joint
             (if log-joint-fn
-              ;; Pure MxArray path — gradients flow through
+              ;; Pure MxArray path — skips handler execution
               (log-joint-fn values data)
-              ;; Handler path — no gradient flow, for evaluation only
+              ;; Handler path — gradients flow through the generate weight
+              ;; (one connected lazy graph; the volatile! is host-side only)
               (let [obs (observations-fn data)
                     constraints (reduce (fn [cm [i addr]]
                                           (cm/set-choice cm [addr] (mx/index values i)))

--- a/src/genmlx/inference/differentiable_resample.cljs
+++ b/src/genmlx/inference/differentiable_resample.cljs
@@ -111,27 +111,43 @@
 ;; =========================================================================
 
 (defn soft-resample
-  "Simple soft resampling: convex combination of weighted and uniform resampling.
+  "Soft resampling (Karkus et al. 2018, Particle Filter Networks): sample
+   ancestor indices from the mixture q(i) = alpha·w_i + (1-alpha)/N, then
+   importance-reweight each survivor by w_{a_k}/q(a_k). The hard gather is
+   not differentiated; gradients flow through the RETURNED log-weights,
+   whose ratio depends on the pre-resample weights — that is the method's
+   point. alpha < 1 keeps q's support full so the ratio stays finite;
+   the importance correction makes the scheme unbiased for alpha in (0,1].
 
+   (The previous implementation broadcast one mixed row to all N output
+   particles — every output was the same convex combination and the
+   ensemble collapsed to its weighted mean; genmlx-7sqe.)
+
+   particles: [N,K] array
    log-weights: [N] unnormalized log-weights
-   alpha: mixing coefficient in [0,1]. alpha=1 → pure categorical, alpha=0 → uniform.
+   alpha: mixing coefficient in (0,1]
+   key: PRNG key for the categorical draw
 
-   Returns {:particles [N,K]}.
-
-   Differentiable. Lower variance than gumbel-softmax but always biased."
-  [particles log-weights alpha]
+   Returns {:particles [N,K] :log-weights [N] :indices [N]}."
+  [particles log-weights alpha key]
   (let [N (first (mx/shape log-weights))
-        ;; Categorical weights
-        cat-weights (mx/softmax log-weights)
-        ;; Uniform weights
-        uniform-w (mx/divide (mx/ones [N]) (mx/scalar N))
-        ;; Mix
-        mixed (mx/add (mx/multiply (mx/scalar alpha) cat-weights)
-                       (mx/multiply (mx/scalar (- 1.0 alpha)) uniform-w))
-        ;; [N] → [N,N] → @ [N,K] → [N,K]
-        weight-matrix (mx/broadcast-to (mx/reshape mixed [1 N]) [N N])
-        resampled (mx/matmul weight-matrix particles)]
-    {:particles resampled}))
+        ;; Normalized log categorical weights
+        log-cat (mx/subtract log-weights (mx/logsumexp log-weights))
+        ;; Mixture q(i) = alpha*w_i + (1-alpha)/N
+        mix-w (mx/add (mx/multiply (mx/scalar alpha) (mx/exp log-cat))
+                      (mx/scalar (/ (- 1.0 alpha) N)))
+        log-mix (mx/log mix-w)
+        ;; N independent draws from categorical(q)
+        indices (rng/categorical (rng/ensure-key key)
+                                 (mx/broadcast-to (mx/reshape log-mix [1 N])
+                                                  [N N]))
+        resampled (mx/take-idx particles indices)
+        ;; Importance correction: log w'_k = log w_{a_k} - log q(a_k)
+        new-log-w (mx/subtract (mx/take-idx log-cat indices)
+                               (mx/take-idx log-mix indices))]
+    {:particles resampled
+     :log-weights new-log-w
+     :indices indices}))
 
 ;; =========================================================================
 ;; 1D convenience: soft resample for per-particle state

--- a/src/genmlx/inference/vi.cljs
+++ b/src/genmlx/inference/vi.cljs
@@ -44,29 +44,33 @@
 (defn- advi-sample-fn
   "Build the posterior sampler returned by ADVI: draws n reparameterized
    samples from the mean-field Gaussian q(mu, sigma). For d==1 returns a
-   vector of CLJS doubles; otherwise the [n,d] sample array as nested CLJS."
-  [mu sigma d rk]
-  (fn [n]
-    (let [sample-key (or rk (rng/fresh-key))
-          eps (rng/normal sample-key [n d])
-          samples (mx/add mu (mx/multiply sigma eps))]
-      (mx/materialize! samples)
-      (if (= d 1)
-        (mapv #(mx/item (mx/index samples %)) (range n))
-        (mx/->clj samples)))))
+   vector of CLJS doubles; otherwise the [n,d] sample array as nested CLJS.
+   (sample-fn n) uses fresh entropy each call; (sample-fn n key) is
+   deterministic in the caller's key. Pre-fix, every call closed over one
+   fixed key, so repeated calls returned identical samples (genmlx-7sqe)."
+  [mu sigma d]
+  (fn sample
+    ([n] (sample n (rng/fresh-key)))
+    ([n key]
+     (let [eps (rng/normal (rng/ensure-key key) [n d])
+           samples (mx/add mu (mx/multiply sigma eps))]
+       (mx/materialize! samples)
+       (if (= d 1)
+         (mapv #(mx/item (mx/index samples %)) (range n))
+         (mx/->clj samples))))))
 
 (defn- run-advi
   "Shared ADVI driver for `vi` and `compiled-vi`. Builds the mean-field
    Gaussian guide, optimizes the negative ELBO via Adam, and returns
    {:mu :sigma :elbo-history :sample-fn}.
 
-   When `compile?` is true the gradient and ELBO functions are wrapped in
-   mx/compile-fn, and ELBO logging uses the compiled forward pass (fresh
-   key, like the original compiled-vi); otherwise ELBO logging re-estimates
-   with the iteration key (like the original vi). The tidy/materialize
-   boundaries are identical to the original per-function loops."
+   The iteration key drives BOTH the gradient's ELBO samples and the
+   logged ELBO estimate, so a run is reproducible from :key. Pre-fix the
+   gradient path hardwired a nil key (fresh entropy every call) and :key
+   only affected logging (genmlx-7sqe). mx/compile-fn is a documented
+   identity, so `vi` and `compiled-vi` share this exact computation."
   [{:keys [iterations learning-rate elbo-samples beta1 beta2 epsilon callback key
-           vectorized-log-density compile?]
+           vectorized-log-density]
     :or {iterations 1000 learning-rate 0.01 elbo-samples 10
          beta1 0.9 beta2 0.999 epsilon 1e-8}}
    log-density init-params]
@@ -78,15 +82,13 @@
         init-vp (mx/tidy-materialize
                  #(mx/concatenate [init-mu init-log-sigma]))
         vmapped-log-density (or vectorized-log-density (mx/vmap log-density))
-        neg-elbo-fn (fn [vp]
-                      (mx/negative (elbo-estimate vp log-density elbo-samples d vmapped-log-density nil)))
-        grad-neg-elbo (cond-> (mx/grad neg-elbo-fn) compile? mx/compile-fn)
-        neg-elbo-compiled (when compile? (mx/compile-fn neg-elbo-fn))
+        neg-elbo-fn (fn [vp iter-key]
+                      (mx/negative (elbo-estimate vp log-density elbo-samples d
+                                                  vmapped-log-density iter-key)))
         ;; ELBO value at the new params, recomputed at log points only.
-        elbo-at (if compile?
-                  (fn [vp' _iter-key] (mx/negative (neg-elbo-compiled vp')))
-                  (fn [vp' iter-key]
-                    (elbo-estimate vp' log-density elbo-samples d vmapped-log-density iter-key)))]
+        elbo-at (fn [vp' iter-key]
+                  (elbo-estimate vp' log-density elbo-samples d
+                                 vmapped-log-density iter-key))]
     (loop [i 0, vp init-vp
            opt-state (learn/adam-init init-vp)
            elbo-history (transient [])
@@ -99,10 +101,11 @@
           {:mu final-mu
            :sigma final-sigma
            :elbo-history (persistent! elbo-history)
-           :sample-fn (advi-sample-fn final-mu final-sigma d rk)})
+           :sample-fn (advi-sample-fn final-mu final-sigma d)})
         (let [[iter-key next-key] (rng/split-or-nils rk)
               ;; Tidy-materialize gradient — frees intermediate graph nodes
-              g (mx/tidy-materialize #(grad-neg-elbo vp))
+              g (mx/tidy-materialize
+                 #((mx/grad (fn [vp*] (neg-elbo-fn vp* iter-key))) vp))
               [vp' opt-state'] (learn/adam-step vp g opt-state
                                                 {:lr learning-rate :beta1 beta1 :beta2 beta2 :epsilon epsilon})
               ;; Tidy-materialize ELBO — prevents graph accumulation at log points
@@ -131,9 +134,9 @@
             :sample-fn (fn [n] -> samples)}
 
    compiled-vi shares this driver; mx/compile-fn is a documented identity,
-   so the two differ only in ELBO-logging key policy (see run-advi)."
+   so the two run the exact same computation (see run-advi)."
   [opts log-density init-params]
-  (run-advi (assoc opts :compile? false) log-density init-params))
+  (run-advi opts log-density init-params))
 
 ;; ---------------------------------------------------------------------------
 ;; Compiled VI (ADVI with mx/compile-fn)
@@ -151,9 +154,9 @@
 
 (defn compiled-vi
   "Variational Inference via ADVI, compiled-path variant.
-   Same as `vi` except ELBO logging uses a fresh-key compiled forward pass.
    mx/compile-fn is a documented identity (see mlx.cljs), so there is NO
-   kernel-caching speedup over `vi`. Same interface and return type.
+   kernel-caching speedup over `vi` — this differs from `vi` only in the
+   :device option. Same interface and return type.
 
    opts: {:iterations N :learning-rate lr :elbo-samples N
           :beta1 b1 :beta2 b2 :epsilon eps :callback fn :key prng-key
@@ -165,7 +168,7 @@
   [{:keys [device] :or {device :cpu} :as opts} log-density init-params]
   (with-device device
     (fn []
-      (run-advi (assoc opts :compile? true) log-density init-params))))
+      (run-advi opts log-density init-params))))
 
 ;; ---------------------------------------------------------------------------
 ;; VI from model (convenience)
@@ -265,24 +268,30 @@
       (mx/sum (mx/multiply (mx/stop-gradient w-norm) log-q)))))
 
 (defn reinforce-estimator
-  "REINFORCE (score function) gradient estimator.
-   For non-reparameterizable distributions.
-   objective-fn: (fn [samples] -> MLX scalar)
-   log-q-fn: (fn [z] -> MLX scalar)
-   Returns (fn [samples] -> MLX scalar) with REINFORCE gradient."
-  [objective-fn log-q-fn]
+  "REINFORCE (score function) gradient estimator for non-reparameterizable
+   samplers.
+   per-sample-objective-fn: (fn [samples] -> [K] MLX array) — the objective
+   value f(z_k) of EACH sample. A scalar (already-averaged) objective makes
+   f - baseline identically zero, so the score-function term vanishes for
+   exactly the case this estimator exists for (genmlx-7sqe).
+   log-q-fn: (fn [z] -> MLX scalar) — guide log-density.
+   Returns (fn [samples] -> MLX scalar): a surrogate loss whose gradient is
+   mean(∇f) + mean(stopgrad(f_k - b_k)·∇log q(z_k)) with leave-one-out
+   baselines b_k = (Σf - f_k)/(K-1) (unbiased; b = 0 when K = 1)."
+  [per-sample-objective-fn log-q-fn]
   (fn [samples]
     (let [vmapped-q (mx/vmap log-q-fn)
           log-q (vmapped-q samples)
-          obj-val (objective-fn samples)
-          ;; REINFORCE: (f(z) - baseline) * grad log q(z)
-          ;; We use mean as baseline for variance reduction
-          baseline (mx/stop-gradient (mx/mean obj-val))]
-      ;; Return surrogate loss whose gradient equals REINFORCE estimator
-      (mx/add obj-val
-              (mx/mean (mx/multiply (mx/stop-gradient
-                                     (mx/subtract obj-val baseline))
-                                    log-q))))))
+          f (per-sample-objective-fn samples)
+          k (first (mx/shape samples))
+          baseline (if (> k 1)
+                     (mx/divide (mx/subtract (mx/sum f) f)
+                                (mx/scalar (dec k)))
+                     (mx/scalar 0.0))
+          signal (mx/stop-gradient (mx/subtract f baseline))]
+      ;; Surrogate loss whose gradient equals the REINFORCE estimator
+      (mx/add (mx/mean f)
+              (mx/mean (mx/multiply signal log-q))))))
 
 (defn vimco-objective
   "VIMCO (Variational Inference with Multi-sample Objectives) estimator.
@@ -319,6 +328,20 @@
       ;; Surrogate loss: gradient equals VIMCO estimator
       (mx/add l-hat reinforce-term))))
 
+(defn- per-sample-objective
+  "[K]-shaped per-sample objective values f(z_k) for the REINFORCE
+   estimator, or nil when the objective does not decompose per sample.
+   :iwelbo couples samples through a logsumexp — its score-function
+   treatment IS the :vimco estimator; :vimco and :qwake already carry
+   their own score-function surrogates."
+  [objective log-p-fn log-q-fn]
+  (case objective
+    :elbo (fn [samples]
+            (mx/subtract ((mx/vmap log-p-fn) samples)
+                         ((mx/vmap log-q-fn) samples)))
+    :pwake (fn [samples] ((mx/vmap log-p-fn) samples))
+    nil))
+
 (defn- estimate-objective
   "Compute the (negated) programmable-VI objective for one batch of `samples`.
    Rebuilds the guide log-density at the current `params`, dispatches the
@@ -335,7 +358,19 @@
                  :qwake (qwake-objective log-p-fn log-q-curr)
                  (fn [s] (objective log-p-fn log-q-curr s)))
         obj-val (if (= estimator :reinforce)
-                  ((reinforce-estimator obj-fn log-q-curr) samples)
+                  (if-let [psf (per-sample-objective objective log-p-fn log-q-curr)]
+                    ((reinforce-estimator psf log-q-curr) samples)
+                    (case objective
+                      ;; These surrogates already differentiate through
+                      ;; log-q via their own score-function terms.
+                      (:vimco :qwake) (obj-fn samples)
+                      (throw (ex-info
+                              (str ":reinforce needs a per-sample objective; "
+                                   (pr-str objective) " couples samples. Use "
+                                   ":vimco for multi-sample score-function "
+                                   "gradients, or :reparam with a "
+                                   "reparameterized sampler.")
+                              {:objective objective :estimator estimator}))))
                   (obj-fn samples))]
     ;; We minimize negative objective
     (mx/negative obj-val)))

--- a/src/genmlx/learning.cljs
+++ b/src/genmlx/learning.cljs
@@ -192,10 +192,18 @@
              cm/EMPTY addresses))
 
 (defn wake-phase-loss
-  "Wake phase: minimize KL(q||p) by optimizing guide parameters.
-   Uses reparameterized samples from the guide.
+  "Point optimization of the guide's trace VALUES against the model joint.
+
+   HONESTY NOTE (genmlx-7sqe): this is NOT wake-sleep's wake phase. `params`
+   are the guide's latent trace values themselves (params->guide-cm constrains
+   each guide address to params[i]), not recognition-network parameters —
+   nothing amortized is trained. The loss is -(log p(x, z=params) -
+   log q(z=params)): joint MAP over latent values with the guide's density at
+   the same point subtracted. Real wake-sleep needs a parameterized guide
+   (param-store / nn encoder, cf. inference/amortized.cljs).
+
    model: target generative function
-   guide: guide/recognition generative function
+   guide: guide generative function (its trace addresses are the latents)
    args: model arguments
    observations: observed data
 
@@ -223,10 +231,18 @@
       {:loss loss :grad grad}))))
 
 (defn sleep-phase-loss
-  "Sleep phase: minimize KL(p||q) by optimizing guide to match model's prior.
-   Samples from the model prior, trains guide to reconstruct.
+  "Scores the guide on a model-prior sample, with guide addresses NOT in
+   the dream constrained to the point values `params`.
+
+   HONESTY NOTE (genmlx-7sqe): this is NOT wake-sleep's sleep phase — no
+   recognition-network parameters exist. The model's dreamed choices
+   override the param constraints (merge-cm: model-choices win), so when
+   guide and model share all addresses the loss does not depend on params
+   at all and its gradient is zero. Real sleep-phase training needs a
+   parameterized guide (cf. inference/amortized.cljs).
+
    model: target generative function
-   guide: guide/recognition generative function
+   guide: guide generative function
    args: model arguments
 
    Returns (fn [guide-params key] -> {:loss :grad})"
@@ -258,7 +274,16 @@
     (vec (distinct (map first addrs)))))
 
 (defn wake-sleep
-  "Wake-sleep learning for amortized inference.
+  "Alternating point optimization of guide trace values (wake-sleep in
+   name only).
+
+   HONESTY NOTE (genmlx-7sqe): despite the name, this does NOT train a
+   recognition network — `params` are point values for the guide's trace
+   addresses (see wake-phase-loss / sleep-phase-loss). The wake phase is
+   joint MAP over latent values with a guide-density correction; the sleep
+   phase's gradient is zero whenever guide and model share all addresses.
+   For genuinely amortized inference use inference/amortized.cljs, which
+   trains an nn encoder via reparameterized ELBO.
 
    opts:
      :iterations       - number of wake-sleep cycles (default 1000)

--- a/test/genmlx/differentiable_resample_test.cljs
+++ b/test/genmlx/differentiable_resample_test.cljs
@@ -166,30 +166,46 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest soft-resample-test
-  (testing "correct shape"
+  ;; soft-resample is true soft resampling (Karkus et al. 2018): hard
+  ;; gather of ancestors drawn from the alpha-mixture, with gradients
+  ;; flowing through the returned importance log-weights — NOT a convex
+  ;; combination of particles (the old implementation collapsed the
+  ;; ensemble to its weighted mean; genmlx-7sqe).
+  (testing "correct shapes"
     (let [N 4 K 2
-          particles (mx/array [[1.0 2.0] [3.0 4.0] [5.0 6.0] [7.0 8.0]])
+          parts (mx/array [[1.0 2.0] [3.0 4.0] [5.0 6.0] [7.0 8.0]])
           log-weights (mx/array [-1.0 -2.0 -0.5 -3.0])
-          {:keys [particles]} (dr/soft-resample particles log-weights 0.9)]
-      (mx/eval! particles)
-      (is (= [N K] (mx/shape particles)) "soft-resample shape")))
+          {:keys [particles log-weights indices]}
+          (dr/soft-resample parts log-weights 0.9 (rng/fresh-key 31))]
+      (mx/eval! particles log-weights indices)
+      (is (= [N K] (mx/shape particles)) "particles shape")
+      (is (= [N] (mx/shape log-weights)) "log-weights shape")
+      (is (= [N] (mx/shape indices)) "indices shape")))
 
-  (testing "differentiability"
-    (let [particles (mx/array [[1.0] [10.0]])
+  (testing "differentiability through the importance log-weights"
+    ;; Position-weighted sum so balanced ancestor draws cannot cancel the
+    ;; per-survivor gradient contributions.
+    (let [parts (mx/array [[1.0] [10.0]])
           f (fn [lw]
-              (mx/sum (:particles (dr/soft-resample particles lw 0.9))))
-          grad-f (mx/grad f)
-          lw (mx/array [0.0 0.0])
-          g (grad-f lw)]
+              (mx/sum (mx/multiply
+                       (mx/array [1.0 2.0])
+                       (:log-weights
+                        (dr/soft-resample parts lw 0.9 (rng/fresh-key 32))))))
+          g ((mx/grad f) (mx/array [0.0 1.0]))]
       (mx/eval! g)
-      (is (not (every? zero? (mx/->clj g))) "soft-resample gradient non-zero")))
+      (is (not (every? zero? (mx/->clj g)))
+          "gradient flows through the returned log-weights")))
 
-  (testing "alpha=0 -> uniform average"
-    (let [particles (mx/array [[0.0] [10.0]])
+  (testing "outputs are gathered input particles, not averages"
+    (let [parts (mx/array [[0.0] [10.0]])
           log-weights (mx/array [0.0 100.0])
-          {:keys [particles]} (dr/soft-resample particles log-weights 0.0)]
+          {:keys [particles]} (dr/soft-resample parts log-weights 0.5
+                                                (rng/fresh-key 33))]
       (mx/eval! particles)
-      (is (h/close? 5.0 (get-in (mx/->clj particles) [0 0]) 0.01) "alpha=0 -> uniform average"))))
+      (is (every? #(or (h/close? 0.0 (first %) 1e-6)
+                       (h/close? 10.0 (first %) 1e-6))
+                  (mx/->clj particles))
+          "every survivor is one of the input particles"))))
 
 ;; ---------------------------------------------------------------------------
 ;; 5. Integration: compiled-smc with :resample-method

--- a/test/genmlx/vi_learning_honesty_test.cljs
+++ b/test/genmlx/vi_learning_honesty_test.cljs
@@ -1,0 +1,233 @@
+;; @tier medium
+(ns genmlx.vi-learning-honesty-test
+  "Regression tests for the genmlx-7sqe audit cluster: REINFORCE score term
+   identically zero, fit :vi mislabeling MAP as VI, ADVI key dishonesty,
+   soft-resample ensemble collapse, and the false 'gradients through
+   p/generate are always zero' membrane claim. Oracles are closed-form
+   identities and hand-computed densities, never the path under test."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.test-helpers :as h]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.dist :as dist]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.fit :as fit]
+            [genmlx.inference.vi :as vi]
+            [genmlx.inference.differentiable-resample :as dr])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+;; ---------------------------------------------------------------------------
+;; (1) REINFORCE estimator: analytic gradient oracle
+;; ---------------------------------------------------------------------------
+;; For q(z; mu) = N(mu, 1), f(z) = z, samples held fixed (non-reparam):
+;; the REINFORCE gradient of E_q[f] at mu is E[(f(z) - b)·(z - mu)]
+;; ≈ Cov(f, z) = Var(z) = 1. Pre-fix the score term was identically zero
+;; through estimate-objective, so the gradient was 0.
+
+(deftest reinforce-gradient-matches-covariance-identity
+  (testing "REINFORCE gradient ≈ Var(z) = 1 for f(z) = z under N(mu,1)"
+    (let [k 4096
+          samples (rng/normal (rng/fresh-key 42) [k])
+          psf identity
+          surrogate (fn [params]
+                      ((vi/reinforce-estimator
+                        psf
+                        (fn [z] (dist/log-prob
+                                 (dist/gaussian (mx/index params 0) 1) z)))
+                       samples))
+          g ((mx/grad surrogate) (mx/array [0.0]))
+          g-val (h/realize (mx/index g 0))]
+      (is (h/close? 1.0 g-val 0.15)
+          (str "REINFORCE grad " (.toFixed g-val 4) " ≈ 1.0 (MC tol 0.15)")))))
+
+;; ---------------------------------------------------------------------------
+;; (1b) End-to-end: non-reparameterized sampler must still learn
+;; ---------------------------------------------------------------------------
+;; Target p(z) = N(3, 1); guide q(z; mu) = N(mu, 1) sampled WITH
+;; stop-gradient (no pathwise flow). :pwake maximizes E_q[log p], so only
+;; the score-function term can move mu. Pre-fix the gradient was exactly
+;; zero and mu stayed at its 0.0 init.
+
+(deftest reinforce-trains-nonreparam-guide
+  (testing "programmable-vi :pwake + :reinforce moves mu toward the target
+            with a stop-gradient sampler"
+    (let [log-p (fn [z-arr] (dist/log-prob (dist/gaussian 3 1)
+                                           (mx/index z-arr 0)))
+          log-q (fn [z-arr params]
+                  (dist/log-prob (dist/gaussian (mx/index params 0) 1)
+                                 (mx/index z-arr 0)))
+          sample-fn (fn [params key n]
+                      (mx/stop-gradient
+                       (mx/add (mx/index params 0)
+                               (rng/normal (rng/ensure-key key) [n 1]))))
+          {:keys [params]} (vi/programmable-vi
+                            {:iterations 400 :learning-rate 0.05
+                             :n-samples 32 :objective :pwake
+                             :estimator :reinforce
+                             :key (rng/fresh-key 7)}
+                            log-p log-q sample-fn (mx/array [0.0]))
+          mu-val (h/realize (mx/index params 0))]
+      (is (> mu-val 2.0)
+          (str "mu " (.toFixed mu-val 3) " moved toward 3 (pre-fix: stuck at 0)")))))
+
+;; ---------------------------------------------------------------------------
+;; (1c) :reinforce on sample-coupled objectives throws honestly
+;; ---------------------------------------------------------------------------
+
+(deftest reinforce-on-iwelbo-throws
+  (testing ":reinforce + :iwelbo is rejected (its score-function form IS :vimco)"
+    (let [log-p (fn [z-arr] (dist/log-prob (dist/gaussian 0 1)
+                                           (mx/index z-arr 0)))
+          log-q (fn [z-arr params]
+                  (dist/log-prob (dist/gaussian (mx/index params 0) 1)
+                                 (mx/index z-arr 0)))
+          sample-fn (fn [params key n]
+                      (mx/add (mx/index params 0)
+                              (rng/normal (rng/ensure-key key) [n 1])))]
+      (is (thrown? js/Error
+                   (vi/programmable-vi
+                    {:iterations 2 :objective :iwelbo :estimator :reinforce
+                     :key (rng/fresh-key 8)}
+                    log-p log-q sample-fn (mx/array [0.0])))
+          "iwelbo + reinforce throws instead of silently dropping the score term"))))
+
+;; ---------------------------------------------------------------------------
+;; (3) ADVI: :key makes the whole run reproducible; sample-fn is honest
+;; ---------------------------------------------------------------------------
+
+(defn- advi-target
+  "log N(v; 2, 1) over a [1]-shaped parameter vector."
+  [v]
+  (dist/log-prob (dist/gaussian 2 1) (mx/index v 0)))
+
+(deftest advi-key-reproducibility
+  (testing "two vi runs with the same :key produce identical mu and history"
+    (let [run #(vi/vi {:iterations 40 :learning-rate 0.05 :elbo-samples 5
+                       :key (rng/fresh-key 99)}
+                      advi-target (mx/array [0.0]))
+          r1 (run)
+          r2 (run)]
+      (is (= (h/realize (mx/index (:mu r1) 0))
+             (h/realize (mx/index (:mu r2) 0)))
+          "same :key → bit-identical mu (pre-fix: gradient sampling unkeyed)")
+      (is (= (:elbo-history r1) (:elbo-history r2))
+          "same :key → identical elbo history"))))
+
+(deftest advi-sample-fn-honest-entropy
+  (testing "sample-fn draws fresh entropy per unkeyed call; keyed calls
+            are deterministic"
+    (let [{:keys [sample-fn]} (vi/vi {:iterations 20 :learning-rate 0.05
+                                      :elbo-samples 5 :key (rng/fresh-key 5)}
+                                     advi-target (mx/array [0.0]))]
+      (is (not= (sample-fn 5) (sample-fn 5))
+          "unkeyed calls differ (pre-fix: identical — one fixed key)")
+      (is (= (sample-fn 5 (rng/fresh-key 123))
+             (sample-fn 5 (rng/fresh-key 123)))
+          "keyed calls are deterministic"))))
+
+;; ---------------------------------------------------------------------------
+;; (2) fit :vi reports :log-joint, not :log-ml
+;; ---------------------------------------------------------------------------
+;; Model z ~ N(0,1), x ~ N(z,1), x = 2 observed. MAP z* = 1;
+;; joint at z* = logN(1;0,1) + logN(2;1,1) = -log(2π) - 1 ≈ -2.8379.
+;; True log-ml = logN(2; 0, sqrt 2) ≈ -2.2655 — the joint-at-optimum is
+;; NOT a marginal likelihood, which is exactly why :log-ml must be nil.
+
+(deftest fit-vi-relabels-map-result
+  (testing "fit :vi returns :log-joint (joint at MAP) and a nil :log-ml"
+    (let [model (gen []
+                  (let [z (trace :z (dist/gaussian 0 1))]
+                    (trace :x (dist/gaussian z 1))
+                    z))
+          data (cm/choicemap :x (mx/scalar 2.0))
+          result (fit/fit model [] data {:method :vi
+                                         :residual-addrs [:z]
+                                         :iterations 800 :lr 0.05
+                                         :key (rng/fresh-key 3)})
+          expected-joint (+ (h/gaussian-lp 1.0 0.0 1.0)
+                            (h/gaussian-lp 2.0 1.0 1.0))]
+      (is (nil? (:log-ml result)) ":log-ml is nil — MAP yields no evidence")
+      (is (h/close? expected-joint (:log-joint result) 0.1)
+          (str ":log-joint " (:log-joint result)
+               " ≈ joint at MAP " (.toFixed expected-joint 4))))))
+
+;; ---------------------------------------------------------------------------
+;; (5) soft-resample: gathers survivors, importance-reweights, differentiable
+;; ---------------------------------------------------------------------------
+
+(deftest soft-resample-gathers-not-averages
+  (testing "output particles are members of the input set, not its mean"
+    ;; Pre-fix every output row was the SAME convex combination (the
+    ;; weighted ensemble mean) — total particle collapse.
+    (let [particles (mx/array [[0.0] [1.0] [2.0] [3.0] [4.0]])
+          log-w (mx/array [0.0 0.0 0.0 0.0 5.0])
+          {:keys [particles indices]} (dr/soft-resample particles log-w 0.5
+                                                        (rng/fresh-key 21))
+          vals (mapv first (h/realize-vec particles))
+          idxs (h/realize-vec indices)]
+      (is (every? #(some (fn [m] (h/close? m % 1e-6)) [0.0 1.0 2.0 3.0 4.0])
+                  vals)
+          "every output is one of the input particles")
+      (is (= vals (mapv double idxs))
+          "gathered values match the returned ancestor indices"))))
+
+(deftest soft-resample-importance-weights-exact
+  (testing "returned log-weights equal log w_a - log q(a) computed by hand"
+    (let [alpha 0.5
+          n 5
+          lw [0.5 -0.3 1.2 0.0 -1.0]
+          log-w (mx/array lw)
+          {:keys [indices log-weights]} (dr/soft-resample
+                                         (mx/array [[0.0] [1.0] [2.0] [3.0] [4.0]])
+                                         log-w alpha (rng/fresh-key 22))
+          idxs (h/realize-vec indices)
+          got (h/realize-vec log-weights)
+          ;; Hand-computed: normalized w, mixture q = α·w + (1-α)/N
+          z (reduce + (map js/Math.exp lw))
+          w (mapv #(/ (js/Math.exp %) z) lw)
+          q (mapv #(+ (* alpha %) (/ (- 1.0 alpha) n)) w)]
+      (doseq [[k a] (map-indexed vector idxs)]
+        (is (h/close? (- (js/Math.log (nth w a)) (js/Math.log (nth q a)))
+                      (nth got k) 1e-5)
+            (str "survivor " k " (ancestor " a ") weight = log w_a - log q_a"))))))
+
+(deftest soft-resample-gradient-flows
+  (testing "gradients flow through the returned log-weights"
+    (let [particles (mx/array [[0.0] [1.0] [2.0]])
+          loss (fn [lw]
+                 (mx/sum (:log-weights
+                          (dr/soft-resample particles lw 0.5
+                                            (rng/fresh-key 23)))))
+          g ((mx/grad loss) (mx/array [0.1 0.2 0.3]))
+          g-vals (h/realize-vec g)]
+      (is (some #(> (js/Math.abs %) 1e-6) g-vals)
+          "log-weight gradient is nonzero (the method's entire point)"))))
+
+;; ---------------------------------------------------------------------------
+;; (6) Gradients DO flow through p/generate
+;; ---------------------------------------------------------------------------
+;; amortized.cljs claimed the handler's volatile! makes gradients through
+;; p/generate 'always zero'. The volatile! threads host state only; the
+;; weight stays one connected lazy graph. Oracle: d/dz [log N(z;0,1) +
+;; log N(1; z, 0.5)] at z = 0.5 is -z + (1-z)/0.25 = 1.5.
+
+(deftest gradient-flows-through-p-generate
+  (testing "grad of the generate weight wrt a constraint input is analytic"
+    (let [model (dyn/auto-key
+                 (gen []
+                   (let [z (trace :z (dist/gaussian 0 1))]
+                     (trace :x (dist/gaussian z 0.5))
+                     z)))
+          loss (fn [v]
+                 (let [cmap (-> cm/EMPTY
+                                (cm/set-choice [:z] (mx/index v 0))
+                                (cm/set-choice [:x] (mx/scalar 1.0)))]
+                   (mx/negative (:weight (p/generate model [] cmap)))))
+          g ((mx/grad loss) (mx/array [0.5]))
+          g-val (h/realize (mx/index g 0))]
+      (is (h/close? -1.5 g-val 1e-4)
+          (str "grad " (.toFixed g-val 5) " = -1.5 analytic — NOT zero")))))
+
+(cljs.test/run-tests)


### PR DESCRIPTION
## Summary

Closes audit bean `genmlx-7sqe` (epic `genmlx-hqo2`) — all six items, verify-first.

1. **REINFORCE term identically zero** — `reinforce-estimator` took an already-averaged scalar objective, so `stop_grad(obj − mean(obj)) ≡ 0`: the score-function term vanished for exactly the non-reparameterizable case it exists for. The covering test used a reparameterized sampler, so the pathwise gradient masked it. Now: per-sample objective values + unbiased leave-one-out baselines; `estimate-objective` derives per-sample forms for `:elbo`/`:pwake`, passes `:vimco`/`:qwake` through (their surrogates already carry score-function terms), throws for `:iwelbo`+`:reinforce` (its score-function form IS `:vimco`).
2. **fit `:vi` mislabeled MAP as VI** — `co/learn` is point optimization; the joint at the optimum is now `:log-joint` with `:log-ml` nil (a MAP joint is not evidence), docs updated.
3. **ADVI keys** — the gradient's ELBO sampling hardwired a nil key (`:key` only made logging reproducible); the iteration key now drives both, so same `:key` ⇒ bit-identical runs. `advi-sample-fn` reused one fixed key (every call returned identical samples); now fresh entropy per call + a keyed deterministic arity. Dead `:compile?` plumbing removed.
4. **wake-sleep is not wake-sleep** — honest relabel: the phases optimize point VALUES of guide trace addresses (no recognition parameters exist; the sleep gradient is zero when guide and model share all addresses). Docstrings state this and point to `inference/amortized.cljs` for real amortized training. Follow-up feature for param-store wake-sleep tracked separately.
5. **soft-resample ensemble collapse** — one mixed row was broadcast to all N output rows: every output particle was the same convex combination. Replaced with true soft resampling (Karkus et al. 2018): ancestors from the α-mixture, hard gather, importance reweighting `w_a/q(a)`; gradients flow through the returned log-weights. The existing test asserted the broken semantics and was updated to the literature contract.
6. **amortized.cljs false membrane claim** — 'gradients through p/generate are always zero' is contradicted by direct verification: the handler's volatile! threads host state only; the weight stays one connected lazy graph.

## Verification (independent-oracle rule)

New `vi_learning_honesty_test.cljs` (10 tests / 18 assertions), oracles all closed-form:
- REINFORCE gradient ≈ Var(z) = 1 (covariance identity, K=4096, MC tol)
- stop-gradient sampler + `:pwake`+`:reinforce` moves mu 0→3 (pre-fix: gradient exactly 0, mu stuck)
- ADVI bit-identical under same `:key`; sample-fn entropy honest
- fit `:vi` `:log-joint` ≈ hand-computed joint at MAP (−2.8379), `:log-ml` nil
- soft-resample survivors are gathered inputs; importance weights match hand-computed `log w_a − log q_a` per survivor; gradient flows
- grad through `p/generate` = analytic −1.5

**Pre-fix the suite aborts** (the old estimator returns a non-scalar surrogate that kills `mx/grad` in C++; stash-verified).

Suites: audit_gaps 26/55 (incl. existing REINFORCE/iwelbo/pwake/qwake convergence under the new estimator), inference_vi, vimco, fused_vi, vi_property, amortized, fit 12/59, gradient_learning_property, differentiable_resample 7/40 — all green. fast-core 34/34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)