### PR TITLE
fix(membrane): honor buffer-count pressure inside tidy scopes (genmlx-8w48)

### DIFF
--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -835,13 +835,20 @@
   "Called from the allocation/read boundary (with-alloc-retry). Every
    count-check-interval guarded ops, if the live Metal buffer count crosses the
    threshold (hysteretic), reclaim dead buffers BEFORE the ~499000 wall is hit.
-   Gated on (not in-tidy?): a tidy scope does its own cleanup on exit, and a
-   force-gc! mid-scope would call jsc-cleanup! out of turn."
+
+   NOT gated on in-tidy?: a tidy scope defers ordinary cleanup to scope exit,
+   but the buffer-COUNT wall does not wait for it — a gradient-heavy hot loop
+   inside one tidy scope (e.g. one SBC sim's HMC pass) allocates straight
+   past 499000 with every deferred cleanup silent, and the resulting
+   metal::malloc throw inside an FFI call is a failed op, not a recoverable
+   alloc-retry (genmlx-8w48, same disease as the smc case in genmlx-q6lh).
+   Under count pressure the wall is the greater evil; the hysteresis makes
+   this fire once per climb, so an all-live count cannot thrash."
   []
   (set! allocs-since-count-check (inc allocs-since-count-check))
   (when (>= allocs-since-count-check count-check-interval)
     (set! allocs-since-count-check 0)
-    (when (and (not (in-tidy?)) (buffer-count-pressure?))
+    (when (buffer-count-pressure?)
       (count-sweep!))))
 
 (defn auto-cleanup!


### PR DESCRIPTION
## Summary
- `maybe-count-sweep!` (the proactive count sweep at the allocation boundary, every 4096 guarded allocs) was gated on `(not (in-tidy?))` — inside a tidy scope the live Metal buffer count climbed unchecked past the ~499k wall. One gradient-heavy SBC sim (mvr-5d:hmc) allocated straight past it; the resulting `metal::malloc` throw inside `.computeGradients` was a failed op, failing 29/50 sims on budget even after the native guard (mlx-node 8f4c8f6) converted the former process death into a catchable error.
- Drop the gate: under hysteretic count pressure the wall is the greater evil — same reasoning as PR #97's `sweep-dead-arrays!` escape hatch, now at allocation-boundary granularity for every hot loop.

## Verification
- mvr-5d:hmc N=50 L=200 — 0 sim failures, 5/5 params pass (pre-guard: process death at rep 0; pre-fix: 29/50 failed)
- mvr-5d:cmh N=50 L=200 — 0 sim failures, 5/5 params pass (previously: C++ panic ~1 min in)
- Contract guard after rebuild: exact 120/0, gradient_fd, score_gradient, clip_contract, native_guard green; fast-core 39/39

Companion mlx-node commit: 8f4c8f6 (MLX_GUARD on mlx_compute_gradients — the last unguarded shim — + process-global terminate-handler diagnostics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)