### PR TITLE
fix(membrane): honesty bundle — eq? truncation, mid-tidy GC, meshgrid, verify executor (genmlx-vd2j)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,15 +194,27 @@ direct import of dynamic.cljs).
 ## Key design principles
 
 1. **Purely functional.** Layers 1-9 are referentially transparent. Mutation is
-   confined to the membrane (Layer 0) and verified by property tests
-   (`mutation_boundary_test.cljs`). The mutable boundaries are:
+   confined to the membrane (Layer 0) plus a small audited set of caches and
+   training state, verified by property tests (`mutation_boundary_test.cljs`).
+   The mutable boundaries are:
    - The handler's `volatile!` in `runtime.cljs` (scoped to a single `run-handler`
      call — created fresh, consumed locally, never escapes)
-   - Two atoms in `mlx.cljs` (`tidy-depth`, `grad-depth` for nesting counters)
-   - Two atoms for dev mode extension (`dispatch-fn`, `validate-fn` — only
-     swapped by `dev.cljs` start!/stop!, no-ops in production)
-   - Auto-cleanup counters in `mlx.cljs` (`ops-since-check`, `gfi-ops-count` —
-     resource management heuristics, do not affect computation results)
+   - Resource-management state in `mlx.cljs`: five atoms (`tidy-depth`,
+     `grad-depth` nesting counters; `alloc-retry-count`, `proactive-sweep-count`
+     telemetry; `buffer-count-threshold` hysteresis) and four `^:mutable`
+     counters (`ops-since-check`, `allocs-since-count-check`, `proactive-armed?`,
+     `gfi-ops-count`) — cleanup heuristics only, never affect computation results
+   - Two atoms for dev mode extension (`dispatch-fn` in `dynamic.cljs`,
+     `validate-fn` in `runtime.cljs` — only swapped by `dev.cljs` start!/stop!,
+     no-ops in production)
+   - Memoization caches of deterministic values: `fused-cache` atoms on
+     Unfold/Scan combinator records (`combinators.cljs`), `with-cache` in
+     `inference/exact.cljs`, and the construction-scoped expected-utility
+     atoms in `agents/` built on it — write-once, invisible to results
+   - Training state owned by the caller: `nn.cljs` layer refs and optimizer
+     state atoms, the encoder atom in `inference/amortized.cljs`
+   - The `defdist` registry bookkeeping atom in `dist/core.cljs` (never read
+     by computation paths)
    - KV cache mutation in `llm/backend.cljs` (always in try/finally)
 
 2. **Data-driven, open for extension.** Distributions are a single `Distribution`

--- a/src/genmlx/inference/hmm_forward.cljs
+++ b/src/genmlx/inference/hmm_forward.cljs
@@ -50,21 +50,25 @@
       v)))
 
 (defdist hmm-obs
-  "Observation under discrete latent state.
+  "Marker distribution for the HMM forward-algorithm handler ONLY.
    log-emission-probs: [K]-shaped log p(obs | state=k) for each state k.
    mask: 1=observed, 0=missing (masked obs contribute 0 to LL).
 
-   Under standard handler: returns the log-prob of the latent state's emission.
-   Under HMM handler: provides emission log-probs for update step."
+   The forward handler (with-hmm-forward) intercepts sites carrying this
+   distribution and folds the emission log-probs into the forward recursion.
+
+   HONESTY: under a plain handler this distribution samples a dummy 0.0 AND
+   scores log-prob 0.0 — the observation contributes ZERO likelihood to the
+   trace score. A model using hmm-obs is only meaningful under the HMM
+   forward handler; running it under plain simulate/generate/assess yields
+   prior-only scores with no error."
   [log-emission-probs mask]
   (sample [key]
-    ;; Under standard handler, this is just a scoring distribution
-    ;; (the observation is always constrained). Return dummy value.
+    ;; Plain-handler dummy; only the forward handler gives this site meaning.
     (mx/scalar 0.0))
   (log-prob [v]
-    ;; v is ignored — log-emission-probs already contains the per-state LL
-    ;; Under standard handler this isn't directly useful; use kalman-obs
-    ;; pattern or constrain this site.
+    ;; v is ignored and the contribution is ZERO under plain handlers —
+    ;; log-emission-probs is consumed by the forward handler, never here.
     (mx/scalar 0.0)))
 
 ;; ---------------------------------------------------------------------------

--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -13,7 +13,7 @@
    namespace is purely functional: graph construction is value manipulation.
 
    The only effectful operations are in the 'Effectful Operations' section:
-   eval!, materialize!, item, ->clj, realize, async-eval!, training-step!.
+   eval!, materialize!, item, ->clj, realize, async-eval!.
    Everything else builds lazy graph nodes or reads metadata.
 
    Most ops are direct references to Rust NAPI exports (genmlx.rs).
@@ -193,9 +193,14 @@
 ;; Model-level helpers -- auto-promote integers, return float32.
 (defn- ->cmp
   "Coerce a number to a comparison operand; pass MLX arrays through.
-   eq?/neq? promote integers (dt int32); gt?/lt? use the float32 default."
+   eq?/neq? promote integers (dt int32) for exact comparison; a non-integer
+   number stays float32 even when dt is int32 — an int32 scalar would
+   truncate it ((eq? arr 2.5) must not compare against 2)."
   ([x] (if (number? x) (scalar x) x))
-  ([x dt] (if (number? x) (scalar x dt) x)))
+  ([x dt] (cond
+            (not (number? x)) x
+            (and (= dt int32) (not (js/Number.isInteger x))) (scalar x)
+            :else (scalar x dt))))
 
 (defn eq?
   "Element-wise a == b. Promotes integer operands (int32) and returns a
@@ -477,10 +482,13 @@
 (defn linspace [start stop num] (.linspace c start stop num))
 
 (defn meshgrid [a b]
+  ;; Via broadcast-to, not native broadcastTo: the [na 1]->[na nb] and
+  ;; [1 nb]->[na nb] expansions are exactly the size-1-source-dim case the
+  ;; v0.31.2 native broadcast_to mis-fills (see broadcast-to).
   (let [sa (shape a) sb (shape b)
         na (first sa) nb (first sb)
-        a-col (.broadcastTo c (.reshape c a (clj->js [na 1])) (clj->js [na nb]))
-        b-row (.broadcastTo c (.reshape c b (clj->js [1 nb])) (clj->js [na nb]))]
+        a-col (broadcast-to (.reshape c a (clj->js [na 1])) [na nb])
+        b-row (broadcast-to (.reshape c b (clj->js [1 nb])) [na nb])]
     #js [a-col b-row]))
 
 ;; --- Neural network ops ---
@@ -612,26 +620,6 @@
                  (mapv #(aget result (inc %)) argnum-vec))]
          [v g])
        (finally (swap! grad-depth dec))))))
-
-(defn jvp [f primals tangents]
-  (let [result-val (apply f primals)
-        eps 1e-5
-        perturbed (mapv (fn [p t] (add p (multiply (scalar eps) t)))
-                        (vec primals) (vec tangents))
-        result-perturbed (apply f perturbed)]
-    [result-val (divide (subtract result-perturbed result-val) (scalar eps))]))
-
-(defn vjp [f primals cotangents]
-  (let [cotangents-arr (vec cotangents)
-        surrogate (fn [& xs]
-                    (let [result (apply f xs)]
-                      (if (sequential? cotangents-arr)
-                        (sum (multiply result (first cotangents-arr)))
-                        (sum (multiply result cotangents-arr)))))
-        result (.valueAndGrad M surrogate (to-array (vec primals)))
-        fval (apply f (vec primals))
-        grads (into-array (map #(aget result (inc %)) (range (dec (.-length result)))))]
-    [fval grads]))
 
 ;; =========================================================================
 ;; EFFECTFUL OPERATIONS (Layer C — triggers GPU dispatch)
@@ -877,7 +865,10 @@
       (and (not (in-tidy?)) (buffer-count-pressure?))
       (count-sweep!)
 
-      (> (get-active-memory) gfi-pressure-threshold)
+      ;; Same in-tidy? gate as the count branch and auto-cleanup!: a tidy
+      ;; scope does its own cleanup on exit, and jsc-cleanup!/clear-cache!
+      ;; mid-scope is the mid-tidy GC the design forbids.
+      (and (not (in-tidy?)) (> (get-active-memory) gfi-pressure-threshold))
       (do (jsc-cleanup!)
           (sweep-dead-arrays!)
           (clear-cache!)))))
@@ -1044,16 +1035,6 @@
   [& arrays]
   (let [promises (mapv #(.evalAsync %) (filter some? arrays))]
     (js/Promise.all (to-array promises))))
-
-(defn training-step!
-  "One training step: forward, backward, update, extract loss.
-   EFFECTFUL: triggers eval on module, loss, and extracts scalar."
-  [module optim vg-fn & inputs]
-  (let [[loss grads] (apply vg-fn inputs)]
-    (.update optim module grads)
-    (eval! module)
-    (eval! loss)
-    (item loss)))
 
 ;; =========================================================================
 ;; CONFIGURATION — device, constants

--- a/src/genmlx/mlx/random.cljs
+++ b/src/genmlx/mlx/random.cljs
@@ -58,17 +58,30 @@
                     {:key-shape (when (mx/array? k) (mx/shape k))
                      :key-dtype (when (mx/array? k) (mx/dtype k))}))))
 
+(defn- check-key-present
+  "Like check-key, but nil is also an error: split/split-n require a real key.
+   Raising here gives an actionable message instead of the raw NAPI error a
+   nil reaching .randomSplit produces. Nil-tolerant call sites use
+   split-or-nils / split-n-or-nils."
+  [k where]
+  (when (nil? k)
+    (throw (ex-info (str "rng/" where ": key is nil — thread a real PRNG key "
+                         "(rng/fresh-key), or use rng/" where "-or-nils for "
+                         "nil-as-no-entropy call sites.")
+                    {:key nil})))
+  (check-key k where))
+
 (defn split
   "Split a key into two independent sub-keys. Returns [k1 k2]."
   [key]
-  (check-key key "split")
+  (check-key-present key "split")
   (let [ks (.randomSplit c key)]
     [(aget ks 0) (aget ks 1)]))
 
 (defn split-n
   "Split a key into n independent sub-keys. Returns vector of n keys."
   [key n]
-  (check-key key "split-n")
+  (check-key-present key "split-n")
   (let [ks (.randomSplitN c key n)]
     (mapv #(mx/index ks %) (range n))))
 

--- a/src/genmlx/verify.cljs
+++ b/src/genmlx/verify.cljs
@@ -144,6 +144,18 @@
 ;; Single-trial validation
 ;; ---------------------------------------------------------------------------
 
+(defn- validation-executor
+  "Splice executor for validation trials: simulate the sub-gf (threading the
+   split PRNG key via with-key) and merge its choices/score under the splice
+   address. Validation trials run simulate semantics only, so constraints/
+   old-choices/selection are always empty here. Without this, any model with
+   a scalar splice crashed the trial and reported :valid? false."
+  [gf args {:keys [key]}]
+  (let [trace (p/simulate (if key (dyn/with-key gf key) gf) (vec args))]
+    {:choices (:choices trace)
+     :score (:score trace)
+     :retval (:retval trace)}))
+
 (defn- run-validation-trial
   "Run one validation trial. Returns {:violations [...] :trace trace} or
    {:violations [{:type :execution-error ...}]} on exception."
@@ -155,7 +167,7 @@
                                   :key key
                                   :seen-addrs #{}
                                   :violations []
-                                  :executor nil}
+                                  :executor validation-executor}
                                  (fn [rt] (apply (:body-fn gf) rt args)))
           violations (:violations result)
           trace (tr/make-trace {:gen-fn gf :args args
@@ -184,9 +196,11 @@
        :trace nil})))
 
 (defn- check-halts
-  "Run n-trials simulates to test that the model terminates.
-   DML restriction 1: model must halt with probability 1.
-   Returns violations vector (empty if all trials succeed)."
+  "Run n-trials simulates as a smoke test for DML restriction 1 (halts with
+   probability 1). HONESTY: this can only catch models that CRASH during a
+   trial — a genuinely non-terminating model hangs the process and cannot be
+   detected here. A trial exception is therefore reported as
+   :halting-trial-error, not non-termination."
   [gf args n-trials key]
   (try
     (let [keys (rng/split-n key n-trials)]
@@ -194,9 +208,10 @@
         (p/simulate (dyn/with-key gf k) args))
       [])
     (catch :default e
-      [{:type :non-termination
+      [{:type :halting-trial-error
         :severity :warning
-        :message (str "Model failed during halting test: " (.-message e))}])))
+        :message (str "Model crashed during halting smoke test (this check "
+                      "cannot detect true non-termination): " (.-message e))}])))
 
 ;; ---------------------------------------------------------------------------
 ;; Public API

--- a/test/genmlx/membrane_honesty_test.cljs
+++ b/test/genmlx/membrane_honesty_test.cljs
@@ -1,0 +1,64 @@
+;; @tier fast
+(ns genmlx.membrane-honesty-test
+  "Regression tests for the genmlx-vd2j membrane honesty bundle:
+   eq?/neq? float truncation, meshgrid broadcast-to correctness,
+   rng split nil-key guard, hmm-obs zero-lp contract."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.dist.core :as dc]
+            [genmlx.inference.hmm-forward :as hmm]))
+
+(deftest eq-float-operand-test
+  (testing "eq?/neq? must not truncate non-integer number operands (genmlx-vd2j)"
+    ;; pre-fix: (eq? arr 2.5) promoted 2.5 via int32 scalar -> compared against 2
+    (let [arr (mx/array [2.0 2.5 3.0])]
+      (is (= [0.0 1.0 0.0] (vec (mx/->clj (mx/eq? arr 2.5))))
+          "eq? against 2.5 matches only 2.5")
+      (is (= [1.0 0.0 1.0] (vec (mx/->clj (mx/neq? arr 2.5))))
+          "neq? against 2.5 is the complement")
+      (is (= [1.0 0.0 0.0] (vec (mx/->clj (mx/eq? arr 2))))
+          "integer operands still compare exactly"))))
+
+(deftest meshgrid-broadcast-test
+  (testing "meshgrid fills broadcast dims correctly (genmlx-vd2j)"
+    ;; pre-fix: native broadcastTo mis-fills size-1 source dims -> [v 0 0 ...]
+    (let [grids (mx/meshgrid (mx/array [1.0 2.0 3.0]) (mx/array [10.0 20.0]))
+          a-col (aget grids 0)
+          b-row (aget grids 1)]
+      (is (= [3 2] (vec (mx/shape a-col))) "a-col shape")
+      (is (= [[1.0 1.0] [2.0 2.0] [3.0 3.0]]
+             (mapv vec (mx/->clj a-col)))
+          "a-col rows are constant (no zero-fill)")
+      (is (= [[10.0 20.0] [10.0 20.0] [10.0 20.0]]
+             (mapv vec (mx/->clj b-row)))
+          "b-row columns are constant (no zero-fill)"))))
+
+(deftest rng-split-nil-guard-test
+  (testing "split/split-n on nil key raise actionable errors (genmlx-vd2j)"
+    ;; pre-fix: check-key passed nil through -> raw NAPI error from .randomSplit
+    (is (thrown-with-msg? js/Error #"rng/split: key is nil"
+                          (rng/split nil))
+        "split nil throws with clear message")
+    (is (thrown-with-msg? js/Error #"rng/split-n: key is nil"
+                          (rng/split-n nil 3))
+        "split-n nil throws with clear message")
+    (is (= [nil nil] (rng/split-or-nils nil))
+        "split-or-nils still supports nil-as-no-entropy")
+    (is (= [nil nil nil] (rng/split-n-or-nils nil 3))
+        "split-n-or-nils still supports nil-as-no-entropy")
+    (let [[k1 k2] (rng/split (rng/fresh-key 42))]
+      (is (and (rng/valid-key? k1) (rng/valid-key? k2))
+          "split on a real key still works"))))
+
+(deftest hmm-obs-zero-lp-contract-test
+  (testing "hmm-obs contributes ZERO under plain handlers — documented contract (genmlx-vd2j)"
+    ;; This pins the honest docstring: if hmm-obs ever gains a real plain-handler
+    ;; log-prob, update the docstring and this test together.
+    (let [d (hmm/hmm-obs (mx/array [-1.0 -2.0]) (mx/scalar 1.0))]
+      (is (zero? (mx/item (dc/dist-log-prob d (mx/scalar 0.0))))
+          "log-prob is 0.0 under plain handler")
+      (is (zero? (mx/item (dc/dist-sample* d (rng/fresh-key 1))))
+          "sample is dummy 0.0 under plain handler"))))
+
+(cljs.test/run-tests)

--- a/test/genmlx/verify_test.cljs
+++ b/test/genmlx/verify_test.cljs
@@ -101,4 +101,16 @@
       (is (= 0 (count (:violations result))) "no violations")
       (is (instance? tr/Trace (:trace result)) "trace returned"))))
 
+(deftest splice-model-validates
+  (testing "scalar splice no longer crashes validation (genmlx-vd2j)"
+    ;; pre-fix: run-validation-trial passed :executor nil -> ANY model with a
+    ;; splice crashed the trial and reported :valid? false
+    (let [sub (gen [] (trace :z (dist/gaussian 0 1)))
+          model (gen [] (let [z (splice :sub sub)]
+                          (trace :x (dist/gaussian z 1))))
+          result (verify/validate-gen-fn model [])]
+      (is (:valid? result) "splice model is valid")
+      (is (= 0 (count (:violations result))) "no violations")
+      (is (some? (:trace result)) "trace returned"))))
+
 (cljs.test/run-tests)

--- a/test/genmlx/well_formedness_test.cljs
+++ b/test/genmlx/well_formedness_test.cljs
@@ -183,16 +183,17 @@
 (deftest clean-model-halts
   (let [model (gen [] (trace :x (dist/gaussian 0 1)))
         result (verify/validate-gen-fn model [])]
-    (is (not (has-violation? result :non-termination)))))
+    (is (not (has-violation? result :halting-trial-error)))))
 
-(deftest throwing-model-detected-as-non-halting
-  (testing "model that always throws gets non-termination warning"
+(deftest throwing-model-detected-by-halting-smoke-test
+  (testing "model that crashes during trials gets halting-trial-error warning
+            (true non-termination is undetectable — it would hang; genmlx-vd2j)"
     (let [model (dyn/auto-key
                   (dyn/make-gen-fn
                     (fn [_rt] (throw (js/Error. "infinite loop simulation")))
                     '([] (loop [] (recur)))))
           result (verify/validate-gen-fn model [])]
-      (is (has-violation? result :non-termination)))))
+      (is (has-violation? result :halting-trial-error)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Integration: validate-gen-fn catches all DML violations
@@ -226,7 +227,7 @@
     (is (not (has-violation? result :external-randomness)))
     (is (not (has-violation? result :mutation)))
     (is (not (has-violation? result :hof-gen-fn)))
-    (is (not (has-violation? result :non-termination)))))
+    (is (not (has-violation? result :halting-trial-error)))))
 
 (deftest validate-gen-fn-multiple-violations-combined
   (testing "source with both mutation and external randomness"


### PR DESCRIPTION
Closes the membrane audit bundle from epic genmlx-hqo2 (Phase 0 row 10). All 7 line-cited findings verified first, then fixed.

## Removed (dead + dishonest — membrane transparency rule)
- **mx/training-step!**: zero callers (`nn/training-step!` is the real one); passed a JS module object to `eval!` which filters non-arrays, so the post-update param eval was a silent no-op.
- **jvp**: finite differences presented as forward-mode autodiff. **vjp**: silently used only the first cotangent. Zero callers each.

## Fixed
- **eq?/neq?**: number operands were promoted via int32 scalar — `(eq? arr 2.5)` compared against 2. Non-integers now stay float32; integers still compare exactly.
- **gfi-cleanup!**: memory-pressure branch ran `jsc-cleanup!`+`clear-cache!` without the `in-tidy?` gate the count branch has — mid-tidy GC the design forbids, triggered by any GFI op in a tidy scope over 128MB. Now gated.
- **meshgrid**: used native `broadcastTo`, whose size-1-source-dim fill is broken (per broadcast-to's own docstring) — and meshgrid's `[na 1]`/`[1 nb]` expansions are exactly that case. Now uses the corrected `broadcast-to`.
- **verify.cljs**: `run-validation-trial` passed `:executor nil` → any scalar-splice model crashed and reported `:valid? false`. New simulate-based validation executor threads the split key. `check-halts` relabeled honestly (`:halting-trial-error`; a crash is not non-termination, and true non-termination would hang undetected).
- **hmm-obs**: docstring claimed it returns emission log-prob under the standard handler; it returns 0.0. Docstring now states the forward-handler-only contract plainly; a test pins it.
- **rng/split, split-n**: nil key now raises an actionable error instead of a raw NAPI crash; `split-or-nils`/`split-n-or-nils` keep nil-as-no-entropy.

## Docs
CLAUDE.md mutable-state inventory aligned with reality (5 mlx atoms + 4 `^:mutable` counters, combinator/exact/agents caches, nn/amortized training state, defdist registry atom).

## Tests
New `membrane_honesty_test.cljs` (eq? floats, meshgrid fill, nil-key guard, hmm-obs contract); `verify_test` + splice-model case; `well_formedness_test` relabeled. Green: fast-core 34/34; exact/gradient_fd/score_gradient/clip_contract membrane guards; hmm_forward, nn, mutation_boundary, prng_hygiene, prng_key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)