### PR TITLE
fix(sbc): surface failed-verdict combos in merge + skip-resume (genmlx-hojy)

### DIFF
--- a/scripts/merge_sbc_results.py
+++ b/scripts/merge_sbc_results.py
@@ -2,15 +2,30 @@
 """Merge per-combo SBC fragments into results/sbc_results.json (genmlx-18q9).
 
 Each fragment is one sbc_test.cljs run with SBC_ONLY=model:algo and
-SBC_OUT=results/sbc/<model>_<algo>.json. Only fragments whose own summary
-says complete? true are trusted — a fragment from a killed/wedged process
-is ignored and its combo reported missing.
+SBC_OUT=results/sbc/<model>_<algo>.json. A fragment whose own summary says
+complete? true ran to a VERDICT — either passed (per-param rows present;
+individual params may still fail chi2/ks) or FAILED (run-sbc exceeded the
+sim-failure budget and produced no per-param rows). Fragments from
+killed/wedged processes (absent, unparseable, or complete? false) are
+reported missing.
 
-The merged file's summary.complete? is true only when every combo in the
-registry (enumerated via SBC_LIST by test/run_sbc.sh) has a completed
-fragment. Pass/fail totals are recomputed from the per-param pass? flags.
+Three-way classification per registry combo (genmlx-hojy):
+  passed  — complete fragment with per-param rows for the combo
+  failed  — complete fragment that ran to a failed verdict; surfaces in
+            merged results as {model, algorithm, verdict: "failed", reason}
+            and in summary.failed_combos
+  missing — no trustworthy fragment; summary.missing_combos
 
-Usage: merge_sbc_results.py <fragment-dir> <output-json>
+summary.complete? is true only when registry coverage is full AND no combo
+ran to a failed verdict. Pass/fail totals are recomputed from per-param
+pass? flags; each failed combo adds one to fail (the same convention as
+sbc_test.cljs's combo-level fail counter).
+
+Usage:
+  merge_sbc_results.py <fragment-dir> <output-json>
+  merge_sbc_results.py --skip-ok <fragment> <model:algo>
+      exit 0 iff the fragment ran to a PASSED verdict for that combo
+      (used by test/run_sbc.sh skip-resume so failed combos re-run)
 """
 import json
 import pathlib
@@ -30,7 +45,87 @@ def combo_registry() -> list[str]:
             if line.startswith("COMBO ")]
 
 
+def classify_fragment(combo: str, frag_path: pathlib.Path):
+    """Classify one registry combo against its fragment file.
+
+    Returns (status, rows, config) where status is "passed" | "failed" |
+    "missing", rows are the merged-results rows to ingest (a synthesized
+    verdict row for legacy failed fragments that wrote no rows), and config
+    is the fragment's config (None when missing).
+    """
+    if not frag_path.exists():
+        return "missing", [], None
+    try:
+        data = json.loads(frag_path.read_text())
+    except json.JSONDecodeError:
+        return "missing", [], None
+    if not data.get("summary", {}).get("complete?"):
+        return "missing", [], None
+
+    config = {k: v for k, v in data.get("config", {}).items() if k != "only"}
+    model, _, algo = combo.partition(":")
+    rows = [r for r in data.get("results", [])
+            if r.get("model") == model and r.get("algorithm") == algo]
+
+    if any(r.get("verdict") == "failed" for r in rows):
+        return "failed", rows, config
+    if rows:
+        return "passed", rows, config
+    if data.get("summary", {}).get("fail", 0) > 0:
+        # Legacy failed fragment: ran to a failed verdict before
+        # sbc_test.cljs recorded verdict rows — no per-param rows, only
+        # the combo-level fail counter. Synthesize the verdict row.
+        return "failed", [{
+            "model": model,
+            "algorithm": algo,
+            "verdict": "failed",
+            "reason": ("ran to failed verdict: no per-param rows "
+                       "(sim-failure budget exceeded; legacy fragment "
+                       "without verdict field)"),
+            "params": [],
+        }], config
+    # complete? true but no rows and no failures recorded — inconsistent;
+    # don't trust it.
+    return "missing", [], None
+
+
+def merge_fragments(registry: list[str], frag_dir: pathlib.Path) -> dict:
+    results, config = [], None
+    failed, missing = [], []
+    for combo in registry:
+        frag = frag_dir / (combo.replace(":", "_") + ".json")
+        status, rows, frag_config = classify_fragment(combo, frag)
+        if status == "missing":
+            missing.append(combo)
+            continue
+        config = config or frag_config
+        results.extend(rows)
+        if status == "failed":
+            failed.append(combo)
+
+    n_pass = sum(1 for r in results for p in r.get("params", []) if p["pass?"])
+    n_fail = (sum(1 for r in results for p in r.get("params", [])
+                  if not p["pass?"])
+              + len(failed))
+    return {
+        "config": config or {},
+        "results": results,
+        "summary": {
+            "pass": n_pass,
+            "fail": n_fail,
+            "total": n_pass + n_fail,
+            "complete?": not missing and not failed,
+            "failed_combos": failed,
+            "missing_combos": missing,
+        },
+    }
+
+
 def main() -> int:
+    if sys.argv[1] == "--skip-ok":
+        status, _, _ = classify_fragment(sys.argv[3], pathlib.Path(sys.argv[2]))
+        return 0 if status == "passed" else 1
+
     frag_dir = pathlib.Path(sys.argv[1])
     out_path = pathlib.Path(sys.argv[2])
 
@@ -39,44 +134,18 @@ def main() -> int:
         print("ERROR: empty combo registry (SBC_LIST run failed)")
         return 1
 
-    results, config, missing = [], None, []
-    for combo in registry:
-        frag = frag_dir / (combo.replace(":", "_") + ".json")
-        if not frag.exists():
-            missing.append(combo)
-            continue
-        try:
-            data = json.loads(frag.read_text())
-        except json.JSONDecodeError:
-            missing.append(combo)
-            continue
-        if not data.get("summary", {}).get("complete?"):
-            missing.append(combo)
-            continue
-        config = config or {k: v for k, v in data["config"].items() if k != "only"}
-        results.extend(data.get("results", []))
-
-    n_pass = sum(1 for r in results for p in r["params"] if p["pass?"])
-    n_fail = sum(1 for r in results for p in r["params"] if not p["pass?"])
-    merged = {
-        "config": config or {},
-        "results": results,
-        "summary": {
-            "pass": n_pass,
-            "fail": n_fail,
-            "total": n_pass + n_fail,
-            "complete?": not missing,
-            "missing_combos": missing,
-        },
-    }
+    merged = merge_fragments(registry, frag_dir)
     out_path.write_text(json.dumps(merged, indent=2))
-    print(f"merged {len(results)} combos -> {out_path}  "
-          f"({n_pass}/{n_pass + n_fail} params passed)")
-    if missing:
-        print(f"INCOMPLETE: {len(missing)} combos missing/unfinished: "
-              + ", ".join(missing))
-        return 1
-    return 0
+    s = merged["summary"]
+    print(f"merged {len(merged['results'])} combos -> {out_path}  "
+          f"({s['pass']}/{s['total']} params passed)")
+    if s["failed_combos"]:
+        print(f"FAILED VERDICT: {len(s['failed_combos'])} combos: "
+              + ", ".join(s["failed_combos"]))
+    if s["missing_combos"]:
+        print(f"INCOMPLETE: {len(s['missing_combos'])} combos "
+              "missing/unfinished: " + ", ".join(s["missing_combos"]))
+    return 0 if s["complete?"] else 1
 
 
 if __name__ == "__main__":

--- a/test/genmlx/sbc_test.cljs
+++ b/test/genmlx/sbc_test.cljs
@@ -734,7 +734,19 @@
                                  :pass? (and (:pass? chi2) (:pass? ecdf))})
                               param-results)
                 :elapsed_s elapsed}))
-      (swap! summary update :fail inc))
+      ;; run-sbc returned nil: the combo ran to a FAILED verdict (sim-failure
+      ;; budget exceeded). Record it as a results row so the merge step can
+      ;; surface it — a failed combo must never be invisible (genmlx-hojy).
+      (do
+        (swap! all-results conj
+               {:model (:name model-spec)
+                :algorithm (name algo-key)
+                :verdict "failed"
+                :reason (str "sim-failure budget exceeded (>"
+                             (* 100 MAX-FAIL-RATE) "% of sims failed)")
+                :params []
+                :elapsed_s elapsed})
+        (swap! summary update :fail inc)))
     (println (str "  [" (.toFixed elapsed 1) "s]"))
     ;; Write after each combo so crashes don't lose everything
     (write-results!)

--- a/test/merge_sbc_results_test.py
+++ b/test/merge_sbc_results_test.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Regression test for scripts/merge_sbc_results.py (genmlx-hojy).
+
+The bug: a fragment that ran to a FAILED verdict (complete?: true, no
+per-param rows) was ingested as zero rows and listed in neither results
+nor missing_combos — an executed-and-failed combo was invisible in the
+merged summary. These tests round-trip synthetic fragments through the
+merge and assert the three-way passed/failed/missing classification.
+
+Run: python3 test/merge_sbc_results_test.py
+"""
+import json
+import pathlib
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "scripts"))
+import merge_sbc_results as m  # noqa: E402
+
+FAILURES = 0
+
+
+def check(desc: str, ok: bool):
+    global FAILURES
+    print(("PASS: " if ok else "FAIL: ") + desc)
+    if not ok:
+        FAILURES += 1
+
+
+CONFIG = {"N": 500, "L": 200, "N_BINS": 10, "ALPHA": 0.01,
+          "n_total_tests": 50, "only": "x"}
+
+
+def write_frag(d: pathlib.Path, combo: str, body: dict):
+    (d / (combo.replace(":", "_") + ".json")).write_text(json.dumps(body))
+
+
+def green_frag(model: str, algo: str, n_params: int = 2) -> dict:
+    params = [{"name": f"p{i}", "ranks": [], "chi2": {}, "ecdf": {},
+               "pass?": True} for i in range(n_params)]
+    return {"config": CONFIG,
+            "results": [{"model": model, "algorithm": algo,
+                         "params": params, "elapsed_s": 1.0}],
+            "summary": {"pass": n_params, "fail": 0, "total": n_params,
+                        "complete?": True}}
+
+
+def legacy_failed_frag() -> dict:
+    # Exact shape of the 2026-06-11 conjugate-linreg-elim_smc.json fragment:
+    # ran to a failed verdict before verdict rows existed.
+    return {"config": CONFIG, "results": [],
+            "summary": {"pass": 0, "fail": 1, "total": 1, "complete?": True}}
+
+
+def verdict_failed_frag(model: str, algo: str) -> dict:
+    return {"config": CONFIG,
+            "results": [{"model": model, "algorithm": algo,
+                         "verdict": "failed",
+                         "reason": "sim-failure budget exceeded (>5% of sims failed)",
+                         "params": [], "elapsed_s": 2.0}],
+            "summary": {"pass": 0, "fail": 1, "total": 1, "complete?": True}}
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        d = pathlib.Path(tmp)
+        registry = ["m1:cmh", "m2:smc", "m3:hmc", "m4:is", "m5:mh"]
+        write_frag(d, "m1:cmh", green_frag("m1", "cmh"))
+        write_frag(d, "m2:smc", legacy_failed_frag())
+        write_frag(d, "m3:hmc", verdict_failed_frag("m3", "hmc"))
+        # m4:is — no fragment at all
+        incomplete = green_frag("m5", "mh")
+        incomplete["summary"]["complete?"] = False
+        write_frag(d, "m5:mh", incomplete)
+
+        merged = m.merge_fragments(registry, d)
+        s = merged["summary"]
+        rows = {(r["model"], r["algorithm"]): r for r in merged["results"]}
+
+        print("\n-- three-way classification --")
+        check("passed combo ingested with params",
+              ("m1", "cmh") in rows and len(rows[("m1", "cmh")]["params"]) == 2)
+        check("legacy failed fragment surfaces as FAILED row",
+              ("m2", "smc") in rows
+              and rows[("m2", "smc")].get("verdict") == "failed")
+        check("legacy failed row carries a reason",
+              bool(rows.get(("m2", "smc"), {}).get("reason")))
+        check("verdict-format failed fragment surfaces as FAILED row",
+              rows.get(("m3", "hmc"), {}).get("verdict") == "failed")
+        check("failed_combos lists exactly the two failed combos",
+              s["failed_combos"] == ["m2:smc", "m3:hmc"])
+        check("missing = registry minus (passed + failed)",
+              s["missing_combos"] == ["m4:is", "m5:mh"])
+
+        print("\n-- summary counting --")
+        check("per-param passes counted", s["pass"] == 2)
+        check("failed combos counted in fail (fail > 0)", s["fail"] == 2)
+        check("complete? false with failed combos present",
+              s["complete?"] is False)
+
+        print("\n-- all-green run --")
+        registry2 = ["m1:cmh"]
+        merged2 = m.merge_fragments(registry2, d)
+        s2 = merged2["summary"]
+        check("complete? true when all combos passed",
+              s2["complete?"] is True and s2["failed_combos"] == []
+              and s2["missing_combos"] == [])
+
+        print("\n-- skip-resume classification (--skip-ok) --")
+        check("passed fragment is skip-ok",
+              m.classify_fragment("m1:cmh", d / "m1_cmh.json")[0] == "passed")
+        check("legacy failed fragment is NOT skip-ok",
+              m.classify_fragment("m2:smc", d / "m2_smc.json")[0] == "failed")
+        check("verdict failed fragment is NOT skip-ok",
+              m.classify_fragment("m3:hmc", d / "m3_hmc.json")[0] == "failed")
+        check("incomplete fragment classified missing",
+              m.classify_fragment("m5:mh", d / "m5_mh.json")[0] == "missing")
+
+    print(f"\n{'ALL PASS' if FAILURES == 0 else str(FAILURES) + ' FAILURES'}")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/run_sbc.sh
+++ b/test/run_sbc.sh
@@ -19,9 +19,10 @@
 # - A combo that exceeds SBC_COMBO_TIMEOUT (default 7200s) is abandoned; if
 #   the process entered the Metal uninterruptible-sleep state it may linger
 #   until reboot, but the runner moves on (see memory: Metal-wedge runs).
-# - Re-running skips combos whose fragment is already complete, so an
-#   interrupted sweep resumes where it left off. Delete results/sbc/ for a
-#   fresh run.
+# - Re-running skips combos whose fragment ran to a PASSED verdict, so an
+#   interrupted sweep resumes where it left off; combos that ran to a
+#   FAILED verdict (sim-failure budget) are re-run. Delete results/sbc/
+#   for a fresh run.
 set -u
 cd "$(dirname "$0")/.."
 
@@ -48,8 +49,8 @@ failed=0
 for combo in $combos; do
   i=$((i+1))
   frag="$FRAG_DIR/$(echo "$combo" | tr ':' '_').json"
-  if [ -f "$frag" ] && python3 -c "import json,sys; sys.exit(0 if json.load(open('$frag'))['summary']['complete?'] else 1)" 2>/dev/null; then
-    echo "[$i/$total] $combo — fragment complete, skipping"
+  if [ -f "$frag" ] && python3 scripts/merge_sbc_results.py --skip-ok "$frag" "$combo" 2>/dev/null; then
+    echo "[$i/$total] $combo — fragment passed, skipping"
     continue
   fi
   echo "[$i/$total] $combo"


### PR DESCRIPTION
## Summary
- A combo that ran to a FAILED verdict (sim-failure budget) was invisible in the merged SBC summary: the fragment said `complete?: true` with no per-param rows, so the merge ingested zero rows and listed it in neither `results` nor `missing_combos`. Found inspecting the 2026-06-11 overnight run, where `conjugate-linreg-elim:smc` failed its budget yet the merged summary read "38/38 pass, 2 missing".
- Merge now classifies each registry combo three-way (passed/failed/missing); failed combos surface as verdict rows with reasons, are counted in `summary.fail`, and force `complete?: false`.
- `sbc_test.cljs` records a self-describing verdict row on budget failure; legacy no-row failed fragments are still classified correctly.
- `run_sbc.sh` skip-resume now re-runs failed-verdict combos automatically (previously they had to be `rm`'d by hand or were silently skipped).

## Verification
- `python3 test/merge_sbc_results_test.py` — 14/14 assertions (synthetic green / legacy-failed / verdict-failed / missing / incomplete fragments).
- Real merge over tonight's fragments now reports: 25 combos, FAILED VERDICT `conjugate-linreg-elim:smc`, missing the two mvr-5d crash combos, exit 1.
- `--skip-ok` returns 1 for the real failed fragment, 0 for a green one.
- `bash test/run.sh check` — OK (363 files classified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)