### PR TITLE
fix(deps): bump malli pin for nbb 1.4.206 IPrintWithWriter compat; add load smoke test

### DIFF
--- a/test/genmlx/malli_load_test.cljs
+++ b/test/genmlx/malli_load_test.cljs
@@ -1,0 +1,59 @@
+;; @tier fast
+(ns genmlx.malli-load-test
+  "Smoke test: the malli submodule loads under the pinned nbb, and the two
+   GenMLX consumers (genmlx.schemas, genmlx.dev) work end-to-end.
+
+   No other test requires these namespaces, so without this file a malli
+   that fails to load under nbb's SCI (cljs.core/-pr-writer and
+   IPrintWithWriter are exposed only from nbb 1.4.207 — bean genmlx-7oxz)
+   leaves the suite green while dev-mode instrumentation is broken."
+  (:require [cljs.test :refer [deftest is testing]]
+            [malli.core :as m]
+            [malli.error :as me]
+            [malli.util :as mu]
+            [genmlx.schemas :as gs]
+            [genmlx.dev :as dev]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.dist :as dist]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.trace :as tr]
+            [genmlx.choicemap :as cm])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(def tiny-model
+  (gen []
+    (trace :x (dist/gaussian 0 1))))
+
+(deftest malli-loads-and-validates-test
+  (testing "malli.core basics"
+    (is (m/validate [:map [:x :int]] {:x 1}) "validate accepts")
+    (is (not (m/validate [:map [:x :int]] {:x "no"})) "validate rejects")
+    (is (some? (me/humanize (m/explain :int "x"))) "explain + humanize"))
+  (testing "malli.util"
+    (is (m/validate (mu/merge [:map [:x :int]] [:map [:y :int]])
+                    {:x 1 :y 2})
+        "mu/merge"))
+  (testing "schema printing (the nbb-compat regression surface)"
+    (is (string? (pr-str (m/schema [:map [:x :int]]))) "pr-str of a schema")))
+
+(deftest genmlx-schemas-validate-real-data-test
+  (testing "gs/ChoiceMap against a real choicemap"
+    (is (m/validate gs/ChoiceMap (cm/choicemap :x 1.0)) "Node validates")
+    (is (m/validate gs/ChoiceMap cm/EMPTY) "EMPTY validates"))
+  (testing "gs/Trace against a real trace"
+    (let [t (p/simulate (dyn/with-key tiny-model (rng/fresh-key 42)) [])]
+      (is (m/validate gs/Trace t) "simulate result validates")
+      (is (some? (me/humanize (m/explain gs/Trace {:not :a-trace})))
+          "explain humanizes a non-trace"))))
+
+(deftest dev-instrumentation-roundtrip-test
+  (testing "start! -> instrumented simulate -> stop!"
+    (is (= :started (dev/start!)) "start! returns :started")
+    (let [t (p/simulate (dyn/with-key tiny-model (rng/fresh-key 43)) [])]
+      (is (tr/trace? t) "simulate works under validation")
+      (is (number? (mx/item (:score t))) "score extracts under validation"))
+    (is (= :stopped (dev/stop!)) "stop! returns :stopped")))
+
+(cljs.test/run-tests)

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -226,6 +226,7 @@ medium test/genmlx/loop_compiled_mala_test.cljs
 fast test/genmlx/loop_obs_test.cljs
 bench test/genmlx/lowering_ground_truth_2.cljs
 bench test/genmlx/lowering_ground_truth.cljs
+fast test/genmlx/malli_load_test.cljs
 fast test/genmlx/map_dist_test.cljs
 medium test/genmlx/map_test.cljs
 fast test/genmlx/mcmc_defaults_test.cljs core


### PR DESCRIPTION
## Problem

`malli.core` failed to load under the project-pinned nbb 1.4.206 (`bun run --bun nbb`): nbb's SCI exposes `cljs.core/-pr-writer` and `IPrintWithWriter` only from 1.4.207, and malli #1186 uses both in CLJS schema printing. The fork's earlier compat commit (`a7876ddf`) fixed the `-pr-writer` helper fns but left `IPrintWithWriter` protocol clauses in 46 `reify` sites, so analysis still failed.

The breakage was invisible: only `genmlx.schemas` and `genmlx.dev` require malli, and no test loaded either namespace — the suite stayed green while dev-mode instrumentation (`dev/start!`) was unusable.

## Fix

- **Fork** (robert-johansson/malli@`1e2c59f7`, pushed to `master` + `nbb-1.4.206-compat`): guard every `IPrintWithWriter` reify clause behind an empty `:org.babashka/nbb` reader-conditional branch (46 sites in `malli.core`, 2 in `malli.experimental/validate`). Under nbb, schemas fall back to default reify printing; regular ClojureScript is unchanged.
- **Here**: bump the `malli` submodule pin to `1e2c59f7`.
- **Guard**: new `test/genmlx/malli_load_test.cljs` (fast tier) requires `genmlx.schemas` + `genmlx.dev`, exercises `m/validate` / `m/explain` + `me/humanize` / `mu/merge` / `pr-str` of a schema (the regression surface), validates a real trace against `gs/Trace`, and roundtrips `dev/start!` → instrumented simulate → `dev/stop!`.

## Verification

- `malli_load_test.cljs`: 13 assertions, 0 failures
- `test/run.sh check`: 359 files classified exactly once
- `test/run.sh core`: 36/36 PASS

Tracked as bean genmlx-7oxz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)