### PR TITLE
fix(test): SBC linear-regression args double-wrap + cmh thinning (genmlx-m6yw, genmlx-t757)

### DIFF
--- a/test/genmlx/sbc_test.cljs
+++ b/test/genmlx/sbc_test.cljs
@@ -280,7 +280,12 @@
    :args []
    :param-addrs [:a :b], :obs-addrs [:obs-a :obs-b]
    :algorithms [:cmh :hmc :is]
-   :cmh-opts {:addresses [:a :b] :proposal-std 0.7}
+   ;; cmh combos thin to near-independence: cmh is a JOINT random-walk MH, so
+   ;; autocorrelation time grows with dimension/posterior correlation (measured
+   ;; tau 6-23 here, 14-53 on mvr-5d). At thin=1 the L draws carry too few
+   ;; effective samples and SBC ranks go U-shaped (chi2 fails, ks passes).
+   ;; Thin values validated by mini-SBC at N=200/150 (genmlx-t757).
+   :cmh-opts {:addresses [:a :b] :proposal-std 0.7 :thin 20}
    :hmc-opts {:addresses [:a :b] :step-size 0.1 :leapfrog-steps 10}
    :is-opts {}})
 
@@ -339,7 +344,9 @@
                                         (dist/gaussian (mx/add (mx/multiply slope (mx/scalar x))
                                                                intercept) 1)))
                                [slope intercept])))
-   :args [[(mx/scalar 0.0) (mx/scalar 1.0) (mx/scalar 2.0)]]
+   ;; xs must be plain numbers: the body wraps each x in (mx/scalar x), whose
+   ;; NAPI param is a creation f64 — an MxArray here fails napi conversion.
+   :args [[0.0 1.0 2.0]]
    :param-addrs [:slope :intercept], :obs-addrs [:y0 :y1 :y2]
    :algorithms [:hmc :is]
    :hmc-opts {:addresses [:slope :intercept] :step-size 0.05 :leapfrog-steps 15}
@@ -413,7 +420,7 @@
    :param-addrs [:slope :intercept], :obs-addrs [:y0 :y1 :y2]
    :require-analytical? true
    :algorithms [:cmh :hmc :smc]
-   :cmh-opts {:addresses [:slope :intercept] :proposal-std 0.5}
+   :cmh-opts {:addresses [:slope :intercept] :proposal-std 0.5 :thin 20}
    :hmc-opts {:addresses [:slope :intercept] :step-size 0.05 :leapfrog-steps 15}
    :smc-opts {:selection (sel/select :slope :intercept)}})
 
@@ -428,7 +435,7 @@
    :param-addrs [:mu :x], :obs-addrs [:obs]
    :require-analytical? true
    :algorithms [:cmh :hmc :smc]
-   :cmh-opts {:addresses [:mu :x] :proposal-std 0.7}
+   :cmh-opts {:addresses [:mu :x] :proposal-std 0.7 :thin 20}
    :hmc-opts {:addresses [:mu :x] :step-size 0.1 :leapfrog-steps 10}
    :smc-opts {:selection (sel/select :mu :x)}})
 
@@ -463,7 +470,7 @@
    :param-addrs [:w0 :w1 :w2 :w3 :w4]
    :obs-addrs [:y0 :y1 :y2 :y3 :y4 :y5 :y6 :y7 :y8 :y9]
    :algorithms [:cmh :hmc]
-   :cmh-opts {:addresses [:w0 :w1 :w2 :w3 :w4] :proposal-std 0.4}
+   :cmh-opts {:addresses [:w0 :w1 :w2 :w3 :w4] :proposal-std 0.4 :thin 25 :burn 200}
    :hmc-opts {:addresses [:w0 :w1 :w2 :w3 :w4] :step-size 0.05 :leapfrog-steps 15}})
 
 ;; Discrete latent: two-component Gaussian mixture. The bernoulli component


### PR DESCRIPTION
Two SBC calibration fixes from the 2026-06-11 overnight-run triage.

## genmlx-m6yw — linear-regression × {hmc, is}: 500/500 sims failed (napi f64)

The spec passed MLX scalars in `:args` while the model body wraps each x in
`(mx/scalar x)` — an MxArray reached Rust `scalar_float(value: f64)`, a
creation function whose plain-f64 signature is correct (not a narrowed NAPI
contract). Born broken in 68bff9a with no passing baseline; binary drift ruled
out. Fix: plain numbers in `:args`, matching the CLAUDE.md canonical example.

**Verified at N=500** (fragments merged): hmc slope/intercept chi2 6.40/14.20,
is 12.68/6.04 (crit 21.67), 0/500 sim failures per combo.

## genmlx-t757 — all 9 chi2-failing params were cmh combos

compiled-MH is a joint random-walk in flat parameter space; measured
autocorrelation times (tau 6–23 on two-gaussians, 14–53 on mvr-5d) mean L=200
draws at thin=1 carry only ~5–15 effective samples → U-shaped ranks → chi2
fails while ks passes. Pass/fail separated perfectly by n-params ≥ 2, not by
elimination (mvr-5d fails without it; single-gaussian passes with it).

Kernel and score path exonerated by three-way mini-SBC on two-gaussians:
thin=1 reproduces (20.4/14.5), thin=20 passes (4.6/11.3), handler-path
per-site MH oracle passes (7.7/9.9). mvr-5d at thin=25/burn=200 passes
(14.9/8.4/4.9/8.8/2.9). Fix: `:thin 20` on the three 2-D cmh combos,
`:thin 25 :burn 200` on mvr-5d, with a rationale comment in the spec.

N=500 re-run of the 4 combos runs tonight (results commit follows the
complete?:true run per genmlx-18q9).

Side discovery during the oracle work, filed separately: trace-based MH is
silently miscalibrated on analytically-eliminated models (genmlx-540f).

🤖 Generated with [Claude Code](https://claude.com/claude-code)