### PR TITLE
fix(experiments): size funnel timeout for the 4-chain rewrite (genmlx-2zxo)

### DIFF
--- a/experiments.edn
+++ b/experiments.edn
@@ -111,7 +111,9 @@
   {:name        "funnel"
    :script      "bench/funnel.cljs"
    :category    :inference
-   :timeout-ms  600000
+   ;; 4-chain rewrite (6b55c8a, genmlx-5gww) runs ~9.5 min wall; the old
+   ;; 10-min budget was sized for the single-chain script (genmlx-2zxo).
+   :timeout-ms  1200000
    :description "Neal's funnel (D=11): NUTS vs HMC vs MALA vs MH on pathological geometry."
    :sources     ["src/genmlx/inference/mcmc.cljs"
                  "src/genmlx/inference/diagnostics.cljs"]}


### PR DESCRIPTION
## Summary

The 6b55c8a funnel rewrite (genmlx-5gww: joint model, 4 chains, rank-normalized R-hat/bulk/tail-ESS, MALA) made the benchmark ~4x heavier, but its experiments.edn :timeout-ms stayed at the 10-min budget sized for the old single-chain script. The rewrite never ran under the runner until the 2026-06-12 Phase-0 close-out pass, where it hit ETIMEDOUT as the suite's only failure (25/26 green).

A bounded solo probe confirmed the benchmark is healthy: ~9.5 min wall, HMC 55.5s / NUTS 80.4s / compiled-MH 13.3s, per-chain NUTS ~20s (vs 56s single-chain pre-rewrite) - no engine regression from the mlx-node pin bump or the in-tidy pressure fix. This is runner-config catch-up, not spec-weakening: the budget rises to 20 min (~2x observed wall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
