### PR TITLE
fix(serialize): combinator traces save, full dtype table, batched scores (genmlx-000i)

### DIFF
--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -56,6 +56,10 @@
 (def int32   (.-Int32   (.-DType c)))
 (def int64   (.-Int32   (.-DType c)))  ;; SILENT ALIAS: MLX has no int64
 (def bool-dt (.-Int32   (.-DType c)))  ;; SILENT ALIAS: MLX has no bool
+(def float16  (.-Float16  (.-DType c)))
+(def bfloat16 (.-BFloat16 (.-DType c)))
+(def uint32   (.-Uint32   (.-DType c)))  ;; categorical/token indices
+(def uint8    (.-Uint8    (.-DType c)))
 
 ;; =========================================================================
 ;; Internal helpers

--- a/src/genmlx/serialize.cljs
+++ b/src/genmlx/serialize.cljs
@@ -18,17 +18,27 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private dtype-code->str
-  "Forward map: numeric NAPI DType enum → string name."
+  "Forward map: numeric NAPI DType enum → string name.
+   Covers the full enum — uint32 is the categorical/token index dtype,
+   so every LLM token trace hits it (genmlx-000i)."
   {0 "float32"
-   1 "int32"})
+   1 "int32"
+   2 "float16"
+   3 "bfloat16"
+   4 "uint32"
+   5 "uint8"})
 
 (def ^:private str->dtype-map
   "Reverse map: string name → MLX dtype constant."
-  {"float32" mx/float32
-   "float64" mx/float64
-   "int32"   mx/int32
-   "int64"   mx/int32
-   "bool"    mx/bool-dt})
+  {"float32"  mx/float32
+   "float64"  mx/float64
+   "int32"    mx/int32
+   "int64"    mx/int32
+   "bool"     mx/bool-dt
+   "float16"  mx/float16
+   "bfloat16" mx/bfloat16
+   "uint32"   mx/uint32
+   "uint8"    mx/uint8})
 
 (defn- dtype->str [dtype]
   (or (get dtype-code->str dtype)
@@ -61,6 +71,37 @@
       (mx/array (:value data) dt))))
 
 ;; ---------------------------------------------------------------------------
+;; Address codec
+;; ---------------------------------------------------------------------------
+;; JSON object keys must be strings, but choicemap addresses are keywords,
+;; integers (Map/Unfold/Scan element indices), or strings. A type prefix
+;; keeps them distinct through the round trip — (name 0) used to throw, so
+;; no combinator trace could be saved, and the load side keywordized
+;; everything anyway (genmlx-000i). Unprefixed keys (legacy v1 files)
+;; decode as keywords, the only address type the old codec produced.
+
+(defn- addr->str
+  "Encode a choicemap address as a prefixed string."
+  [addr]
+  (cond
+    (keyword? addr) (str "k:" (subs (str addr) 1))  ;; keeps namespace
+    (integer? addr) (str "i:" addr)
+    (string? addr)  (str "s:" addr)
+    :else (throw (ex-info (str "Unserializable address type: " (pr-str addr))
+                          {:addr addr}))))
+
+(defn- str->addr
+  "Decode a prefixed address string (or the keyword js->clj made of it).
+   Unprefixed strings decode as keywords for legacy-file compatibility."
+  [s]
+  (let [s (if (keyword? s) (subs (str s) 1) s)]
+    (cond
+      (= "k:" (subs s 0 (min 2 (count s)))) (keyword (subs s 2))
+      (= "i:" (subs s 0 (min 2 (count s)))) (js/parseInt (subs s 2) 10)
+      (= "s:" (subs s 0 (min 2 (count s)))) (subs s 2)
+      :else (keyword s))))
+
+;; ---------------------------------------------------------------------------
 ;; ChoiceMap <-> serializable data
 ;; ---------------------------------------------------------------------------
 
@@ -77,7 +118,7 @@
         {:type "clj" :value (pr-str v)}))
 
     (instance? cm/Node cm-node)
-    (-> (update-keys (:m cm-node) name)
+    (-> (update-keys (:m cm-node) addr->str)
         (update-vals choicemap->data))
 
     :else {}))
@@ -100,9 +141,9 @@
     (and (map? data) (= "clj" (:type data)))
     (cm/->Value (reader/read-string (:value data)))
 
-    ;; Node: map of string -> sub
+    ;; Node: map of encoded-address -> sub
     (map? data)
-    (cm/->Node (-> (update-keys data keyword)
+    (cm/->Node (-> (update-keys data str->addr)
                    (update-vals data->choicemap)))
 
     :else cm/EMPTY))
@@ -112,13 +153,14 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- serialize-value
-  "Serialize a value that may contain MLX arrays."
+  "Serialize a value that may contain MLX arrays. Map keys use the same
+   prefixed address codec as choicemaps, so integer/string keys survive."
   [v]
   (cond
     (mx/array? v)   (mlx-value->data v)
     (sequential? v) (mapv serialize-value v)
-    (map? v)        (-> (update-keys v name) (update-vals serialize-value))
-    (keyword? v)    {:type "keyword" :value (name v)}
+    (map? v)        (-> (update-keys v addr->str) (update-vals serialize-value))
+    (keyword? v)    {:type "keyword" :value (subs (str v) 1)}
     :else           v))
 
 (defn- deserialize-value
@@ -132,7 +174,7 @@
     (keyword (:value v))
 
     (sequential? v) (mapv deserialize-value v)
-    (map? v)        (-> (update-keys v keyword) (update-vals deserialize-value))
+    (map? v)        (-> (update-keys v str->addr) (update-vals deserialize-value))
     :else           v))
 
 ;; ---------------------------------------------------------------------------
@@ -182,11 +224,17 @@
    Options:
      :gen-fn-id - optional string identifier for the gen-fn"
   [trace & {:keys [gen-fn-id]}]
-  (let [data {:version 1
+  (let [score (:score trace)
+        data {:version 1
               :format "genmlx-trace-v1"
               :choices (choicemap->data (:choices trace))
               :args (mapv serialize-value (:args trace))
-              :score (mx/realize (:score trace))}
+              ;; 0-d scores stay plain numbers (legacy format); [N]-shaped
+              ;; batched scores serialize as array data — mx/realize on
+              ;; them used to throw (item needs size 1; genmlx-000i).
+              :score (if (and (mx/array? score) (pos? (count (mx/shape score))))
+                       (mlx-value->data score)
+                       (mx/realize score))}
         ;; retval is best-effort — closures, protocol instances won't survive
         data (try
                (assoc data :retval (serialize-value (:retval trace)))

--- a/test/genmlx/serialize_test.cljs
+++ b/test/genmlx/serialize_test.cljs
@@ -9,6 +9,7 @@
             [genmlx.protocols :as p]
             [genmlx.trace :as tr]
             [genmlx.choicemap :as cm]
+            [genmlx.combinators :as comb]
             [genmlx.serialize :as ser])
   (:require-macros [genmlx.gen :refer [gen]]))
 
@@ -159,5 +160,89 @@
         (is (h/close? x-orig x-recon 1e-6) "reconstruct from file x")
         (is (h/close? y-orig y-recon 1e-6) "reconstruct from file y"))
       (.unlinkSync fs path))))
+
+;; ---------------------------------------------------------------------------
+;; Combinator traces, full dtype table, batched scores (genmlx-000i)
+;; ---------------------------------------------------------------------------
+
+(deftest map-combinator-round-trip
+  (testing "Map traces save and load with integer element addresses intact"
+    ;; Pre-fix: (name 0) threw on save, so no Map/Unfold/Scan trace could
+    ;; be serialized at all; the load side keywordized everything to :0.
+    (let [kernel (dyn/auto-key (gen [x] (trace :y (dist/gaussian x 1))))
+          mapped (comb/map-combinator kernel)
+          tr1 (p/simulate mapped [[1.0 2.0 3.0]])
+          json (ser/save-choices tr1)
+          choices (ser/load-choices json)]
+      (doseq [i (range 3)]
+        (let [orig (mx/item (cm/get-choice (:choices tr1) [i :y]))
+              loaded (mx/item (cm/get-choice choices [i :y]))]
+          (is (h/close? orig loaded 1e-6)
+              (str "element " i " value survives under INTEGER address"))))
+      ;; Fully-constrained generate reproduces the original score exactly
+      (let [{tr2 :trace} (p/generate mapped [[1.0 2.0 3.0]] choices)]
+        (is (h/close? (h/realize (:score tr1)) (h/realize (:score tr2)) 1e-5)
+            "reconstructed Map trace scores identically")))))
+
+(deftest unfold-combinator-round-trip
+  (testing "Unfold traces round-trip through save/load + generate"
+    (let [step (dyn/auto-key (gen [t state]
+                 (trace :x (dist/gaussian state 0.5))))
+          unfold (comb/unfold-combinator step)
+          tr1 (p/simulate unfold [4 (mx/scalar 0.0)])
+          json (ser/save-choices tr1)
+          choices (ser/load-choices json)
+          {tr2 :trace} (p/generate unfold [4 (mx/scalar 0.0)] choices)]
+      (is (h/close? (h/realize (:score tr1)) (h/realize (:score tr2)) 1e-5)
+          "reconstructed Unfold trace scores identically"))))
+
+(deftest namespaced-keyword-address-round-trip
+  (testing "namespaced keyword addresses keep their namespace"
+    ;; Pre-fix the codec used (name k), which drops the namespace.
+    (let [choices (cm/set-choice cm/EMPTY [:obs/y] (mx/scalar 2.5))
+          loaded (ser/load-choices (ser/save-choices {:choices choices}))]
+      (is (h/close? 2.5 (mx/item (cm/get-choice loaded [:obs/y])) 1e-6)
+          ":obs/y survives with namespace"))))
+
+(deftest uint32-categorical-round-trip
+  (testing "uint32 leaves (categorical/token samples) serialize"
+    ;; Pre-fix the dtype table only knew float32/int32 — every trace
+    ;; containing a categorical sample failed with Unknown dtype code: 4.
+    (let [model (dyn/auto-key
+                 (gen [] (trace :k (dist/categorical
+                                    (mx/array [0.2 0.3 0.5])))))
+          tr1 (p/simulate model [])
+          loaded (ser/load-choices (ser/save-choices tr1))
+          orig (mx/item (cm/get-choice (:choices tr1) [:k]))
+          got (mx/item (cm/get-choice loaded [:k]))]
+      (is (= orig got) "categorical index value survives")
+      (is (= (mx/dtype (cm/get-value (cm/get-submap loaded :k)))
+             (mx/dtype (cm/get-value (cm/get-submap (:choices tr1) :k))))
+          "uint32 dtype survives"))))
+
+(deftest batched-score-save-trace
+  (testing "save-trace handles [N]-shaped batched scores"
+    ;; Pre-fix mx/realize on an [N] score threw (item needs size 1).
+    (let [trace (tr/make-trace {:gen-fn nil :args []
+                                :choices (cm/choicemap :x (mx/zeros [5]))
+                                :retval nil
+                                :score (mx/array [1.0 2.0 3.0 4.0 5.0])})
+          json (ser/save-trace trace)
+          data (js->clj (js/JSON.parse json) :keywordize-keys true)]
+      (is (string? json) "save-trace returns JSON, does not throw")
+      (is (= "array" (get-in data [:score :type])) "score saved as array data")
+      (is (= [1 2 3 4 5] (mapv int (get-in data [:score :value])))
+          "score values intact"))))
+
+(deftest legacy-unprefixed-keys-load-as-keywords
+  (testing "v1 files written by the old codec still load"
+    (let [json (js/JSON.stringify
+                (clj->js {:version 1
+                          :format "genmlx-choices-v1"
+                          :choices {"x" {:type "scalar" :value 1.5
+                                         :dtype "float32"}}}))
+          loaded (ser/load-choices json)]
+      (is (h/close? 1.5 (mx/item (cm/get-choice loaded [:x])) 1e-6)
+          "unprefixed legacy key decodes as keyword :x"))))
 
 (cljs.test/run-tests)


### PR DESCRIPTION
## Summary

Closes audit bean `genmlx-000i` (epic `genmlx-hqo2`). Also unblocks the Phase 4 persistence face (genmlx.memory v0 requires these fixes per the roadmap).

- **Combinator traces were unsaveable.** The address codec called `(name addr)`, and Map/Unfold/Scan use INTEGER element addresses — `(name 0)` throws in CLJS, so no combinator trace could be serialized; the load side keywordized every key, so integers could only come back as `:0`. Addresses now use a prefixed codec (`k:`/`i:`/`s:`); keyword namespaces are preserved (`(name :obs/y)` silently dropped them). Unprefixed keys decode as keywords, so **legacy v1 files still load**. `serialize-value`/`deserialize-value` apply the same codec to map keys in args/retval.
- **dtype table covered only float32/int32.** uint32 (NAPI code 4) is the categorical-index dtype — every trace containing a categorical sample, **including all LLM token traces**, failed with `Unknown dtype code: 4`. The table now covers the full NAPI enum (float32/int32/float16/bfloat16/uint32/uint8); `mlx.cljs` gains the matching dtype constants.
- **`save-trace` realized `:score` unconditionally** — `mx/realize` on an `[N]`-shaped batched score throws. 0-d scores stay plain numbers (legacy format); batched scores serialize as array data.

## Verification

6 new tests in `serialize_test.cljs` — **5 error pre-fix (stash-verified)**:
- Map round trip: integer element addresses survive, fully-constrained `generate` reproduces the original score identically
- Unfold round trip (same score oracle)
- namespaced keyword address survives with namespace
- uint32 categorical leaf: value AND dtype survive
- `[N]`-score `save-trace` returns array data instead of throwing
- legacy unprefixed-key file loads as keyword addresses (passes pre- and post-fix by design)

Suites: serialize 16/29, serialize_property 5/5, fast-core 34/34 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)