### PR TITLE
docs(inference): explain the inert eliminated-address filter + pin both score parameterizations (genmlx-10z1)

### DIFF
--- a/src/genmlx/inference/util.cljs
+++ b/src/genmlx/inference/util.cljs
@@ -422,7 +422,19 @@
 (defn prepare-mcmc-score
   "Prepare score function + init params for compiled MCMC.
    Tries tensor-native score first (bypasses GFI), falls back to GFI-based.
-   Automatically filters out analytically eliminated addresses (L3.5).
+
+   Eliminated-address filtering (L3.5) applies ONLY on the GFI fallback
+   paths: there the score constrains the filtered addresses and p/generate's
+   analytical handlers marginalize the eliminated ones (Rao-Blackwell).
+   The TENSOR-NATIVE path derives its latent index from the schema/source
+   and ignores the filtered list — MCMC then samples the FULL JOINT,
+   eliminated addresses included. Both parameterizations are valid targets;
+   every current eliminated SBC model is static gaussian and tensor-compiles,
+   so the filter is exercised only by plan-bearing models whose prior lacks
+   a noise transform (genmlx-10z1; pinned by mcmc_elim_filter_test). A model
+   whose latents are ALL eliminated and that falls back to GFI yields
+   n-params 0 — there is nothing left for MCMC to sample; the posterior is
+   fully analytical.
 
    Returns {:score-fn    (fn [D-tensor] -> scalar)
             :init-params [D] MLX array

--- a/test/genmlx/mcmc_elim_filter_test.cljs
+++ b/test/genmlx/mcmc_elim_filter_test.cljs
@@ -1,0 +1,72 @@
+;; @tier fast core
+(ns genmlx.mcmc-elim-filter-test
+  "Pins the two parameterizations prepare-mcmc-score gives an analytically-
+   eliminated model (bean genmlx-10z1).
+
+   prepare-mcmc-score filters eliminated addresses out of the MCMC param
+   vector (L3.5 Rao-Blackwell: score = analytical marginal over the rest).
+   But the TENSOR-NATIVE score path derives its latent index from the
+   schema/source and ignores the filtered address list entirely — so on
+   every static model that tensor-compiles (all current eliminated SBC
+   models), MCMC samples the FULL JOINT parameterization and the filter is
+   bypassed. Both parameterizations are valid targets; they are different
+   methods. The filter is live only on the GFI fallback (e.g. a conjugate
+   pair whose prior has no noise transform, like beta-bernoulli).
+
+   These tests pin which path each model class takes, so a dispatch change
+   that silently flips a model between joint and Rao-Blackwellized MCMC
+   (or zeroes out a param vector) fails here first."
+  (:require [cljs.test :refer [deftest is]]
+            [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.inference.util :as u])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+;; Static gaussian-gaussian pairs: eliminated AND tensor-compilable.
+(def two-g (dyn/auto-key (gen [] (let [a (trace :a (dist/gaussian 0 2))
+                                       b (trace :b (dist/gaussian 0 2))]
+                                   (trace :obs-a (dist/gaussian a 1))
+                                   (trace :obs-b (dist/gaussian b 1)) [a b]))))
+
+;; Beta-bernoulli: eliminated but beta has no noise transform, so the
+;; tensor-native compile declines and the GFI fallback (filter live) runs.
+(def bb (dyn/auto-key (gen [] (let [p (trace :p (dist/beta-dist 2 2))]
+                                (trace :obs (dist/bernoulli p)) p))))
+
+(def obs-2g (-> cm/EMPTY
+                (cm/set-choice [:obs-a] (mx/scalar 1.0))
+                (cm/set-choice [:obs-b] (mx/scalar -1.0))))
+(def obs-bb (cm/set-choice cm/EMPTY [:obs] (mx/scalar 1.0)))
+
+(deftest both-models-are-eliminated  ;; preconditions: the class is active
+  (is (= #{:a :b} (u/get-eliminated-addresses two-g)))
+  (is (= #{:p} (u/get-eliminated-addresses bb))))
+
+(deftest tensor-native-path-samples-the-full-joint
+  ;; The filter empties the address list (#{:a :b} eliminates everything),
+  ;; but the tensor-native score derives latents from the schema, so MCMC
+  ;; still samples BOTH params — this is why SBC cmh/hmc on eliminated
+  ;; models calibrate with all addresses present.
+  (let [{:keys [trace]} (p/generate two-g [] obs-2g)
+        r (u/prepare-mcmc-score two-g [] obs-2g [:a :b] trace)]
+    (is (:tensor-native? r) "static model takes the tensor-native score")
+    (is (= 2 (:n-params r)) "full joint: both eliminated params sampled")
+    (is (= #{:a :b} (set (keys (:latent-index r))))
+        "latent index covers the schema's latents, not the filtered list")))
+
+(deftest gfi-fallback-applies-the-filter
+  ;; beta-bernoulli declines tensor-native -> the filter is LIVE: with its
+  ;; only latent eliminated the param vector is empty. MCMC over zero
+  ;; params is meaningless (the posterior is fully analytical) — this test
+  ;; pins the current contract so the n-params=0 surface is explicit.
+  (let [{:keys [trace]} (p/generate bb [] obs-bb)
+        r (u/prepare-mcmc-score bb [] obs-bb [:p] trace)]
+    (is (not (:tensor-native? r)) "beta prior has no noise transform")
+    (is (= 0 (:n-params r))
+        "filter removed the eliminated latent from the param vector")))
+
+(cljs.test/run-tests)
+


### PR DESCRIPTION
## Summary

Resolves the genmlx-10z1 loose end before the Phase 0 freeze: `prepare-mcmc-score` filters analytically-eliminated addresses out of the MCMC param vector, yet SBC cmh/hmc on fully-eliminated models demonstrably sample ALL params with correct calibration. Explain or fix.

**Mechanism (explained, pinned by test):**

1. **Why it's inert on every current SBC model**: the tensor-native score path (`make-tensor-score-fn` → `cops/make-tensor-score-with-index`) derives its latent index from the schema/source and **ignores the filtered address list entirely**. Every eliminated SBC model is static gaussian, so it always tensor-compiles — MCMC samples the **full joint** (a valid posterior target, hence the passing calibration).
2. **Why it's not dead code**: a plan-bearing model whose prior lacks a noise transform (beta-bernoulli) declines tensor-native; the GFI fallback applies the filter (L3.5 Rao-Blackwell: filtered addresses constrained, eliminated ones marginalized by the analytical handlers). With every latent eliminated the param vector is empty — `n-params 0` is the explicit, documented surface: nothing left for MCMC, the posterior is fully analytical.

## Changes

- `util.cljs`: `prepare-mcmc-score` docstring no longer claims unconditional filtering; documents which path filters and the n-params-0 surface.
- `test/genmlx/mcmc_elim_filter_test.cljs` (fast core): pins two-gaussians (eliminated `#{:a :b}`) to tensor-native / n-params 2 / full-joint latent index, and beta-bernoulli (eliminated `#{:p}`) to fallback / n-params 0. A dispatch change that silently flips a model between joint and Rao-Blackwellized MCMC fails here first.

**No behavior change** — docstring + test only. fast-core 36/36.

Incidental finding filed as genmlx-7zuq: conjugacy detection matches let-binding symbol names against address names (`(let [pp (trace :p ...)])` silently loses detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)