### PR TITLE
fix(smc): bound Metal buffer-count peak inside tidy scopes (genmlx-q6lh)

### DIFF
--- a/src/genmlx/inference/smc.cljs
+++ b/src/genmlx/inference/smc.cljs
@@ -55,6 +55,19 @@
               (if (u/accept-mh? (mx/realize weight) rk) trace t)))
           trace step-keys))
 
+(defn break-trace-graph!
+  "Break the lazy graph riding a rejuvenated trace: materialize its score
+   (forcing the regenerated choice values it references), then sweep dead
+   arrays every 50 particles. The rejuvenation counterpart of
+   break-particle-graph! — without it a full rejuvenation pass holds all
+   N x steps regenerate graphs live at once, and on multi-stage runs that
+   peak blows the Metal buffer-count ceiling (genmlx-q6lh). Returns the
+   trace unchanged."
+  [trace i]
+  (mx/materialize! (:score trace))
+  (when (zero? (mod (inc i) 50)) (mx/sweep-dead-arrays!))
+  trace)
+
 (defn strip-analytical
   "Strip analytical handlers from a model for particle-based inference.
    The analytical path returns deterministic posterior means, eliminating
@@ -170,16 +183,19 @@
     {:traces traces :log-weights log-weights :log-ml-increment ml-inc}))
 
 (defn- smc-rejuvenate
-  "Apply rejuvenation-steps MH moves to each trace.
+  "Apply rejuvenation-steps MH moves to each trace, breaking each
+   particle's regenerate graph as it completes (genmlx-q6lh).
    Returns vector of (possibly updated) traces."
   [traces rejuvenation-steps rejuvenation-selection key]
   (if (pos? rejuvenation-steps)
     (let [keys (if key (rng/split-n key (count traces)) (repeat (count traces) nil))]
-      (mapv (fn [trace ki]
+      (mapv (fn [i trace ki]
               (let [trace-keys (if ki (rng/split-n ki rejuvenation-steps)
                                       (repeat rejuvenation-steps nil))]
-                (rejuvenate-trace trace rejuvenation-selection trace-keys)))
-            traces keys))
+                (break-trace-graph!
+                 (rejuvenate-trace trace rejuvenation-selection trace-keys)
+                 i)))
+            (range) traces keys))
     traces))
 
 (defn- smc-step
@@ -412,10 +428,12 @@
                                    (mapv (fn [i trace ki]
                                            (if (= i ref-idx)
                                              trace  ;; Don't rejuvenate reference
-                                             (rejuvenate-trace
-                                              trace rejuvenation-selection
-                                              (if ki (rng/split-n ki rejuvenation-steps)
-                                                     (repeat rejuvenation-steps nil)))))
+                                             (break-trace-graph!
+                                              (rejuvenate-trace
+                                               trace rejuvenation-selection
+                                               (if ki (rng/split-n ki rejuvenation-steps)
+                                                      (repeat rejuvenation-steps nil)))
+                                              i)))
                                          (range particles) new-traces keys))
                                  new-traces)
                   ;; Same adaptive-resampling increment as smc-step: subtract

--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -747,8 +747,22 @@
    Named for backward compatibility; use get-active-memory for clarity."
   [] (.getActiveMemory c))
 
-(defn sweep-dead-arrays! []
-  (when-not (in-tidy?)
+(declare ^:private buffer-count-pressure?)
+
+(defn sweep-dead-arrays!
+  "Collect dead MxArray wrappers (forced GC) and drop the Metal buffer cache.
+
+   Inside a tidy scope this normally defers to the scope-exit cleanup — BUT
+   the ~499000 Metal buffer-COUNT wall does not wait for scope exit: a
+   tiny-array hot loop inside one tidy scope (e.g. one SBC sim's full
+   multi-stage SMC pass, ~10^6 wrapper allocations) climbs to the wall with
+   the deferred cleanup never firing, because every in-loop sweep site
+   no-ops (genmlx-q6lh). Under hysteretic buffer-count pressure the wall is
+   the greater evil, so the sweep fires anyway — once per climb past the
+   high watermark (buffer-count-pressure? disarms until the count falls
+   below the low watermark), so an all-live count cannot make it thrash."
+  []
+  (when (or (not (in-tidy?)) (buffer-count-pressure?))
     (jsc-cleanup!)
     (.clearCache c)))
 


### PR DESCRIPTION
## Summary
- Root cause of the overnight SBC failure of `conjugate-linreg-elim:smc` (Metal buffer-count ceiling at ~sim 163): `sweep-dead-arrays!` was a hard no-op inside tidy scopes, and the SBC harness wraps each sim in `mx/tidy` — every engineered reclamation site (smc per-step sweeps, `break-particle-graph!` per-50 sweeps, the x7cl proactive count machinery) was silently disabled for the entire sim. A multi-stage 2000-particle sim allocates ~10^6 tiny wrappers; survival depended on natural JSC GC timing.
- Second compounding cause: the rejuvenation pass had no sweep call sites at all (~280k allocations between checkpoints at SBC scale).
- Fix: hysteretic count-pressure escape hatch in `sweep-dead-arrays!` (fires inside tidy only past the high watermark, disarms until the low watermark — no thrashing; unchanged outside tidy) + new `break-trace-graph!` applied per-particle in `smc-rejuvenate` and `csmc` rejuvenation.

## Verification
- Full-combo-config diagnostic (3 stages × 2000 particles × 2 rejuvenation steps, 2GB cache, per-sim `mx/tidy`, rank-extraction parity): pre-fix dies at sim 0–1 at the 499k wall; post-fix **15/15 sims flat at exactly 14 buffers**.
- Seeded `smc` output bit-for-bit identical pre/post (17 sig digits) — numerically inert.
- fast-core 39/39; inference_smc, smc_property, smc_scoring 41/41, smc_evidence 17/17, mutation_boundary all green.
- pmcmc_test flakiness investigated, exonerated (flaky on main 6/8 vs branch 4/9; rooted in csmc's unkeyed entropy → filed genmlx-g5ys).
- N=500 SBC re-run of the combo follows on main (gated work, genmlx-q6lh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)