### PR TITLE
fix(dist): boundary guards, fractional-df student-t, GFI citizenship, registry protection (genmlx-yeam)

### DIFF
--- a/src/genmlx/dist.cljs
+++ b/src/genmlx/dist.cljs
@@ -684,14 +684,16 @@
   "Student-t distribution with df degrees of freedom, location and scale."
   [df loc scale]
   (sample [key]
-          (let [df-val (mx/realize df)
-                n-keys (rng/split-n key (+ (int df-val) 1))
-                chi2 (loop [i 0 acc 0.0]
-                       (if (>= i (int df-val))
-                         acc
-                         (let [z (mx/realize (rng/normal (nth n-keys i) []))]
-                           (recur (inc i) (+ acc (* z z))))))
-                z (mx/realize (rng/normal (nth n-keys (int df-val)) []))
+          ;; chi2(df) = Gamma(df/2, rate 1/2) — valid for ANY df > 0. The old
+          ;; sum-of-int(df)-squared-normals sampler silently truncated df
+          ;; (df=2.5 sampled t(2) while log-prob scored t(2.5) — sample/score
+          ;; mismatch breaking importance weights; df<1 divided by an empty
+          ;; chi2 sum = 0 → Inf samples) (genmlx-yeam).
+          (let [[k1 k2] (rng/split key)
+                df-val (mx/realize df)
+                chi2 (gamma-sample-scalar (mx/scalar (/ df-val 2.0))
+                                          (mx/scalar 0.5) k1)
+                z (mx/realize (rng/normal k2 []))
                 t (* z (js/Math.sqrt (/ df-val chi2)))]
             (mx/add loc (mx/multiply scale (mx/scalar t)))))
   (log-prob [v]
@@ -712,11 +714,11 @@
 
 (defmethod dc/dist-sample-n* :student-t [d key n]
   (let [{:keys [df loc scale]} (:params d)
-        df-val (int (mx/realize df))
+        df-val (mx/realize df)
         [k1 k2] (rng/split (rng/ensure-key key))
-        ;; Chi-squared: sum of df squared normals -> [n]
-        normals (rng/normal k1 [n df-val])
-        chi2 (mx/sum (mx/square normals) [1])
+        ;; chi2(df) = Gamma(df/2, rate 1/2) — exact for fractional df
+        ;; (the old [n, int(df)] normals matrix truncated df; genmlx-yeam)
+        chi2 (gamma-sample-n (/ df-val 2.0) (mx/scalar 0.5) k1 n)
         ;; Standard normal -> [n]
         z (rng/normal k2 [n])
         ;; t = z * sqrt(df / chi2)
@@ -795,7 +797,10 @@
 ;; ---------------------------------------------------------------------------
 
 (defdist delta
-  "Delta (point mass) distribution at value v."
+  "Delta (point mass) distribution at value v.
+   log-prob compares by EXACT float equality — correct for the point-mass
+   semantics (constrained values pass through bit-identically), but any
+   recomputation that perturbs the value scores -Inf."
   [v]
   (sample [_key] v)
   (log-prob [value]
@@ -804,8 +809,12 @@
   (support [] [v]))
 
 (defmethod dc/dist-sample-n* :delta [d _key n]
-  (let [{:keys [v]} (:params d)]
-    (mx/broadcast-to v [n])))
+  (let [{:keys [v]} (:params d)
+        ;; Batch shape prepends the particle axis: scalar v → [n],
+        ;; [d]-shaped v → [n d]. broadcast-to v [n] is a shape error for
+        ;; any non-scalar point (genmlx-yeam).
+        sh (if (mx/array? v) (mx/shape v) [])]
+    (mx/broadcast-to v (into [n] sh))))
 
 ;; ---------------------------------------------------------------------------
 ;; Cauchy
@@ -897,7 +906,11 @@
             (mx/floor (mx/divide log-u log-1mp))))
   (log-prob [v]
     ;; log p(k) = k * log(1-p) + log(p)
-            (mx/add (mx/multiply v (mx/log (mx/subtract ONE p)))
+    ;; xlogy guard: at p=1 (legal — success on the first trial, k=0 w.p. 1)
+    ;; the k*log(1-p) term is 0*-Inf = NaN without it (genmlx-yeam).
+            (mx/add (mx/where (mx/equal v ZERO)
+                              ZERO
+                              (mx/multiply v (mx/log (mx/subtract ONE p))))
                     (mx/log p)))
   (support []
     ;; Dynamic support up to 0.999 quantile (capped at 10000)
@@ -916,9 +929,14 @@
 
 (let [raw geometric]
   (defn geometric
-    "Geometric distribution: number of failures before first success, p in (0,1)."
+    "Geometric distribution: number of failures before first success, p in (0,1]."
     [p]
+    ;; p=1 is legal (k=0 w.p. 1; the log-prob xlogy guard handles it), but
+    ;; p=0 sampled floor(log u / log 1) = -Inf garbage (genmlx-yeam).
     (check-probability "geometric" "p" p)
+    (when (and (number? p) (zero? p))
+      (throw (ex-info "geometric: p must be in (0,1], got 0"
+                      {:distribution "geometric" :parameter "p" :value p})))
     (raw p)))
 
 ;; ---------------------------------------------------------------------------
@@ -952,10 +970,13 @@
 (let [raw neg-binomial]
   (defn neg-binomial
     "Negative binomial (Polya) distribution.
-   r: number of successes, p: probability of success."
+   r: number of successes, p: probability of success, p in (0,1)."
     [r p]
     (check-positive "neg-binomial" "r" r)
-    (check-probability "neg-binomial" "p" p)
+    ;; Strictly open: the gamma-Poisson sampler's rate p/(1-p) divides by
+    ;; zero at p=1, and p=0 never terminates — the closed-interval check
+    ;; let both through to garbage (genmlx-yeam).
+    (check-open-probability "neg-binomial" "p" p)
     (raw r p)))
 
 ;; ---------------------------------------------------------------------------
@@ -975,11 +996,19 @@
             (mx/scalar successes)))
   (log-prob [v]
     ;; log C(n, k) + k*log(p) + (n-k)*log(1-p)
-            (let [log-coeff (log-choose n-trials v)]
+    ;; xlogy guards (cf. bernoulli): at p=0 with v=0 the first term is
+    ;; 0*log(0) = 0*-Inf = NaN without the guard; at p=1 with v=n the
+    ;; second term likewise (genmlx-yeam).
+            (let [log-coeff (log-choose n-trials v)
+                  n-minus-v (mx/subtract n-trials v)]
               (-> log-coeff
-                  (mx/add (mx/multiply v (mx/log p)))
-                  (mx/add (mx/multiply (mx/subtract n-trials v)
-                                       (mx/log (mx/subtract ONE p)))))))
+                  (mx/add (mx/where (mx/equal v ZERO)
+                                    ZERO
+                                    (mx/multiply v (mx/log p))))
+                  (mx/add (mx/where (mx/equal n-minus-v ZERO)
+                                    ZERO
+                                    (mx/multiply n-minus-v
+                                                 (mx/log (mx/subtract ONE p))))))))
   (support []
            (let [nt (int (mx/realize n-trials))]
              (mapv #(mx/scalar % mx/int32) (range (inc nt))))))
@@ -1679,9 +1708,11 @@
   "Optimized IID Gaussian. mu/sigma can be scalar or [T]-shaped.
    Generates T samples in a single noise draw."
   [mu sigma t]
+  ;; Validate BEFORE ensure-array: check-positive only inspects JS numbers,
+  ;; so converting first made the check dead code (genmlx-yeam).
+  (check-positive "iid-gaussian" "sigma" sigma)
   (let [mu (mx/ensure-array mu)
         sigma (mx/ensure-array sigma)]
-    (check-positive "iid-gaussian" "sigma" sigma)
     (dc/->Distribution :iid-gaussian {:mu mu :sigma sigma :t t})))
 
 (defmethod dc/dist-sample* :iid-gaussian [d key]
@@ -1730,7 +1761,10 @@
         mu-nd (if (seq (mx/shape mu))
                 (if (= (count (mx/shape mu)) 1)
                   ;; 1D: could be [T] or [N]. If length=t → [T] params (row),
-                  ;; otherwise [N] batched (column).
+                  ;; otherwise [N] batched (column). KNOWN AMBIGUITY: when
+                  ;; N == t a batched [N] mu is misread as per-element [T]
+                  ;; params — shape-pun class tracked in genmlx-ql6a; fixing
+                  ;; it needs an explicit batch-axis marker, not a heuristic.
                   (if (= (first (mx/shape mu)) t)
                     (mx/reshape mu [1 t])
                     (mx/expand-dims mu -1))

--- a/src/genmlx/dist/core.cljs
+++ b/src/genmlx/dist/core.cljs
@@ -97,6 +97,43 @@
       {:retval v :weight lp})
     (throw (ex-info "assess requires fully-specified choices" {:dist (:type dist)}))))
 
+(defn- root-selected?
+  "Does this selection select a Distribution's single root value? The root
+   has no address, so only selections that select everything at this level
+   can select it: canonical `all`, or a Complement whose inner does not.
+   Address-naming selections (SelectAddrs/Hierarchical) name addresses a
+   single-value trace does not have."
+  [selection]
+  (cond
+    (identical? sel/all selection) true
+    (instance? sel/Complement selection) (not (root-selected? (:inner selection)))
+    :else false))
+
+(defn- dist-update
+  "Update a distribution trace. A constrained value replaces the old one
+   with weight lp(v') - lp(v) (thesis update convention: non-fresh new
+   score minus old score; the single site is constrained, so everything
+   is non-fresh). Empty constraints leave the trace unchanged."
+  [dist trace constraints]
+  (if (cm/has-value? constraints)
+    (let [v' (cm/get-value constraints)
+          lp' (dist-log-prob dist v')]
+      {:trace (tr/make-trace {:gen-fn dist :args [] :choices (cm/->Value v')
+                              :retval v' :score lp'})
+       :weight (mx/subtract lp' (:score trace))
+       :discard (:choices trace)})
+    {:trace trace :weight ZERO :discard cm/EMPTY}))
+
+(defn- dist-regenerate
+  "Regenerate a distribution trace. A selected root value resamples from
+   the distribution itself with weight 0 (prior-proposal cancellation:
+   the score delta equals the proposal ratio exactly). Unselected leaves
+   the trace unchanged, also weight 0."
+  [dist trace selection]
+  (if (root-selected? selection)
+    {:trace (dist-simulate dist) :weight ZERO}
+    {:trace trace :weight ZERO}))
+
 ;; ---------------------------------------------------------------------------
 ;; THE single record for all distributions
 ;; ---------------------------------------------------------------------------
@@ -114,12 +151,21 @@
   p/IPropose
   (propose [this _] (dist-propose this))
 
+  p/IUpdate
+  (update [this trace constraints] (dist-update this trace constraints))
+
+  p/IRegenerate
+  (regenerate [this trace selection] (dist-regenerate this trace selection))
+
   p/IProject
   (project [this trace selection]
-    ;; A distribution has a single choice. If nothing is selected, return 0.
-    (if (identical? selection sel/none)
-      ZERO
-      (:score trace))))
+    ;; A distribution has a single root choice: project returns its score
+    ;; iff the selection selects the root. The old check returned the FULL
+    ;; score for ANY selection other than canonical `none` — an unrelated
+    ;; (select :foo) projected the whole score (genmlx-yeam).
+    (if (root-selected? selection)
+      (:score trace)
+      ZERO)))
 
 ;; ---------------------------------------------------------------------------
 ;; IHasArgumentGrads — distributions do not declare argument differentiability
@@ -133,10 +179,19 @@
 ;; map->dist — create a Distribution from a plain map
 ;; ---------------------------------------------------------------------------
 
+(def ^:private map->dist-types
+  "Types registered by map->dist. Re-registering YOUR OWN custom type is
+   normal REPL flow; clobbering a type someone else registered (e.g. a
+   builtin like :gaussian) silently redefined it process-wide, so that
+   now throws (genmlx-yeam). Registry bookkeeping only — never read by
+   computation paths."
+  (atom #{}))
+
 (defn map->dist
   "Create a Distribution from a plain map with :sample and :log-prob functions.
    Required keys:
-     :type      - keyword identifier (auto-generated if omitted)
+     :type      - keyword identifier (auto-generated if omitted); must not
+                  collide with an already-registered distribution type
      :sample    - (fn [key] -> MLX-value)
      :log-prob  - (fn [value] -> MLX-scalar)
    Optional keys:
@@ -145,6 +200,14 @@
      :sample-n  - (fn [key n] -> MLX-array) batch sampling"
   [{:keys [type sample log-prob reparam support sample-n]}]
   (let [type-kw (or type (keyword (gensym "custom-dist")))]
+    (when (and (contains? (methods dist-sample*) type-kw)
+               (not (contains? @map->dist-types type-kw)))
+      (throw (ex-info (str "map->dist: " type-kw " is already a registered "
+                           "distribution type — choose a unique :type "
+                           "(registering it would silently redefine the "
+                           "existing distribution process-wide)")
+                      {:type type-kw})))
+    (swap! map->dist-types conj type-kw)
     (defmethod dist-sample* type-kw [_ key] (sample key))
     (defmethod dist-log-prob type-kw [_ value] (log-prob value))
     (when reparam

--- a/test/genmlx/dist_boundary2_test.cljs
+++ b/test/genmlx/dist_boundary2_test.cljs
@@ -1,0 +1,177 @@
+;; @tier fast
+(ns genmlx.dist-boundary2-test
+  "Boundary and GFI-citizenship tests for the genmlx-yeam audit cluster:
+   xlogy guards at p in {0,1}, student-t fractional df, delta batch shapes,
+   map->dist registry protection, and Distribution update/regenerate/project.
+   Oracles are closed-form densities and IEEE semantics, never the path
+   under test. (dist_boundary_test.cljs covers general support boundaries;
+   this file covers the audit's specific holes.)"
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.test-helpers :as h]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.dist :as dist]
+            [genmlx.dist.core :as dc]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]))
+
+(defn- lp [d v] (h/realize (dist/log-prob d (mx/scalar v))))
+
+;; ---------------------------------------------------------------------------
+;; (1) xlogy guards: binomial and geometric at p in {0,1}
+;; ---------------------------------------------------------------------------
+
+(deftest binomial-boundary-log-probs
+  (testing "binomial log-prob at degenerate p (pre-fix: NaN)"
+    (is (h/close? 0.0 (lp (dist/binomial 5 0.0) 0.0) 1e-6)
+        "P(0 successes | p=0) = 1 -> lp 0")
+    (is (h/close? 0.0 (lp (dist/binomial 5 1.0) 5.0) 1e-6)
+        "P(5 successes in 5 | p=1) = 1 -> lp 0")
+    (is (= ##-Inf (lp (dist/binomial 5 0.0) 3.0))
+        "P(3 | p=0) = 0 -> lp -Inf")
+    (is (= ##-Inf (lp (dist/binomial 5 1.0) 2.0))
+        "P(2 | p=1) = 0 -> lp -Inf")))
+
+(deftest geometric-boundary-log-probs
+  (testing "geometric at p=1 (pre-fix: NaN) and p=0 (pre-fix: garbage samples)"
+    (is (h/close? 0.0 (lp (dist/geometric 1.0) 0.0) 1e-6)
+        "P(k=0 | p=1) = 1 -> lp 0")
+    (is (= ##-Inf (lp (dist/geometric 1.0) 2.0))
+        "P(k=2 | p=1) = 0 -> lp -Inf")
+    (is (h/close? 0.0 (h/realize (dc/dist-sample (dist/geometric 1.0)
+                                                 (rng/fresh-key 1)))
+                  1e-6)
+        "p=1 always samples k=0")
+    (is (thrown? js/Error (dist/geometric 0.0))
+        "p=0 rejected at construction (sampler divides by log(1)=0)")))
+
+(deftest neg-binomial-open-interval
+  (testing "neg-binomial p boundaries rejected (pre-fix: rate division by
+            zero at p=1, non-termination at p=0)"
+    (is (thrown? js/Error (dist/neg-binomial 3 1.0)) "p=1 rejected")
+    (is (thrown? js/Error (dist/neg-binomial 3 0.0)) "p=0 rejected")
+    (is (some? (dist/neg-binomial 3 0.5)) "interior p constructs")))
+
+;; ---------------------------------------------------------------------------
+;; (2) student-t: fractional df samples from the distribution it scores
+;; ---------------------------------------------------------------------------
+
+(deftest student-t-fractional-df
+  (testing "df < 1 produces finite samples (pre-fix: int(0.5)=0 normals ->
+            chi2=0 -> division -> Inf)"
+    (let [d (dist/student-t 0.5 0.0 1.0)
+          scalar-draws (mapv #(h/realize (dc/dist-sample d (rng/fresh-key %)))
+                             (range 50))
+          batch-draws (h/realize-vec (dc/dist-sample-n d (rng/fresh-key 99) 50))]
+      (is (every? h/finite? scalar-draws) "50 scalar draws all finite")
+      (is (every? h/finite? batch-draws) "50 batched draws all finite")))
+  (testing "gamma-based chi2 reproduces the t variance df/(df-2)"
+    ;; df=7: Var = 7/5 = 1.4, finite kurtosis -> stable sample variance.
+    (let [draws (h/realize-vec (dc/dist-sample-n (dist/student-t 7.0 0.0 1.0)
+                                                 (rng/fresh-key 7) 4000))]
+      (is (h/close? 1.4 (h/sample-variance draws) 0.25)
+          "sample variance ~ 1.4 over 4000 draws"))))
+
+;; ---------------------------------------------------------------------------
+;; (4) delta: batch sampling with non-scalar points
+;; ---------------------------------------------------------------------------
+
+(deftest delta-batch-shapes
+  (testing "dist-sample-n prepends the particle axis (pre-fix: broadcast-to
+            [n] is a shape error for any non-scalar point)"
+    (let [vec-point (mx/array [1.0 2.0])
+          batch (dc/dist-sample-n (dist/delta vec-point) (rng/fresh-key 3) 4)]
+      (is (= [4 2] (h/realize-shape batch)) "[d] point -> [n d]")
+      (is (every? #(= [1 2] (mapv int %)) (mx/->clj batch))
+          "every row is the point"))
+    (is (= [4] (h/realize-shape
+                (dc/dist-sample-n (dist/delta (mx/scalar 5.0))
+                                  (rng/fresh-key 4) 4)))
+        "scalar point -> [n]")))
+
+;; ---------------------------------------------------------------------------
+;; (5) map->dist: registry protection
+;; ---------------------------------------------------------------------------
+
+(deftest map->dist-registry-protection
+  (testing "colliding with a builtin type throws (pre-fix: silently
+            redefined :gaussian process-wide)"
+    (is (thrown? js/Error
+                 (dc/map->dist {:type :gaussian
+                                :sample (fn [_] (mx/scalar 0.0))
+                                :log-prob (fn [_] (mx/scalar 0.0))}))
+        "registering :gaussian rejected"))
+  (testing "re-registering your own custom type is allowed (REPL flow)"
+    (let [spec {:type ::my-dist
+                :sample (fn [_] (mx/scalar 1.0))
+                :log-prob (fn [_] (mx/scalar -1.0))}
+          d1 (dc/map->dist spec)
+          d2 (dc/map->dist spec)]
+      (is (= ::my-dist (:type d1) (:type d2)) "both registrations succeed"))))
+
+;; ---------------------------------------------------------------------------
+;; (6) Distribution GFI citizenship: update / regenerate / project
+;; ---------------------------------------------------------------------------
+
+(deftest distribution-update
+  (testing "raw distribution supports update (pre-fix: no IUpdate -> throw)"
+    (let [d (dist/gaussian 0 1)
+          trace (p/simulate (vary-meta d assoc :genmlx.dynamic/key
+                                       (rng/fresh-key 5)) [])
+          old-v (h/realize (:retval trace))
+          {:keys [trace weight discard]} (p/update d trace (cm/->Value (mx/scalar 2.0)))]
+      (is (h/close? 2.0 (h/realize (:retval trace)) 1e-6) "value replaced")
+      (is (h/close? (- (h/gaussian-lp 2.0 0.0 1.0) (h/gaussian-lp old-v 0.0 1.0))
+                    (h/realize weight) 1e-4)
+          "update weight = lp(v') - lp(v), closed form")
+      (is (h/close? old-v (h/realize (cm/get-value discard)) 1e-6)
+          "discard holds the old value"))))
+
+(deftest distribution-regenerate
+  (testing "raw distribution supports regenerate (pre-fix: no IRegenerate)"
+    (let [d (dist/gaussian 0 1)
+          trace (p/simulate (vary-meta d assoc :genmlx.dynamic/key
+                                       (rng/fresh-key 6)) [])
+          old-v (h/realize (:retval trace))
+          sel-res (p/regenerate d trace sel/all)
+          none-res (p/regenerate d trace sel/none)]
+      (is (h/close? 0.0 (h/realize (:weight sel-res)) 1e-6)
+          "selected regenerate weight 0 (prior-proposal cancellation)")
+      (is (not= old-v (h/realize (:retval (:trace sel-res))))
+          "selected regenerate resamples the value")
+      (is (h/close? old-v (h/realize (:retval (:trace none-res))) 1e-6)
+          "unselected regenerate keeps the value")
+      (is (h/close? 0.0 (h/realize (:weight none-res)) 1e-6)
+          "unselected regenerate weight 0"))))
+
+(deftest distribution-project
+  (testing "project returns the score iff the root is selected (pre-fix:
+            ANY selection other than `none` projected the full score)"
+    (let [d (dist/gaussian 0 1)
+          trace (p/simulate (vary-meta d assoc :genmlx.dynamic/key
+                                       (rng/fresh-key 8)) [])
+          score (h/realize (:score trace))]
+      (is (h/close? score (h/realize (p/project d trace sel/all)) 1e-6)
+          "sel/all -> score")
+      (is (h/close? 0.0 (h/realize (p/project d trace sel/none)) 1e-6)
+          "sel/none -> 0")
+      (is (h/close? 0.0 (h/realize (p/project d trace (sel/select :unrelated))) 1e-6)
+          "unrelated address selection -> 0, NOT the full score")
+      (is (h/close? score (h/realize (p/project d trace
+                                                (sel/complement-sel sel/none)))
+                    1e-6)
+          "complement of none -> score"))))
+
+;; ---------------------------------------------------------------------------
+;; (3) iid-gaussian: validation no longer dead
+;; ---------------------------------------------------------------------------
+
+(deftest iid-gaussian-validation
+  (testing "negative sigma rejected (pre-fix: ensure-array ran first, so
+            the number? guard in check-positive never fired)"
+    (is (thrown? js/Error (dist/iid-gaussian 0.0 -1.0 5))
+        "sigma must be positive")
+    (is (some? (dist/iid-gaussian 0.0 1.0 5)) "valid params construct")))
+
+(cljs.test/run-tests)


### PR DESCRIPTION
## Summary

Closes audit bean `genmlx-yeam` (epic `genmlx-hqo2`) — all seven items, verify-first.

1. **xlogy guards**: binomial/geometric log-probs hit `0 · log(0) = NaN` at p ∈ {0,1} (bernoulli already had the guards). Degenerate p now scores the certain outcome at lp 0, impossible ones at −Inf.
2. **student-t sample/score mismatch**: sampling summed `int(df)` squared normals while log-prob scored the true df — fractional df broke importance weights, df<1 produced Inf samples (empty chi² sum). Both paths now draw chi²(df) = Γ(df/2, rate ½), exact for any df > 0, reusing the Marsaglia–Tsang samplers.
3. **iid-gaussian dead validation**: `ensure-array` ran before `check-positive`, whose `number?` guard then never fired. Validation now runs first; the N==t batch shape-pun is documented and tracked in `genmlx-ql6a`.
4. **delta batch broadcast**: `broadcast-to v [n]` is a shape error for non-scalar points; the batch shape now prepends the particle axis. Exact-equality lp documented as the point-mass semantic.
5. **map->dist registry clobber**: `:type :gaussian` silently redefined the builtin process-wide. Re-registering your own custom type stays legal (REPL flow); clobbering anything else throws.
6. **GFI citizenship**: `Distribution` now implements `IUpdate` (weight = lp(v′) − lp(v), thesis convention) and `IRegenerate` (selected root resamples at weight 0, prior-proposal cancellation) — raw dists as combinator kernels used to throw. `project` returned the FULL score for any selection other than canonical `none`; it now returns the score iff the selection selects the root (`all`, or complements that do).
7. **geometric/neg-binomial closed-interval p**: geometric now requires p ∈ (0,1] (p=0 sampled −Inf garbage), neg-binomial p ∈ (0,1) strictly (rate p/(1−p) divides by zero at p=1; never terminates at p=0).

## Verification (independent-oracle rule)

New `dist_boundary2_test.cljs` (10 tests / 32 assertions) — closed-form density and IEEE oracles; **8+ assertions fail pre-fix (stash-verified)** across binomial, geometric, neg-binomial, student-t, delta, map->dist, and the GFI trio. The t(7) sample variance check (≈ df/(df−2) = 1.4 over 4000 draws) pins the new gamma-based sampler.

Suites: dist 14/48, dist_boundary 23/100, dist_batch 20/27, dist_error 20/88, dist_logprob 33/96, dist_moments 32/127, fast-core 34/34 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)