### PR TITLE
fix(inference): strip L3 analytical path in trace-MH entry points (genmlx-540f)

### DIFF
--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -642,18 +642,29 @@
       (mx/gfi-cleanup!)
       result)))
 
+(def analytical-path-schema-keys
+  "Every schema key the dispatcher stack consults for the L3 analytical
+   path. Stripping these forces stochastic prior sampling and joint scores
+   while keeping the L1 compiled paths (which are score-equivalent to the
+   handler). Sampling-based methods need this: analytical generate pins
+   eliminated latents at their deterministic posterior MEAN, and
+   :auto-regenerate-transition intercepts regenerate — correct for marginal
+   likelihoods, corrupting for particle diversity (smc) and trace-MH chains
+   (genmlx-540f)."
+  [:auto-handlers :conjugate-pairs :has-conjugate? :analytical-plan
+   :auto-regenerate-transition])
+
 (def alternate-path-schema-keys
   "Every schema key the dispatcher stack consults for a non-handler execution
    path: L1-M2 full-compile keys, L1-M3 prefix keys, and the L3 analytical
    keys. strip-alternate-paths must remove ALL of them — leaving any behind
    lets a 'handler ground truth' comparison silently exercise a compiled or
    analytical path (genmlx-pkmx)."
-  [:compiled-simulate :compiled-generate :compiled-update :compiled-assess
-   :compiled-project :compiled-regenerate
-   :compiled-prefix :compiled-prefix-generate :compiled-prefix-update
-   :compiled-prefix-regenerate :compiled-prefix-assess :compiled-prefix-project
-   :auto-handlers :conjugate-pairs :has-conjugate? :analytical-plan
-   :auto-regenerate-transition])
+  (into [:compiled-simulate :compiled-generate :compiled-update :compiled-assess
+         :compiled-project :compiled-regenerate
+         :compiled-prefix :compiled-prefix-generate :compiled-prefix-update
+         :compiled-prefix-regenerate :compiled-prefix-assess :compiled-prefix-project]
+        analytical-path-schema-keys))
 
 (defn strip-alternate-paths
   "Return a copy of gf with all alternate execution paths removed from its
@@ -667,6 +678,21 @@
       (->DynamicGF (:body-fn gf) (:source gf)
                    (apply dissoc schema alternate-path-schema-keys))
       (meta gf))
+    gf))
+
+(defn strip-analytical-path
+  "Return a copy of gf with ONLY the L3 analytical path removed from its
+   schema, keeping the L1 compiled paths. The canonical strip for every
+   sampling-based method: particle methods (smc, csmc, smcp3, importance)
+   and trace-MH (kern/mh-kernel, mcmc/mh) — analytical generate returns
+   eliminated latents at their deterministic posterior mean and intercepts
+   regenerate, so unstripped chains/particles sample a corrupted posterior
+   (genmlx-540f; chi2 290.9 vs crit 21.67 on two-gaussians mh-cycle).
+   assoc-based so any GFI record with a :schema (DynamicGF, combinators)
+   keeps its type and metadata (the PRNG ::key). Unchanged if no schema."
+  [gf]
+  (if-let [schema (:schema gf)]
+    (assoc gf :schema (apply dissoc schema analytical-path-schema-keys))
     gf))
 
 (defn- propagate-meta

--- a/src/genmlx/inference/kernel.cljs
+++ b/src/genmlx/inference/kernel.cljs
@@ -51,11 +51,14 @@
 
 (defn mh-kernel
   "Create an MH kernel that regenerates the given selection.
-   Returns (fn [trace key] -> trace). Symmetric by default."
+   Returns (fn [trace key] -> trace). Symmetric by default.
+   Strips the L3 analytical path from the trace's gen-fn: analytical
+   regenerate is intercepted by :auto-regenerate-transition and anchors
+   chains at the posterior mean instead of sampling it (genmlx-540f)."
   [selection]
   (symmetric-kernel
     (fn [trace key]
-      (let [gf (dyn/auto-key (:gen-fn trace))
+      (let [gf (dyn/auto-key (dyn/strip-analytical-path (:gen-fn trace)))
             result (p/regenerate gf trace selection)
             w (mx/realize (:weight result))]
         (if (u/accept-mh? w key)

--- a/src/genmlx/inference/mcmc.cljs
+++ b/src/genmlx/inference/mcmc.cljs
@@ -43,11 +43,14 @@
 
 (defn mh-step
   "One MH step. regenerate proposes + computes acceptance ratio.
-   Optional `key` for functional PRNG."
+   Optional `key` for functional PRNG.
+   Strips the L3 analytical path from the trace's gen-fn: analytical
+   regenerate is intercepted by :auto-regenerate-transition and anchors
+   chains at the posterior mean instead of sampling it (genmlx-540f)."
   ([current-trace selection]
    (mh-step current-trace selection nil))
   ([current-trace selection key]
-   (let [gf (:gen-fn current-trace)
+   (let [gf (dyn/strip-analytical-path (:gen-fn current-trace))
          [regen-key accept-key] (rng/split (rng/ensure-key key))
          result (p/regenerate (dyn/with-key gf regen-key) current-trace selection)
          w (mx/realize (:weight result))]
@@ -65,11 +68,17 @@
 
    :selection defaults to the complement of the observed addresses (all
    latents). The old default sel/all also resampled the OBSERVATIONS via
-   regenerate — silently targeting the prior (genmlx-7ca0)."
+   regenerate — silently targeting the prior (genmlx-7ca0).
+
+   The model is stripped of its L3 analytical path (mirroring smc): the
+   analytical generate would pin eliminated latents at their posterior
+   MEAN (a deterministic init with a marginal score) and intercept every
+   regenerate step, anchoring the chain instead of sampling (genmlx-540f)."
   [{:keys [samples burn thin selection callback key]
     :or {burn 0 thin 1}}
    model args observations]
-  (let [selection (or selection
+  (let [model (dyn/strip-analytical-path model)
+        selection (or selection
                       (sel/complement-sel (sel/from-choicemap observations)))
         [init-key chain-key] (rng/split (rng/ensure-key key))
         {:keys [trace]} (p/generate (dyn/with-key model init-key) args observations)]

--- a/test/genmlx/sbc_test.cljs
+++ b/test/genmlx/sbc_test.cljs
@@ -279,7 +279,13 @@
                                [a b])))
    :args []
    :param-addrs [:a :b], :obs-addrs [:obs-a :obs-b]
-   :algorithms [:cmh :hmc :is]
+   ;; :mh-cycle covers the static-conjugate x trace-MH cell: this model is
+   ;; statically eliminated (#{:a :b}), and per-site trace-MH on eliminated
+   ;; models was silently mean-anchored until kern/mh-kernel stripped the
+   ;; analytical path (genmlx-540f). Every other :mh/:mh-cycle model in the
+   ;; registry is dynamic (mx/item or splices), so this is the only combo
+   ;; that keeps the class covered.
+   :algorithms [:cmh :hmc :is :mh-cycle]
    ;; cmh combos thin to near-independence: cmh is a JOINT random-walk MH, so
    ;; autocorrelation time grows with dimension/posterior correlation (measured
    ;; tau 6-23 here, 14-53 on mvr-5d). At thin=1 the L draws carry too few
@@ -287,6 +293,7 @@
    ;; Thin values validated by mini-SBC at N=200/150 (genmlx-t757).
    :cmh-opts {:addresses [:a :b] :proposal-std 0.7 :thin 20}
    :hmc-opts {:addresses [:a :b] :step-size 0.1 :leapfrog-steps 10}
+   :mh-opts {:selections [(sel/select :a) (sel/select :b)]}
    :is-opts {}})
 
 (def gaussian-multi-obs

--- a/test/genmlx/trace_mh_elim_test.cljs
+++ b/test/genmlx/trace_mh_elim_test.cljs
@@ -1,0 +1,92 @@
+;; @tier fast core
+(ns genmlx.trace-mh-elim-test
+  "Regression guard for trace-MH on analytically-eliminated models
+   (bean genmlx-540f).
+
+   On a static-conjugate model the L3 analytical generate pins eliminated
+   latents at their DETERMINISTIC posterior mean and intercepts regenerate
+   via :auto-regenerate-transition. Unstripped trace-MH chains therefore
+   anchored at the posterior mean instead of sampling it: mini-SBC chi2(a)
+   = 290.9 vs crit 21.67, draw sd 0.40 vs the analytic 0.894. The fix
+   strips the analytical path in the trace-MH entry points
+   (kern/mh-kernel, mcmc/mh-step, mcmc/mh), mirroring smc.
+
+   These tests check the chain's marginal moments against the closed-form
+   posterior — an independent oracle, never the path under test."
+  (:require [cljs.test :refer [deftest is]]
+            [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.inference.mcmc :as mcmc]
+            [genmlx.inference.kernel :as kern]
+            [genmlx.mlx.random :as rng])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+;; Same shape as sbc_test's two-gaussians: two independent gaussian-gaussian
+;; conjugate pairs, statically eliminable (#{:a :b}).
+(def model
+  (dyn/auto-key (gen []
+                     (let [a (trace :a (dist/gaussian 0 2))
+                           b (trace :b (dist/gaussian 0 2))]
+                       (trace :obs-a (dist/gaussian a 1))
+                       (trace :obs-b (dist/gaussian b 1))
+                       [a b]))))
+
+;; Closed-form posterior for a ~ N(0, 2^2), obs ~ N(a, 1^2), y observed:
+;; mean = y * 4/5, sd = sqrt(4/5).
+(def y-a 1.0)
+(def y-b -1.0)
+(def post-mean-a (* y-a 0.8))
+(def post-sd (js/Math.sqrt 0.8))
+
+(def obs (-> cm/EMPTY
+             (cm/set-choice [:obs-a] (mx/scalar y-a))
+             (cm/set-choice [:obs-b] (mx/scalar y-b))))
+
+(defn- a-value [trace]
+  (let [v (cm/get-value (cm/get-submap (:choices trace) :a))]
+    (mx/eval! v)
+    (mx/item v)))
+
+(defn- mean [xs] (/ (reduce + xs) (count xs)))
+(defn- sd [xs]
+  (let [m (mean xs)]
+    (js/Math.sqrt (/ (reduce + (map #(let [d (- % m)] (* d d)) xs))
+                     (dec (count xs))))))
+
+(deftest model-is-eliminated  ;; precondition: the class under test is active
+  (is (= #{:a :b} (get-in (:schema model) [:analytical-plan :rewrite-result :eliminated]))
+      "two-gaussians must be statically eliminated or this guard tests nothing")
+  (is (some? (get-in (:schema model) [:auto-regenerate-transition]))
+      "the regenerate interception must be present on the unstripped model"))
+
+;; 400 post-burn draws: sd estimate has ~5% relative error at tau~1-2, so a
+;; [0.6, 1.2] band separates the analytic 0.894 cleanly from the broken 0.40.
+(deftest mh-cycle-samples-the-posterior  ;; the sbc mh-cycle path
+  (let [kernel (kern/cycle-kernels [(kern/mh-kernel (sel/select :a))
+                                    (kern/mh-kernel (sel/select :b))])
+        {:keys [trace]} (p/generate model [] obs)
+        traces (kern/run-kernel {:samples 400 :burn 200 :key (rng/fresh-key 540)}
+                                kernel trace)
+        draws (mapv a-value traces)
+        m (mean draws) s (sd draws)]
+    (is (< (js/Math.abs (- m post-mean-a)) 0.25)
+        (str "chain mean " m " near analytic posterior mean " post-mean-a))
+    (is (< 0.6 s 1.2)
+        (str "chain sd " s " near analytic posterior sd " post-sd
+             " (0.40 = mean-anchored regression)"))))
+
+(deftest mcmc-mh-samples-the-posterior  ;; the mcmc/mh entry point
+  (let [traces (mcmc/mh {:samples 400 :burn 200 :key (rng/fresh-key 541)}
+                        model [] obs)
+        draws (mapv a-value traces)
+        m (mean draws) s (sd draws)]
+    (is (< (js/Math.abs (- m post-mean-a)) 0.25)
+        (str "chain mean " m " near analytic posterior mean " post-mean-a))
+    (is (< 0.6 s 1.2)
+        (str "chain sd " s " near analytic posterior sd " post-sd))))
+
+(cljs.test/run-tests)


### PR DESCRIPTION
## Summary

Trace-based MH (`kern/mh-kernel`, `mcmc/mh`, SBC's mh-cycle) was **silently miscalibrated on analytically-eliminated models**: analytical generate pins eliminated latents at their deterministic posterior MEAN, and `:auto-regenerate-transition` intercepts every regenerate step, so chains anchored at the mean instead of sampling the posterior. Mini-SBC evidence on two-gaussians mh-cycle: chi2(a)=290.9 / chi2(b)=80.8 vs crit 21.67, draw sd 0.40 vs the analytic 0.894. `smc/strip-analytical` exists for exactly this class — every particle method strips — but trace-MH paths never did.

The per-site cycle was the broken cell; joint-selection `mh` survived via m3tn block-regenerate parity. SBC never caught it because every other `:mh`/`:mh-cycle` model in the registry is dynamic (`mx/item` or splices in body), so static-conjugate × trace-MH was an uncovered cell.

## Changes

- **`dynamic.cljs`**: `analytical-path-schema-keys` (single source of truth — `alternate-path-schema-keys` now composes it) + **`dyn/strip-analytical-path`**, the canonical analytical-only strip. assoc-based so any GFI record with a `:schema` (DynamicGF, combinators) keeps its type and metadata; keeps L1 compiled paths, which are score-equivalent.
- **`kern/mh-kernel`, `mcmc/mh-step`, `mcmc/mh`** strip before regenerate/init. Marginal-score init traces are converted by the existing pkmx `joint-rescore-marginal`, so callers need no change.
- **`sbc_test.cljs`**: two-gaussians gains `:mh-cycle` — the registry's only static-conjugate × trace-MH combo, keeping this class covered in every future SBC run.
- **`test/genmlx/trace_mh_elim_test.cljs`**: closed-form-posterior oracle, independent of the path under test. Teeth verified: fails on pre-fix src (cycle-path sd 0.52), passes post-fix.

## Verification

- Mini-SBC two-gaussians:mh-cycle N=200 L=200: **PASS** — chi2 10.90/9.90 (crit 21.67), ks 0.071/0.057 (crit 0.152), 0/200 rep failures (was 290.9/80.8)
- fast-core tier 36/36; `inference_mh`, `kernel_combinator`, `kernel_dsl`, `kernel_reversal`, `l3_5_regenerate`, `l2_mcmc` all green; `linear_gaussian_elim` 60/60

🤖 Generated with [Claude Code](https://claude.com/claude-code)