### PR TITLE
fix(core-data): set-value nil tolerance + de-vacuous two constraint test sites (ybw9 follow-up)

### DIFF
--- a/src/genmlx/choicemap.cljs
+++ b/src/genmlx/choicemap.cljs
@@ -41,10 +41,13 @@
   "Create a choice map from keyword-value pairs.
    Values are wrapped as leaves; maps become nested nodes.
    (choicemap :x 1.0 :y 2.0)
-   (choicemap :params {:slope 2.0 :intercept 1.0})"
+   (choicemap :params {:slope 2.0 :intercept 1.0})
+   For a single plain map use from-map. NOTE: (choicemap {m}) used to return
+   EMPTY silently — 11 test sites passed vacuous EMPTY constraints that way
+   (genmlx-ybw9); the odd-args throw keeps that mistake loud."
   [& kvs]
   (when (odd? (count kvs))
-    (throw (ex-info "choicemap expects an even number of key-value arguments"
+    (throw (ex-info "choicemap expects an even number of key-value arguments (for a single map, use from-map)"
                     {:arg-count (count kvs) :trailing (last kvs)})))
   (->Node
     (into {}
@@ -100,13 +103,15 @@
 (defn set-value
   "Fast-path: set a Value at a single keyword address in a Node.
    Used by handler transitions where cm is always a Node and value is always raw.
-   Throws when cm is not a Node — silently rebuilding from a Value leaf would
-   discard the leaf."
+   nil cm is treated as empty (callers build choices via (update m :choices ...)
+   where the key may be absent). Throws on a Value leaf or any other non-Node —
+   silently rebuilding from a leaf would discard it."
   [cm addr value]
-  (if (instance? Node cm)
-    (->Node (assoc (:m cm) addr (->Value value)))
-    (throw (ex-info "set-value expects a Node choicemap"
-                    {:cm-type (type cm) :addr addr}))))
+  (cond
+    (instance? Node cm) (->Node (assoc (:m cm) addr (->Value value)))
+    (nil? cm)           (->Node {addr (->Value value)})
+    :else (throw (ex-info "set-value expects a Node choicemap (or nil)"
+                          {:cm-type (type cm) :addr addr}))))
 
 (defn set-submap
   "Fast-path: set a sub-choicemap at a single address in a Node.

--- a/test/genmlx/l4_certification_test.cljs
+++ b/test/genmlx/l4_certification_test.cljs
@@ -126,7 +126,10 @@
 
   (testing "GFI-based score function"
     (let [model-k (dyn/auto-key m-conjugate)
-          obs (cm/choicemap {:y (mx/scalar 5.0)})
+          ;; flat kv form — (cm/choicemap {map}) was silently EMPTY pre-ybw9
+          ;; (the partition-2 dropped the lone arg), so generate ran
+          ;; UNCONSTRAINED here; the odd-args guard exposed it
+          obs (cm/choicemap :y (mx/scalar 5.0))
           {:keys [trace]} (p/generate model-k [0] obs)
           score (:score trace)]
       (mx/materialize! score)

--- a/test/genmlx/vectorized_mcmc_fix_test.cljs
+++ b/test/genmlx/vectorized_mcmc_fix_test.cljs
@@ -24,9 +24,13 @@
       slope)))
 
 (def xs [1.0 2.0 3.0])
-(def obs (cm/choicemap [:y0 (mx/scalar 2.1)]
-                       [:y1 (mx/scalar 4.0)]
-                       [:y2 (mx/scalar 5.9)]))
+;; flat kv form — the old bracketed-pairs call was silently mangled by
+;; (partition 2): key [:y0 v], value [:y1 v], [:y2 v] dropped — so the MH ran
+;; UNCONSTRAINED and this test passed vacuously. The choicemap constructor
+;; now throws on odd args, which exposed it (genmlx-ybw9).
+(def obs (cm/choicemap :y0 (mx/scalar 2.1)
+                       :y1 (mx/scalar 4.0)
+                       :y2 (mx/scalar 5.9)))
 (def n-chains 4)
 (def n-samples 5)
 


### PR DESCRIPTION
Follow-up to #82, found during the q69j parallel-runner validation.

## Regression fix
The new `set-value` guard was too strict: callers legitimately pass nil (building choices via `(update m :choices cm/set-value ...)` where the key may be absent — linear_gaussian/L3 paths). nil now means empty Node again; Value leaves and other non-Nodes still throw. l3_false_positive_test back to 62/62.

## Vacuous tests exposed by the odd-args guard (and fixed)
- `l4_certification_test`: `(cm/choicemap {:y v})` was silently EMPTY — g1's generate ran unconstrained. Now flat-form; 41/41 with the constraint real.
- `vectorized_mcmc_fix_test`: bracketed-pair form was partition-2-mangled into garbage keys — MH ran unconstrained. Now flat-form; green with real constraints.

## Deliberately left loud
`fused_inference_test` has 11 identical vacuous sites; making them real exposes a **latent SIGTRAP in a fused inference path under real constraints, verified pre-existing on pre-tonight main (2689070)**. Filed as high-priority bean genmlx-i3z8; the file now fails at load with 9 actionable guard errors instead of crashing natively every run. Not quarantined — honest red until the crash is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)