### PR TITLE
fix(native): guard remaining shim escape paths — SBC crashes become catchable errors (genmlx-8w48)

### DIFF
--- a/test/genmlx/native_guard_test.cljs
+++ b/test/genmlx/native_guard_test.cljs
@@ -1,0 +1,58 @@
+;; @tier fast core
+(ns genmlx.native-guard-test
+  "Regression guard for the native exception escape path (bean genmlx-8w48).
+
+   MLX C++ exceptions (allocation failure under Metal buffer-count pressure,
+   eager validation throws) must surface as CATCHABLE JS errors, never as
+   process death. Before the guard sweep completed, an exception thrown inside
+   a void/out-param shim (mlx_random_split — called on EVERY GenMLX sample)
+   unwound through the extern \"C\" frame to std::terminate -> SIGTRAP,
+   killing overnight SBC runs (conjugate-linreg-elim x smc,
+   multivariate-regression-5d x hmc).
+
+   These tests drive the same C++ frames with eager-validation throws (a
+   malformed PRNG key, a 1-D matrix into QR), which exercise the exact same
+   guard + null-out-param + check_handle path as the memory-pressure throws
+   that cannot be triggered deterministically (the Metal resource limit is a
+   device constant). If a guard regresses, these tests don't fail — the
+   process dies, which the test runner reports as a crash."
+  (:require [cljs.test :refer [deftest is]]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]))
+
+(defonce ^:private core (js/require "@mlx-node/core"))
+
+(defn- caught-message
+  "Run f, return the caught error message, or ::no-throw."
+  [f]
+  (try (f) ::no-throw
+       (catch :default e (.-message e))))
+
+(deftest random-split-malformed-key-is-catchable
+  ;; rng::split validates key dtype/shape eagerly inside mlx_random_split.
+  ;; Unguarded, this throw aborted the process (exit 133). The membrane's
+  ;; rng/split pre-checks keys, so call the NAPI export directly.
+  (let [msg (caught-message #(.randomSplit core (mx/scalar 1.5)))]
+    (is (not= ::no-throw msg) "malformed key must throw, not return")
+    (is (re-find #"\[bits\] Expected key type uint32" (str msg))
+        "the MLX exception detail is surfaced in the JS error")))
+
+(deftest linalg-qr-bad-input-is-catchable
+  ;; Same escape-path class through the void out-param decomposition shims.
+  (let [msg (caught-message #(.qr (mx/array #js [1.0 2.0 3.0])))]
+    (is (not= ::no-throw msg) "1-D input to QR must throw, not return")
+    (is (re-find #"MLX error in qr_q" (str msg))
+        "null out-param surfaces as a catchable napi error with context")))
+
+(deftest native-error-channel-recovers
+  ;; After a caught native error the thread-local error slot must be clear
+  ;; and normal operation resume — a wedged channel would mislabel the next
+  ;; unrelated call as failed.
+  (caught-message #(.randomSplit core (mx/scalar 1.5)))
+  (let [[k1 k2] (rng/split (rng/fresh-key))]
+    (is (some? k1) "split works after a caught native error")
+    (is (some? k2))
+    (is (= [2] (mx/shape k1)) "k1 is a real [2] uint32 key")
+    (is (= [2] (mx/shape k2)) "k2 is a real [2] uint32 key")))
+
+(cljs.test/run-tests)


### PR DESCRIPTION
## Summary

The two overnight SBC crashes (`conjugate-linreg-elim x smc` SIGTRAP, `multivariate-regression-5d x hmc` Bun panic at rep 0/500) share one root cause with every macOS crash dump from Jun 8–10: **`MetalAllocator::malloc` throws under Metal buffer-count pressure** (`num_resources_ >= resource_limit_`), and the C++ exception escapes through an unguarded `extern "C"` shim to `std::terminate` → SIGTRAP.

The i3z8 guard sweep covered `mlx_array*`-returning shims only — **void/out-param and count-returning shims were structurally missed**. The worst offender was `mlx_random_split`: called on every GenMLX sample, eagerly evaluating, making it the highest-frequency Metal allocation site in inference loops. Timeline proof: the guarded binary was built 00:38, the overnight run started 00:43, and its crashes went through the still-unguarded void shims.

## Changes

- **mlx-node → f92c9c1**: adds `MLX_GUARD_VOID` / `MLX_GUARD_VAL(sentinel)` next to the existing guard macros and wraps `mlx_random_split` (out-params nulled first; Rust already routes them through `check_handle`), `mlx_seed`, `mlx_linalg_qr/svd/eigh`, `mlx_array_split_multi`, `mlx_compile_apply`, `mlx_compiled_sample_and_logprobs`, `mlx_metal_synchronize`, and the Metal-buffer introspection pair. `mlx_array_slice_assign_axis_inplace` becomes `bool` — its Rust caller previously returned `Ok` unconditionally, so a swallowed failure would have been silent corruption.
- **`test/genmlx/native_guard_test.cljs`**: deterministic same-frame repro (malformed key → eager `[bits]` dtype validation throw inside `mlx_random_split`). Pre-fix: exit 133 (SIGTRAP). Post-fix: catchable `MLX error in split_k1: [bits] Expected key type uint32 but received float32.` Plus QR-on-1D catchability and error-channel recovery.

With the guard in place, `sbc_test`'s existing per-rep try/catch (worst-case rank, 5% failure budget, per-rep `clear-cache!`) absorbs a pressure throw as one failed rep instead of losing the whole process, so the two missing combos can complete N=500 via `run_sbc.sh` skip-resume.

## Verification

- Post-rebuild membrane contract suites: `exact_test` 120/0, `gradient_fd_test`, `score_gradient_test`, `clip_contract_test` — all green
- Fast-core tier: 36/36
- `native_guard_test.cljs`: 3 tests / 8 assertions green
- Both previously-crashing combos smoke-pass at N=2 L=200 on the new binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)