### PR TITLE
feat(sbc): record run provenance for the results freeze (genmlx-9ocx)

### DIFF
--- a/scripts/merge_sbc_results.py
+++ b/scripts/merge_sbc_results.py
@@ -92,6 +92,7 @@ def classify_fragment(combo: str, frag_path: pathlib.Path):
 def merge_fragments(registry: list[str], frag_dir: pathlib.Path) -> dict:
     results, config = [], None
     failed, missing = [], []
+    provenance = set()
     for combo in registry:
         frag = frag_dir / (combo.replace(":", "_") + ".json")
         status, rows, frag_config = classify_fragment(combo, frag)
@@ -99,6 +100,10 @@ def merge_fragments(registry: list[str], frag_dir: pathlib.Path) -> dict:
             missing.append(combo)
             continue
         config = config or frag_config
+        meta = (frag_config or {}).get("meta") or {}
+        if meta.get("genmlx_commit") or meta.get("mlx_node_commit"):
+            provenance.add((meta.get("genmlx_commit"),
+                            meta.get("mlx_node_commit")))
         results.extend(rows)
         if status == "failed":
             failed.append(combo)
@@ -117,6 +122,14 @@ def merge_fragments(registry: list[str], frag_dir: pathlib.Path) -> dict:
             "complete?": not missing and not failed,
             "failed_combos": failed,
             "missing_combos": missing,
+            # Freeze-gate honesty (genmlx-9ocx): every distinct
+            # (genmlx_commit, mlx_node_commit) pair the ingested fragments
+            # were produced on. A clean frozen run has exactly one entry;
+            # more means fragments span code/binary states.
+            "provenance": [
+                {"genmlx_commit": g, "mlx_node_commit": m}
+                for g, m in sorted(provenance, key=str)
+            ],
         },
     }
 

--- a/test/genmlx/sbc_test.cljs
+++ b/test/genmlx/sbc_test.cljs
@@ -39,7 +39,8 @@
             [genmlx.inference.smc :as smc]
             [genmlx.mlx.random :as rng]
             [clojure.string :as str]
-            ["fs" :as fs])
+            ["fs" :as fs]
+            ["child_process" :as cp])
   (:require-macros [genmlx.gen :refer [gen]]))
 
 ;; ── Configuration (from env vars, with defaults) ─────────────────────────
@@ -671,6 +672,24 @@
 (def results-path
   (or (aget js/process.env "SBC_OUT") "results/sbc_results.json"))
 
+(def run-meta
+  "Provenance for the results-freeze gate (genmlx-9ocx): the exact code,
+   binary, runtime, and hardware a run keys to. Recorded once per process;
+   git queries degrade to nil outside a checkout. PRNG seeds are NOT pinned —
+   sims draw fresh entropy by design (rank uniformity is seed-free); see
+   genmlx-g5ys for the csmc determinism caveat."
+  (let [git (fn [dir]
+              (try (-> (cp/execSync (str "git -C " dir " rev-parse HEAD")
+                                    #js {:encoding "utf8"})
+                       str/trim)
+                   (catch :default _ nil)))]
+    {:genmlx_commit (git ".")
+     :mlx_node_commit (git "mlx-node")
+     :bun (some-> js/process.versions .-bun)
+     :node js/process.version
+     :device (:device-name (mx/metal-device-info))
+     :started (.toISOString (js/Date.))}))
+
 (defn write-results!
   "Write current results to JSON incrementally. complete? is false until the
    final write — the merge step (test/run_sbc.sh) trusts only completed
@@ -680,7 +699,8 @@
    (let [{:keys [pass fail]} @summary
          output (clj->js {:config {:N N :L L :N_BINS N-BINS :ALPHA ALPHA
                                    :n_total_tests n-total-tests
-                                   :only (or sbc-only nil)}
+                                   :only (or sbc-only nil)
+                                   :meta run-meta}
                           :results @all-results
                           :summary {:pass pass :fail fail :total (+ pass fail)
                                     :complete? complete?}})


### PR DESCRIPTION
Each fragment now carries config.meta = {genmlx_commit, mlx_node_commit,
bun, node, device, started}; the merge surfaces every distinct
(genmlx_commit, mlx_node_commit) pair across ingested fragments as
summary.provenance — a clean frozen run has exactly one entry, so
fragments spanning code/binary states can no longer masquerade as a
single pinned run. PRNG seeds are intentionally NOT pinned (rank
uniformity is seed-free; csmc determinism caveat tracked in genmlx-g5ys).

Verified: merge regression test 14/14 + provenance passthrough; registry
still 27 combos; metadata smoke on single-gaussian:cmh records both
commits + runtime + device.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
