### PR TITLE
fix: fused inference SIGTRAP under real constraints — guard all mlx-node shims, real constraints + score oracle in fused tests (genmlx-i3z8)

### DIFF
--- a/test/genmlx/fused_inference_test.cljs
+++ b/test/genmlx/fused_inference_test.cljs
@@ -11,6 +11,7 @@
             [genmlx.dynamic :as dyn]
             [genmlx.choicemap :as cm]
             [genmlx.dist :as dist]
+            [genmlx.gfi :as gfi]
             [genmlx.inference.compiled-optimizer :as co]
             [genmlx.inference.compiled-gradient :as cg]
             [genmlx.inference.util :as u])
@@ -51,7 +52,7 @@
 
 (deftest fused-learn-direct-dispatch-test
   (testing "fused-learn :direct dispatch"
-    (let [obs (cm/choicemap {:y (mx/scalar 5.0)})
+    (let [obs (cm/choicemap :y (mx/scalar 5.0))
           result (co/fused-learn simple-model [] obs [:mu :sigma] :direct
                                  {:iterations 20 :lr 0.05 :log-every 10})]
       (is (contains? result :compilation-level) "fused-learn :direct returns :compilation-level")
@@ -62,7 +63,7 @@
     (cleanup!))
 
   (testing "fused-learn nil method falls through to :direct"
-    (let [obs (cm/choicemap {:y (mx/scalar 5.0)})
+    (let [obs (cm/choicemap :y (mx/scalar 5.0))
           result (co/fused-learn simple-model [] obs [:mu :sigma] nil
                                  {:iterations 20 :lr 0.05 :log-every 10})]
       (is (contains? result :compilation-level) "fused-learn nil method falls through to :direct")
@@ -71,7 +72,7 @@
 
 (deftest fused-mcmc-adam-basic-test
   (testing "fused MCMC+Adam basic functionality"
-    (let [obs (cm/choicemap {:y (mx/scalar 5.0)})
+    (let [obs (cm/choicemap :y (mx/scalar 5.0))
           result (co/make-fused-mcmc-train simple-model [] obs [:mu :sigma]
                                            {:iterations 30 :lr 0.01 :mcmc-steps 3 :proposal-std 0.3 :log-every 10})]
       (is (contains? result :params) "returns :params key")
@@ -90,7 +91,7 @@
 
 (deftest noise-pre-generation-shapes-test
   (testing "noise pre-generation shapes"
-    (let [obs (cm/choicemap {:y (mx/scalar 3.0)})
+    (let [obs (cm/choicemap :y (mx/scalar 3.0))
           model-k (dyn/auto-key simple-model)
           {:keys [trace]} (p/generate model-k [] obs)
           {:keys [score-fn n-params]} (u/prepare-mcmc-score simple-model [] obs [:mu :sigma] trace)
@@ -114,7 +115,7 @@
 
 (deftest gradient-direction-through-chain-test
   (testing "gradient direction through chain"
-    (let [obs (cm/choicemap {:y (mx/scalar 5.0)})
+    (let [obs (cm/choicemap :y (mx/scalar 5.0))
           model-k (dyn/auto-key simple-model)
           {:keys [trace]} (p/generate model-k [] obs)
           {:keys [score-fn n-params]}
@@ -126,7 +127,9 @@
           neg-obj (fn [params noise uniforms]
                     (mx/negative (score-fn (chain-fn params noise uniforms))))
           vg (mx/value-and-grad neg-obj)
-          start (mx/array [3.0 1.0 5.0])
+          ;; K-sized: latents are [:mu :sigma] => n-params 2. The old 3-vector
+          ;; dated from the vacuous-EMPTY-constraints era when :y was a latent.
+          start (mx/array [3.0 1.0])
           rk (rng/fresh-key)
           [nk uk] (rng/split rk)
           noise (rng/normal nk [T K])
@@ -142,7 +145,7 @@
 
 (deftest fused-learn-mcmc-dispatch-test
   (testing "fused-learn :mcmc dispatch + metadata"
-    (let [obs (cm/choicemap {:y (mx/scalar 5.0)})
+    (let [obs (cm/choicemap :y (mx/scalar 5.0))
           result (co/fused-learn simple-model [] obs [:mu :sigma] :mcmc
                                  {:iterations 20 :lr 0.01 :mcmc-steps 3 :proposal-std 0.3 :log-every 10})]
       (is (true? (:mcmc-compiled result)) "fused-learn :mcmc returns :mcmc-compiled")
@@ -156,7 +159,7 @@
 
 (deftest callback-invocation-test
   (testing "callback invocation"
-    (let [obs (cm/choicemap {:y (mx/scalar 5.0)})
+    (let [obs (cm/choicemap :y (mx/scalar 5.0))
           callback-log (atom [])
           result (co/make-fused-mcmc-train simple-model [] obs [:mu :sigma]
                                            {:iterations 50 :lr 0.01 :mcmc-steps 3 :proposal-std 0.3
@@ -171,7 +174,7 @@
 
 (deftest prng-key-determinism-test
   (testing "PRNG key determinism"
-    (let [obs (cm/choicemap {:y (mx/scalar 5.0)})
+    (let [obs (cm/choicemap :y (mx/scalar 5.0))
           key1 (rng/fresh-key 42)
           key2 (rng/fresh-key 42)
           r1 (co/make-fused-mcmc-train simple-model [] obs [:mu :sigma]
@@ -189,7 +192,7 @@
 
 (deftest convergence-3-param-model-test
   (testing "fused MCMC+Adam convergence (3-param model)"
-    (let [obs (cm/choicemap {:y (mx/scalar 7.0)})
+    (let [obs (cm/choicemap :y (mx/scalar 7.0))
           result (co/make-fused-mcmc-train three-param-model [] obs [:a :b :c]
                                            {:iterations 300 :lr 0.01 :mcmc-steps 5 :proposal-std 0.3
                                             :log-every 100})
@@ -204,7 +207,7 @@
 
 (deftest memory-bounds-mcmc-test
   (testing "memory bounds: 500 mcmc iterations without leak"
-    (let [obs (cm/choicemap {:y (mx/scalar 5.0)})
+    (let [obs (cm/choicemap :y (mx/scalar 5.0))
           result (co/make-fused-mcmc-train simple-model [] obs [:mu :sigma]
                                            {:iterations 500 :lr 0.01 :mcmc-steps 5 :proposal-std 0.3
                                             :log-every 100})]
@@ -214,11 +217,39 @@
     (cleanup!))
 
   (testing "memory bounds: 500 direct iterations"
-    (let [obs (cm/choicemap {:y (mx/scalar 5.0)})
+    (let [obs (cm/choicemap :y (mx/scalar 5.0))
           result (co/learn simple-model [] obs [:mu :sigma]
                            {:iterations 500 :lr 0.05 :log-every 100})]
       (is (some? result) "direct path 500 iterations completed")
       (is (every? js/isFinite (mx/->clj (:params result))) "direct path params finite after 500 iters"))
+    (cleanup!)))
+
+(deftest fused-score-handler-parity-test
+  (testing "fused score-fn equals handler-path joint score (independent oracle)"
+    ;; Regression oracle for genmlx-i3z8: the fused path's score function,
+    ;; evaluated at explicit latent values, must equal the score of the same
+    ;; fully-constrained model run through the pure handler path. Guards
+    ;; against the fused path silently dropping/ignoring constraints (the
+    ;; vacuous-EMPTY-constraints failure mode this file shipped with).
+    (let [obs (cm/choicemap :y (mx/scalar 5.0))
+          {:keys [trace]} (p/generate (dyn/auto-key simple-model) [] obs)
+          {:keys [score-fn latent-index n-params]}
+          (u/prepare-mcmc-score simple-model [] obs [:mu :sigma] trace)
+          handler-model (gfi/strip-compiled simple-model)]
+      (is (= 2 n-params) "real constraints leave exactly the two latents")
+      (is (= #{:mu :sigma} (set (keys latent-index))) "latent-index covers :mu :sigma")
+      (doseq [[mu sigma] [[0.0 1.0] [3.0 1.0] [5.0 0.5] [-2.0 2.0]]]
+        (let [point {:mu mu :sigma sigma}
+              slots (mapv first (sort-by second latent-index))
+              params (mx/array (mapv point slots))
+              fused-score (mx/item (score-fn params))
+              full (cm/choicemap :mu (mx/scalar mu) :sigma (mx/scalar sigma)
+                                 :y (mx/scalar 5.0))
+              handler-score (-> (p/generate (dyn/auto-key handler-model) [] full)
+                                :trace :score mx/item)]
+          (is (< (js/Math.abs (- fused-score handler-score)) 1e-4)
+              (str "score parity at mu=" mu " sigma=" sigma
+                   " (fused " fused-score " vs handler " handler-score ")")))))
     (cleanup!)))
 
 (cljs.test/run-tests)

--- a/test/genmlx/fused_vi_test.cljs
+++ b/test/genmlx/fused_vi_test.cljs
@@ -30,7 +30,7 @@
 
 (deftest fused-vi-dispatch-test
   (testing "single fused-learn :vi call"
-    (let [obs (cm/choicemap {:y (mx/scalar 5.0)})
+    (let [obs (cm/choicemap :y (mx/scalar 5.0))
           result (co/fused-learn simple-model [] obs [:mu :sigma] :vi
                                  {:iterations 20 :lr 0.01})]
       ;; Dispatch metadata

--- a/test/genmlx/nbb_benchmark.cljs
+++ b/test/genmlx/nbb_benchmark.cljs
@@ -89,7 +89,7 @@
 (println "\n--- Generate (constrained) ---")
 (bench "generate (3-site, 1 constrained)" 200
   (fn [] (let [k (random/fresh-key (rand-int 10000))
-               obs (cm/choicemap {:y (mx/scalar 2.0)})
+               obs (cm/choicemap :y (mx/scalar 2.0))
                result (p/generate simple-model [(mx/scalar 1.0)] obs {:key k})]
            (mx/eval! (:weight result)) result)))
 
@@ -110,7 +110,7 @@
                  t (p/simulate line-model [xs] {:key k})]
              (mx/eval! (:score t)) t)))
 
-  (let [obs (cm/choicemap (into {} (map (fn [j] [(keyword (str "y" j)) (mx/scalar (float j))]) (range 5))))]
+  (let [obs (cm/from-map (into {} (map (fn [j] [(keyword (str "y" j)) (mx/scalar (float j))]) (range 5))))]
     (bench "generate line model (7 sites, 5 obs)" 100
       (fn [] (let [k (random/fresh-key (rand-int 10000))
                    result (p/generate line-model [xs] obs {:key k})]
@@ -119,7 +119,7 @@
 ;; 7. Importance sampling + MH
 (println "\n--- Inference ---")
 (let [xs (vec (range 5))
-      obs (cm/choicemap (into {} (map (fn [j] [(keyword (str "y" j)) (mx/scalar (float j))]) (range 5))))]
+      obs (cm/from-map (into {} (map (fn [j] [(keyword (str "y" j)) (mx/scalar (float j))]) (range 5))))]
   (bench "importance sampling (10 particles)" 20
     (fn [] (is/importance-sampling {:samples 10} line-model [xs] obs)))
   (bench "MH (10 steps)" 20


### PR DESCRIPTION
## Problem
`fused_inference_test` was vacuous its whole life: 11 sites passed `(cm/choicemap {map})`, silently dropped to EMPTY constraints, so every fused test ran unconstrained. With real constraints the fused path SIGTRAPed the whole process.

## Root cause
Two layers:
1. **Test layer**: `gradient-direction-through-chain-test` hardcoded a 3-vector start (sized for the vacuous era when `:y` counted as a latent); with real constraints K=2, so the chain fed a `[3]` params vector against `[T,2]` noise → non-broadcastable `mx/add`.
2. **Native layer (the real bug)**: MLX C++ exceptions escaping unguarded `extern "C"` shims abort the process (libc++abi terminate → SIGTRAP). The guard machinery existed (`MLX_GUARD_PTR`, thread-local last-error, `check_handle`) but covered only ~13 allocator-prone sites. **Any** user-level shape mismatch reaching any binary op killed the host.

## Fix
- **mlx-node@4debd39** (pushed to fork main): all 155 `mlx_array*`-returning shims wrapped in `MLX_GUARD_PTR` (insertion-only, happy paths untouched). Invalid broadcast now throws `MLX error in array_add: [broadcast_shapes] Shapes (3) and (2) cannot be broadcast.` — both directly and through the `value_and_grad` closure trampoline.
- All 11 `fused_inference_test` sites + 1 `fused_vi_test` site + 3 `nbb_benchmark` sites flattened to real constraints; start vector resized to K.
- New `fused-score-handler-parity-test`: fused score-fn vs strip-compiled handler path on the same fully-constrained model at 4 latent points (independent-oracle rule).

## Verification
- `fused_inference_test`: 10 tests / 52 assertions green **with real constraints**; `fused_vi_test` 8 assertions actually run + pass for the first time
- Membrane contract suite (mandatory post-rebuild): exact 120, gradient_fd 83, score_gradient 48, clip_contract 7 — all green
- Fast tier: 5 non-passes proven pre-existing via old-binary rebuild (genmlx-lcka)
- Medium tier (132 files): 125 pass; all 7 non-passes triaged — `fused_mcmc` CRASH pre-existing (06xw), `gfi_laws` vgenerate flake (v4mz), `vimco` + `l3_5_gate` pass serially (contention flakes, 06xw class), `gen_jl_speed` perf-assertion contention class, `gfi_combinator_invariants` deterministic + pre-existing on old binary (genmlx-ly8f, evidence appended), `fused_vi` fixed here

Tracked as bean genmlx-i3z8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)