### PR TITLE
fix(llm): per-op grammar transitions, mask guards, deterministic byte commit (genmlx-xwxh)

### DIFF
--- a/src/genmlx/dispatch.cljs
+++ b/src/genmlx/dispatch.cljs
@@ -50,17 +50,22 @@
 
 (defn with-handler
   "Attach a custom handler transition to a generative function via metadata.
-   The transition has the standard handler signature:
+   `transition` is either:
 
-       (fn [state addr dist] -> [value state'])
+   - a single transition fn (fn [state addr dist] -> [value state']) — used
+     for EVERY GFI op. Only correct when the transition is genuinely
+     op-agnostic; a generate-flavored transition used for update/regenerate
+     silently runs generate semantics (genmlx-xwxh).
+   - a map {op -> transition} with ops from #{:simulate :generate :update
+     :regenerate :assess :project :propose} — the dispatcher picks the
+     entry per op and falls back to the STANDARD transition for ops the
+     map omits. Prefer this for middleware like grammar constraints.
 
-   The dispatcher wraps it into run-handler with the correct init-state
-   per GFI operation. Use this for domain-specific execution strategies
-   that fit the standard handler state shape (grammar constraints,
-   custom proposals, etc.).
+   The dispatcher wraps the chosen transition into run-handler with the
+   correct init-state per GFI operation.
 
    Usage:
-     (with-handler llm (wrap-grammar generate-transition grammar))
+     (with-handler llm {:generate (wrap-grammar generate-transition grammar)})
      (with-handler model (wrap-analytical generate-transition conjugacy-map))"
   [gf transition]
   (vary-meta gf assoc ::custom-transition transition))

--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -479,11 +479,16 @@
              :score-type (or (:score-type (meta df)) :joint)
              :label :custom})
 
-          ;; Transition substitution: (fn [state addr dist] -> [value state'])
+          ;; Transition substitution: a single (fn [state addr dist]) used for
+          ;; every op, or a per-op map {op -> transition} falling back to the
+          ;; standard transition for omitted ops (genmlx-xwxh).
           (::dispatch/custom-transition gf-meta)
-          (let [t (::dispatch/custom-transition gf-meta)]
-            {:run (partial (get transition-run-fns op) t)
-             :score-type (or (:score-type (meta t)) :joint)
+          (let [t  (::dispatch/custom-transition gf-meta)
+                tf (if (map? t)
+                     (or (get t op) (get standard-transitions op))
+                     t)]
+            {:run (partial (get transition-run-fns op) tf)
+             :score-type (or (:score-type (meta (if (map? t) tf t))) :joint)
              :label :custom}))))))
 
 (def ^:private analytical-dispatcher

--- a/src/genmlx/llm/bytes.cljs
+++ b/src/genmlx/llm/bytes.cljs
@@ -195,9 +195,13 @@
 
 (defn commit-token-id
   "Select the token ID to commit at a leaf node. A leaf's token-ids set
-   contains exactly the tokens whose byte sequence ends here."
+   contains exactly the tokens whose byte sequence ends here. Duplicate-text
+   tokens (same bytes, different ids) are resolved to the SMALLEST id: the
+   committed id conditions the KV cache, so an arbitrary (first set) pick made
+   logits nondeterministic for identical byte choices, breaking
+   choices-as-sufficient-statistic (genmlx-xwxh)."
   [node]
-  (first (:token-ids node)))
+  (apply min (:token-ids node)))
 
 (defn with-byte-cache
   "Run thunk under the model's KV-cache lifecycle: initialize the cache,

--- a/src/genmlx/llm/codegen.cljs
+++ b/src/genmlx/llm/codegen.cljs
@@ -296,11 +296,18 @@ Syntax: (fn [args] body), (let [bindings] body), (case val clauses default),
             :text text}))))))
 
 (defn generate-cljs-n
-  "Generate n independent ClojureScript candidates.
-   Returns a vector sorted by :valid? descending."
+  "Generate n independent ClojureScript candidates SEQUENTIALLY (one model
+   session in flight at a time — pr/all on n generate-cljs calls violated the
+   one-in-flight contract and interleaved KV-cache use on the shared model;
+   genmlx-xwxh). Returns a vector sorted by :valid? descending."
   ([model-map prompt n] (generate-cljs-n model-map prompt n {}))
   ([model-map prompt n opts]
-   (pr/let [results (pr/all (repeatedly n #(generate-cljs model-map prompt opts)))]
+   (pr/let [results (reduce (fn [acc-p _]
+                              (pr/let [acc acc-p
+                                       r (generate-cljs model-map prompt opts)]
+                                (conj acc r)))
+                            (pr/resolved [])
+                            (range n))]
      (vec (sort-by (fn [r] (if (:valid? r) 0 1)) results)))))
 
 ;; ============================================================
@@ -505,6 +512,18 @@ Syntax: (fn [args] body), (let [bindings] body), (case val clauses default),
 (defn generate-and-score
   "Generate code via chat API, then score it through the GFI.
    Returns the model's log-probability (weight) alongside the code.
+
+   WEIGHT APPROXIMATIONS (genmlx-xwxh) — :weight is the GF log-prob of a
+   RE-ENCODING of the generated text, not exactly of the sampled tokens:
+   1. Retokenization: the text is re-encoded with the tokenizer, which need
+      not reproduce the token ids the chat API actually sampled (BPE merges
+      are not unique over strings). The score is exact for the re-encoded
+      sequence, approximate for the generation event.
+   2. Template mismatch: the chat API and format-chat may differ in template
+      details (system tokens, role markers), shifting the conditioning prefix
+      the GF scores under.
+   Weights are comparable ACROSS candidates scored the same way (the MSA/
+   ranking use case); do not read them as exact evidence of the generation.
 
    model-map: {:model :tokenizer :type} from llm/load-model.
    gf:        a token-level GF from llm-core/make-llm-gf on the same model.

--- a/src/genmlx/llm/grammar.cljs
+++ b/src/genmlx/llm/grammar.cljs
@@ -447,13 +447,23 @@
    Uses .fromFloat32 directly (not mx/array, which doesn't handle
    JS TypedArrays — it would create a scalar instead of a vector)."
   [constraint dfa-state logits]
+  (when (= dfa-state :dead)
+    (throw (ex-info "apply-mask: DFA is in the :dead state — every token would be
+masked to -inf and the categorical would sample NaN. This happens when
+generation continues past a grammar-final token (e.g. EOS text advanced
+through the DFA) or the prior text left the grammar's language."
+                    {:dfa-state dfa-state})))
   (let [{:keys [dfa eos-id]} constraint
         src-mask (get-mask constraint dfa-state)
         logits-n (first (mx/shape logits))
-        ;; Copy mask to avoid mutating precomputed cache
+        ;; Copy mask to avoid mutating precomputed cache. Truncate when the
+        ;; tokenizer vocab exceeds the model's logits dim (.set with a longer
+        ;; source throws RangeError); ids beyond logits-n cannot be sampled.
         mask-arr (let [buf (js/Float32Array. logits-n)]
                    (.fill buf neg-inf)
-                   (.set buf src-mask)
+                   (.set buf (if (> (.-length src-mask) logits-n)
+                               (.subarray src-mask 0 logits-n)
+                               src-mask))
                    buf)]
     ;; EOS handling: valid only in accept states (bounds-check for model/vocab mismatch)
     (when (< eos-id logits-n)
@@ -490,19 +500,41 @@
               masked-dist (dist/categorical masked-logits)
               [value state'] (base-transition state addr masked-dist)
               tok-id (mx/item value)
-              tok-str (nth token-index tok-id "")
-              new-dfa-state (dfa-advance-string dfa dfa-state tok-str)]
+              ;; EOS terminates generation; advancing the DFA through the EOS
+              ;; LITERAL text would reach :dead and NaN any further site
+              ;; (genmlx-xwxh). Keep the (accepting) state instead.
+              new-dfa-state (if (= tok-id (:eos-id constraint))
+                              dfa-state
+                              (dfa-advance-string dfa dfa-state
+                                                  (nth token-index tok-id "")))]
           [value (assoc state' :grammar-state new-dfa-state)])
         (base-transition state addr dist)))))
+
+(def ^:private standard-transitions
+  "Per-op standard handler transitions, mirrored from the dispatcher table.
+   constrain wraps EACH op's own transition: a single generate-flavored
+   transition serving every op silently ran generate semantics under
+   update/regenerate (old-choices/selection ignored, wrong weights for
+   token-MCMC; genmlx-xwxh)."
+  {:simulate h/simulate-transition, :generate h/generate-transition
+   :update h/update-transition,     :regenerate h/regenerate-transition
+   :assess h/assess-transition,     :project h/project-transition
+   :propose h/simulate-transition})
 
 (defn constrain
   "Convenience: apply grammar constraint to a generative function.
 
    Returns a new GF where all categorical distributions are masked
-   by the grammar. Works with any GF that uses dist/categorical —
-   not limited to LLMs.
+   by the grammar — under EVERY GFI op, each running its own standard
+   transition wrapped with the grammar middleware. Works with any GF
+   that uses dist/categorical — not limited to LLMs.
 
    Equivalent to:
-     (dispatch/with-handler gf (wrap-grammar h/generate-transition constraint))"
+     (dispatch/with-handler gf
+       {:simulate (wrap-grammar h/simulate-transition constraint)
+        :generate (wrap-grammar h/generate-transition constraint)
+        ...})"
   [gf constraint]
-  (dispatch/with-handler gf (wrap-grammar h/generate-transition constraint)))
+  (dispatch/with-handler gf
+    (into {} (map (fn [[op t]] [op (wrap-grammar t constraint)]))
+          standard-transitions)))

--- a/src/genmlx/llm/vision.cljs
+++ b/src/genmlx/llm/vision.cljs
@@ -81,12 +81,15 @@
            result (.send session prompt
                           #js {:images #js [image-bytes]
                                :config config})]
+    ;; Keep the WHOLE answer (lowercased, alphanumerics + single spaces):
+    ;; taking only the first word made multi-word labels ("fire truck")
+    ;; unmatchable in label->index (genmlx-xwxh). label->index normalizes
+    ;; cell-type labels the same way.
     (-> (or (.-text result) "")
-        str/trim
-        (str/split #"\s+")
-        first
         str/lower-case
-        (str/replace #"[^a-z]" ""))))
+        (str/replace #"[^a-z0-9 ]" "")
+        (str/replace #"\s+" " ")
+        str/trim)))
 
 (defn classify-grid
   "Classify all cells of an N×M grid. Returns a promise of
@@ -129,20 +132,47 @@
   [r c]
   (keyword (str "r" r "-c" c)))
 
+(defn- normalize-label
+  "Shared normalization for VLM answers and cell-type labels: lowercase,
+   strip everything but alphanumerics and spaces, collapse whitespace. Both
+   sides of the match go through this, so \"Fire Truck!\" == \"fire truck\"."
+  [s]
+  (-> (or s "")
+      str/lower-case
+      (str/replace #"[^a-z0-9 ]" "")
+      (str/replace #"\s+" " ")
+      str/trim))
+
+(defn- word-contained?
+  "Whole-word containment in either direction between two normalized strings:
+   \"a tree\" contains the label \"tree\"; the terse answer \"fire\" is
+   contained in the label \"fire truck\"."
+  [a b]
+  (let [pa (str " " a " ") pb (str " " b " ")]
+    (or (str/includes? pa pb) (str/includes? pb pa))))
+
 (defn label->index
-  "Look up a label in `cell-types` (case-insensitive). Accepts string or map
-   options. Returns nil if not found."
+  "Look up a label in `cell-types` (case/punctuation/whitespace insensitive —
+   see normalize-label). Accepts string or map options. Exact normalized
+   match first; otherwise whole-word containment in either direction
+   (answer \"a fire truck\" matches label \"fire truck\"; terse answer
+   \"fire\" matches \"fire truck\"), first cell-type winning ties.
+   Returns nil if not found."
   [cell-types label]
-  (let [target (str/lower-case (or label ""))]
-    (first (keep-indexed
-             (fn [i v]
-               (when (= (str/lower-case (option->label v)) target) i))
-             cell-types))))
+  (let [target (normalize-label label)
+        norm   (mapv #(normalize-label (option->label %)) cell-types)]
+    (when (seq target)
+      (or (first (keep-indexed (fn [i v] (when (= v target) i)) norm))
+          (first (keep-indexed
+                   (fn [i v]
+                     (when (and (seq v) (word-contained? target v)) i))
+                   norm))))))
 
 (defn labels->constraints
-  "Build a choicemap-friendly map from a 2D label grid plus `cell-types`,
-   suitable for passing to `p/generate`. Cells whose label is unrecognized
-   (label->index returns nil) are simply omitted."
+  "Build a PLAIN {addr -> mx int32 scalar} map from a 2D label grid plus
+   `cell-types`. NOT itself a choicemap: wrap with cm/from-map (as the
+   examples do) before passing to p/generate. Cells whose label is
+   unrecognized (label->index returns nil) are simply omitted."
   [labels cell-types]
   (into {}
         (for [r (range (count labels))

--- a/test/genmlx/grammar_per_op_test.cljs
+++ b/test/genmlx/grammar_per_op_test.cljs
@@ -1,0 +1,115 @@
+;; @tier fast
+(ns genmlx.grammar-per-op-test
+  "Model-free regressions for the genmlx-xwxh grammar bundle: constrain
+   runs each GFI op under its OWN transition (update/regenerate previously
+   ran generate semantics), apply-mask guards (vocab>logits truncation,
+   :dead state throw), and EOS-then-continue no longer NaNs.
+
+   Uses a toy 4-'token' vocab [a b c <eos>] and hand-built constraint maps —
+   no LLM, no tokenizer; constrain works on any GF using dist/categorical."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.llm.grammar :as gram]
+            [genmlx.mlx :as mx]
+            [genmlx.protocols :as p]
+            [genmlx.dynamic :as dyn]
+            [genmlx.selection :as sel]
+            [genmlx.choicemap :as cm]
+            [genmlx.dist :as dist])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(def token-index ["a" "b" "c" "<eos>"])
+(def eos-id 3)
+
+(defn make-constraint [regex]
+  {:dfa (gram/compile-regex regex)
+   :token-index token-index
+   :eos-id eos-id
+   :masks nil})
+
+(def uniform-logits (mx/array [0.0 0.0 0.0 0.0]))
+
+;; 2 token sites, regex a[bc]: t0 must be a(0); t1 is b(1) or c(2)
+(def gf2
+  (dyn/auto-key
+    (gen []
+      (trace :t0 (dist/categorical uniform-logits))
+      (trace :t1 (dist/categorical uniform-logits)))))
+
+(def abc-constraint (make-constraint "a[bc]"))
+(def gf2c (gram/constrain gf2 abc-constraint))
+
+(defn choice [trace addr] (int (mx/item (cm/get-choice (:choices trace) [addr]))))
+
+(deftest simulate-respects-grammar
+  (testing "simulate masks every site by the DFA"
+    (dotimes [_ 5]
+      (let [tr (p/simulate gf2c [])]
+        (is (= 0 (choice tr :t0)) "t0 forced to a")
+        (is (contains? #{1 2} (choice tr :t1)) "t1 in [bc]")))))
+
+(deftest update-runs-update-semantics
+  (testing "p/update on a constrained GF preserves old choices and discards (genmlx-xwxh)"
+    (let [tr (p/simulate gf2c [])
+          old-t1 (choice tr :t1)
+          new-t1 (if (= old-t1 1) 2 1)
+          {:keys [trace discard weight]} (p/update gf2c tr (cm/choicemap :t1 (mx/scalar new-t1 mx/int32)))]
+      (is (= 0 (choice trace :t0)) "unconstrained t0 replayed (not regenerated)")
+      (is (= new-t1 (choice trace :t1)) "constrained t1 updated")
+      ;; pre-fix: generate semantics -> no discard of the old value
+      (is (= old-t1 (int (mx/item (cm/get-choice discard [:t1]))))
+          "discard holds the OLD t1 (update semantics, not generate)")
+      (is (js/isFinite (mx/item weight)) "finite update weight"))))
+
+(deftest regenerate-runs-regenerate-semantics
+  (testing "p/regenerate resamples only the selection (genmlx-xwxh)"
+    (let [tr (p/simulate gf2c [])
+          t0 (choice tr :t0)
+          {:keys [trace weight]} (p/regenerate gf2c tr (sel/select :t1))]
+      (is (= t0 (choice trace :t0)) "unselected t0 kept")
+      (is (contains? #{1 2} (choice trace :t1)) "resampled t1 stays in grammar")
+      (is (js/isFinite (mx/item weight)) "finite regenerate weight"))))
+
+(deftest assess-and-generate-agree
+  (testing "p/assess scores grammar-masked choices finitely"
+    (let [choices (cm/choicemap :t0 (mx/scalar 0 mx/int32)
+                                :t1 (mx/scalar 1 mx/int32))
+          {:keys [weight]} (p/assess gf2c [] choices)]
+      (is (js/isFinite (mx/item weight)) "finite assess weight")
+      ;; both sites masked: t0 from {a}, t1 from {b,c} -> log(1) + log(1/2)
+      (is (< (Math/abs (- (Math/log 0.5) (mx/item weight))) 1e-4)
+          "assess weight = grammar-conditioned log-prob"))))
+
+(deftest eos-then-continue-no-nan
+  (testing "EOS does not advance the DFA into :dead; later sites stay finite (genmlx-xwxh)"
+    ;; regex ab: t0=a, t1=b, then accept -> t2 must be EOS; pre-fix the DFA
+    ;; advanced through '<eos>' text to :dead and t3's all--inf mask sampled NaN
+    (let [gf4 (dyn/auto-key
+                (gen []
+                  (trace :t0 (dist/categorical uniform-logits))
+                  (trace :t1 (dist/categorical uniform-logits))
+                  (trace :t2 (dist/categorical uniform-logits))
+                  (trace :t3 (dist/categorical uniform-logits))))
+          gf4c (gram/constrain gf4 (make-constraint "ab"))
+          tr (p/simulate gf4c [])]
+      (is (= [0 1 eos-id eos-id] (mapv #(choice tr %) [:t0 :t1 :t2 :t3]))
+          "a, b, then EOS repeats — never NaN")
+      (is (js/isFinite (mx/item (:score tr))) "finite score"))))
+
+(deftest apply-mask-guards
+  (testing "vocab > logits dim truncates instead of RangeError (genmlx-xwxh)"
+    (let [big-constraint {:dfa (gram/compile-regex "[abcdef]")
+                          :token-index ["a" "b" "c" "d" "e" "f"]
+                          :eos-id 5
+                          :masks nil}
+          ;; logits dim 4 < token-index 6
+          masked (gram/apply-mask big-constraint
+                                  (get-in big-constraint [:dfa :start])
+                                  uniform-logits)]
+      (is (= [4] (vec (mx/shape masked))) "masked logits keep logits dim")
+      (is (every? js/isFinite (vec (mx/->clj (mx/exp masked))))
+          "probabilities well-defined")))
+  (testing ":dead DFA state throws actionably instead of NaN sampling (genmlx-xwxh)"
+    (is (thrown-with-msg? js/Error #"dead"
+                          (gram/apply-mask abc-constraint :dead uniform-logits)))))
+
+(cljs.test/run-tests)

--- a/test/genmlx/llm_pure_helpers_test.cljs
+++ b/test/genmlx/llm_pure_helpers_test.cljs
@@ -1,0 +1,30 @@
+;; @tier fast
+(ns genmlx.llm-pure-helpers-test
+  "Model-free regressions for the pure llm helpers fixed in genmlx-xwxh:
+   deterministic byte-trie token commit and vision label matching."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.llm.bytes :as bytes]
+            [genmlx.llm.vision :as vision]))
+
+(deftest commit-token-id-deterministic
+  (testing "duplicate-text tokens resolve to the smallest id (genmlx-xwxh)"
+    ;; pre-fix: (first set) — arbitrary id conditioned the KV cache, making
+    ;; logits nondeterministic for identical byte choices
+    (is (= 2 (bytes/commit-token-id {:token-ids #{9 5 2}})) "min of set")
+    (is (= 7 (bytes/commit-token-id {:token-ids #{7}})) "singleton")
+    (is (= 2 (bytes/commit-token-id {:token-ids (conj (sorted-set 9 5) 2)}))
+        "independent of set ordering")))
+
+(deftest label-matching-multi-word
+  (testing "multi-word labels match (genmlx-xwxh)"
+    (let [cell-types ["fire truck" "tree" "house"]]
+      (is (= 0 (vision/label->index cell-types "fire truck")) "exact multi-word")
+      (is (= 0 (vision/label->index cell-types "Fire Truck!")) "case+punct insensitive")
+      (is (= 0 (vision/label->index cell-types "fire truck is here")) "answer-prefix match")
+      (is (= 0 (vision/label->index cell-types "fire")) "terse answer prefix-matches label")
+      (is (= 1 (vision/label->index cell-types "a tree")) "leading article: no exact match, but label is suffix"
+          )
+      (is (nil? (vision/label->index cell-types "boat")) "unknown stays nil")
+      (is (nil? (vision/label->index cell-types "")) "empty answer stays nil"))))
+
+(cljs.test/run-tests)


### PR DESCRIPTION
Closes the llm audit bundle from epic genmlx-hqo2 (Phase 0 row 10). All 5 line-cited findings verified first.

## The headline fix: grammar middleware ran generate semantics under every GFI op
`constrain` attached ONE `(wrap-grammar h/generate-transition ...)` via `with-handler`, and the custom dispatcher used it for every op — so `p/update`/`p/regenerate` on grammar-constrained GFs silently ignored old-choices/selection and produced wrong weights (the exact hazard blocking token-MCMC, genmlx-3ob2).

Fix: `dispatch/with-handler` now also accepts a per-op map `{op -> transition}` (single-fn form unchanged for wrap-analytical etc.); omitted ops fall back to the STANDARD transition. `grammar/constrain` wires all 7 ops, each wrapping its own transition. A model-free regression proves update produces a real discard and regenerate respects the selection on a toy categorical GF + hand-built DFA constraint.

## Other fixes
- **apply-mask**: tokenizer vocab > model logits dim now truncates (was RangeError from `.set`); `:dead` DFA state throws actionably (was all--inf mask → NaN categorical).
- **EOS-then-continue**: wrap-grammar no longer advances the DFA through the EOS literal text — EOS keeps the accepting state, so post-EOS sites re-emit EOS instead of NaN.
- **bytes/commit-token-id**: duplicate-text token ids now resolve to the smallest id — the committed id conditions the KV cache, so the arbitrary `(first set)` pick made logits nondeterministic for identical byte choices.
- **codegen/generate-cljs-n**: n candidates generate sequentially (promise-chained), honoring the one-in-flight model contract; `generate-and-score` documents its two weight approximations (retokenization, chat-template mismatch) and the across-candidates comparability contract.
- **vision**: whole-answer normalization + whole-word containment matching (multi-word labels could never match; "a tree" now matches "tree", "fire" matches "fire truck"); `labels->constraints` docstring honestly says it returns a plain map (both callers already wrap with `cm/from-map`).

## Tests
New `grammar_per_op_test.cljs` (6 deftests / 24 assertions, no model needed) + `llm_pure_helpers_test.cljs` (10 assertions). Green: fast-core 34/34; conjugate, exact, auto_analytical (single-fn with-handler path unchanged); handler, handler_transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)