### PR TITLE
feat(test): 4-way parallel fast/medium tiers with launcher-race retry (genmlx-q69j)

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -26,7 +26,11 @@
 # (CRASH) or a TIMEOUT is a FAIL, never a silent "skip". Exit is non-zero if any
 # file does not cleanly PASS. CI green must mean CI green.
 #
-# Tunables: TEST_JOBS — parallel degree for fast/medium tiers (default 4).
+# Tunables: TEST_JOBS — parallel degree for fast/medium tiers (default 4,
+# validated 2026-06-10 on the full medium tier: per-file process isolation +
+# the genmlx-5ucd buffer-count mitigation make concurrent GPU load safe, and
+# do_one retries once on the known parallel-bunx launcher race; genmlx-q69j).
+# Slow/bench stay strictly serial. TEST_JOBS=1 restores fully-serial runs.
 set -u -o pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -38,12 +42,14 @@ MANIFEST="test/tiers.txt"
 #  - The direct `nbb` binary runs on NODE — far slower for GenMLX's compute, and it
 #    wedged heavy tests into uninterruptible Metal sleep (unkillable by `timeout`,
 #    exhausted RAM, load spiked to 67). NEVER use node-nbb.
-#  - Concurrent runs race two ways: `bunx` collides on a shared link ("EEXIST"), and
-#    concurrent GPU load wedges Metal (bean genmlx-5ucd). So default SERIAL. Once the
-#    membrane buffer-count fix lands, parallelism can be revisited via TEST_JOBS.
+#  - Concurrent runs used to race two ways: `bunx` collides on a shared link
+#    ("EEXIST" / "could not determine executable" — do_one now retries that one
+#    identifiable launcher race once), and concurrent GPU load wedged Metal before
+#    the genmlx-5ucd buffer-count mitigation. With both addressed, fast/medium run
+#    TEST_JOBS-way parallel (validated at 4; genmlx-q69j). Slow/bench stay serial.
 NBB_CMD="bun run --bun nbb"
 export NBB_CMD
-JOBS="${TEST_JOBS:-1}"
+JOBS="${TEST_JOBS:-4}"
 
 [ -f "$MANIFEST" ] || { echo "FATAL: $MANIFEST not found"; exit 2; }
 
@@ -202,6 +208,12 @@ do_check() {
 do_one() {
   local tier="$1" rdir="$2" file="$3"
   local to; to="$(tier_timeout "$tier")"
+  # Under J-way parallelism GPU-bound files share the device, inflating
+  # wall-clock up to J-fold — scale the per-file cap accordingly so a busy
+  # GPU is not misreported as a hang. TIMEOUT remains a FAIL (honesty
+  # contract); only the cap is contention-aware.
+  local j; j="$(tier_jobs "$tier")"
+  [ "$j" -gt 1 ] && to=$((to * j))
   local key; key="$(echo "$file" | tr '/.' '__')"
   local log="$rdir/$key.log"
   local start=$SECONDS status code dur pid
@@ -212,12 +224,23 @@ do_one() {
   # the worker itself: if the test ignores SIGTERM, timeout SIGKILLs it after 10s
   # rather than hanging the worker forever.
   set -m
-  timeout -k 10 "$to" $NBB_CMD "$file" > "$log" 2>&1 &
-  pid=$!
-  trap 'kill -KILL -'"$pid"' 2>/dev/null' TERM INT
-  wait "$pid"; code=$?
-  trap - TERM INT
-  kill -KILL -"$pid" 2>/dev/null   # sweep any stragglers left alive in the group
+  local attempt
+  for attempt in 1 2; do
+    timeout -k 10 "$to" $NBB_CMD "$file" > "$log" 2>&1 &
+    pid=$!
+    trap 'kill -KILL -'"$pid"' 2>/dev/null' TERM INT
+    wait "$pid"; code=$?
+    trap - TERM INT
+    kill -KILL -"$pid" 2>/dev/null   # sweep any stragglers left alive in the group
+    # Parallel bunx launches race on the shared install link ("could not
+    # determine executable to run for package nbb", the EEXIST class). The
+    # race fires BEFORE any test code runs, so retrying once is safe and
+    # attribution-honest; a real test failure never prints this line.
+    if [ "$code" -ne 0 ] && [ "$attempt" -eq 1 ] &&        grep -q 'could not determine executable to run for package nbb' "$log"; then
+      continue
+    fi
+    break
+  done
   set +m
   dur=$((SECONDS - start))
   if   [ "$code" -eq 124 ]; then status="TIMEOUT"
@@ -243,7 +266,8 @@ run_tiers() {
   # exits); a clean finish goes through the EXIT trap. Both call reap_children.
   trap on_signal INT TERM
   trap cleanup EXIT
-  export -f do_one tier_timeout
+  export -f do_one tier_timeout tier_jobs
+  export JOBS
 
   echo "nbb: '$NBB_CMD'  jobs(fast/medium): $JOBS"
   local grand_pass=0 grand_fail=0

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -97,6 +97,7 @@ medium test/genmlx/differentiable_test.cljs
 medium test/genmlx/directional_dist_test.cljs
 fast test/genmlx/dist_batch_test.cljs
 fast test/genmlx/dist_boundary_test.cljs core
+fast test/genmlx/dist_boundary2_test.cljs
 fast test/genmlx/dist_error_test.cljs
 fast test/genmlx/dist_gradient_test.cljs
 fast test/genmlx/dist_logprob_test.cljs core
@@ -164,6 +165,7 @@ bench test/genmlx/gpu_pipeline_bench.cljs
 fast test/genmlx/gradient_fd_test.cljs core
 medium test/genmlx/gradient_learning_property_test.cljs
 medium test/genmlx/gradient_mcmc_property_test.cljs
+fast test/genmlx/grammar_per_op_test.cljs
 fast test/genmlx/handler_property_test.cljs
 fast test/genmlx/handler_purity_test.cljs core
 fast test/genmlx/handler_test.cljs core
@@ -216,6 +218,7 @@ slow test/genmlx/llm_core_test.cljs
 slow test/genmlx/llm_gemma4_test.cljs
 slow test/genmlx/llm_grammar_test.cljs
 slow test/genmlx/llm_msa_test.cljs
+fast test/genmlx/llm_pure_helpers_test.cljs
 fast test/genmlx/location_scale_property_test.cljs
 medium test/genmlx/loop_compilation_test.cljs
 medium test/genmlx/loop_compiled_hmc_test.cljs
@@ -225,11 +228,13 @@ bench test/genmlx/lowering_ground_truth_2.cljs
 bench test/genmlx/lowering_ground_truth.cljs
 fast test/genmlx/map_dist_test.cljs
 medium test/genmlx/map_test.cljs
+fast test/genmlx/mcmc_defaults_test.cljs core
 slow test/genmlx/mcmc_detailed_balance_test.cljs
 medium test/genmlx/mcmc_diagnostics_test.cljs
 medium test/genmlx/mcmc_property_test.cljs
 slow test/genmlx/mcmc_stationary_test.cljs
 slow test/genmlx/membrane_churn_test.cljs
+fast test/genmlx/membrane_honesty_test.cljs
 fast test/genmlx/memory_test.cljs
 bench test/genmlx/metal_gc_stress.cljs
 fast test/genmlx/method_selection_test.cljs
@@ -259,6 +264,7 @@ medium test/genmlx/phase_a_test.cljs
 medium test/genmlx/phase_bcd_test.cljs
 medium test/genmlx/plate_generate_test.cljs
 medium test/genmlx/pmcmc_test.cljs
+medium test/genmlx/prng_hygiene_test.cljs
 medium test/genmlx/prng_key_test.cljs
 fast test/genmlx/product_dist_test.cljs
 fast test/genmlx/program_golden_test.cljs
@@ -301,6 +307,7 @@ fast test/genmlx/splice_property_test.cljs
 fast test/genmlx/splice_weight_test.cljs core
 fast test/genmlx/stack_unstack_property_test.cljs
 slow test/genmlx/stress_test.cljs
+fast test/genmlx/strip_compiled_test.cljs core
 medium test/genmlx/support_property_test.cljs
 medium test/genmlx/synthesis_exact_test.cljs
 fast test/genmlx/temperature_sampling_test.cljs
@@ -334,6 +341,7 @@ fast test/genmlx/vectorized_property_test.cljs
 fast test/genmlx/vectorized_shape_test.cljs
 medium test/genmlx/vectorized_test.cljs
 fast test/genmlx/verify_test.cljs
+medium test/genmlx/vi_learning_honesty_test.cljs
 medium test/genmlx/vi_property_test.cljs
 medium test/genmlx/vimco_test.cljs
 fast test/genmlx/vis_validation_test.cljs


### PR DESCRIPTION
Closes genmlx-q69j on its re-aimed direction (the bean's own 2026-06-08 findings: single-process batching is a dead end for the GPU-work-dominated medium tier; parallelism is the lever).

## Validation (2026-06-10, full 130-file medium tier)
- **TEST_JOBS=4: 17.5 min wall** vs ~40–60 min serial estimate. Two full runs + 12-file probes at J=2/J=4.
- **No SIGTRAP, no Metal wedge** under sustained 4-way GPU load — per-file process isolation + the genmlx-5ucd buffer-count mitigation hold.
- **Only parallel-specific failure mode found: the bunx launcher race** ('could not determine executable to run for package nbb', the EEXIST class). It fires before any test code runs; do_one now retries it once — attribution-honest.
- Contention TIMEOUTs at the serial 150s cap were false alarms — the per-file cap now scales by the tier's parallel degree (TIMEOUT remains a FAIL).

## Triage of the validation run's failures (all dispositioned)
- set-value nil regression + two vacuous-constraint tests → fixed in #86.
- fused_inference_test latent SIGTRAP under real constraints → bean genmlx-i3z8 (pre-existing, verified on pre-tonight main).
- gfi_combinator_invariants_test (20 failures) → pre-existing on pre-tonight main (2689070), not from tonight's PRs.
- gradient_mcmc/mcmc_diagnostics/vimco/ch02/pmcmc/gfi_laws single-assertion failures → stochastic flakes (different assertions fail run to run; pmcmc passed on re-run).

## Also
- tiers.txt regenerated (8 unclassified files from recent PRs); `check` gate green, 358 files.
- Isolated/serial mode preserved: `TEST_JOBS=1`; slow/bench always serial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)