### PR TITLE
fix(sbc): raise conjugate-linreg-elim smc rejuvenation-steps to 10 (genmlx-mxss)

### DIFF
--- a/test/genmlx/sbc_test.cljs
+++ b/test/genmlx/sbc_test.cljs
@@ -430,7 +430,15 @@
    :algorithms [:cmh :hmc :smc]
    :cmh-opts {:addresses [:slope :intercept] :proposal-std 0.5 :thin 20}
    :hmc-opts {:addresses [:slope :intercept] :step-size 0.05 :leapfrog-steps 15}
-   :smc-opts {:selection (sel/select :slope :intercept)}})
+   ;; rejuvenation-steps 10: at the default 2, prior-regeneration MH cannot
+   ;; restore particle diversity after resampling on this correlated 2D
+   ;; posterior — ranks go structured (chi2 fails while ks passes, the
+   ;; t757 signature). Sampler-adequacy tuning like the cmh thin values,
+   ;; NOT spec-weakening; weight math has independent cover (smc_evidence/
+   ;; smc_scoring). Value validated by mini-SBC at N=200: chi2 slope
+   ;; 36.56 -> 9.20, intercept 24.52 -> 7.10 vs crit 21.67 (genmlx-mxss).
+   :smc-opts {:selection (sel/select :slope :intercept)
+              :rejuvenation-steps 10}})
 
 (def hierarchical-elim
   {:name "hierarchical-elim"


### PR DESCRIPTION
## Summary

Raises conjugate-linreg-elim:smc rejuvenation-steps from the default 2 to 10 in the SBC registry (genmlx-mxss).

The pristine N=500 freeze run gave this combo its first-ever clean calibration verdict: chi2 FAIL on both params (slope 36.56, intercept 24.52, crit 21.67) with ks PASS - the structured-ranks signature seen before on under-thinned cmh (genmlx-t757). A mini-SBC diagnostic at N=200 with rejuvenation-steps 10 confirmed under-rejuvenation as the root cause: chi2 dropped to 9.20 (slope) and 7.10 (intercept) with 0/200 sim failures, ks passing throughout.

This is sampler-adequacy tuning (the proposal cannot restore particle diversity after resampling on a correlated 2D posterior), not spec-weakening: model, N, L, alpha, and both uniformity tests are unchanged. Weight math has independent cover (smc_evidence / smc_scoring suites).

Next: rm the stale fragment and re-run the combo at N=500 via SBC_ONLY (the freeze-blocking step for genmlx-18q9 / genmlx-9ocx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
