### PR TITLE
fix(agents): belief guards, unified nil-obs contract, safe-where, key threading (genmlx-xpbm)

### DIFF
--- a/src/genmlx/agents/agent.cljs
+++ b/src/genmlx/agents/agent.cljs
@@ -24,6 +24,7 @@
    Scope: MDP planning + rollout + the recursive≡tensor equivalence. POMDP
    (make-pomdp-agent, belief filtering, :update-belief, simulate-pomdp) remains."
   (:require [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
             [genmlx.dist :as dist]
             [genmlx.protocols :as p]
             [genmlx.dynamic :as dyn]
@@ -124,6 +125,11 @@
    Returns {:eu (fn [s a t]) :soft-v (fn [s t])}; EU(s,a,horizon) is the t-step Q
    that `value-iteration` computes with `n = horizon` sweeps."
   [{:keys [A gamma terminals] :as mdp}]
+  (when-not (number? (:alpha mdp))
+    (throw (ex-info "recursive-eu: mdp is missing a numeric :alpha — callers
+bypassing make-mdp-agent must supply it ((* nil q) silently yields 0, making
+the softmax policy uniform; alpha = ##Inf belongs in recursive-eu-inf)."
+                    {:alpha (:alpha mdp)})))
   (let [Rh      (mx/->clj (:R mdp))       ; [S][A] JS numbers
         Th      (mx/->clj (:T mdp))       ; [S][A][S'] JS numbers
         terms   (set (keys terminals))
@@ -183,7 +189,11 @@
         policy     (gen [s] (trace :action (h/softmax-action alpha (mx/idx Q s))))
         rec        (delay (if (= alpha ##Inf) (recursive-eu-inf mdp) (recursive-eu mdp)))]
     {:mdp mdp :Q Q :V V :policy policy
-     :act (fn [s] (int (mx/item (:retval (p/simulate (dyn/auto-key policy) [s])))))
+     ;; act: optional key arity for reproducible rollouts (genmlx-xpbm) —
+     ;; (act s) draws fresh entropy, (act s key) is deterministic in key.
+     :act (fn
+            ([s] (int (mx/item (:retval (p/simulate (dyn/auto-key policy) [s])))))
+            ([s key] (int (mx/item (:retval (p/simulate (if key (dyn/with-key policy key) (dyn/auto-key policy)) [s]))))))
      :expected-utility (fn [s a] ((:eu @rec) s a n-iters))   ; recursive EU(s,a,horizon)
      :params {:alpha alpha :gamma gamma :horizon n-iters}}))
 
@@ -196,10 +206,12 @@
 (defn sample-next
   "Sample the next state from T[s,a,:] (the env-step generative function).
    Deterministic when the row is one-hot (noise = 0). Public so the POMDP rollout
-   (genmlx.agents.pomdp/simulate-pomdp) threads the world transition the same way."
-  [T s a]
-  (let [probs (vec (mx/->clj (mx/idx (mx/idx T s) a)))]      ; T[s,a,:] -> [S'] probs
-    (int (mx/item (:retval (p/simulate (dyn/auto-key env-step) [probs]))))))
+   (genmlx.agents.pomdp/simulate-pomdp) threads the world transition the same way.
+   Optional key for reproducible rollouts (genmlx-xpbm)."
+  ([T s a] (sample-next T s a nil))
+  ([T s a key]
+   (let [probs (vec (mx/->clj (mx/idx (mx/idx T s) a)))]     ; T[s,a,:] -> [S'] probs
+     (int (mx/item (:retval (p/simulate (if key (dyn/with-key env-step key) (dyn/auto-key env-step)) [probs])))))))
 
 (defn simulate-mdp
   "Roll the agent's policy out from `start` for at most `horizon` steps, stopping
@@ -214,10 +226,16 @@
   [{:keys [mdp act] :as agent} start horizon & [{:keys [rollout-mode key]}]]
   (if (= rollout-mode :fused)
     (rollout/rollout-mdp agent start horizon {:key key})
+    ;; :key was previously accepted but IGNORED on the :host path (genmlx-xpbm);
+    ;; it now threads per-step sub-keys through act and sample-next, so the same
+    ;; key reproduces the same trajectory.
     (let [{:keys [T terminals]} mdp]
-      (loop [s start, step 0, states [start], actions []]
+      (loop [s start, step 0, k key, states [start], actions []]
         (if (or (>= step horizon) (contains? terminals s))
           {:states states :actions actions}
-          (let [a  (act s)
-                s' (sample-next T s a)]
-            (recur s' (inc step) (conj states s') (conj actions a))))))))
+          (let [[k-act k-next k'] (if k (rng/split-n k 3) [nil nil nil])
+                ;; keyless path stays 1-arity so custom agents whose :act is
+                ;; (fn [s]) keep working; the key arity is opt-in
+                a  (if k-act (act s k-act) (act s))
+                s' (sample-next T s a k-next)]
+            (recur s' (inc step) k' (conj states s') (conj actions a))))))))

--- a/src/genmlx/agents/belief.cljs
+++ b/src/genmlx/agents/belief.cljs
@@ -57,11 +57,17 @@
 (defn filter-step
   "Pure differentiable belief filter core: b' = where(Σ(b⊙L) > eps, (b⊙L)/Σ, b).
    Both b and L are [W] MLX arrays; returns a [W] MLX array. No mx/item, no host
-   arithmetic — the gradient flows through b (L is a constant likelihood)."
+   arithmetic — the gradient flows through b (L is a constant likelihood).
+   Safe-where: the division uses a guarded denominator (1 where z ≤ eps) so the
+   untaken branch never computes raw/0 — with autograd, a NaN/Inf in the untaken
+   where branch poisons the gradient even though the forward value is fine
+   (genmlx-xpbm; prerequisite for the 5x3f differentiable-planning path)."
   [b L]
-  (let [raw (mx/multiply b L)
-        z   (mx/sum raw)]
-    (mx/where (mx/greater z eps) (mx/divide raw z) b)))
+  (let [raw    (mx/multiply b L)
+        z      (mx/sum raw)
+        ok     (mx/greater z eps)
+        z-safe (mx/where ok z (mx/scalar 1.0))]
+    (mx/where ok (mx/divide raw z-safe) b)))
 
 (defn tensor-update-belief
   "One Bayes filtering step as pure tensor ops. `b` is a [W] MLX belief aligned to

--- a/src/genmlx/agents/biased_planners.cljs
+++ b/src/genmlx/agents/biased_planners.cljs
@@ -483,13 +483,19 @@
 
 (defn- bayes-update
   "Exact Bayes filter on a discrete world belief: b'(w) ∝ b(w)·[observe(w,s')=o].
-   With a deterministic reveal this collapses to the revealed world (and is the
-   identity when o=nil, since every world is consistent). Returns a prob vector
-   aligned to `worlds`. If o is impossible under b, keeps b (defensive)."
+   Observation-model contract (unified across pomdp/belief/biased filters,
+   genmlx-xpbm): o = nil means NO observation and is an unconditional identity —
+   it is never treated as a value to match against observe (which would make
+   absence informative when observe returns non-nil for some worlds). With a
+   deterministic reveal a non-nil o collapses to the revealed world. Returns a
+   prob vector aligned to `worlds`. If o is impossible under b, keeps b
+   (defensive)."
   [worlds observe belief s' o]
-  (let [raw (mapv (fn [bw w] (if (= (observe w s') o) bw 0.0)) belief worlds)
-        z   (reduce + raw)]
-    (if (pos? z) (mapv #(/ % z) raw) belief)))
+  (if (nil? o)
+    belief
+    (let [raw (mapv (fn [bw w] (if (= (observe w s') o) bw 0.0)) belief worlds)
+          z   (reduce + raw)]
+      (if (pos? z) (mapv #(/ % z) raw) belief))))
 
 (defn- build-biased-eu-belief
   "Belief-space delay-indexed biased EU (the faithful information-valuing Ch-3c

--- a/src/genmlx/agents/pomdp.cljs
+++ b/src/genmlx/agents/pomdp.cljs
@@ -79,19 +79,27 @@
                       (mx/sum (mx/multiply (mx/reshape bvec [W 1]) (mx/idx Qstack s 1)) [0])))
         ;; one Bayes filtering step: b'(w) ∝ b(w) · P(obs | w, loc).
         ;; obs = nil (uninformative location) => belief unchanged (flat-then-snap).
+        ;; Observation-model contract (unified across pomdp/belief/biased filters,
+        ;; genmlx-xpbm): obs = nil is unconditionally uninformative (identity), and
+        ;; an obs impossible under the current belief keeps b unchanged (defensive)
+        ;; instead of NaN-ing through normalize-logs.
         update-belief (fn [belief loc obs]
                         (if (nil? obs)
                           belief
-                          (inv/normalize-logs
-                            (into {} (map (fn [[w b]]
-                                            [w (+ (Math/log b)
-                                                  (if (= (observe w loc) obs) 0.0 ##-Inf))])
-                                          belief)))))
-        ;; act = softmax-action over the belief-mixed Q row, as a real GFI choice
+                          (let [logm (into {} (map (fn [[w b]]
+                                                     [w (+ (Math/log b)
+                                                           (if (= (observe w loc) obs) 0.0 ##-Inf))])
+                                                   belief))]
+                            (if (every? #(= % ##-Inf) (vals logm))
+                              belief
+                              (inv/normalize-logs logm)))))
+        ;; act = softmax-action over the belief-mixed Q row, as a real GFI choice.
+        ;; policy is hoisted and parameterized on q: constructing a gen fn per act
+        ;; call re-ran schema extraction every rollout step (genmlx-xpbm).
+        policy (gen [q] (trace :action (h/softmax-action alpha q)))
         act (fn [belief s]
-              (let [q      (belief-Q belief s)
-                    policy (gen [] (trace :action (h/softmax-action alpha q)))]
-                (int (mx/item (:retval (p/simulate (dyn/auto-key policy) []))))))]
+              (let [q (belief-Q belief s)]
+                (int (mx/item (:retval (p/simulate (dyn/auto-key policy) [q]))))))]
     {:worlds (vec worlds) :world-agents world-agents :prior prior :observe observe
      :belief-Q belief-Q :update-belief update-belief :act act
      ;; tensor belief kernel (bean genmlx-kpuo): same map-in/map-out contract as
@@ -188,7 +196,10 @@
    uncertain and collapses as the Beta sharpens — NOT the optimal Bayes-adaptive
    (information-valuing) policy."
   [{:keys [strategy alpha] :or {strategy :thompson alpha 4.0}}]
-  (let [arm-values (fn [{:keys [arms]}] (mapv (fn [[a b]] (/ a (+ a b))) arms))]
+  (let [arm-values (fn [{:keys [arms]}] (mapv (fn [[a b]] (/ a (+ a b))) arms))
+        ;; hoisted + parameterized on eu: a per-act (gen ...) re-ran schema
+        ;; extraction every pull (genmlx-xpbm)
+        softmax-pol (gen [eu] (trace :action (h/softmax-action alpha eu)))]
     {:arm-values    arm-values
      :update-belief update-arm
      :act (fn [{:keys [arms]} key]
@@ -206,9 +217,8 @@
                     theta (dist/beta-sample-vec av bv key)]                    ; [K] posterior draw
                 (int (mx/item (mx/argmax theta))))
               :softmax
-              (let [eu  (mx/array (clj->js (arm-values {:arms arms})))
-                    pol (gen [] (trace :action (h/softmax-action alpha eu)))]
-                (int (mx/item (:retval (p/simulate (dyn/with-key pol key) [])))))))
+              (let [eu (mx/array (clj->js (arm-values {:arms arms})))]
+                (int (mx/item (:retval (p/simulate (dyn/with-key softmax-pol key) [eu])))))))
      :params {:strategy strategy :alpha alpha}}))
 
 (defn simulate-bandit

--- a/test/genmlx/agents_api_test.cljs
+++ b/test/genmlx/agents_api_test.cljs
@@ -18,6 +18,7 @@
             [genmlx.mlx :as mx]
             [genmlx.protocols :as p]
             [genmlx.dynamic :as dyn]
+            [genmlx.mlx.random :as rng]
             [genmlx.choicemap :as cm]))
 
 (def passed (volatile! 0))
@@ -70,6 +71,24 @@
 (let [box (h/uniform-draw [:a :b :c])]
   (assert-true "helpers value-carrying draw: box + draw-value by index"
                (and (:dist box) (= 3 (count (:values box))) (= :b (h/draw-value box 1)))))
+
+;; ---- genmlx-xpbm regressions ----
+(println "\n== genmlx-xpbm regressions ==")
+;; recursive-eu without numeric :alpha throws (pre-fix: (* nil q) -> 0 -> silently
+;; uniform softmax policy when callers bypass make-mdp-agent)
+(assert-true "recursive-eu without :alpha throws actionably"
+             (try (agent/recursive-eu mdp) false
+                  (catch :default e (boolean (re-find #"alpha" (str (.-message e)))))))
+;; simulate-mdp :key now threads on the :host path (pre-fix: accepted but ignored)
+(let [k  (rng/fresh-key 7)
+      r1 (agent/simulate-mdp ag (:start-idx mdp) 6 {:key k})
+      r2 (agent/simulate-mdp ag (:start-idx mdp) 6 {:key k})]
+  (assert-true "simulate-mdp: same :key -> identical host trajectory"
+               (and (= (:states r1) (:states r2)) (= (:actions r1) (:actions r2)))))
+;; keyless host path still works (custom 1-arity :act agents keep working)
+(let [r (agent/simulate-mdp ag (:start-idx mdp) 4)]
+  (assert-true "simulate-mdp: keyless host path still rolls out"
+               (and (vector? (:states r)) (vector? (:actions r)))))
 
 ;; ---- biased-planners: k=0 limit recovery (biased == unbiased) ----
 (assert-close "biased-planners/delta(0,d)=1" 1.0 (bp/delta 0 3) 1e-12)

--- a/test/genmlx/belief_tensor_test.cljs
+++ b/test/genmlx/belief_tensor_test.cljs
@@ -79,11 +79,35 @@
                 (vec (mx/->clj b))
                 (vec (mx/->clj (belief/tensor-update-belief gw-observe gw-worlds b signpost nil))))
   ;; impossible obs (:C, which no world produces at the signpost) -> keep b (mirrors
-  ;; biased_planners.cljs:491 (pos? z) guard); the host pomdp path would NaN here.
+  ;; biased_planners.cljs (pos? z) guard; the host pomdp filter guards the same
+  ;; way since genmlx-xpbm).
   (assert-true "impossible obs -> belief unchanged (z=0 defensive)"
                (vecs-close? (vec (mx/->clj b))
                             (vec (mx/->clj (belief/tensor-update-belief gw-observe gw-worlds b signpost :C)))
                             1e-6)))
+
+(println "\n== Section 3b: genmlx-xpbm regressions (host guard + safe-where grad) ==")
+;; HOST pomdp filter: impossible obs keeps belief unchanged, never NaN
+;; (pre-fix: all log-weights -Inf -> normalize-logs exp(-Inf - -Inf) = NaN)
+(let [ub-host (:update-belief gw-agent)
+      out     (ub-host gw-prior signpost :C)]
+  (assert-true "host filter: impossible obs -> belief unchanged (no NaN)"
+               (maps-close? gw-prior out 1e-12))
+  (assert-true "host filter: no NaN in output"
+               (every? #(js/isFinite %) (vals out))))
+;; host == tensor on the impossible-obs case (the equivalence claim is now true)
+(let [ub-host (:update-belief gw-agent)
+      b       (belief/belief->vec gw-worlds gw-prior)
+      host    (ub-host gw-prior signpost :C)
+      tens    (belief/vec->belief gw-worlds (belief/tensor-update-belief gw-observe gw-worlds b signpost :C))]
+  (assert-true "host == tensor on impossible obs" (maps-close? host tens 1e-6)))
+;; safe-where: gradient through a z=0 filter-step is finite (pre-fix: raw/0 in
+;; the untaken where branch poisoned the gradient with NaN)
+(let [L0   (mx/array #js [0.0 0.0] mx/float32)            ; impossible obs likelihood
+      loss (fn [bv] (mx/sum (belief/filter-step bv L0)))
+      g    ((mx/grad loss) (mx/array #js [0.5 0.5] mx/float32))]
+  (assert-true "filter-step gradient finite at z=0 (safe-where)"
+               (every? #(js/isFinite %) (vec (mx/->clj g)))))
 
 (println "\n== Section 4: belief<->vec round-trip ==")
 (doseq [[label m] [["uniform" gw-prior] ["skewed" {:A 0.8 :B 0.2}]]]


### PR DESCRIPTION
Closes the agents audit bundle from epic genmlx-hqo2 (Phase 0 row 10). All findings verified against cited lines first.

## The design decision (asked for by the bean): observation-model contract
**nil = no observation = unconditional identity, across all three belief filters.** pomdp.cljs and belief.cljs already short-circuited nil; biased_planners/bayes-update treated nil as a matchable value, so absence became informative whenever `observe` returned non-nil for some worlds — the filters diverged. Now unified and documented at all three sites; a model where absence should be informative must encode it as an explicit observation value (e.g. `:none`).

## Fixes
- **pomdp update-belief**: impossible observation (all log-weights -Inf) kept NaN-ing through `normalize-logs` and propagating silently. Now keeps the belief unchanged — same defensive contract as the sibling filters. belief.cljs's host-equivalence claim becomes true.
- **belief/filter-step safe-where**: `(mx/where ok (mx/divide raw z) b)` computed `raw/0` in the untaken branch — the classic where/NaN autograd hazard on the planned differentiable-planning path (genmlx-5x3f). Denominator now guarded; regression asserts the gradient is finite at z=0.
- **simulate-mdp**: `:key` was accepted and silently ignored on the default :host path. Now splits per-step sub-keys through `act`/`sample-next` — same key, same trajectory. Key arities are opt-in; keyless 1-arity calls (and custom agents with 1-arity `:act`) unchanged.
- **recursive-eu**: missing `:alpha` made `(* nil q)` silently 0 → uniform softmax policy. Now throws actionably.
- **Hot loops**: pomdp `act` and bandit softmax `act` constructed a `(gen ...)` per rollout step — full schema extraction each call. Hoisted once, parameterized on q/eu.

## Tests
belief_tensor_test +Section 3b (host impossible-obs guard, host==tensor equivalence, safe-where gradient finiteness); agents_api_test +3 (alpha throw, key reproducibility, keyless path). All agents suites green serially: pomdp 23, biased_planners 41, adjacency 22, bandit 34, biased_inverse 42, irl 24, diff_learn 12, psrl 35, multi_agent 34, worlds 22, api 27, belief_tensor 36 — 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)