### PR TITLE
fix(prng): consume-or-split discipline across inference paths (genmlx-njaq)

### DIFF
--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -2009,9 +2009,14 @@
               idx-constraint (when (and sub-constraints
                                         (not= sub-constraints cm/EMPTY))
                                (cm/get-submap sub-constraints :component-idx))
-              ;; Sample or constrain [N]-shaped component indices
+              ;; Sample or constrain [N]-shaped component indices.
+              ;; Three-way split: k-idx samples the indices, k-comps drives
+              ;; the component runs, k-next continues the parent. The parent
+              ;; used to continue with the SAME key that sampled the indices,
+              ;; correlating every downstream site with index sampling
+              ;; (genmlx-njaq; Switch/Unfold already keep these disjoint).
               cat-dist (dc/->Distribution :categorical {:logits log-w})
-              [k1 k2] (rng/split (:key state))
+              [k-next k-comps k-idx] (rng/split-n (:key state) 3)
               [idx-vals idx-score idx-weight]
               (if (and idx-constraint (cm/has-value? idx-constraint))
                 ;; Constrained: fixed value, weight = log-prob
@@ -2019,7 +2024,7 @@
                       lp (dc/dist-log-prob cat-dist v)]
                   [v lp lp])
                 ;; Unconstrained: sample [N] indices
-                (let [sampled (dc/dist-sample-n cat-dist k2 batch-size)
+                (let [sampled (dc/dist-sample-n cat-dist k-idx batch-size)
                       lp (dc/dist-log-prob cat-dist sampled)]
                   [sampled lp (mx/zeros [batch-size])]))
               ;; Inner constraints = everything except :component-idx
@@ -2032,7 +2037,7 @@
               batch-zero (mx/zeros [batch-size])
               ;; Run each component once with batched handler
               comp-results
-              (loop [i 0 results [] key k1]
+              (loop [i 0 results [] key k-comps]
                 (if (>= i (count comps))
                   results
                   (let [[ck nk] (rng/split key)
@@ -2068,7 +2073,7 @@
                           :score final-score
                           :weight final-weight}
               state' (-> state
-                         (assoc :key k2)
+                         (assoc :key k-next)
                          (h/merge-sub-result addr sub-result))]
           [state' combined-retval])))))
 

--- a/src/genmlx/dist.cljs
+++ b/src/genmlx/dist.cljs
@@ -262,15 +262,17 @@
         c (/ 1.0 (js/Math.sqrt (* 9.0 d)))
         [key-sample key-boost] (rng/split key)
         raw (loop [k key-sample]
-              (let [[k1 k2] (rng/split k)
+              ;; Three-way split per attempt: k2 is consumed by the uniform
+              ;; draw, so splitting it for the next attempt correlated
+              ;; successive rejection rounds (genmlx-njaq).
+              (let [[k1 k2 k-next] (rng/split-n k 3)
                     x (mx/realize (rng/normal k1 []))
                     v (js/Math.pow (+ 1.0 (* c x)) 3)
                     u (mx/realize (rng/uniform k2 []))]
                 (if (and (> v 0)
                          (< (js/Math.log u) (+ (* 0.5 x x) (* d (+ 1 (- v) (js/Math.log v))))))
                   (/ (* d v) r)
-                  (let [[k' _] (rng/split k2)]
-                    (recur k')))))]
+                  (recur k-next))))]
     (if alpha<1?
       (* raw (js/Math.pow (mx/realize (rng/uniform key-boost [])) (/ 1.0 a)))
       raw)))

--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -1249,11 +1249,14 @@
                      (loop [t init i 0 acc [] k (rng/fresh-key 13)]
                        (if (>= i n-steps)
                          acc
-                         (let [[k1 k2] (rng/split k)
+                         (let [;; select and accept need disjoint keys —
+                               ;; reusing k1 for both correlated kernel
+                               ;; selection with acceptance (genmlx-njaq)
+                               [k1 k-acc k2] (rng/split-n k 3)
                                sel (select-fn i k1)
                                {:keys [trace weight]} (p/regenerate kern-model t sel)
                                w (ev weight)
-                               accept? (u/accept-mh? w k1)
+                               accept? (u/accept-mh? w k-acc)
                                next-t (if accept? trace t)
                                x-val (choice-num (:choices next-t) :x)
                                y-val (choice-num (:choices next-t) :y)]

--- a/src/genmlx/inference/importance.cljs
+++ b/src/genmlx/inference/importance.cljs
@@ -111,10 +111,14 @@
    Returns {:vtrace VectorizedTrace (resampled, uniform weights)
             :log-ml-estimate MLX-scalar}"
   [{:keys [particles key] :or {particles 1000}} model args observations]
-  (let [{:keys [vtrace log-ml-estimate]}
-        (vectorized-importance-sampling {:samples particles :key key}
+  (let [;; Split once: reusing the caller's key for both vgenerate and the
+        ;; resample uniforms correlates resampling with particle generation
+        ;; (genmlx-njaq).
+        [k-gen k-res] (rng/split (rng/ensure-key key))
+        {:keys [vtrace log-ml-estimate]}
+        (vectorized-importance-sampling {:samples particles :key k-gen}
                                         model args observations)
-        resampled (vec/resample-vtrace vtrace (or key (rng/fresh-key)))]
+        resampled (vec/resample-vtrace vtrace k-res)]
     {:vtrace resampled
      :log-ml-estimate log-ml-estimate}))
 
@@ -130,12 +134,16 @@
   [{:keys [samples particles key] :or {samples 100 particles 1000}}
    model args observations]
   (let [model (dyn/auto-key model)
+        ;; Split once: split-n of the SAME key for per-particle generate and
+        ;; again for the resample uniforms makes the first `samples` resample
+        ;; keys identical to the generate keys (split prefix semantics) —
+        ;; resampling correlated with particle generation (genmlx-njaq).
+        [k-gen k-res] (rng/split (rng/ensure-key key))
         {:keys [traces log-weights]}
-        (importance-sampling {:samples particles :key key} model args observations)
+        (importance-sampling {:samples particles :key k-gen} model args observations)
         ;; Normalize weights via log-softmax
         {:keys [probs]} (u/normalize-log-weights log-weights)
-        key (or key (rng/fresh-key))
-        keys (rng/split-n key samples)]
+        keys (rng/split-n k-res samples)]
     ;; Resample
     (mapv (fn [ki]
             (let [u (mx/realize (rng/uniform ki []))

--- a/src/genmlx/inference/mcmc.cljs
+++ b/src/genmlx/inference/mcmc.cljs
@@ -115,13 +115,16 @@
          backward-gf (when backward-gf (dyn/auto-key backward-gf))
          current-trace (ensure-joint-trace model current-trace)
          [k1 k2 k3] (rng/split-n (rng/ensure-key key) 3)
-         ;; 1. Run propose on the proposal GF → forward choices + forward score
+         ;; 1. Run propose on the proposal GF → forward choices + forward score.
+         ;; k1/k2 thread into propose/update — they were split and then never
+         ;; used, leaving both operations on fresh entropy so a seeded chain
+         ;; was not reproducible (genmlx-njaq).
          proposal-args [(:choices current-trace)]
-         forward-result (p/propose proposal-gf proposal-args)
+         forward-result (p/propose (dyn/with-key proposal-gf k1) proposal-args)
          forward-choices (:choices forward-result)
          forward-score (:weight forward-result)
          ;; 2. Apply proposed choices to model via update → new trace
-         update-result (p/update model current-trace forward-choices)
+         update-result (p/update (dyn/with-key model k2) current-trace forward-choices)
          new-trace (:trace update-result)
          ;; 3. Compute backward score
          backward-score (if backward-gf
@@ -1119,9 +1122,11 @@
   (let [model (dyn/auto-key model)
         proposal-gf (dyn/auto-key proposal-gf)
         current-trace (ensure-joint-trace model current-trace)
-        [k1 k2] (rng/split (rng/ensure-key key))
+        ;; k1 → propose, k2 → update, k3 → accept. k1 was split and never
+        ;; used (propose ran on fresh entropy; genmlx-njaq).
+        [k1 k2 k3] (rng/split-n (rng/ensure-key key) 3)
         ;; 1. Propose auxiliary choices
-        fwd-result (p/propose proposal-gf [(:choices current-trace)])
+        fwd-result (p/propose (dyn/with-key proposal-gf k1) [(:choices current-trace)])
         aux-choices (:choices fwd-result)
         fwd-score (:weight fwd-result)
         ;; 2. Apply involution (may return optional log|det J| as third element)
@@ -1133,7 +1138,7 @@
                           (if (mx/array? j) j (mx/scalar j)))
                         (mx/scalar 0.0))
         ;; 3. Update model with new choices
-        update-result (p/update model current-trace new-trace-cm)
+        update-result (p/update (dyn/with-key model k2) current-trace new-trace-cm)
         new-trace (:trace update-result)
         ;; 4. Score backward auxiliary choices under proposal
         bwd-result (p/assess proposal-gf [(:choices new-trace)] new-aux-cm)
@@ -1144,7 +1149,7 @@
         log-alpha (mx/realize (mx/add (mx/add update-weight
                                               (mx/subtract bwd-score fwd-score))
                                       log-abs-det-J))]
-    (if (u/accept-mh? log-alpha k2)
+    (if (u/accept-mh? log-alpha k3)
       new-trace
       current-trace)))
 
@@ -2534,16 +2539,19 @@
                                              (/ total-alpha total-n-alpha)
                                              0.0)}
                              (let [[dk1 dk-next] (rng/split dk)
-                                   [tk1 tk-next] (rng/split tk)
+                                   ;; ak must be disjoint from tk1: build-tree
+                                   ;; splits tk1 internally, so re-splitting it
+                                   ;; here made the accept uniform reuse the
+                                   ;; tree's first key (genmlx-njaq).
+                                   [tk1 ak tk-next] (rng/split-n tk 3)
                                    v (if (< (mx/realize (rng/uniform dk1 [])) 0.5) -1 1)
                                    [qs ps] (if (pos? v)
                                              [q-plus p-plus]
                                              [q-minus p-minus])
                                    tree (build-tree local-ctx qs ps log-u v j current-H tk1)
                                    accept? (and (:s' tree)
-                                                (let [[ak _] (rng/split tk1)]
-                                                  (< (mx/realize (rng/uniform ak []))
-                                                     (/ (:n' tree) (max 1 depth-n)))))
+                                                (< (mx/realize (rng/uniform ak []))
+                                                   (/ (:n' tree) (max 1 depth-n))))
                                    q'' (if accept? (:q' tree) q')
                                    qm' (if (neg? v) (:q-minus tree) q-minus)
                                    pm' (if (neg? v) (:p-minus tree) p-minus)
@@ -2595,16 +2603,16 @@
                           (if (or (not continue?) (>= j max-depth))
                             q'
                             (let [[dk1 dk-next] (rng/split dk)
-                                  [tk1 tk-next] (rng/split tk)
+                                  ;; ak disjoint from tk1 (see warmup loop note)
+                                  [tk1 ak tk-next] (rng/split-n tk 3)
                                   v (if (< (mx/realize (rng/uniform dk1 [])) 0.5) -1 1)
                                   [qs ps] (if (pos? v)
                                             [q-plus p-plus]
                                             [q-minus p-minus])
                                   tree (build-tree ctx qs ps log-u v j current-H tk1)
                                   accept? (and (:s' tree)
-                                               (let [[ak _] (rng/split tk1)]
-                                                 (< (mx/realize (rng/uniform ak []))
-                                                    (/ (:n' tree) (max 1 depth-n)))))
+                                               (< (mx/realize (rng/uniform ak []))
+                                                  (/ (:n' tree) (max 1 depth-n))))
                                   q'' (if accept? (:q' tree) q')
                                   qm' (if (neg? v) (:q-minus tree) q-minus)
                                   pm' (if (neg? v) (:p-minus tree) p-minus)
@@ -2642,7 +2650,9 @@
         addrs (if (vector? selection) selection [selection])
         f (u/extract-params current-trace addrs)
         d (count addrs)
-        [k1 k2 k3] (rng/split-n (rng/ensure-key key) 3)
+        ;; k-loop seeds the shrink loop — looping on the PARENT key would
+        ;; re-derive k1's stream (split prefix semantics; genmlx-njaq).
+        [k1 k2 k3 k-loop] (rng/split-n (rng/ensure-key key) 4)
         ;; 1. nu ~ N(0, σ²I)
         nu (mx/multiply (mx/scalar prior-std) (rng/normal k1 [d]))
         _ (mx/materialize! nu)
@@ -2660,7 +2670,7 @@
            tmin theta-min
            tmax theta-max
            iter 0
-           rk key]
+           rk k-loop]
       (let [;; Propose: f' = f*cos(θ) + nu*sin(θ)
             f' (mx/add (mx/multiply f (mx/scalar (js/Math.cos theta)))
                        (mx/multiply nu (mx/scalar (js/Math.sin theta))))

--- a/src/genmlx/inference/smc.cljs
+++ b/src/genmlx/inference/smc.cljs
@@ -152,11 +152,17 @@
 
 (defn- smc-init-step
   "First timestep: generate particles from prior with constraints.
+   Per-particle keys derive from `key` (nil → fresh entropy) — unkeyed
+   init made a seeded SMC run irreproducible (genmlx-njaq).
    Returns {:traces :log-weights :log-ml-increment}."
-  [model args obs particles]
-  (let [results    (mapv (fn [i]
-                          (break-particle-graph! (p/generate model args obs) i))
-                        (range particles))
+  [model args obs particles key]
+  (let [pkeys      (rng/split-n-or-nils key particles)
+        results    (mapv (fn [i ki]
+                           (break-particle-graph!
+                            (p/generate (if ki (dyn/with-key model ki) model)
+                                        args obs)
+                            i))
+                         (range particles) pkeys)
         traces     (mapv :trace results)
         log-weights (mapv :weight results)
         w-arr      (u/materialize-weights log-weights)
@@ -188,7 +194,7 @@
   (let [;; Check ESS and resample if needed
         ess        (u/compute-ess log-weights)
         resample?  (< ess (* ess-threshold particles))
-        [resample-key step-key rejuv-key]
+        [resample-key update-key rejuv-key]
         (rng/split-n-or-nils key 3)
         [traces' weights'] (if resample?
                              (let [indices (dispatch-resample resample-method
@@ -196,10 +202,18 @@
                                [(mapv #(nth traces %) indices)
                                 (vec (repeat particles (mx/scalar 0.0)))])
                              [traces log-weights])
-        ;; Update each particle with new observations
-        results       (mapv (fn [i trace]
-                               (break-particle-graph! (p/update (:gen-fn trace) trace obs) i))
-                             (range) traces')
+        ;; Update each particle with new observations. Per-particle keys —
+        ;; the middle split used to be reserved and never threaded, so
+        ;; updates ran on fresh entropy (genmlx-njaq).
+        update-keys   (rng/split-n-or-nils update-key particles)
+        results       (mapv (fn [i ki trace]
+                              (break-particle-graph!
+                               (p/update (if ki
+                                           (dyn/with-key (:gen-fn trace) ki)
+                                           (:gen-fn trace))
+                                         trace obs)
+                               i))
+                            (range) update-keys traces')
         new-traces    (mapv :trace results)
         update-weights (mapv :weight results)
         new-weights   (mapv mx/add weights' update-weights)
@@ -264,7 +278,7 @@
               _ (when (and (pos? t) (zero? (mod t 5))) (mx/clear-cache!))]
           (if (zero? t)
             (let [{:keys [traces log-weights log-ml-increment]}
-                  (smc-init-step model args obs-t particles)]
+                  (smc-init-step model args obs-t particles step-key)]
               (when callback
                 (callback {:step t :ess (u/compute-ess log-weights)}))
               (recur (inc t) traces log-weights

--- a/test/genmlx/prng_hygiene_test.cljs
+++ b/test/genmlx/prng_hygiene_test.cljs
@@ -1,0 +1,131 @@
+;; @tier medium
+(ns genmlx.prng-hygiene-test
+  "Deterministic-seed laws for the genmlx-njaq audit cluster: a seeded run
+   must be bit-reproducible, and key streams for distinct purposes must be
+   disjoint. smc/mh-custom/involutive-mh FAIL these pre-fix (their inner
+   operations ran on fresh entropy); nuts/elliptical-slice/importance-
+   resampling were deterministic-but-correlated, so their tests are
+   regression guards pinning the property going forward."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.test-helpers :as h]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.dist :as dist]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.inference.smc :as smc]
+            [genmlx.inference.importance :as imp]
+            [genmlx.inference.mcmc :as mcmc])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(def ^:private xy-model
+  (gen []
+    (let [x (trace :x (dist/gaussian 0 1))]
+      (trace :y0 (dist/gaussian x 0.5))
+      (trace :y1 (dist/gaussian x 0.5))
+      x)))
+
+(defn- x-of [trace]
+  (h/realize (cm/get-choice (:choices trace) [:x])))
+
+;; ---------------------------------------------------------------------------
+;; SMC: seeded run is bit-reproducible (pre-fix: init + update unkeyed)
+;; ---------------------------------------------------------------------------
+
+(deftest smc-seeded-determinism
+  (testing "same :key → identical log-ML and identical particles"
+    (let [obs-seq [(cm/choicemap :y0 (mx/scalar 1.0))
+                   (cm/choicemap :y1 (mx/scalar 1.2))]
+          run #(smc/smc {:particles 20 :key (rng/fresh-key 17)}
+                        xy-model [] obs-seq)
+          r1 (run)
+          r2 (run)]
+      (is (= (h/realize (:log-ml-estimate r1))
+             (h/realize (:log-ml-estimate r2)))
+          "log-ML bit-identical under the same seed")
+      (is (= (mapv x-of (:traces r1)) (mapv x-of (:traces r2)))
+          "particle :x values bit-identical under the same seed")
+      (is (not= (mapv x-of (:traces r1))
+                (mapv x-of (:traces (smc/smc {:particles 20
+                                              :key (rng/fresh-key 18)}
+                                             xy-model [] obs-seq))))
+          "different seed → different particles"))))
+
+;; ---------------------------------------------------------------------------
+;; mh-custom: seeded chain is bit-reproducible (pre-fix: propose/update unkeyed)
+;; ---------------------------------------------------------------------------
+
+(def ^:private x-proposal
+  (gen [_current-choices]
+    (trace :x (dist/gaussian 0 1.5))))
+
+(deftest mh-custom-seeded-determinism
+  (testing "same :key → identical custom-proposal MH chain"
+    (let [obs (cm/choicemap :y0 (mx/scalar 1.0) :y1 (mx/scalar 1.2))
+          run #(mapv x-of (mcmc/mh-custom {:samples 8 :proposal-gf x-proposal
+                                           :key (rng/fresh-key 23)}
+                                          xy-model [] obs))]
+      (is (= (run) (run)) "chains bit-identical under the same seed"))))
+
+;; ---------------------------------------------------------------------------
+;; involutive-mh: seeded chain is bit-reproducible (pre-fix: propose unkeyed)
+;; ---------------------------------------------------------------------------
+
+(deftest involutive-mh-seeded-determinism
+  (testing "same :key → identical involutive MH chain"
+    ;; Involution: reflect :x around the auxiliary midpoint m — an
+    ;; involution in (trace, aux) jointly: applying it twice is identity.
+    (let [aux-proposal (dyn/auto-key
+                        (gen [_current-choices]
+                          (trace :m (dist/gaussian 0 1))))
+          involution (fn [trace-cm aux-cm]
+                       (let [x (cm/get-choice trace-cm [:x])
+                             m (cm/get-choice aux-cm [:m])
+                             x' (mx/subtract (mx/multiply (mx/scalar 2.0) m) x)]
+                         [(cm/set-choice trace-cm [:x] x')
+                          aux-cm]))
+          obs (cm/choicemap :y0 (mx/scalar 1.0) :y1 (mx/scalar 1.2))
+          run #(mapv x-of (mcmc/involutive-mh {:samples 8
+                                               :proposal-gf aux-proposal
+                                               :involution involution
+                                               :key (rng/fresh-key 29)}
+                                              xy-model [] obs))]
+      (is (= (run) (run)) "chains bit-identical under the same seed"))))
+
+;; ---------------------------------------------------------------------------
+;; Regression guards: paths that were deterministic-but-correlated pre-fix
+;; ---------------------------------------------------------------------------
+
+(deftest nuts-seeded-determinism
+  (testing "same :key → identical NUTS samples (guards the disjoint
+            tree/accept key streams)"
+    (let [obs (cm/choicemap :y0 (mx/scalar 1.0) :y1 (mx/scalar 1.2))
+          run #(mcmc/nuts {:samples 5 :burn 5 :adapt-step-size false
+                           :step-size 0.2 :addresses [:x] :compile? false
+                           :device :cpu :key (rng/fresh-key 31)}
+                          xy-model [] obs)]
+      (is (= (run) (run)) "NUTS samples bit-identical under the same seed"))))
+
+(deftest elliptical-slice-seeded-determinism
+  (testing "same :key → identical elliptical slice chain (guards the
+            shrink-loop key being disjoint from k1/k2/k3)"
+    (let [obs (cm/choicemap :y0 (mx/scalar 1.0) :y1 (mx/scalar 1.2))
+          run #(mapv x-of (mcmc/elliptical-slice {:samples 6 :selection [:x]
+                                                  :prior-std 1.0
+                                                  :key (rng/fresh-key 37)}
+                                                 xy-model [] obs))]
+      (is (= (run) (run)) "chains bit-identical under the same seed"))))
+
+(deftest importance-resampling-seeded-determinism
+  (testing "same :key → identical resampled traces (guards the
+            generate/resample key streams being disjoint)"
+    (let [obs (cm/choicemap :y0 (mx/scalar 1.0) :y1 (mx/scalar 1.2))
+          run #(mapv x-of (imp/importance-resampling
+                           {:samples 10 :particles 30
+                            :key (rng/fresh-key 41)}
+                           xy-model [] obs))]
+      (is (= (run) (run)) "resampled traces bit-identical under the same seed"))))
+
+(cljs.test/run-tests)


### PR DESCRIPTION
## Summary

Closes audit bean `genmlx-njaq` (epic `genmlx-hqo2`) — all five items, verify-first.

1. **importance-resampling prefix collision**: `split-n` of the SAME key for per-particle generate and again for the resample draws makes the first resample keys identical to the generate keys (split prefix semantics) — resampling correlated with particle generation. Both scalar and vectorized variants now split once into disjoint streams.
2. **Mix batched key reuse**: the parent continued with the key that sampled the component indices, correlating every downstream site with index sampling (Switch/Unfold already did this right). Three-way split: idx / components / parent.
3. **Unkeyed operations breaking reproducibility**: `mh-custom-step` split keys it never used and `involutive-mh-step` left k1 dead — propose/update ran on fresh entropy, so seeded chains were not reproducible. `smc-init-step` took no key at all and `smc-step`'s middle split was reserved-but-never-threaded. All now thread per-particle/per-op keys (nil stays honest no-key mode).
4. **NUTS accept-key overlap**: the accept uniform re-split the `tk1` that `build-tree` consumes internally, so the accept key equaled the tree's first derived key — in both doubling loops. **elliptical-slice** shrink loop re-split the parent key, re-deriving k1's stream. **gamma-sample-scalar** split the k2 it had just consumed.
5. **gfi.cljs mixture-kernel law** reused k1 for kernel selection AND accept.

## Verification

New `prng_hygiene_test.cljs` — deterministic-seed laws (same `:key` ⇒ bit-identical run, different key ⇒ different run):
- **smc / mh-custom / involutive-mh fail pre-fix (stash-verified)** — their inner ops were fresh-entropy, so this is the bean's 'deterministic-seed law over smc/mh-custom paths' checkbox
- nuts / elliptical-slice / importance-resampling were deterministic-but-correlated pre-fix; their tests are regression guards pinning the property

Suites: inference_smc, smc_evidence 17/17, mcmc_defaults 4/14, dist 14/48, pmcmc 6/14, adaptive_nuts 6/12, batched_switch 11/37, fast-core 34/34 — green. gfi_laws shows only the known pre-existing vgenerate flake (`genmlx-v4mz`) across 3 runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)