### PR TITLE
feat(gfi): score-type as enforced metadata (genmlx-lbae)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -426,16 +426,36 @@ L0 is neither -- it is the identity. It is the base transition that everything e
 The middleware pattern means L3 composes with L0 or L1. A partially-compiled model can have its static prefix compiled (L1) while its dynamic suffix runs under an analytical-wrapped handler (L3 on L0). The dispatcher stack resolves per-site, not per-model.
 
 
-## 3.3 Score Encoding as Transition Metadata
+## 3.3 Score Encoding as Enforced Metadata
 
 Different transitions assign different meanings to the score field:
 
 - **Standard transitions**: score = log *p*(*τ*; *x*) (joint log-probability)
 - **Analytical middleware**: score = marginal log-likelihood (conjugate sites collapsed)
 - **Enumerate transition**: score = exact marginal likelihood (all latents collapsed)
-- **Beam transition**: score = beam-approximated marginal likelihood
+- **Beam transition**: score = beam-approximated marginal likelihood (reserved)
 
-The score encoding should be explicit metadata on the transition result, not an implicit convention. When `merge-sub-result` accumulates a sub-result's score into the parent state, it must know whether that score is a joint density, a marginal likelihood, or an approximation. Making it metadata makes the convention checkable.
+The score encoding is explicit, checked metadata, not an implicit convention.
+Every trace carries `:genmlx.trace/score-type` metadata (`:joint`,
+`:marginal`, `:collapsed`), set by every producing path: handler and
+compiled paths tag `:joint`, the analytical path tags `:marginal` when a
+handler actually marginalized, enumerate tags `:collapsed`. Composite
+producers propagate: `merge-sub-result` lubs a spliced sub-result's
+score-type into the parent state, and combinators tag their result traces
+with the lub over element traces — a marginal sub-score cannot launder into
+a joint-looking total.
+
+Consumers enforce the contract at joint-scoring boundaries
+(update/project/regenerate, via the dispatcher guard for `DynamicGF` and
+`ensure-joint-self` for combinator records): `:marginal` traces convert by
+re-generating fully constrained from their own choices (one handler
+generate; alternate paths stay semantically invisible), while `:collapsed`
+traces throw — their choicemaps are empty, so no joint conversion exists.
+Trace-MH entry points additionally assert their regenerate results are
+joint-scored, so a forgotten analytical strip throws instead of silently
+anchoring chains at the posterior mean (the genmlx-540f failure class).
+The law `:score-type-soundness` in `gfi.cljs` and `score_type_test.cljs`
+guard the convention.
 
 ---
 

--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -37,6 +37,57 @@
     kern
     (vary-meta kern assoc :genmlx.dynamic/key :genmlx.dynamic/auto-key)))
 
+;; ---------------------------------------------------------------------------
+;; Score-type propagation (genmlx-lbae)
+;;
+;; Combinator records bypass the DynamicGF dispatcher stack, so the
+;; score-type machinery (tag producers, convert-or-throw at joint-scoring
+;; boundaries — ARCHITECTURE §3.3, genmlx-pkmx) is applied here:
+;;   - result traces are tagged with the lub of their element/sub-trace
+;;     score-types (tag-from-traces), or :joint on compiled/fused element
+;;     paths which cannot fire the analytical path (tag-joint)
+;;   - update/regenerate/project entries convert a :marginal self-trace
+;;     before any recorded old score is reused (ensure-joint-self)
+;; ---------------------------------------------------------------------------
+
+(defn- tag-joint
+  "Tag a combinator result trace :joint — compiled/fused element paths are
+   joint by construction."
+  [trace]
+  (tr/with-score-type trace :joint))
+
+(defn- tag-from-traces
+  "Tag a combinator result trace with the lub of its element/sub-trace
+   score-types: a marginal sub-score summed into a composite total makes
+   the composite score marginal."
+  [trace sub-traces]
+  (tr/with-score-type
+    trace
+    (reduce tr/combine-score-types :joint (map tr/score-type sub-traces))))
+
+(defn- ensure-joint-self
+  "Score-type boundary for combinator update/regenerate/project. A
+   :marginal self-trace re-generates fully constrained from its own
+   choices: sub-gfs fall through to plain joint scoring when their latents
+   are constrained (genmlx-b470), restoring joint element scores before any
+   recorded old score is reused in a weight. Throws when no joint
+   conversion exists (a :collapsed sub-gf reproduces a collapsed score).
+   No-op for joint traces."
+  [this op trace]
+  (let [st (tr/score-type trace)]
+    (if (= :joint st)
+      trace
+      (let [converted (:trace (p/generate (ensure-kernel-key this)
+                                          (:args trace) (:choices trace)))]
+        (if (= :joint (tr/score-type converted))
+          converted
+          (throw (ex-info
+                   (str "Combinator " op " cannot consume a " st
+                        "-scored trace — re-generating its choices does not"
+                        " yield a joint score")
+                   {:genmlx/error :score-type-mismatch
+                    :op op :score-type st :expected :joint})))))))
+
 (defn- assemble-indexed-discards
   "Collect non-empty per-element discards under their ORIGINAL element
    indices. Filtering before positional reassembly records element i's
@@ -130,10 +181,11 @@
         {:keys [choices element-scores]}
         (unpack-fused-map-outputs values scores n addr-order)
         retvals (mapv #(mx/index retval %) (range n))]
-    (with-meta
-      (tr/make-trace {:gen-fn this :args args
-                      :choices choices :retval retvals :score total-score})
-      {::element-scores element-scores ::compiled-path true ::fused true})))
+    (tag-joint
+      (with-meta
+        (tr/make-trace {:gen-fn this :args args
+                        :choices choices :retval retvals :score total-score})
+        {::element-scores element-scores ::compiled-path true ::fused true}))))
 
 (defn- map-simulate-compiled
   "Compiled Map simulate: call compiled-simulate per element."
@@ -156,10 +208,11 @@
         score (reduce (fn [acc r] (mx/add acc (:score r)))
                       ZERO results)
         element-scores (mapv :score results)]
-    (with-meta
-      (tr/make-trace {:gen-fn this :args args
-                      :choices choices :retval retvals :score score})
-      {::element-scores element-scores ::compiled-path true})))
+    (tag-joint
+      (with-meta
+        (tr/make-trace {:gen-fn this :args args
+                        :choices choices :retval retvals :score score})
+        {::element-scores element-scores ::compiled-path true}))))
 
 (defn- map-simulate-handler
   "Handler Map simulate: delegate to kernel per element."
@@ -172,10 +225,12 @@
         retvals (mapv :retval results)
         score (sum-field results :score)
         element-scores (mapv :score results)]
-    (with-meta
-      (tr/make-trace {:gen-fn this :args args
-                      :choices choices :retval retvals :score score})
-      {::element-scores element-scores})))
+    (tag-from-traces
+      (with-meta
+        (tr/make-trace {:gen-fn this :args args
+                        :choices choices :retval retvals :score score})
+        {::element-scores element-scores})
+      results)))
 
 (defrecord MapCombinator [kernel]
   p/IGenerativeFunction
@@ -197,10 +252,11 @@
                choices cm/EMPTY score ZERO weight ZERO
                retvals [] element-scores []]
           (if (>= i n)
-            {:trace (with-meta
-                      (tr/make-trace {:gen-fn this :args args
-                                      :choices choices :retval retvals :score score})
-                      {::element-scores element-scores ::compiled-path true})
+            {:trace (tag-joint
+                      (with-meta
+                        (tr/make-trace {:gen-fn this :args args
+                                        :choices choices :retval retvals :score score})
+                        {::element-scores element-scores ::compiled-path true}))
              :weight weight}
             (let [[k1 k2] (rng/split key)
                   elem-args (mapv #(nth % i) args)
@@ -223,15 +279,18 @@
             score (sum-field results (comp :score :trace))
             weight (sum-field results :weight)
             element-scores (mapv (comp :score :trace) results)]
-        {:trace (with-meta
-                  (tr/make-trace {:gen-fn this :args args
-                                  :choices choices :retval retvals :score score})
-                  {::element-scores element-scores})
+        {:trace (tag-from-traces
+                  (with-meta
+                    (tr/make-trace {:gen-fn this :args args
+                                    :choices choices :retval retvals :score score})
+                    {::element-scores element-scores})
+                  (map :trace results))
          :weight weight})))
 
   p/IUpdate
   (update [this trace constraints]
-    (if-let [cupd (cops/get-compiled-update kernel)]
+    (let [trace (ensure-joint-self this :update trace)]
+      (if-let [cupd (cops/get-compiled-update kernel)]
       ;; WP-8: compiled update path
       (let [old-choices (:choices trace)
             args (:args trace)
@@ -241,10 +300,11 @@
                choices cm/EMPTY score ZERO discard cm/EMPTY
                retvals [] element-scores []]
           (if (>= i n)
-            {:trace (with-meta
-                      (tr/make-trace {:gen-fn this :args args
-                                      :choices choices :retval retvals :score score})
-                      {::element-scores element-scores ::compiled-path true})
+            {:trace (tag-joint
+                      (with-meta
+                        (tr/make-trace {:gen-fn this :args args
+                                        :choices choices :retval retvals :score score})
+                        {::element-scores element-scores ::compiled-path true}))
              :weight (mx/subtract score (:score trace)) :discard discard}
             (let [[k1 k2] (rng/split key)
                   elem-args (mapv #(nth % i) args)
@@ -289,11 +349,13 @@
                                 (:score trace))
             discard (assemble-indexed-discards results)
             element-scores (mapv (comp :score :trace) results)]
-        {:trace (with-meta
-                  (tr/make-trace {:gen-fn this :args args
-                                  :choices choices :retval retvals :score score})
-                  {::element-scores element-scores})
-         :weight weight :discard discard})))
+        {:trace (tag-from-traces
+                  (with-meta
+                    (tr/make-trace {:gen-fn this :args args
+                                    :choices choices :retval retvals :score score})
+                    {::element-scores element-scores})
+                  (map :trace results))
+         :weight weight :discard discard}))))
 
   p/IRegenerate
   ;; Per-element old scores come from ::element-scores metadata. When that
@@ -303,7 +365,8 @@
   ;; (:score trace). Correct at the end instead of silently returning wrong
   ;; weights (genmlx-v740). When metadata is present the path is unchanged.
   (regenerate [this trace selection]
-    (if-let [cregen (cops/get-compiled-regenerate kernel)]
+    (let [trace (ensure-joint-self this :regenerate trace)]
+     (if-let [cregen (cops/get-compiled-regenerate kernel)]
       ;; WP-9A: compiled regenerate path
       (let [old-choices (:choices trace)
             args (:args trace)
@@ -314,10 +377,11 @@
                choices cm/EMPTY score ZERO weight ZERO
                retvals [] element-scores []]
           (if (>= i n)
-            {:trace (with-meta
-                      (tr/make-trace {:gen-fn this :args args
-                                      :choices choices :retval retvals :score score})
-                      {::element-scores element-scores ::compiled-path true})
+            {:trace (tag-joint
+                      (with-meta
+                        (tr/make-trace {:gen-fn this :args args
+                                        :choices choices :retval retvals :score score})
+                        {::element-scores element-scores ::compiled-path true}))
              :weight (if old-element-scores
                        weight
                        (mx/subtract weight (:score trace)))}
@@ -358,13 +422,15 @@
             score (sum-field results (comp :score :trace))
             weight (sum-field results :weight)
             element-scores (mapv (comp :score :trace) results)]
-        {:trace (with-meta
-                  (tr/make-trace {:gen-fn this :args args
-                                  :choices choices :retval retvals :score score})
-                  {::element-scores element-scores})
+        {:trace (tag-from-traces
+                  (with-meta
+                    (tr/make-trace {:gen-fn this :args args
+                                    :choices choices :retval retvals :score score})
+                    {::element-scores element-scores})
+                  (map :trace results))
          :weight (if old-element-scores
                    weight
-                   (mx/subtract weight (:score trace)))}))))
+                   (mx/subtract weight (:score trace)))})))))
 
 (defn map-combinator
   "Create a Map combinator from a kernel generative function.
@@ -450,10 +516,11 @@
         _ (mx/materialize! outputs-tensor scores-tensor total-score)
         {:keys [choices states step-scores]}
         (unpack-fused-outputs outputs-tensor scores-tensor n addr-order state-keys)]
-    (with-meta
-      (tr/make-trace {:gen-fn this :args args
-                      :choices choices :retval states :score total-score})
-      {::step-scores step-scores ::compiled-path true ::fused true})))
+    (tag-joint
+      (with-meta
+        (tr/make-trace {:gen-fn this :args args
+                        :choices choices :retval states :score total-score})
+        {::step-scores step-scores ::compiled-path true ::fused true}))))
 
 (defn- unfold-simulate-compiled
   "Compiled Unfold simulate: call compiled-simulate per step."
@@ -463,10 +530,11 @@
            choices cm/EMPTY score ZERO
            states [] step-scores []]
       (if (>= t n)
-        (with-meta
-          (tr/make-trace {:gen-fn this :args args
-                          :choices choices :retval states :score score})
-          {::step-scores step-scores ::compiled-path true})
+        (tag-joint
+          (with-meta
+            (tr/make-trace {:gen-fn this :args args
+                            :choices choices :retval states :score score})
+            {::step-scores step-scores ::compiled-path true}))
         (let [[k1 k2] (rng/split key)
               result (csim k1 (into [t state] extra))
               new-state (:retval result)
@@ -483,12 +551,14 @@
   [this args kernel n init-state extra]
   (loop [t 0 state init-state
          choices cm/EMPTY score ZERO
-         states [] step-scores []]
+         states [] step-scores [] st :joint]
     (if (>= t n)
-      (with-meta
-        (tr/make-trace {:gen-fn this :args args
-                        :choices choices :retval states :score score})
-        {::step-scores step-scores})
+      (tr/with-score-type
+        (with-meta
+          (tr/make-trace {:gen-fn this :args args
+                          :choices choices :retval states :score score})
+          {::step-scores step-scores})
+        st)
       (let [trace (p/simulate kernel (into [t state] extra))
             new-state (:retval trace)]
         (recur (inc t)
@@ -496,7 +566,8 @@
                (cm/set-choice choices [t] (:choices trace))
                (mx/add score (:score trace))
                (conj states new-state)
-               (conj step-scores (:score trace)))))))
+               (conj step-scores (:score trace))
+               (tr/combine-score-types st (tr/score-type trace)))))))
 
 (defrecord UnfoldCombinator [kernel fused-cache]
   p/IGenerativeFunction
@@ -518,10 +589,11 @@
                  choices cm/EMPTY score ZERO weight ZERO
                  states [] step-scores []]
             (if (>= t n)
-              {:trace (with-meta
-                        (tr/make-trace {:gen-fn this :args args
-                                        :choices choices :retval states :score score})
-                        {::step-scores step-scores ::compiled-path true})
+              {:trace (tag-joint
+                        (with-meta
+                          (tr/make-trace {:gen-fn this :args args
+                                          :choices choices :retval states :score score})
+                          {::step-scores step-scores ::compiled-path true}))
                :weight weight}
               (let [[k1 k2] (rng/split key)
                     result (cgen k1 (into [t state] extra)
@@ -537,12 +609,14 @@
         ;; Fallback: handler path
         (loop [t 0 state init-state
                choices cm/EMPTY score ZERO weight ZERO
-               states [] step-scores []]
+               states [] step-scores [] st :joint]
           (if (>= t n)
-            {:trace (with-meta
-                      (tr/make-trace {:gen-fn this :args args
-                                      :choices choices :retval states :score score})
-                      {::step-scores step-scores})
+            {:trace (tr/with-score-type
+                      (with-meta
+                        (tr/make-trace {:gen-fn this :args args
+                                        :choices choices :retval states :score score})
+                        {::step-scores step-scores})
+                      st)
              :weight weight}
             (let [result (p/generate kernel (into [t state] extra)
                                      (cm/get-submap constraints t))
@@ -554,12 +628,14 @@
                      (mx/add score (:score trace))
                      (mx/add weight (:weight result))
                      (conj states new-state)
-                     (conj step-scores (:score (:trace result)))))))))))
+                     (conj step-scores (:score (:trace result)))
+                     (tr/combine-score-types st (tr/score-type trace))))))))))
 
 (extend-type UnfoldCombinator
   p/IUpdate
   (update [this trace constraints]
-    (let [kern (:kernel this)
+    (let [trace (ensure-joint-self this :update trace)
+          kern (:kernel this)
           cupd (cops/get-compiled-update kern)
           {:keys [args choices]} trace
           [n init-state & extra] args
@@ -606,13 +682,16 @@
                  new-choices prefix-choices score prefix-score
                  nf prefix-score
                  discard cm/EMPTY
-                 states prefix-states step-scores prefix-step-scores]
+                 states prefix-states step-scores prefix-step-scores
+                 st :joint]
             (if (>= t n)
-              {:trace (with-meta
-                        (tr/make-trace {:gen-fn this :args args
-                                        :choices new-choices :retval states :score score})
-                        (cond-> {::step-scores step-scores}
-                          cupd (assoc ::compiled-path true)))
+              {:trace (tr/with-score-type
+                        (with-meta
+                          (tr/make-trace {:gen-fn this :args args
+                                          :choices new-choices :retval states :score score})
+                          (cond-> {::step-scores step-scores}
+                            cupd (assoc ::compiled-path true)))
+                        st)
                :weight (mx/subtract nf (:score trace)) :discard discard}
               (if cupd
                 ;; WP-8: compiled update path
@@ -632,7 +711,8 @@
                            (cm/set-choice discard [t] step-discard)
                            discard)
                          (conj states new-state)
-                         (conj step-scores (:score result))))
+                         (conj step-scores (:score result))
+                         st))
                 ;; Fallback: handler path
                 (let [old-sub-choices (cm/get-submap choices t)
                       kernel-args (into [t state] extra)
@@ -653,7 +733,8 @@
                            (cm/set-choice discard [t] (:discard result))
                            discard)
                          (conj states new-state)
-                         (conj step-scores (:score new-trace)))))))))))
+                         (conj step-scores (:score new-trace))
+                         (tr/combine-score-types st (tr/score-type new-trace)))))))))))
 
   p/IRegenerate
   ;; Per-step old scores come from ::step-scores metadata; when it is lost
@@ -661,7 +742,8 @@
   ;; against ZERO olds and the summed weight is too high by the old total —
   ;; recorded on (:score trace). Correct at the end (genmlx-v740).
   (regenerate [this trace selection]
-    (let [kern (:kernel this)
+    (let [trace (ensure-joint-self this :regenerate trace)
+          kern (:kernel this)
           cregen (cops/get-compiled-regenerate kern)
           {:keys [args choices]} trace
           [n init-state & extra] args
@@ -669,13 +751,15 @@
           init-key (when cregen (rng/fresh-key))]
       (loop [t 0 state init-state key init-key
              new-choices cm/EMPTY score ZERO weight ZERO
-             states [] step-scores []]
+             states [] step-scores [] st :joint]
         (if (>= t n)
-          {:trace (with-meta
-                    (tr/make-trace {:gen-fn this :args args
-                                    :choices new-choices :retval states :score score})
-                    (cond-> {::step-scores step-scores}
-                      cregen (assoc ::compiled-path true)))
+          {:trace (tr/with-score-type
+                    (with-meta
+                      (tr/make-trace {:gen-fn this :args args
+                                      :choices new-choices :retval states :score score})
+                      (cond-> {::step-scores step-scores}
+                        cregen (assoc ::compiled-path true)))
+                    st)
            :weight (if old-step-scores
                      weight
                      (mx/subtract weight (:score trace)))}
@@ -696,7 +780,8 @@
                        (mx/add score (:score result))
                        (mx/add weight step-weight)
                        (conj states new-state)
-                       (conj step-scores (:score result))))
+                       (conj step-scores (:score result))
+                       st))
               ;; Fallback: handler path (weight bug fixed: no - (:score trace))
               (let [old-trace (tr/make-trace
                                {:gen-fn kern :args kernel-args
@@ -711,7 +796,8 @@
                        (mx/add score (:score new-trace))
                        (mx/add weight (:weight result))
                        (conj states new-state)
-                       (conj step-scores (:score new-trace)))))))))))
+                       (conj step-scores (:score new-trace))
+                       (tr/combine-score-types st (tr/score-type new-trace)))))))))))
 
 (defn unfold-combinator
   "Create an Unfold combinator from a kernel generative function.
@@ -775,10 +861,11 @@
    Used to initialize particles for incremental unfold-extend."
   [unfold-gf init-state & extra-args]
   (let [args (into [0 init-state] extra-args)]
-    (with-meta
-      (tr/make-trace {:gen-fn unfold-gf :args args
-                      :choices cm/EMPTY :retval [] :score ZERO})
-      {::step-scores []})))
+    (tag-joint
+      (with-meta
+        (tr/make-trace {:gen-fn unfold-gf :args args
+                        :choices cm/EMPTY :retval [] :score ZERO})
+        {::step-scores []}))))
 
 (defn unfold-extend
   "Extend an Unfold trace by ONE step, returning {:trace :weight}.
@@ -813,10 +900,12 @@
         new-retval (conj old-retval new-state)
         new-step-scores (conj (vec old-step-scores) step-score)
         new-args (into [(inc old-n) init-state] extra)]
-    {:trace (with-meta
-              (tr/make-trace {:gen-fn unfold-gf :args new-args
-                              :choices new-choices :retval new-retval :score new-score})
-              {::step-scores new-step-scores})
+    {:trace (tag-from-traces
+              (with-meta
+                (tr/make-trace {:gen-fn unfold-gf :args new-args
+                                :choices new-choices :retval new-retval :score new-score})
+                {::step-scores new-step-scores})
+              [trace step-trace])
      :weight step-weight}))
 
 ;; ---------------------------------------------------------------------------
@@ -836,20 +925,23 @@
         (let [key (rng/fresh-key)
               result (csim key (vec branch-args))
               choices (cm/from-flat-map (:values result))]
-          (with-meta
-            (tr/make-trace {:gen-fn this :args args
-                            :choices choices
-                            :retval (:retval result)
-                            :score (:score result)})
-            {::switch-idx idx ::compiled-path true}))
+          (tag-joint
+            (with-meta
+              (tr/make-trace {:gen-fn this :args args
+                              :choices choices
+                              :retval (:retval result)
+                              :score (:score result)})
+              {::switch-idx idx ::compiled-path true})))
         ;; L0: handler path
         (let [trace (p/simulate branch (vec branch-args))]
-          (with-meta
-            (tr/make-trace {:gen-fn this :args args
-                            :choices (:choices trace)
-                            :retval (:retval trace)
-                            :score (:score trace)})
-            {::switch-idx idx})))))
+          (tag-from-traces
+            (with-meta
+              (tr/make-trace {:gen-fn this :args args
+                              :choices (:choices trace)
+                              :retval (:retval trace)
+                              :score (:score trace)})
+              {::switch-idx idx})
+            [trace])))))
 
   p/IGenerate
   (generate [this args constraints]
@@ -860,27 +952,31 @@
         (let [key (rng/fresh-key)
               result (cgen key (vec branch-args) constraints)
               choices (values->choices (:values result))]
-          {:trace (with-meta
-                    (tr/make-trace {:gen-fn this :args args
-                                    :choices choices
-                                    :retval (:retval result)
-                                    :score (:score result)})
-                    {::switch-idx idx ::compiled-path true})
+          {:trace (tag-joint
+                    (with-meta
+                      (tr/make-trace {:gen-fn this :args args
+                                      :choices choices
+                                      :retval (:retval result)
+                                      :score (:score result)})
+                      {::switch-idx idx ::compiled-path true}))
            :weight (:weight result)})
         ;; Fallback: handler path
         (let [{:keys [trace weight]} (p/generate branch (vec branch-args) constraints)]
-          {:trace (with-meta
-                    (tr/make-trace {:gen-fn this :args args
-                                    :choices (:choices trace)
-                                    :retval (:retval trace)
-                                    :score (:score trace)})
-                    {::switch-idx idx})
+          {:trace (tag-from-traces
+                    (with-meta
+                      (tr/make-trace {:gen-fn this :args args
+                                      :choices (:choices trace)
+                                      :retval (:retval trace)
+                                      :score (:score trace)})
+                      {::switch-idx idx})
+                    [trace])
            :weight weight})))))
 
 (extend-type SwitchCombinator
   p/IUpdate
   (update [this trace constraints]
-    (let [orig-args (:args trace)
+    (let [trace (ensure-joint-self this :update trace)
+          orig-args (:args trace)
           [new-idx & branch-args] orig-args
           old-idx (or (::switch-idx (meta trace)) new-idx)]
       (if (= old-idx new-idx)
@@ -893,12 +989,13 @@
                   result (cupd key (vec branch-args) constraints (:choices trace))
                   new-choices (values->choices (:values result))
                   new-discard (values->choices (:discard result))]
-              {:trace (with-meta
-                        (tr/make-trace {:gen-fn this :args orig-args
-                                        :choices new-choices
-                                        :retval (:retval result)
-                                        :score (:score result)})
-                        {::switch-idx new-idx ::compiled-path true})
+              {:trace (tag-joint
+                        (with-meta
+                          (tr/make-trace {:gen-fn this :args orig-args
+                                          :choices new-choices
+                                          :retval (:retval result)
+                                          :score (:score result)})
+                          {::switch-idx new-idx ::compiled-path true}))
                :weight (mx/subtract (:score result) (:score trace))
                :discard new-discard})
             ;; Fallback: handler path
@@ -908,12 +1005,14 @@
                                      :retval (:retval trace) :score (:score trace)})
                   result (p/update branch old-branch-trace constraints)
                   new-branch-trace (:trace result)]
-              {:trace (with-meta
-                        (tr/make-trace {:gen-fn this :args orig-args
-                                        :choices (:choices new-branch-trace)
-                                        :retval (:retval new-branch-trace)
-                                        :score (:score new-branch-trace)})
-                        {::switch-idx new-idx})
+              {:trace (tag-from-traces
+                        (with-meta
+                          (tr/make-trace {:gen-fn this :args orig-args
+                                          :choices (:choices new-branch-trace)
+                                          :retval (:retval new-branch-trace)
+                                          :score (:score new-branch-trace)})
+                          {::switch-idx new-idx})
+                        [new-branch-trace])
                :weight (:weight result) :discard (:discard result)})))
         ;; Different branch: generate new branch from scratch.
         ;; Thesis weight: the generate weight counts only constrained sites
@@ -923,18 +1022,21 @@
               gen-result (p/generate new-branch (vec branch-args) constraints)
               new-branch-trace (:trace gen-result)
               new-score (:score new-branch-trace)]
-          {:trace (with-meta
-                    (tr/make-trace {:gen-fn this :args orig-args
-                                    :choices (:choices new-branch-trace)
-                                    :retval (:retval new-branch-trace)
-                                    :score new-score})
-                    {::switch-idx new-idx})
+          {:trace (tag-from-traces
+                    (with-meta
+                      (tr/make-trace {:gen-fn this :args orig-args
+                                      :choices (:choices new-branch-trace)
+                                      :retval (:retval new-branch-trace)
+                                      :score new-score})
+                      {::switch-idx new-idx})
+                    [new-branch-trace])
            :weight (mx/subtract (:weight gen-result) (:score trace))
            :discard (:choices trace)}))))
 
   p/IRegenerate
   (regenerate [this trace selection]
-    (let [orig-args (:args trace)
+    (let [trace (ensure-joint-self this :regenerate trace)
+          orig-args (:args trace)
           [idx & branch-args] orig-args
           branch (nth (:branches this) idx)]
       (if-let [cregen (cops/get-compiled-regenerate branch)]
@@ -946,12 +1048,13 @@
               ;; weight = new_score - old_score - proposal_ratio
               weight (mx/subtract (mx/subtract (:score result) (:score trace))
                                   (:weight result))]
-          {:trace (with-meta
-                    (tr/make-trace {:gen-fn this :args orig-args
-                                    :choices new-choices
-                                    :retval (:retval result)
-                                    :score (:score result)})
-                    {::switch-idx idx ::compiled-path true})
+          {:trace (tag-joint
+                    (with-meta
+                      (tr/make-trace {:gen-fn this :args orig-args
+                                      :choices new-choices
+                                      :retval (:retval result)
+                                      :score (:score result)})
+                      {::switch-idx idx ::compiled-path true}))
            :weight weight})
         ;; Fallback: handler path
         (let [old-branch-trace (tr/make-trace
@@ -960,12 +1063,14 @@
                                  :retval (:retval trace) :score (:score trace)})
               result (p/regenerate branch old-branch-trace selection)
               new-branch-trace (:trace result)]
-          {:trace (with-meta
-                    (tr/make-trace {:gen-fn this :args orig-args
-                                    :choices (:choices new-branch-trace)
-                                    :retval (:retval new-branch-trace)
-                                    :score (:score new-branch-trace)})
-                    {::switch-idx idx})
+          {:trace (tag-from-traces
+                    (with-meta
+                      (tr/make-trace {:gen-fn this :args orig-args
+                                      :choices (:choices new-branch-trace)
+                                      :retval (:retval new-branch-trace)
+                                      :score (:score new-branch-trace)})
+                      {::switch-idx idx})
+                    [new-branch-trace])
            :weight (:weight result)})))))
 
 (defn switch-combinator
@@ -1139,29 +1244,35 @@
     (let [[active? & inner-args] args]
       (if active?
         (let [trace (p/simulate inner (vec inner-args))]
+          (tag-from-traces
+            (tr/make-trace {:gen-fn this :args args
+                            :choices (:choices trace)
+                            :retval (:retval trace)
+                            :score (:score trace)})
+            [trace]))
+        (tag-joint
           (tr/make-trace {:gen-fn this :args args
-                          :choices (:choices trace)
-                          :retval (:retval trace)
-                          :score (:score trace)}))
-        (tr/make-trace {:gen-fn this :args args
-                        :choices cm/EMPTY
-                        :retval nil
-                        :score ZERO}))))
+                          :choices cm/EMPTY
+                          :retval nil
+                          :score ZERO})))))
 
   p/IGenerate
   (generate [this args constraints]
     (let [[active? & inner-args] args]
       (if active?
         (let [{:keys [trace weight]} (p/generate inner (vec inner-args) constraints)]
-          {:trace (tr/make-trace {:gen-fn this :args args
-                                  :choices (:choices trace)
-                                  :retval (:retval trace)
-                                  :score (:score trace)})
+          {:trace (tag-from-traces
+                    (tr/make-trace {:gen-fn this :args args
+                                    :choices (:choices trace)
+                                    :retval (:retval trace)
+                                    :score (:score trace)})
+                    [trace])
            :weight weight})
-        {:trace (tr/make-trace {:gen-fn this :args args
-                                :choices cm/EMPTY
-                                :retval nil
-                                :score ZERO})
+        {:trace (tag-joint
+                  (tr/make-trace {:gen-fn this :args args
+                                  :choices cm/EMPTY
+                                  :retval nil
+                                  :score ZERO}))
          :weight ZERO}))))
 
 (defn mask-combinator
@@ -1173,7 +1284,8 @@
 (extend-type MaskCombinator
   p/IUpdate
   (update [this trace constraints]
-    (let [[active? & inner-args] (:args trace)]
+    (let [trace (ensure-joint-self this :update trace)
+          [active? & inner-args] (:args trace)]
       (if active?
         (let [inner (:inner this)
               old-inner-trace (tr/make-trace
@@ -1182,16 +1294,19 @@
                                 :retval (:retval trace) :score (:score trace)})
               result (p/update inner old-inner-trace constraints)
               new-trace (:trace result)]
-          {:trace (tr/make-trace {:gen-fn this :args (:args trace)
-                                  :choices (:choices new-trace)
-                                  :retval (:retval new-trace)
-                                  :score (:score new-trace)})
+          {:trace (tag-from-traces
+                    (tr/make-trace {:gen-fn this :args (:args trace)
+                                    :choices (:choices new-trace)
+                                    :retval (:retval new-trace)
+                                    :score (:score new-trace)})
+                    [new-trace])
            :weight (:weight result) :discard (:discard result)})
         {:trace trace :weight ZERO :discard cm/EMPTY})))
 
   p/IRegenerate
   (regenerate [this trace selection]
-    (let [[active? & inner-args] (:args trace)]
+    (let [trace (ensure-joint-self this :regenerate trace)
+          [active? & inner-args] (:args trace)]
       (if active?
         (let [inner (:inner this)
               old-inner-trace (tr/make-trace
@@ -1200,10 +1315,12 @@
                                 :retval (:retval trace) :score (:score trace)})
               result (p/regenerate inner old-inner-trace selection)
               new-trace (:trace result)]
-          {:trace (tr/make-trace {:gen-fn this :args (:args trace)
-                                  :choices (:choices new-trace)
-                                  :retval (:retval new-trace)
-                                  :score (:score new-trace)})
+          {:trace (tag-from-traces
+                    (tr/make-trace {:gen-fn this :args (:args trace)
+                                    :choices (:choices new-trace)
+                                    :retval (:retval new-trace)
+                                    :score (:score new-trace)})
+                    [new-trace])
            :weight (:weight result)})
         {:trace trace :weight ZERO}))))
 
@@ -1219,55 +1336,66 @@
   (simulate [this args]
     (let [gf (maker this)
           trace (p/simulate gf args)]
-      (tr/make-trace {:gen-fn this :args args
-                      :choices (:choices trace)
-                      :retval (:retval trace)
-                      :score (:score trace)})))
+      (tag-from-traces
+        (tr/make-trace {:gen-fn this :args args
+                        :choices (:choices trace)
+                        :retval (:retval trace)
+                        :score (:score trace)})
+        [trace])))
 
   p/IGenerate
   (generate [this args constraints]
     (let [gf (maker this)
           {:keys [trace weight]} (p/generate gf args constraints)]
-      {:trace (tr/make-trace {:gen-fn this :args args
-                              :choices (:choices trace)
-                              :retval (:retval trace)
-                              :score (:score trace)})
+      {:trace (tag-from-traces
+                (tr/make-trace {:gen-fn this :args args
+                                :choices (:choices trace)
+                                :retval (:retval trace)
+                                :score (:score trace)})
+                [trace])
        :weight weight})))
 
 (extend-type RecurseCombinator
   p/IUpdate
   (update [this trace constraints]
-    (let [gf ((:maker this) this)
+    (let [trace (ensure-joint-self this :update trace)
+          gf ((:maker this) this)
           old-inner-trace (tr/make-trace
                            {:gen-fn gf :args (:args trace)
                             :choices (:choices trace)
                             :retval (:retval trace) :score (:score trace)})
           result (p/update gf old-inner-trace constraints)
           new-trace (:trace result)]
-      {:trace (tr/make-trace {:gen-fn this :args (:args trace)
-                              :choices (:choices new-trace)
-                              :retval (:retval new-trace)
-                              :score (:score new-trace)})
+      {:trace (tag-from-traces
+                (tr/make-trace {:gen-fn this :args (:args trace)
+                                :choices (:choices new-trace)
+                                :retval (:retval new-trace)
+                                :score (:score new-trace)})
+                [new-trace])
        :weight (:weight result) :discard (:discard result)}))
 
   p/IRegenerate
   (regenerate [this trace selection]
-    (let [gf ((:maker this) this)
+    (let [trace (ensure-joint-self this :regenerate trace)
+          gf ((:maker this) this)
           old-inner-trace (tr/make-trace
                            {:gen-fn gf :args (:args trace)
                             :choices (:choices trace)
                             :retval (:retval trace) :score (:score trace)})
           result (p/regenerate gf old-inner-trace selection)
           new-trace (:trace result)]
-      {:trace (tr/make-trace {:gen-fn this :args (:args trace)
-                              :choices (:choices new-trace)
-                              :retval (:retval new-trace)
-                              :score (:score new-trace)})
+      {:trace (tag-from-traces
+                (tr/make-trace {:gen-fn this :args (:args trace)
+                                :choices (:choices new-trace)
+                                :retval (:retval new-trace)
+                                :score (:score new-trace)})
+                [new-trace])
        :weight (:weight result)}))
 
   p/IProject
   (project [this trace selection]
-    (let [gf ((:maker this) this)
+    (let [trace (ensure-joint-self this :project trace)
+          gf ((:maker this) this)
           inner-trace (tr/make-trace
                        {:gen-fn gf :args (:args trace)
                         :choices (:choices trace)
@@ -1442,13 +1570,14 @@
         _ (mx/materialize! outputs-tensor scores-tensor total-score)
         {:keys [choices carries outputs step-scores]}
         (unpack-fused-scan-outputs outputs-tensor scores-tensor n addr-order)]
-    (with-meta
-      (tr/make-trace {:gen-fn this :args args
-                      :choices choices
-                      :retval {:carry (last carries) :outputs outputs}
-                      :score total-score})
-      {::step-scores step-scores ::step-carries carries
-       ::compiled-path true ::fused true})))
+    (tag-joint
+      (with-meta
+        (tr/make-trace {:gen-fn this :args args
+                        :choices choices
+                        :retval {:carry (last carries) :outputs outputs}
+                        :score total-score})
+        {::step-scores step-scores ::step-carries carries
+         ::compiled-path true ::fused true}))))
 
 (defn- scan-simulate-compiled
   "Compiled Scan simulate: call compiled-simulate per step."
@@ -1458,13 +1587,14 @@
            choices cm/EMPTY score ZERO
            outputs [] step-scores [] step-carries []]
       (if (>= t n)
-        (with-meta
-          (tr/make-trace {:gen-fn this :args args
-                          :choices choices
-                          :retval {:carry carry :outputs outputs}
-                          :score score})
-          {::step-scores step-scores ::step-carries step-carries
-           ::compiled-path true})
+        (tag-joint
+          (with-meta
+            (tr/make-trace {:gen-fn this :args args
+                            :choices choices
+                            :retval {:carry carry :outputs outputs}
+                            :score score})
+            {::step-scores step-scores ::step-carries step-carries
+             ::compiled-path true}))
         (let [[k1 k2] (rng/split key)
               result (csim k1 [carry (nth inputs t)])
               [new-carry output] (:retval result)
@@ -1482,14 +1612,16 @@
   [this args kernel init-carry inputs n]
   (loop [t 0 carry init-carry
          choices cm/EMPTY score ZERO
-         outputs [] step-scores [] step-carries []]
+         outputs [] step-scores [] step-carries [] st :joint]
     (if (>= t n)
-      (with-meta
-        (tr/make-trace {:gen-fn this :args args
-                        :choices choices
-                        :retval {:carry carry :outputs outputs}
-                        :score score})
-        {::step-scores step-scores ::step-carries step-carries})
+      (tr/with-score-type
+        (with-meta
+          (tr/make-trace {:gen-fn this :args args
+                          :choices choices
+                          :retval {:carry carry :outputs outputs}
+                          :score score})
+          {::step-scores step-scores ::step-carries step-carries})
+        st)
       (let [trace (p/simulate kernel [carry (nth inputs t)])
             [new-carry output] (:retval trace)]
         (recur (inc t)
@@ -1498,7 +1630,8 @@
                (mx/add score (:score trace))
                (conj outputs output)
                (conj step-scores (:score trace))
-               (conj step-carries new-carry))))))
+               (conj step-carries new-carry)
+               (tr/combine-score-types st (tr/score-type trace)))))))
 
 (defrecord ScanCombinator [kernel fused-cache]
   p/IGenerativeFunction
@@ -1522,13 +1655,14 @@
                  choices cm/EMPTY score ZERO weight ZERO
                  outputs [] step-scores [] step-carries []]
             (if (>= t n)
-              {:trace (with-meta
-                        (tr/make-trace {:gen-fn this :args args
-                                        :choices choices
-                                        :retval {:carry carry :outputs outputs}
-                                        :score score})
-                        {::step-scores step-scores ::step-carries step-carries
-                         ::compiled-path true})
+              {:trace (tag-joint
+                        (with-meta
+                          (tr/make-trace {:gen-fn this :args args
+                                          :choices choices
+                                          :retval {:carry carry :outputs outputs}
+                                          :score score})
+                          {::step-scores step-scores ::step-carries step-carries
+                           ::compiled-path true}))
                :weight weight}
               (let [[k1 k2] (rng/split key)
                     result (cgen k1 [carry (nth inputs t)]
@@ -1545,14 +1679,16 @@
         ;; Fallback: handler path
         (loop [t 0 carry init-carry
                choices cm/EMPTY score ZERO weight ZERO
-               outputs [] step-scores [] step-carries []]
+               outputs [] step-scores [] step-carries [] st :joint]
           (if (>= t n)
-            {:trace (with-meta
-                      (tr/make-trace {:gen-fn this :args args
-                                      :choices choices
-                                      :retval {:carry carry :outputs outputs}
-                                      :score score})
-                      {::step-scores step-scores ::step-carries step-carries})
+            {:trace (tr/with-score-type
+                      (with-meta
+                        (tr/make-trace {:gen-fn this :args args
+                                        :choices choices
+                                        :retval {:carry carry :outputs outputs}
+                                        :score score})
+                        {::step-scores step-scores ::step-carries step-carries})
+                      st)
              :weight weight}
             (let [result (p/generate kernel [carry (nth inputs t)]
                                      (cm/get-submap constraints t))
@@ -1565,12 +1701,14 @@
                      (mx/add weight (:weight result))
                      (conj outputs output)
                      (conj step-scores (:score (:trace result)))
-                     (conj step-carries new-carry)))))))))
+                     (conj step-carries new-carry)
+                     (tr/combine-score-types st (tr/score-type trace))))))))))
 
 (extend-type ScanCombinator
   p/IUpdate
   (update [this trace constraints]
-    (let [kern (:kernel this)
+    (let [trace (ensure-joint-self this :update trace)
+          kern (:kernel this)
           cupd (cops/get-compiled-update kern)
           {:keys [args choices]} trace
           [init-carry inputs] args
@@ -1619,15 +1757,18 @@
                  nf prefix-score
                  discard cm/EMPTY
                  outputs prefix-outputs
-                 step-scores prefix-step-scores step-carries prefix-step-carries]
+                 step-scores prefix-step-scores step-carries prefix-step-carries
+                 st :joint]
             (if (>= t n)
-              {:trace (with-meta
-                        (tr/make-trace {:gen-fn this :args args
-                                        :choices new-choices
-                                        :retval {:carry carry :outputs outputs}
-                                        :score score})
-                        (cond-> {::step-scores step-scores ::step-carries step-carries}
-                          cupd (assoc ::compiled-path true)))
+              {:trace (tr/with-score-type
+                        (with-meta
+                          (tr/make-trace {:gen-fn this :args args
+                                          :choices new-choices
+                                          :retval {:carry carry :outputs outputs}
+                                          :score score})
+                          (cond-> {::step-scores step-scores ::step-carries step-carries}
+                            cupd (assoc ::compiled-path true)))
+                        st)
                :weight (mx/subtract nf (:score trace)) :discard discard}
               (if cupd
                 ;; WP-8: compiled update path
@@ -1647,7 +1788,8 @@
                            discard)
                          (conj outputs output)
                          (conj step-scores (:score result))
-                         (conj step-carries new-carry)))
+                         (conj step-carries new-carry)
+                         st))
                 ;; Fallback: handler path
                 (let [old-sub-choices (cm/get-submap choices t)
                       constructed-old (if old-step-scores (nth old-step-scores t) ZERO)
@@ -1668,12 +1810,14 @@
                            discard)
                          (conj outputs output)
                          (conj step-scores (:score new-trace))
-                         (conj step-carries new-carry))))))))))
+                         (conj step-carries new-carry)
+                         (tr/combine-score-types st (tr/score-type new-trace)))))))))))
 
   p/IRegenerate
   ;; Same ::step-scores-loss correction as Unfold regenerate (genmlx-v740).
   (regenerate [this trace selection]
-    (let [kern (:kernel this)
+    (let [trace (ensure-joint-self this :regenerate trace)
+          kern (:kernel this)
           cregen (cops/get-compiled-regenerate kern)
           {:keys [args choices]} trace
           [init-carry inputs] args
@@ -1682,15 +1826,17 @@
           init-key (when cregen (rng/fresh-key))]
       (loop [t 0 carry init-carry key init-key
              new-choices cm/EMPTY score ZERO weight ZERO
-             outputs [] step-scores [] step-carries []]
+             outputs [] step-scores [] step-carries [] st :joint]
         (if (>= t n)
-          {:trace (with-meta
-                    (tr/make-trace {:gen-fn this :args args
-                                    :choices new-choices
-                                    :retval {:carry carry :outputs outputs}
-                                    :score score})
-                    (cond-> {::step-scores step-scores ::step-carries step-carries}
-                      cregen (assoc ::compiled-path true)))
+          {:trace (tr/with-score-type
+                    (with-meta
+                      (tr/make-trace {:gen-fn this :args args
+                                      :choices new-choices
+                                      :retval {:carry carry :outputs outputs}
+                                      :score score})
+                      (cond-> {::step-scores step-scores ::step-carries step-carries}
+                        cregen (assoc ::compiled-path true)))
+                    st)
            :weight (if old-step-scores
                      weight
                      (mx/subtract weight (:score trace)))}
@@ -1712,7 +1858,8 @@
                        (mx/add weight step-weight)
                        (conj outputs output)
                        (conj step-scores (:score result))
-                       (conj step-carries new-carry)))
+                       (conj step-carries new-carry)
+                       st))
               ;; Fallback: handler path (weight bug fixed: no - (:score trace))
               (let [old-trace (tr/make-trace
                                {:gen-fn kern :args kernel-args
@@ -1728,7 +1875,8 @@
                        (mx/add weight (:weight result))
                        (conj outputs output)
                        (conj step-scores (:score new-trace))
-                       (conj step-carries new-carry))))))))))
+                       (conj step-carries new-carry)
+                       (tr/combine-score-types st (tr/score-type new-trace)))))))))))
 
 (defn scan-combinator
   "Create a Scan combinator from a kernel generative function.
@@ -1793,19 +1941,23 @@
   (simulate [this args]
     (let [transformed-args (f args)
           trace (p/simulate inner transformed-args)]
-      (tr/make-trace {:gen-fn this :args args
-                      :choices (:choices trace)
-                      :retval (:retval trace)
-                      :score (:score trace)})))
+      (tr/with-score-type
+        (tr/make-trace {:gen-fn this :args args
+                        :choices (:choices trace)
+                        :retval (:retval trace)
+                        :score (:score trace)})
+        (tr/score-type trace))))
 
   p/IGenerate
   (generate [this args constraints]
     (let [transformed-args (f args)
           {:keys [trace weight]} (p/generate inner transformed-args constraints)]
-      {:trace (tr/make-trace {:gen-fn this :args args
-                              :choices (:choices trace)
-                              :retval (:retval trace)
-                              :score (:score trace)})
+      {:trace (tr/with-score-type
+                (tr/make-trace {:gen-fn this :args args
+                                :choices (:choices trace)
+                                :retval (:retval trace)
+                                :score (:score trace)})
+                (tr/score-type trace))
        :weight weight})))
 
 (defrecord MapRetvalGF [inner g]
@@ -1813,18 +1965,22 @@
   p/IGenerativeFunction
   (simulate [this args]
     (let [trace (p/simulate inner args)]
-      (tr/make-trace {:gen-fn this :args args
-                      :choices (:choices trace)
-                      :retval (g (:retval trace))
-                      :score (:score trace)})))
+      (tr/with-score-type
+        (tr/make-trace {:gen-fn this :args args
+                        :choices (:choices trace)
+                        :retval (g (:retval trace))
+                        :score (:score trace)})
+        (tr/score-type trace))))
 
   p/IGenerate
   (generate [this args constraints]
     (let [{:keys [trace weight]} (p/generate inner args constraints)]
-      {:trace (tr/make-trace {:gen-fn this :args args
-                              :choices (:choices trace)
-                              :retval (g (:retval trace))
-                              :score (:score trace)})
+      {:trace (tr/with-score-type
+                (tr/make-trace {:gen-fn this :args args
+                                :choices (:choices trace)
+                                :retval (g (:retval trace))
+                                :score (:score trace)})
+                (tr/score-type trace))
        :weight weight})))
 
 (defn contramap-gf
@@ -1850,52 +2006,68 @@
   p/IUpdate
   (update [this trace constraints]
     (let [transformed-args ((:f this) (:args trace))
-          inner-trace (tr/make-trace {:gen-fn (:inner this) :args transformed-args
-                                      :choices (:choices trace)
-                                      :retval (:retval trace) :score (:score trace)})
+          inner-trace (tr/with-score-type
+                        (tr/make-trace {:gen-fn (:inner this) :args transformed-args
+                                        :choices (:choices trace)
+                                        :retval (:retval trace) :score (:score trace)})
+                        (tr/score-type trace))
           result (p/update (:inner this) inner-trace constraints)]
-      {:trace (tr/make-trace {:gen-fn this :args (:args trace)
-                              :choices (:choices (:trace result))
-                              :retval (:retval (:trace result))
-                              :score (:score (:trace result))})
+      {:trace (tr/with-score-type
+                (tr/make-trace {:gen-fn this :args (:args trace)
+                                :choices (:choices (:trace result))
+                                :retval (:retval (:trace result))
+                                :score (:score (:trace result))})
+                (tr/score-type (:trace result)))
        :weight (:weight result) :discard (:discard result)}))
 
   p/IRegenerate
   (regenerate [this trace selection]
     (let [transformed-args ((:f this) (:args trace))
-          inner-trace (tr/make-trace {:gen-fn (:inner this) :args transformed-args
-                                      :choices (:choices trace)
-                                      :retval (:retval trace) :score (:score trace)})
+          inner-trace (tr/with-score-type
+                        (tr/make-trace {:gen-fn (:inner this) :args transformed-args
+                                        :choices (:choices trace)
+                                        :retval (:retval trace) :score (:score trace)})
+                        (tr/score-type trace))
           result (p/regenerate (:inner this) inner-trace selection)]
-      {:trace (tr/make-trace {:gen-fn this :args (:args trace)
-                              :choices (:choices (:trace result))
-                              :retval (:retval (:trace result))
-                              :score (:score (:trace result))})
+      {:trace (tr/with-score-type
+                (tr/make-trace {:gen-fn this :args (:args trace)
+                                :choices (:choices (:trace result))
+                                :retval (:retval (:trace result))
+                                :score (:score (:trace result))})
+                (tr/score-type (:trace result)))
        :weight (:weight result)})))
 
 (extend-type MapRetvalGF
   p/IUpdate
   (update [this trace constraints]
-    (let [inner-trace (tr/make-trace {:gen-fn (:inner this) :args (:args trace)
-                                      :choices (:choices trace)
-                                      :retval nil :score (:score trace)})
+    (let [inner-trace (tr/with-score-type
+                        (tr/make-trace {:gen-fn (:inner this) :args (:args trace)
+                                        :choices (:choices trace)
+                                        :retval nil :score (:score trace)})
+                        (tr/score-type trace))
           result (p/update (:inner this) inner-trace constraints)]
-      {:trace (tr/make-trace {:gen-fn this :args (:args trace)
-                              :choices (:choices (:trace result))
-                              :retval ((:g this) (:retval (:trace result)))
-                              :score (:score (:trace result))})
+      {:trace (tr/with-score-type
+                (tr/make-trace {:gen-fn this :args (:args trace)
+                                :choices (:choices (:trace result))
+                                :retval ((:g this) (:retval (:trace result)))
+                                :score (:score (:trace result))})
+                (tr/score-type (:trace result)))
        :weight (:weight result) :discard (:discard result)}))
 
   p/IRegenerate
   (regenerate [this trace selection]
-    (let [inner-trace (tr/make-trace {:gen-fn (:inner this) :args (:args trace)
-                                      :choices (:choices trace)
-                                      :retval nil :score (:score trace)})
+    (let [inner-trace (tr/with-score-type
+                        (tr/make-trace {:gen-fn (:inner this) :args (:args trace)
+                                        :choices (:choices trace)
+                                        :retval nil :score (:score trace)})
+                        (tr/score-type trace))
           result (p/regenerate (:inner this) inner-trace selection)]
-      {:trace (tr/make-trace {:gen-fn this :args (:args trace)
-                              :choices (:choices (:trace result))
-                              :retval ((:g this) (:retval (:trace result)))
-                              :score (:score (:trace result))})
+      {:trace (tr/with-score-type
+                (tr/make-trace {:gen-fn this :args (:args trace)
+                                :choices (:choices (:trace result))
+                                :retval ((:g this) (:retval (:trace result)))
+                                :score (:score (:trace result))})
+                (tr/score-type (:trace result)))
        :weight (:weight result)})))
 
 ;; ---------------------------------------------------------------------------
@@ -1920,20 +2092,23 @@
               choices (cm/from-flat-map (:values result))
               choices (cm/set-choice choices [:component-idx]
                                      (mx/scalar (int idx) mx/int32))]
-          (with-meta
-            (tr/make-trace {:gen-fn this :args args
-                            :choices choices
-                            :retval (:retval result)
-                            :score (mx/add (:score result) (:score idx-trace))})
-            {::compiled-path true}))
+          (tag-joint
+            (with-meta
+              (tr/make-trace {:gen-fn this :args args
+                              :choices choices
+                              :retval (:retval result)
+                              :score (mx/add (:score result) (:score idx-trace))})
+              {::compiled-path true})))
         ;; L0: handler path
         (let [comp-trace (p/simulate component args)]
-          (tr/make-trace {:gen-fn this :args args
-                          :choices (cm/set-choice (:choices comp-trace)
-                                                  [:component-idx]
-                                                  (mx/scalar (int idx) mx/int32))
-                          :retval (:retval comp-trace)
-                          :score (mx/add (:score comp-trace) (:score idx-trace))})))))
+          (tag-from-traces
+            (tr/make-trace {:gen-fn this :args args
+                            :choices (cm/set-choice (:choices comp-trace)
+                                                    [:component-idx]
+                                                    (mx/scalar (int idx) mx/int32))
+                            :retval (:retval comp-trace)
+                            :score (mx/add (:score comp-trace) (:score idx-trace))})
+            [comp-trace])))))
 
   p/IGenerate
   (generate [this args constraints]
@@ -1953,25 +2128,28 @@
         (let [key (rng/fresh-key)
               result (cgen key (vec args) comp-constraints)
               comp-choices (values->choices (:values result))]
-          {:trace (with-meta
-                    (tr/make-trace {:gen-fn this :args args
-                                    :choices (cm/set-choice comp-choices
-                                                            [:component-idx]
-                                                            (mx/scalar (int idx) mx/int32))
-                                    :retval (:retval result)
-                                    :score (mx/add (:score result)
-                                                   (:score (:trace idx-result)))})
-                    {::compiled-path true})
+          {:trace (tag-joint
+                    (with-meta
+                      (tr/make-trace {:gen-fn this :args args
+                                      :choices (cm/set-choice comp-choices
+                                                              [:component-idx]
+                                                              (mx/scalar (int idx) mx/int32))
+                                      :retval (:retval result)
+                                      :score (mx/add (:score result)
+                                                     (:score (:trace idx-result)))})
+                      {::compiled-path true}))
            :weight (mx/add (:weight result) (:weight idx-result))})
         ;; Fallback: handler path
         (let [{:keys [trace weight]} (p/generate component args comp-constraints)]
-          {:trace (tr/make-trace {:gen-fn this :args args
-                                  :choices (cm/set-choice (:choices trace)
-                                                          [:component-idx]
-                                                          (mx/scalar (int idx) mx/int32))
-                                  :retval (:retval trace)
-                                  :score (mx/add (:score trace)
-                                                 (:score (:trace idx-result)))})
+          {:trace (tag-from-traces
+                    (tr/make-trace {:gen-fn this :args args
+                                    :choices (cm/set-choice (:choices trace)
+                                                            [:component-idx]
+                                                            (mx/scalar (int idx) mx/int32))
+                                    :retval (:retval trace)
+                                    :score (mx/add (:score trace)
+                                                   (:score (:trace idx-result)))})
+                    [trace])
            :weight (mx/add weight (:weight idx-result))})))))
 
 (defn mix-combinator
@@ -2078,7 +2256,8 @@
 (extend-type MixCombinator
   p/IUpdate
   (update [this trace constraints]
-    (let [old-choices (:choices trace)
+    (let [trace (ensure-joint-self this :update trace)
+          old-choices (:choices trace)
           _ (when-not (cm/has-value? (cm/get-submap old-choices :component-idx))
               (throw (ex-info "Mix combinator requires :component-idx in choices"
                               {:operation :update})))
@@ -2109,12 +2288,13 @@
                                              [:component-idx]
                                              (mx/scalar old-idx mx/int32))
                   new-discard (values->choices (:discard result))]
-              {:trace (with-meta
-                        (tr/make-trace {:gen-fn this :args args
-                                        :choices new-choices
-                                        :retval (:retval result)
-                                        :score new-score})
-                        {::compiled-path true})
+              {:trace (tag-joint
+                        (with-meta
+                          (tr/make-trace {:gen-fn this :args args
+                                          :choices new-choices
+                                          :retval (:retval result)
+                                          :score new-score})
+                          {::compiled-path true}))
                :weight (mx/subtract new-score (:score trace))
                :discard new-discard})
             ;; Fallback: handler path
@@ -2125,12 +2305,14 @@
                   result (p/update component inner-old-trace inner-constraints)
                   new-inner-trace (:trace result)
                   new-score (mx/add (:score new-inner-trace) old-idx-score)]
-              {:trace (tr/make-trace {:gen-fn this :args args
-                                      :choices (cm/set-choice (:choices new-inner-trace)
-                                                              [:component-idx]
-                                                              (mx/scalar old-idx mx/int32))
-                                      :retval (:retval new-inner-trace)
-                                      :score new-score})
+              {:trace (tag-from-traces
+                        (tr/make-trace {:gen-fn this :args args
+                                        :choices (cm/set-choice (:choices new-inner-trace)
+                                                                [:component-idx]
+                                                                (mx/scalar old-idx mx/int32))
+                                        :retval (:retval new-inner-trace)
+                                        :score new-score})
+                        [new-inner-trace])
                :weight (mx/subtract new-score (:score trace))
                :discard (:discard result)})))
         ;; Different component: generate new component from scratch
@@ -2139,18 +2321,21 @@
               gen-result (p/generate new-component args inner-constraints)
               new-inner-trace (:trace gen-result)
               new-score (mx/add (:score new-inner-trace) new-idx-score)]
-          {:trace (tr/make-trace {:gen-fn this :args args
-                                  :choices (cm/set-choice (:choices new-inner-trace)
-                                                          [:component-idx]
-                                                          (mx/scalar new-idx mx/int32))
-                                  :retval (:retval new-inner-trace)
-                                  :score new-score})
+          {:trace (tag-from-traces
+                    (tr/make-trace {:gen-fn this :args args
+                                    :choices (cm/set-choice (:choices new-inner-trace)
+                                                            [:component-idx]
+                                                            (mx/scalar new-idx mx/int32))
+                                    :retval (:retval new-inner-trace)
+                                    :score new-score})
+                    [new-inner-trace])
            :weight (mx/subtract new-score (:score trace))
            :discard old-choices}))))
 
   p/IRegenerate
   (regenerate [this trace selection]
-    (let [old-choices (:choices trace)
+    (let [trace (ensure-joint-self this :regenerate trace)
+          old-choices (:choices trace)
           _ (when-not (cm/has-value? (cm/get-submap old-choices :component-idx))
               (throw (ex-info "Mix combinator requires :component-idx in choices"
                               {:operation :regenerate})))
@@ -2174,12 +2359,14 @@
               new-component (ensure-kernel-key (nth (:components this) new-idx))
               new-comp-trace (p/simulate new-component args)
               new-score (mx/add (:score new-comp-trace) new-idx-score)]
-          {:trace (tr/make-trace {:gen-fn this :args args
-                                  :choices (cm/set-choice (:choices new-comp-trace)
-                                                          [:component-idx]
-                                                          (mx/scalar new-idx mx/int32))
-                                  :retval (:retval new-comp-trace)
-                                  :score new-score})
+          {:trace (tag-from-traces
+                    (tr/make-trace {:gen-fn this :args args
+                                    :choices (cm/set-choice (:choices new-comp-trace)
+                                                            [:component-idx]
+                                                            (mx/scalar new-idx mx/int32))
+                                    :retval (:retval new-comp-trace)
+                                    :score new-score})
+                    [new-comp-trace])
            :weight ZERO})
         ;; Same component: regenerate within the component
         (let [component (nth (:components this) old-idx)
@@ -2197,12 +2384,13 @@
                   ;; weight = new_score - old_score - proposal_ratio
                   proposal-ratio (:weight result)
                   weight (mx/subtract (mx/subtract new-score (:score trace)) proposal-ratio)]
-              {:trace (with-meta
-                        (tr/make-trace {:gen-fn this :args args
-                                        :choices new-choices
-                                        :retval (:retval result)
-                                        :score new-score})
-                        {::compiled-path true})
+              {:trace (tag-joint
+                        (with-meta
+                          (tr/make-trace {:gen-fn this :args args
+                                          :choices new-choices
+                                          :retval (:retval result)
+                                          :score new-score})
+                          {::compiled-path true}))
                :weight weight})
             ;; Fallback: handler path
             (let [inner-old-trace (tr/make-trace {:gen-fn component :args args
@@ -2211,12 +2399,14 @@
                   result (p/regenerate component inner-old-trace selection)
                   new-inner-trace (:trace result)
                   new-score (mx/add (:score new-inner-trace) old-idx-score)]
-              {:trace (tr/make-trace {:gen-fn this :args args
-                                      :choices (cm/set-choice (:choices new-inner-trace)
-                                                              [:component-idx]
-                                                              (mx/scalar old-idx mx/int32))
-                                      :retval (:retval new-inner-trace)
-                                      :score new-score})
+              {:trace (tag-from-traces
+                        (tr/make-trace {:gen-fn this :args args
+                                        :choices (cm/set-choice (:choices new-inner-trace)
+                                                                [:component-idx]
+                                                                (mx/scalar old-idx mx/int32))
+                                        :retval (:retval new-inner-trace)
+                                        :score new-score})
+                        [new-inner-trace])
                :weight (:weight result)})))))))
 
 ;; ---------------------------------------------------------------------------
@@ -2270,7 +2460,8 @@
 (extend-type MapCombinator
   p/IUpdateWithDiffs
   (update-with-diffs [this trace constraints argdiffs]
-    (let [old-choices (:choices trace)
+    (let [trace (ensure-joint-self this :update trace)
+          old-choices (:choices trace)
           args (:args trace)
           n (count (first args))
           old-element-scores (::element-scores (meta trace))
@@ -2318,10 +2509,12 @@
               weight (mx/subtract score (:score trace))
               discard (assemble-indexed-discards results)
               element-scores (mapv (comp :score :trace) results)]
-          {:trace (with-meta
-                    (tr/make-trace {:gen-fn this :args args
-                                    :choices choices :retval retvals :score score})
-                    {::element-scores element-scores})
+          {:trace (tag-from-traces
+                    (with-meta
+                      (tr/make-trace {:gen-fn this :args args
+                                      :choices choices :retval retvals :score score})
+                      {::element-scores element-scores})
+                    (map :trace results))
            :weight weight :discard discard})
 
         ;; Unknown change: fall back to full update
@@ -2401,7 +2594,8 @@
 (extend-type MapCombinator
   p/IProject
   (project [this trace selection]
-    (let [old-choices (:choices trace)
+    (let [trace (ensure-joint-self this :project trace)
+          old-choices (:choices trace)
           args (:args trace)
           n (count (first args))
           kernel (:kernel this)
@@ -2441,7 +2635,8 @@
 (extend-type SwitchCombinator
   p/IProject
   (project [this trace selection]
-    (let [[idx & branch-args] (:args trace)
+    (let [trace (ensure-joint-self this :project trace)
+          [idx & branch-args] (:args trace)
           branch (nth (:branches this) idx)
           branch-trace (tr/make-trace
                         {:gen-fn branch :args (vec branch-args)
@@ -2470,7 +2665,8 @@
 (extend-type MaskCombinator
   p/IProject
   (project [this trace selection]
-    (let [[active? & inner-args] (:args trace)]
+    (let [trace (ensure-joint-self this :project trace)
+          [active? & inner-args] (:args trace)]
       (if active?
         (let [inner-trace (tr/make-trace
                            {:gen-fn (:inner this) :args (vec inner-args)
@@ -2482,7 +2678,8 @@
 (extend-type MixCombinator
   p/IProject
   (project [this trace selection]
-    (let [old-choices (:choices trace)
+    (let [trace (ensure-joint-self this :project trace)
+          old-choices (:choices trace)
           _ (when-not (cm/has-value? (cm/get-submap old-choices :component-idx))
               (throw (ex-info "Mix combinator requires :component-idx in choices"
                               {:operation :project})))
@@ -2509,17 +2706,21 @@
   p/IProject
   (project [this trace selection]
     (let [transformed-args ((:f this) (:args trace))
-          inner-trace (tr/make-trace {:gen-fn (:inner this) :args transformed-args
-                                      :choices (:choices trace)
-                                      :retval (:retval trace) :score (:score trace)})]
+          inner-trace (tr/with-score-type
+                        (tr/make-trace {:gen-fn (:inner this) :args transformed-args
+                                        :choices (:choices trace)
+                                        :retval (:retval trace) :score (:score trace)})
+                        (tr/score-type trace))]
       (p/project (:inner this) inner-trace selection))))
 
 (extend-type MapRetvalGF
   p/IProject
   (project [this trace selection]
-    (let [inner-trace (tr/make-trace {:gen-fn (:inner this) :args (:args trace)
-                                      :choices (:choices trace)
-                                      :retval nil :score (:score trace)})]
+    (let [inner-trace (tr/with-score-type
+                        (tr/make-trace {:gen-fn (:inner this) :args (:args trace)
+                                        :choices (:choices trace)
+                                        :retval nil :score (:score trace)})
+                        (tr/score-type trace))]
       (p/project (:inner this) inner-trace selection))))
 
 ;; ---------------------------------------------------------------------------

--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -63,23 +63,29 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- attach-splice-scores
-  "Attach splice scores (and nested splice scores) as metadata on a trace, if present."
+  "Attach splice scores (and nested splice scores) as metadata on a trace, if
+   present. vary-meta, not with-meta: the trace already carries its
+   score-type tag (genmlx-lbae) which must survive."
   [trace result]
   (let [ss (:splice-scores result)
         nss (:nested-splice-scores result)]
     (if (or ss nss)
-      (with-meta trace (cond-> {}
-                         ss (assoc ::splice-scores ss)
-                         nss (assoc ::nested-splice-scores nss)))
+      (vary-meta trace (fn [m] (cond-> (or m {})
+                                 ss (assoc ::splice-scores ss)
+                                 nss (assoc ::nested-splice-scores nss))))
       trace)))
 
 (defn- make-result-trace
-  "Build a Trace from a handler/compiled result map."
+  "Build a Trace from a handler/compiled result map. Tags the trace with the
+   state's accumulated score-type — :joint unless a spliced sub-result
+   carried a non-joint score (merge-sub-result lubs it into the state)."
   [gf args result]
-  (tr/make-trace {:gen-fn gf :args args
-                  :choices (:choices result)
-                  :retval (:retval result)
-                  :score (:score result)}))
+  (tr/with-score-type
+    (tr/make-trace {:gen-fn gf :args args
+                    :choices (:choices result)
+                    :retval (:retval result)
+                    :score (:score result)})
+    (or (:score-type result) :joint)))
 
 (defn- attach-unused
   "Assoc :unused-constraints onto a result map when the trace left some
@@ -112,10 +118,12 @@
   (let [new-score (:score result)
         proposal-ratio (:weight result)
         weight (mx/subtract (mx/subtract new-score old-score) proposal-ratio)
-        new-trace (tr/make-trace {:gen-fn gf :args (:args trace)
-                                  :choices (:choices result)
-                                  :retval (:retval result)
-                                  :score new-score})]
+        new-trace (tr/with-score-type
+                    (tr/make-trace {:gen-fn gf :args (:args trace)
+                                    :choices (:choices result)
+                                    :retval (:retval result)
+                                    :score new-score})
+                    (or (:score-type result) :joint))]
     {:trace (attach-splice-scores new-trace result)
      :weight weight}))
 
@@ -210,27 +218,31 @@
 
 ;; -- L1-M2: Compiled path --
 
-(defn- run-simulate-compiled [gf args key _opts]
-  (let [cfn (:compiled-simulate (:schema gf))
-        result (cfn key (vec args))]
+(defn- make-compiled-trace
+  "Build a :joint-tagged Trace from a compiled-path result. Compiled paths
+   are score-equivalent to the handler (joint by construction) and have no
+   splices, so the tag is unconditional."
+  [gf args result]
+  (tr/with-score-type
     (tr/make-trace {:gen-fn gf :args args
                     :choices (cm/from-flat-map (:values result))
-                    :retval (:retval result) :score (:score result)})))
+                    :retval (:retval result) :score (:score result)})
+    :joint))
+
+(defn- run-simulate-compiled [gf args key _opts]
+  (let [cfn (:compiled-simulate (:schema gf))]
+    (make-compiled-trace gf args (cfn key (vec args)))))
 
 (defn- run-generate-compiled [gf args key {:keys [constraints]}]
   (let [cfn (:compiled-generate (:schema gf))
         result (cfn key (vec args) constraints)]
-    {:trace (tr/make-trace {:gen-fn gf :args args
-                            :choices (cm/from-flat-map (:values result))
-                            :retval (:retval result) :score (:score result)})
+    {:trace (make-compiled-trace gf args result)
      :weight (:weight result)}))
 
 (defn- run-update-compiled [gf _args key {:keys [trace constraints]}]
   (let [cfn (:compiled-update (:schema gf))
         result (cfn key (vec (:args trace)) constraints (:choices trace))]
-    {:trace (tr/make-trace {:gen-fn gf :args (:args trace)
-                            :choices (cm/from-flat-map (:values result))
-                            :retval (:retval result) :score (:score result)})
+    {:trace (make-compiled-trace gf (:args trace) result)
      :weight (mx/subtract (:score result) (:score trace))
      :discard (cm/from-flat-map (:discard result))}))
 
@@ -239,9 +251,7 @@
         old-score (:score trace)
         result (cfn key (vec (:args trace)) (:choices trace) selection)
         weight (mx/subtract (mx/subtract (:score result) old-score) (:weight result))]
-    {:trace (tr/make-trace {:gen-fn gf :args (:args trace)
-                            :choices (cm/from-flat-map (:values result))
-                            :retval (:retval result) :score (:score result)})
+    {:trace (make-compiled-trace gf (:args trace) result)
      :weight weight}))
 
 (defn- run-assess-compiled [gf args key {:keys [constraints]}]
@@ -358,7 +368,7 @@
                  (fn [rt] (run-body gf rt args)))
         trace (cond-> (make-result-trace gf args result)
                 (analytical-fired? result)
-                (vary-meta assoc ::score-type :marginal))]
+                (tr/with-score-type :marginal))]
     (make-generate-result trace (:weight result) constraints (:choices result) result)))
 
 (defn- run-assess-analytical [gf args key {:keys [constraints]}]
@@ -390,7 +400,7 @@
                  (fn [rt] (run-body gf rt (:args trace))))
         regen-result (make-regen-result gf trace result old-score)]
     (if (analytical-fired? result)
-      (clojure.core/update regen-result :trace vary-meta assoc ::score-type :marginal)
+      (clojure.core/update regen-result :trace tr/with-score-type :marginal)
       regen-result)))
 
 ;; -- Utility --
@@ -508,7 +518,7 @@
 
           :regenerate
           (when (and (:auto-regenerate-transition schema)
-                     (= :marginal (::score-type (meta (:trace opts)))))
+                     (= :marginal (tr/score-type (:trace opts))))
             {:run run-fn :score-type :marginal :label :analytical})
 
           nil)))))
@@ -537,22 +547,48 @@
 (declare run-dispatched* strip-alternate-paths)
 
 (defn- joint-rescore-marginal
-  "An analytically-scored trace (::score-type :marginal) carries a collapsed
-   score. Running a joint-scoring update/project/regenerate against it would
-   subtract a marginal old score from a joint new score — silently mixing
-   decompositions (ARCHITECTURE §3.3, genmlx-pkmx). Alternate paths must stay
-   semantically invisible (a model written at L0 runs unchanged at L3), so
-   convert instead of throwing: re-generate the trace fully constrained from
-   its own choices via the handler path, yielding an identical-choices trace
-   with an exact joint score. Costs one handler generate per conversion."
-  [gf key opts]
-  (let [t (:trace opts)]
-    (if (= :marginal (::score-type (meta t)))
+  "Score-type boundary check for joint-scoring update/project/regenerate
+   (ARCHITECTURE §3.3, genmlx-pkmx, genmlx-lbae). Consuming a non-joint
+   trace would subtract a marginal old score from a joint new score —
+   silently mixing decompositions.
+
+   :marginal traces CONVERT: alternate paths must stay semantically
+   invisible (a model written at L0 runs unchanged at L3), so re-generate
+   the trace fully constrained from its own choices via the handler path,
+   yielding an identical-choices trace with an exact joint score. Costs one
+   handler generate per conversion.
+
+   :collapsed (and any other non-joint) traces THROW: their choicemaps are
+   empty (all latents integrated out by enumerate/exact), so there is
+   nothing to re-generate from — no conversion exists."
+  [gf op key opts]
+  (let [t (:trace opts)
+        st (tr/score-type t)]
+    (case st
+      :joint opts
+      :marginal
       (let [stripped (strip-alternate-paths gf)
             res (run-dispatched* stripped :generate (:args t) key
-                                 {:constraints (:choices t)})]
-        (assoc opts :trace (:trace res)))
-      opts)))
+                                 {:constraints (:choices t)})
+            converted (:trace res)]
+        ;; Convergence guard: when a sub-gf reproduces a non-joint score
+        ;; even fully constrained (e.g. an enumerate splice), no joint
+        ;; conversion exists — throw, don't pass a still-mixed trace on.
+        (when (not= :joint (tr/score-type converted))
+          (throw (ex-info
+                   (str "Joint-scoring " op ": re-generating the trace's"
+                        " choices did not yield a joint score (a sub-gf"
+                        " reproduces a " (tr/score-type converted) " score)")
+                   {:genmlx/error :score-type-mismatch
+                    :op op :score-type (tr/score-type converted)
+                    :expected :joint})))
+        (assoc opts :trace converted))
+      (throw (ex-info
+               (str "Joint-scoring " op " cannot consume a " st
+                    "-scored trace — its choices do not determine a joint"
+                    " density (collapsed traces have no recorded choices)")
+               {:genmlx/error :score-type-mismatch
+                :op op :score-type st :expected :joint})))))
 
 (defn run-dispatched*
   "Core dispatch: walk the dispatcher stack and execute the first match.
@@ -563,7 +599,7 @@
     (assert spec (str "No dispatcher resolved for op " op))
     (let [opts (if (and (contains? #{:update :project :regenerate} op)
                         (= :joint (:score-type spec)))
-                 (joint-rescore-marginal gf key opts)
+                 (joint-rescore-marginal gf op key opts)
                  opts)]
       ((:run spec) gf args key opts))))
 
@@ -782,7 +818,10 @@
                          (let [trace (p/simulate gf args)]
                            [trace {:choices (:choices trace) :retval (:retval trace)
                                    :score (:score trace)}]))]
-    (extract-splice-meta result trace)))
+    ;; Propagate the sub-trace's score-type: a marginal-scored sub-result
+    ;; must not launder into a joint-looking parent score (genmlx-lbae,
+    ;; ARCHITECTURE §3.3 merge-sub-result).
+    (extract-splice-meta (assoc result :score-type (tr/score-type trace)) trace)))
 
 (defn- execute-sub-project
   "Execute sub-GF in project mode: replay via generate, then project.
@@ -794,6 +833,7 @@
     {:choices (:choices trace)
      :retval (:retval trace)
      :score (:score trace)
+     :score-type (tr/score-type trace)
      :weight weight}))
 
 (defn- execute-sub-assess
@@ -950,6 +990,13 @@
 ;; uses batched handler transitions with [N]-shaped arrays via MLX broadcasting.
 ;; ---------------------------------------------------------------------------
 
+(defn- tag-vtrace
+  "Tag a VectorizedTrace :joint. Batched execution always runs batched
+   handler transitions — no analytical or collapsed producer exists for
+   vectorized traces — so the tag is unconditional (genmlx-lbae)."
+  [vt]
+  (tr/with-score-type vt :joint))
+
 (defn vsimulate
   "Run model body ONCE with batched handler, producing a VectorizedTrace
    with [n]-shaped arrays at each choice site.
@@ -963,8 +1010,9 @@
                                 :executor execute-sub
                                 :param-store (param-store gf)}
                                (fn [rt] (run-body gf rt args)))]
-    (vec/->VectorizedTrace gf args (:choices result) (:score result)
-                           (mx/zeros [n]) n (:retval result))))
+    (tag-vtrace
+      (vec/->VectorizedTrace gf args (:choices result) (:score result)
+                             (mx/zeros [n]) n (:retval result)))))
 
 (defn vgenerate
   "Run model body ONCE with batched generate handler, producing a
@@ -982,8 +1030,9 @@
                                 :executor execute-sub
                                 :param-store (param-store gf)}
                                (fn [rt] (run-body gf rt args)))]
-    (vec/->VectorizedTrace gf args (:choices result) (:score result)
-                           (:weight result) n (:retval result))))
+    (tag-vtrace
+      (vec/->VectorizedTrace gf args (:choices result) (:score result)
+                             (:weight result) n (:retval result)))))
 
 (defn vupdate
   "Batched update: run model body ONCE with batched update handler.
@@ -1006,9 +1055,10 @@
         ;; Thesis update weight: non-fresh score minus old [N]-shaped score —
         ;; the same convention as the scalar run-update path.
         weight (mx/subtract (:weight result) (:score vtrace))]
-    {:vtrace (vec/->VectorizedTrace gf (:args vtrace) (:choices result)
-                                    (:score result) weight
-                                    n (:retval result))
+    {:vtrace (tag-vtrace
+               (vec/->VectorizedTrace gf (:args vtrace) (:choices result)
+                                      (:score result) weight
+                                      n (:retval result)))
      :weight weight
      :discard (:discard result)}))
 
@@ -1033,8 +1083,9 @@
         new-score (:score result)
         proposal-ratio (:weight result)
         weight (mx/subtract (mx/subtract new-score old-score) proposal-ratio)]
-    {:vtrace (vec/->VectorizedTrace gf (:args vtrace) (:choices result)
-                                    new-score weight n (:retval result))
+    {:vtrace (tag-vtrace
+               (vec/->VectorizedTrace gf (:args vtrace) (:choices result)
+                                      new-score weight n (:retval result)))
      :weight weight}))
 
 (defn loop-obs

--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -31,6 +31,7 @@
             [genmlx.selection :as sel]
             [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
+            [genmlx.trace :as tr]
             [genmlx.dynamic :as dyn]
             [genmlx.dist :as dist]
             [genmlx.gradients :as grad]
@@ -611,6 +612,23 @@
                (and (js/Number.isFinite pw)
                     (let [{:keys [weight]} (p/assess model args choices)]
                       (approx= pw (ev weight) 0.01)))))}
+
+   {:name :score-type-soundness
+    :from "ARCHITECTURE §3.3 (genmlx-lbae)"
+    :theorem "Every produced trace carries an EXPLICIT score-type tag
+              (:genmlx.trace/score-type metadata). simulate never fires the
+              analytical path and generate without constraints declines it,
+              so both must tag :joint; the accessor default agrees. Boundary
+              semantics (marginal converts, collapsed throws) are pinned in
+              score_type_test.cljs."
+    :tags #{:simulate :generate :dispatch :consistency}
+    :check (fn [{:keys [model args]}]
+             (let [t (p/simulate model args)
+                   {gt :trace} (p/generate model args cm/EMPTY)]
+               (and (contains? (meta t) :genmlx.trace/score-type)
+                    (= :joint (tr/score-type t))
+                    (contains? (meta gt) :genmlx.trace/score-type)
+                    (= :joint (tr/score-type gt)))))}
 
    ;; ===================================================================
    ;; COMPOSITIONALITY laws

--- a/src/genmlx/handler.cljs
+++ b/src/genmlx/handler.cljs
@@ -297,12 +297,17 @@
 ;; ---------------------------------------------------------------------------
 
 (defn merge-sub-result
-  "Pure: merge a sub-generative-function result into parent state."
+  "Pure: merge a sub-generative-function result into parent state.
+   Lubs the sub-result's score-type into the state so a marginal-scored
+   sub-trace cannot launder into a joint-looking parent score
+   (ARCHITECTURE §3.3, genmlx-lbae); make-result-trace reads the
+   accumulated :score-type when tagging the final trace."
   [state addr sub-result]
   (-> state
       (update :choices cm/set-submap addr (:choices sub-result))
       (update :score mx/add (:score sub-result))
       (update :splice-scores (fn [ss] (assoc (or ss {}) addr (:score sub-result))))
+      (update :score-type tr/combine-score-types (:score-type sub-result))
       (cond->
        (and (contains? state :weight) (:weight sub-result))
         (update :weight mx/add (:weight sub-result))

--- a/src/genmlx/inference/exact.cljs
+++ b/src/genmlx/inference/exact.cljs
@@ -143,30 +143,41 @@
    Replaces the former ExactGF record with dispatch-based execution.
    Called as (enumerate-run op gf args key opts) by custom-transition-dispatcher."
   [op gf args key {:keys [constraints trace selection]}]
+  ;; All traces are tagged :collapsed: every latent is integrated out, the
+  ;; choicemap is empty, and the score is a marginal likelihood. Joint-scoring
+  ;; consumers (trace-MH) must throw on these, never reuse them (genmlx-lbae).
   (case op
     :simulate
     (let [{:keys [probs]} (enumerate-and-normalize gf args nil)]
-      (tr/make-trace {:gen-fn gf :args (vec args) :choices cm/EMPTY
-                      :retval probs :score (mx/scalar 0.0)}))
+      (tr/with-score-type
+        (tr/make-trace {:gen-fn gf :args (vec args) :choices cm/EMPTY
+                        :retval probs :score (mx/scalar 0.0)})
+        :collapsed))
 
     :generate
     (let [{:keys [probs log-ml]} (enumerate-and-normalize gf args constraints)]
-      {:trace (tr/make-trace {:gen-fn gf :args (vec args) :choices cm/EMPTY
-                              :retval probs :score log-ml})
+      {:trace (tr/with-score-type
+                (tr/make-trace {:gen-fn gf :args (vec args) :choices cm/EMPTY
+                                :retval probs :score log-ml})
+                :collapsed)
        :weight log-ml})
 
     :update
     (let [old-score (:score trace)
           {:keys [probs log-ml]} (enumerate-and-normalize gf (:args trace) constraints)]
-      {:trace (tr/make-trace {:gen-fn gf :args (:args trace) :choices cm/EMPTY
-                              :retval probs :score log-ml})
+      {:trace (tr/with-score-type
+                (tr/make-trace {:gen-fn gf :args (:args trace) :choices cm/EMPTY
+                                :retval probs :score log-ml})
+                :collapsed)
        :weight (mx/subtract log-ml old-score)
        :discard cm/EMPTY})
 
     :regenerate
     (let [{:keys [probs]} (enumerate-and-normalize gf (:args trace) nil)]
-      {:trace (tr/make-trace {:gen-fn gf :args (:args trace) :choices cm/EMPTY
-                              :retval probs :score (mx/scalar 0.0)})
+      {:trace (tr/with-score-type
+                (tr/make-trace {:gen-fn gf :args (:args trace) :choices cm/EMPTY
+                                :retval probs :score (mx/scalar 0.0)})
+                :collapsed)
        :weight (mx/scalar 0.0)})
 
     :assess

--- a/src/genmlx/inference/importance.cljs
+++ b/src/genmlx/inference/importance.cljs
@@ -8,15 +8,13 @@
             [genmlx.dynamic :as dyn]
             [genmlx.vectorized :as vec]))
 
-(defn- strip-analytical
-  "Remove L3 analytical handlers so generate samples from the prior,
-   not the deterministic posterior mean. The analytical path is correct
-   for single-trace operations (MCMC, marginal LL) but returns identical
-   particles in multi-particle IS, breaking the method."
-  [model]
-  (if-let [schema (:schema model)]
-    (assoc model :schema (dissoc schema :auto-handlers :conjugate-pairs))
-    model))
+(def ^:private strip-analytical
+  "Remove the L3 analytical path so generate samples from the prior, not
+   the deterministic posterior mean — identical particles break
+   multi-particle IS (genmlx-540f). Delegates to the canonical strip in
+   genmlx.dynamic: the old local copy here removed only 2 of the 5
+   analytical schema keys (genmlx-jr90 copy drift)."
+  dyn/strip-analytical-path)
 
 (defn- log-ml-from-weights
   "Marginal-likelihood estimate from JS-number log-weights:

--- a/src/genmlx/inference/kernel.cljs
+++ b/src/genmlx/inference/kernel.cljs
@@ -7,6 +7,7 @@
             [genmlx.selection :as sel]
             [genmlx.choicemap :as cm]
             [genmlx.mlx :as mx]
+            [genmlx.trace :as tr]
             [genmlx.dynamic :as dyn]
             [genmlx.inference.util :as u]))
 
@@ -54,12 +55,17 @@
    Returns (fn [trace key] -> trace). Symmetric by default.
    Strips the L3 analytical path from the trace's gen-fn: analytical
    regenerate is intercepted by :auto-regenerate-transition and anchors
-   chains at the posterior mean instead of sampling it (genmlx-540f)."
+   chains at the posterior mean instead of sampling it (genmlx-540f).
+   The MH ratio is only valid for joint-scored regenerate results, so the
+   result is asserted :joint — if the strip ever regresses (or the trace's
+   gen-fn substitutes a collapsed regenerate), the chain throws instead of
+   silently miscalibrating (genmlx-lbae)."
   [selection]
   (symmetric-kernel
     (fn [trace key]
       (let [gf (dyn/auto-key (dyn/strip-analytical-path (:gen-fn trace)))
             result (p/regenerate gf trace selection)
+            _ (tr/assert-joint! (:trace result) :mh-kernel)
             w (mx/realize (:weight result))]
         (if (u/accept-mh? w key)
           (:trace result)

--- a/src/genmlx/inference/mcmc.cljs
+++ b/src/genmlx/inference/mcmc.cljs
@@ -8,6 +8,7 @@
             [genmlx.selection :as sel]
             [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
+            [genmlx.trace :as tr]
             [genmlx.dynamic :as dyn]
             [genmlx.inference.util :as u]
             [genmlx.inference.kernel :as kern]
@@ -53,6 +54,10 @@
    (let [gf (dyn/strip-analytical-path (:gen-fn current-trace))
          [regen-key accept-key] (rng/split (rng/ensure-key key))
          result (p/regenerate (dyn/with-key gf regen-key) current-trace selection)
+         ;; MH ratios are only valid for joint-scored regenerate results:
+         ;; throw if the strip regressed or the gen-fn substitutes a
+         ;; collapsed regenerate (genmlx-lbae, genmlx-540f).
+         _ (tr/assert-joint! (:trace result) :mh-step)
          w (mx/realize (:weight result))]
      (if (u/accept-mh? w accept-key)
        (:trace result)
@@ -97,12 +102,12 @@
 (defn- ensure-joint-trace
   "MH acceptance ratios are joint-score deltas computed via p/update. A trace
    produced by an analytical (collapsed) generate carries a marginal score
-   (::dyn/score-type :marginal) and would mix score decompositions — the
-   dispatcher guard throws on it (genmlx-pkmx). Its choices are a perfectly
-   good chain state, so re-generate it jointly from its own choices via the
-   handler path. No-op for joint traces."
+   (:genmlx.trace/score-type :marginal) and would mix score decompositions
+   (genmlx-pkmx). Its choices are a perfectly good chain state, so
+   re-generate it jointly from its own choices via the handler path.
+   No-op for joint traces."
   [model trace]
-  (if (= :marginal (::dyn/score-type (meta trace)))
+  (if (= :marginal (tr/score-type trace))
     (:trace (p/generate (dyn/strip-alternate-paths model)
                         (:args trace) (:choices trace)))
     trace))

--- a/src/genmlx/inference/smc.cljs
+++ b/src/genmlx/inference/smc.cljs
@@ -5,6 +5,7 @@
             [genmlx.choicemap :as cm]
             [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
+            [genmlx.trace :as tr]
             [genmlx.inference.util :as u]
             [genmlx.dynamic :as dyn]
             [genmlx.vectorized :as vz]
@@ -52,6 +53,10 @@
   [trace selection step-keys]
   (reduce (fn [t rk]
             (let [{:keys [trace weight]} (p/regenerate (:gen-fn t) t selection)]
+              ;; MH ratios are only valid for joint-scored regenerate results
+              ;; (genmlx-lbae) — particles enter with the stripped model, so
+              ;; this only fires if the entry strip regresses (genmlx-540f).
+              (tr/assert-joint! trace :rejuvenate-trace)
               (if (u/accept-mh? (mx/realize weight) rk) trace t)))
           trace step-keys))
 
@@ -68,19 +73,15 @@
   (when (zero? (mod (inc i) 50)) (mx/sweep-dead-arrays!))
   trace)
 
-(defn strip-analytical
+(def strip-analytical
   "Strip analytical handlers from a model for particle-based inference.
    The analytical path returns deterministic posterior means, eliminating
    particle diversity. Particle methods need stochastic prior sampling.
    Public so every particle method (smc, csmc, smcp3) shares ONE stripping
    — mixed stripped/un-stripped scoring puts particles on different weight
-   scales."
-  [model]
-  (assoc model :schema
-         (dissoc (:schema model)
-                 :auto-handlers :conjugate-pairs
-                 :has-conjugate? :analytical-plan
-                 :auto-regenerate-transition)))
+   scales. Delegates to the canonical strip in genmlx.dynamic
+   (genmlx-jr90: one strip, no copy drift)."
+  dyn/strip-analytical-path)
 
 (defn- obs-selection
   "Selection covering exactly the addresses present in an observation

--- a/src/genmlx/serialize.cljs
+++ b/src/genmlx/serialize.cljs
@@ -8,6 +8,7 @@
    Follows GenSerialization.jl conventions."
   (:require [genmlx.mlx :as mx]
             [genmlx.choicemap :as cm]
+            [genmlx.trace :as tr]
             [genmlx.protocols :as p]
             [cljs.reader :as reader]))
 
@@ -234,7 +235,12 @@
               ;; them used to throw (item needs size 1; genmlx-000i).
               :score (if (and (mx/array? score) (pos? (count (mx/shape score))))
                        (mlx-value->data score)
-                       (mx/realize score))}
+                       (mx/realize score))
+              ;; Declare the score's encoding (genmlx-lbae): a marginal
+              ;; (analytically-eliminated) trace's saved score is NOT a joint
+              ;; density. load-trace re-generates from choices, so the loaded
+              ;; trace is freshly joint-scored regardless of this field.
+              :score-type (name (tr/score-type trace))}
         ;; retval is best-effort — closures, protocol instances won't survive
         data (try
                (assoc data :retval (serialize-value (:retval trace)))

--- a/src/genmlx/tensor_trace.cljs
+++ b/src/genmlx/tensor_trace.cljs
@@ -42,11 +42,15 @@
   tr/ITrace)
 
 (defn make-tensor-trace
-  "Create a TensorTrace. Builds TensorChoiceMap from values + addr-index."
+  "Create a TensorTrace. Builds TensorChoiceMap from values + addr-index.
+   L4 tensor traces are joint-scored by construction (fused graphs compose
+   handler-equivalent log-densities), so the tag is unconditional."
   [{:keys [gen-fn args values addr-index score retval]}]
-  (->TensorTrace gen-fn args
-                 (->TensorChoiceMap values addr-index)
-                 values addr-index score retval))
+  (tr/with-score-type
+    (->TensorTrace gen-fn args
+                   (->TensorChoiceMap values addr-index)
+                   values addr-index score retval)
+    :joint))
 
 ;; =========================================================================
 ;; addr-index construction

--- a/src/genmlx/trace.cljs
+++ b/src/genmlx/trace.cljs
@@ -42,9 +42,8 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private score-type-rank
-  "Lattice order for combine-score-types: a composite trace is as collapsed
-   as its most-collapsed part."
-  {:joint 0 :marginal 1 :beam-marginal 2 :collapsed 3})
+  "Propagation order for combine-score-types among the path-unstable tags."
+  {:joint 0 :marginal 1 :beam-marginal 2})
 
 (defn score-type
   "The score encoding of a trace: its ::score-type metadata, or :joint when
@@ -58,15 +57,25 @@
   (vary-meta trace assoc ::score-type st))
 
 (defn combine-score-types
-  "Least upper bound of score-types over the :joint < :marginal <
-   :beam-marginal < :collapsed lattice. nil counts as :joint (untagged).
-   Used to derive a composite trace's tag from its parts (combinator
-   elements, spliced sub-traces)."
+  "Compose a composite trace's score-type from its parts (spliced
+   sub-traces, combinator elements). nil counts as :joint (untagged).
+
+   Only path-UNSTABLE tags propagate (:marginal, :beam-marginal): an
+   analytically-marginal part records latent choices its score does not
+   cover (posterior-mean pinning; scoring switches decomposition between
+   ops), poisoning score deltas for the whole composite. A :collapsed part
+   (enumerate) is the opposite — it records NO internal choices, its score
+   is the exact reproducible density of its empty block (encapsulated
+   exact marginalization), and every op re-derives it consistently, so it
+   composes like any deterministic factor: :joint (the certified
+   MCMC-around-an-enumerate-splice pattern, exact_test 41). Top-level
+   :collapsed tags are assigned directly by enumerate, never derived."
   ([] :joint)
-  ([a] (or a :joint))
+  ([a] (if (contains? score-type-rank a) a :joint))
   ([a b]
-   (let [a (or a :joint) b (or b :joint)]
-     (if (>= (score-type-rank a 0) (score-type-rank b 0)) a b))))
+   (let [a (if (contains? score-type-rank a) a :joint)
+         b (if (contains? score-type-rank b) b :joint)]
+     (if (>= (score-type-rank a) (score-type-rank b)) a b))))
 
 (defn assert-joint!
   "Throw unless trace is joint-scored. Consumers whose math requires joint

--- a/src/genmlx/trace.cljs
+++ b/src/genmlx/trace.cljs
@@ -23,3 +23,67 @@
    VectorizedTrace)."
   [x]
   (satisfies? ITrace x))
+
+;; ---------------------------------------------------------------------------
+;; Score-type metadata (genmlx-lbae)
+;;
+;; Different producing paths assign different meanings to :score
+;; (ARCHITECTURE §3.3):
+;;   :joint     — log p(tau; x), the joint density of all recorded choices
+;;   :marginal  — marginal likelihood: some latents analytically integrated
+;;                out (L3 elimination); eliminated latents appear in the
+;;                choicemap pinned at their posterior mean
+;;   :collapsed — exact marginal likelihood, ALL latents integrated out
+;;                (enumerate); the choicemap is empty
+;; The tag lives in Clojure metadata under ::score-type, set explicitly by
+;; every producing path. Only :marginal traces can cross a joint-scoring
+;; boundary (by re-generating from their own choices); :collapsed traces
+;; have no choices to re-generate from and must throw.
+;; ---------------------------------------------------------------------------
+
+(def ^:private score-type-rank
+  "Lattice order for combine-score-types: a composite trace is as collapsed
+   as its most-collapsed part."
+  {:joint 0 :marginal 1 :beam-marginal 2 :collapsed 3})
+
+(defn score-type
+  "The score encoding of a trace: its ::score-type metadata, or :joint when
+   untagged (hand-rolled traces in tests, deserialized traces)."
+  [trace]
+  (get (meta trace) ::score-type :joint))
+
+(defn with-score-type
+  "Return trace tagged with score-type st, preserving other metadata."
+  [trace st]
+  (vary-meta trace assoc ::score-type st))
+
+(defn combine-score-types
+  "Least upper bound of score-types over the :joint < :marginal <
+   :beam-marginal < :collapsed lattice. nil counts as :joint (untagged).
+   Used to derive a composite trace's tag from its parts (combinator
+   elements, spliced sub-traces)."
+  ([] :joint)
+  ([a] (or a :joint))
+  ([a b]
+   (let [a (or a :joint) b (or b :joint)]
+     (if (>= (score-type-rank a 0) (score-type-rank b 0)) a b))))
+
+(defn assert-joint!
+  "Throw unless trace is joint-scored. Consumers whose math requires joint
+   scores (trace-MH acceptance ratios) call this so a marginal/collapsed
+   trace that slipped past the strip+convert machinery fails loudly
+   (genmlx-540f) instead of silently miscalibrating. Returns the trace."
+  [trace op]
+  (let [st (score-type trace)]
+    (if (= :joint st)
+      trace
+      (throw (ex-info
+               (str op " requires a joint-scored trace, got " st
+                    (case st
+                      :marginal
+                      " — this trace came from the L3 analytical path; strip the model with genmlx.dynamic/strip-analytical-path or re-generate the trace from its own choices"
+                      :collapsed
+                      " — collapsed traces (enumerate/exact) have no recorded choices and cannot be consumed by sampling-based methods"
+                      ""))
+               {:genmlx/error :score-type-mismatch
+                :op op :score-type st :expected :joint})))))

--- a/test/genmlx/l3_false_positive_test.cljs
+++ b/test/genmlx/l3_false_positive_test.cljs
@@ -110,7 +110,7 @@
   (:trace (p/generate (dyn/with-key model key) [] constraints)))
 
 (defn marginal-trace? [trace]
-  (= :marginal (:genmlx.dynamic/score-type (meta trace))))
+  (= :marginal (:genmlx.trace/score-type (meta trace))))
 
 (defn cmv [m] (reduce-kv (fn [c k v] (cm/set-value c k (mx/scalar v))) cm/EMPTY m))
 

--- a/test/genmlx/paper/bench_f32_robustness.cljs
+++ b/test/genmlx/paper/bench_f32_robustness.cljs
@@ -204,7 +204,7 @@
       (throw (ex-info "model not eliminated as expected"
                       {:expected expect-elim :got elim})))
     (let [{:keys [trace weight]} (p/generate (dyn/with-key model (rng/fresh-key 7)) [] obs)]
-      (when (not= :marginal (::dyn/score-type (meta trace)))
+      (when (not= :marginal (:genmlx.trace/score-type (meta trace)))
         (throw (ex-info "generate did not take the analytical path" {})))
       (mx/eval! weight)
       (mx/item weight))))

--- a/test/genmlx/score_type_test.cljs
+++ b/test/genmlx/score_type_test.cljs
@@ -1,0 +1,392 @@
+;; @tier fast core
+(ns genmlx.score-type-test
+  "genmlx-lbae: score-type as enforced metadata.
+
+   Every trace-producing path tags its traces with :genmlx.trace/score-type
+   (:joint | :marginal | :collapsed), combinators and splice propagate the
+   tag from sub-traces (no laundering), and joint-scoring boundaries
+   (update/project/regenerate) convert :marginal traces (genmlx-pkmx) or
+   THROW on unconvertible ones (:collapsed — empty choices, nothing to
+   re-generate from). Trace-MH entry points assert their regenerate results
+   are joint-scored, so a regressed/forgotten analytical strip throws
+   instead of silently anchoring chains at the posterior mean (genmlx-540f:
+   chi2 290.9 vs crit 21.67)."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.protocols :as p]
+            [genmlx.dynamic :as dyn]
+            [genmlx.gfi :as gfi]
+            [genmlx.trace :as tr]
+            [genmlx.dist :as dist]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.combinators :as comb]
+            [genmlx.serialize :as ser]
+            [genmlx.inference.exact :as exact]
+            [genmlx.inference.mcmc :as mcmc]
+            [genmlx.inference.kernel :as kern]
+            [genmlx.inference.importance :as imp])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(def ^:private st-key :genmlx.trace/score-type)
+
+(defn- score-type-error?
+  "True iff (f) throws the score-type contract violation."
+  [f]
+  (try (f) false
+       (catch :default e
+         (= :score-type-mismatch (:genmlx/error (ex-data e))))))
+
+(defn- conjugate-model
+  "mu ~ N(0,1); y ~ N(mu,1). Normal-normal conjugate — static, L3-eliminable."
+  []
+  (gen []
+    (let [mu (trace :mu (dist/gaussian (mx/scalar 0) (mx/scalar 1)))]
+      (trace :y (dist/gaussian mu (mx/scalar 1)))
+      mu)))
+
+(defn- prefix-model
+  "Static prefix + dynamic loop suffix — L1-M3 prefix path."
+  []
+  (gen [n]
+    (let [mu (trace :mu (dist/gaussian (mx/scalar 0) (mx/scalar 1)))]
+      (doseq [i (range n)]
+        (trace (keyword (str "y" i)) (dist/gaussian mu (mx/scalar 1))))
+      mu)))
+
+(defn- discrete-model
+  "coin ~ Bernoulli(0.5); obs ~ Bernoulli(coin ? 0.9 : 0.1) — enumerable."
+  []
+  (gen []
+    (let [coin (trace :coin (dist/bernoulli 0.5))
+          pr (mx/where coin (mx/scalar 0.9) (mx/scalar 0.1))]
+      (trace :obs (dist/bernoulli pr))
+      coin)))
+
+;; Two independent conjugate pairs — same shape as trace_mh_elim_test/sbc
+;; two-gaussians; statically eliminated #{:a :b}.
+(defn- two-gaussians []
+  (gen []
+    (let [a (trace :a (dist/gaussian 0 2))
+          b (trace :b (dist/gaussian 0 2))]
+      (trace :obs-a (dist/gaussian a 1))
+      (trace :obs-b (dist/gaussian b 1))
+      [a b])))
+
+(def ^:private tg-obs
+  (-> cm/EMPTY
+      (cm/set-choice [:obs-a] (mx/scalar 1.0))
+      (cm/set-choice [:obs-b] (mx/scalar -1.0))))
+
+(defn- choice-val [trace addr]
+  (let [v (cm/get-value (cm/get-submap (:choices trace) addr))]
+    (mx/eval! v)
+    (mx/item v)))
+
+;; ============================================================
+;; 1. trace.cljs helpers
+;; ============================================================
+
+(deftest helpers-accessor-and-tagging
+  (let [t (tr/make-trace {:gen-fn nil :args [] :choices cm/EMPTY
+                          :retval nil :score (mx/scalar 0.0)})]
+    (testing "untagged trace defaults to :joint"
+      (is (= :joint (tr/score-type t))))
+    (testing "with-score-type round-trips"
+      (is (= :marginal (tr/score-type (tr/with-score-type t :marginal))))
+      (is (= :collapsed (tr/score-type (tr/with-score-type t :collapsed)))))
+    (testing "with-score-type preserves other metadata"
+      (let [t' (-> t (with-meta {:other 1}) (tr/with-score-type :marginal))]
+        (is (= 1 (:other (meta t'))))))))
+
+(deftest helpers-combine-score-types
+  (testing "lub over the joint < marginal < collapsed lattice"
+    (is (= :joint (tr/combine-score-types)))
+    (is (= :joint (tr/combine-score-types :joint :joint)))
+    (is (= :marginal (tr/combine-score-types :joint :marginal)))
+    (is (= :marginal (tr/combine-score-types :marginal :joint)))
+    (is (= :collapsed (tr/combine-score-types :marginal :collapsed)))
+    (is (= :collapsed (tr/combine-score-types :collapsed :joint))))
+  (testing "nil (untagged) counts as :joint"
+    (is (= :joint (tr/combine-score-types nil nil)))
+    (is (= :marginal (tr/combine-score-types nil :marginal)))))
+
+(deftest helpers-assert-joint!
+  (let [t (tr/make-trace {:gen-fn nil :args [] :choices cm/EMPTY
+                          :retval nil :score (mx/scalar 0.0)})]
+    (testing "passes through joint and untagged traces"
+      (is (identical? t (tr/assert-joint! t :test-op)))
+      (is (some? (tr/assert-joint! (tr/with-score-type t :joint) :test-op))))
+    (testing "throws descriptive ex-info on non-joint traces"
+      (is (score-type-error?
+            #(tr/assert-joint! (tr/with-score-type t :marginal) :test-op)))
+      (is (score-type-error?
+            #(tr/assert-joint! (tr/with-score-type t :collapsed) :test-op)))
+      (let [data (try (tr/assert-joint! (tr/with-score-type t :collapsed) :my-op)
+                      nil
+                      (catch :default e (ex-data e)))]
+        (is (= :collapsed (:score-type data)) "ex-data carries the actual tag")
+        (is (= :joint (:expected data)) "ex-data carries the expectation")
+        (is (= :my-op (:op data)) "ex-data carries the consuming op")))))
+
+;; ============================================================
+;; 2. Producer matrix — every path tags EXPLICITLY
+;; ============================================================
+
+(deftest producer-handler-path-tags-joint
+  (let [model (dyn/auto-key (gfi/strip-compiled (conjugate-model)))
+        t (p/simulate model [])]
+    (is (= :handler (:label (dyn/resolve-dispatch model :simulate))) "precondition")
+    (is (contains? (meta t) st-key) "tag is explicit, not just defaulted")
+    (is (= :joint (tr/score-type t)))))
+
+(deftest producer-compiled-path-tags-joint
+  (let [model (dyn/auto-key (conjugate-model))
+        t (p/simulate model [])]
+    (is (= :compiled (:label (dyn/resolve-dispatch model :simulate))) "precondition")
+    (is (contains? (meta t) st-key))
+    (is (= :joint (tr/score-type t)))
+    (testing "compiled update and regenerate tag :joint too"
+      (let [u (p/update model t (cm/choicemap :y (mx/scalar 2.0)))
+            r (p/regenerate model t (sel/select :mu))]
+        (is (= :joint (tr/score-type (:trace u))))
+        (is (contains? (meta (:trace u)) st-key))
+        (is (= :joint (tr/score-type (:trace r))))
+        (is (contains? (meta (:trace r)) st-key))))))
+
+(deftest producer-prefix-path-tags-joint
+  (let [model (dyn/auto-key (prefix-model))
+        t (p/simulate model [2])]
+    (is (= :prefix (:label (dyn/resolve-dispatch model :simulate))) "precondition")
+    (is (contains? (meta t) st-key))
+    (is (= :joint (tr/score-type t)))))
+
+(deftest producer-analytical-fired-tags-marginal
+  (let [model (dyn/with-key (conjugate-model) (rng/fresh-key 7))
+        {t :trace} (p/generate model [] (cm/choicemap :y (mx/scalar 1.5)))]
+    (is (= :marginal (tr/score-type t)))))
+
+(deftest producer-analytical-declined-tags-joint
+  ;; genmlx-b470: fully-constrained prior → every handler falls through →
+  ;; plain joint scoring, and the tag must say so EXPLICITLY.
+  (let [model (dyn/with-key (conjugate-model) (rng/fresh-key 8))
+        {t :trace} (p/generate model [] (cm/choicemap :mu (mx/scalar 0.3)
+                                                      :y (mx/scalar 1.5)))]
+    (is (contains? (meta t) st-key))
+    (is (= :joint (tr/score-type t)))))
+
+(deftest producer-enumerate-tags-collapsed
+  (let [em (exact/enumerate (dyn/auto-key (discrete-model)))]
+    (testing "generate"
+      (let [{t :trace} (p/generate em [] (cm/choicemap :obs (mx/scalar 1.0)))]
+        (is (= :collapsed (tr/score-type t)))))
+    (testing "simulate"
+      (is (= :collapsed (tr/score-type (p/simulate em [])))))))
+
+(deftest producer-combinator-plain-tags-joint
+  (let [kernel (dyn/auto-key (gen [x]
+                  (trace :y (dist/gaussian (mx/scalar 0) (mx/scalar 1)))))
+        mapped (dyn/auto-key (comb/map-combinator kernel))
+        t (p/simulate mapped [[1.0 2.0]])]
+    (is (contains? (meta t) st-key))
+    (is (= :joint (tr/score-type t)))))
+
+(deftest producer-combinator-laundering-tags-marginal
+  ;; A Map over a conjugate-but-uncompilable kernel: Map falls back to the
+  ;; per-element handler path, each sub-generate fires the analytical path →
+  ;; marginal sub-scores summed into the parent total. The parent trace must
+  ;; carry the tag — this is the §3.3 laundering hole. Gamma-Poisson is the
+  ;; real such cell: a conjugate family whose prior has no noise transform.
+  (let [kernel (dyn/auto-key (gen [x]
+                  (let [lam (trace :lam (dist/gamma-dist (mx/scalar 2) (mx/scalar 2)))]
+                    (trace :y (dist/poisson lam))
+                    lam)))
+        mapped (dyn/auto-key (comb/map-combinator kernel))
+        obs (-> cm/EMPTY
+                (cm/set-choice [0 :y] (mx/scalar 3.0))
+                (cm/set-choice [1 :y] (mx/scalar 1.0)))
+        {t :trace} (p/generate mapped [[1.0 2.0]] obs)]
+    (is (seq (:auto-handlers (:schema kernel)))
+        "precondition: kernel is analytically eliminable")
+    (is (nil? (:compiled-generate (:schema kernel)))
+        "precondition: kernel is NOT compilable (gamma has no noise transform), so Map takes the handler fallback")
+    (is (= :marginal (tr/score-type t))
+        "marginal-ness propagates from sub-traces to the combinator trace")))
+
+(deftest producer-combinator-compiled-elements-stay-joint
+  ;; The complementary cell: a static conjugate kernel compiles, Map prefers
+  ;; the compiled per-element path which scores JOINTLY — the analytical
+  ;; sub-generate never runs, no laundering occurs, and :joint is correct.
+  (let [kernel (dyn/auto-key (gen [x]
+                  (let [mu (trace :mu (dist/gaussian (mx/scalar 0) (mx/scalar 1)))]
+                    (trace :y (dist/gaussian mu (mx/scalar 1)))
+                    mu)))
+        mapped (dyn/auto-key (comb/map-combinator kernel))
+        obs (-> cm/EMPTY
+                (cm/set-choice [0 :y] (mx/scalar 1.5))
+                (cm/set-choice [1 :y] (mx/scalar -0.5)))
+        {t :trace} (p/generate mapped [[1.0 2.0]] obs)]
+    (is (seq (:auto-handlers (:schema kernel)))
+        "precondition: kernel is analytically eliminable")
+    (is (some? (:compiled-generate (:schema kernel)))
+        "precondition: kernel IS compilable — Map takes the compiled element path")
+    (is (= :joint (tr/score-type t))
+        "compiled element scores are joint; no laundering, tag says so")))
+
+(deftest producer-splice-laundering-tags-marginal
+  ;; Same hole through splice: execute-sub must propagate the sub-trace tag
+  ;; and merge-sub-result must lub it into the parent state.
+  (let [sub (conjugate-model)
+        parent (dyn/with-key (gen [] (splice :sub sub)) (rng/fresh-key 11))
+        obs (cm/set-submap cm/EMPTY :sub (cm/choicemap :y (mx/scalar 1.5)))
+        {t :trace} (p/generate parent [] obs)]
+    (is (seq (:auto-handlers (:schema sub)))
+        "precondition: sub-gf is analytically eliminable")
+    (is (= :marginal (tr/score-type t))
+        "marginal-ness propagates through splice into the parent trace")
+    (testing "splice-scores metadata coexists with the tag (no meta wipe)"
+      (is (some? (:genmlx.dynamic/splice-scores (meta t)))
+          "parent trace still carries splice scores"))))
+
+(deftest producer-vectorized-tags-joint
+  (let [model (dyn/auto-key (conjugate-model))
+        vt (dyn/vsimulate model [] 4 (rng/fresh-key 3))]
+    (is (contains? (meta vt) st-key))
+    (is (= :joint (tr/score-type vt)))))
+
+;; ============================================================
+;; 3. Conversion at boundaries — laundered parents convert exactly
+;; ============================================================
+
+(deftest laundered-parent-converts-at-joint-boundaries
+  ;; Oracle: the same choices re-generated on the fully stripped parent (a
+  ;; joint trace, handler ground truth) pushed through the same op.
+  (let [sub (conjugate-model)
+        parent (dyn/with-key (gen [] (splice :sub sub)) (rng/fresh-key 11))
+        obs (cm/set-submap cm/EMPTY :sub (cm/choicemap :y (mx/scalar 1.5)))
+        {lt :trace} (p/generate parent [] obs)
+        stripped (dyn/auto-key (gfi/strip-compiled parent))
+        {jt :trace} (p/generate stripped [] (:choices lt))
+        new-obs (cm/set-submap cm/EMPTY :sub (cm/choicemap :y (mx/scalar 2.0)))]
+    (is (= :marginal (tr/score-type lt)) "precondition: parent is laundered-marginal")
+    (is (= :joint (tr/score-type jt)) "oracle trace is joint")
+    (testing "update converts and matches the joint oracle"
+      (let [u-l (p/update parent lt new-obs)
+            u-j (p/update stripped jt new-obs)
+            _ (mx/materialize! (:weight u-l) (:weight u-j))]
+        (is (< (js/Math.abs (- (mx/item (:weight u-l)) (mx/item (:weight u-j)))) 1e-4)
+            "update weights match")
+        (is (= :joint (tr/score-type (:trace u-l))) "converted result is joint")
+        (is (contains? (meta (:trace u-l)) st-key) "and explicitly tagged")))
+    (testing "project converts and matches the joint oracle"
+      (let [p-l (p/project parent lt (sel/select :sub))
+            p-j (p/project stripped jt (sel/select :sub))
+            _ (mx/materialize! p-l p-j)]
+        (is (< (js/Math.abs (- (mx/item p-l) (mx/item p-j))) 1e-4)
+            "project values match")))))
+
+;; ============================================================
+;; 4. Boundary checks — unconvertible tags THROW
+;; ============================================================
+
+(deftest collapsed-traces-throw-at-joint-boundaries
+  (let [model (dyn/auto-key (gfi/strip-compiled (conjugate-model)))
+        {t :trace} (p/generate model [] (cm/choicemap :y (mx/scalar 1.5)))
+        ct (tr/with-score-type t :collapsed)]
+    (is (score-type-error? #(p/update model ct (cm/choicemap :y (mx/scalar 2.0))))
+        "update on a :collapsed trace throws")
+    (is (score-type-error? #(p/regenerate model ct (sel/select :mu)))
+        "regenerate on a :collapsed trace throws")
+    (is (score-type-error? #(p/project model ct (sel/select :mu)))
+        "project on a :collapsed trace throws")
+    (testing "unknown tags throw too (closed vocabulary at the boundary)"
+      (is (score-type-error?
+            #(p/update model (tr/with-score-type t :bogus)
+                       (cm/choicemap :y (mx/scalar 2.0))))))))
+
+(deftest enumerate-trace-into-trace-mh-throws
+  ;; The bean's canonical example: trace-MH receiving a :collapsed trace.
+  ;; Pre-lbae this silently no-ops (regenerate weight 0 → always accept).
+  (let [em (exact/enumerate (dyn/auto-key (discrete-model)))
+        {t :trace} (p/generate em [] (cm/choicemap :obs (mx/scalar 1.0)))]
+    (is (= :collapsed (tr/score-type t)) "precondition")
+    (is (score-type-error?
+          #((kern/mh-kernel (sel/select :coin)) t (rng/fresh-key 2)))
+        "kern/mh-kernel throws on a collapsed trace")
+    (is (score-type-error?
+          #(mcmc/mh-step t (sel/select :coin) (rng/fresh-key 3)))
+        "mcmc/mh-step throws on a collapsed trace")))
+
+(deftest marginal-init-traces-still-flow-through-trace-mh
+  ;; The legitimate pkmx flow must KEEP working: SBC inits mh-cycle chains
+  ;; with analytical-generate (marginal) traces and relies on conversion.
+  (let [model (dyn/with-key (conjugate-model) (rng/fresh-key 7))
+        {t :trace} (p/generate model [] (cm/choicemap :y (mx/scalar 1.5)))]
+    (is (= :marginal (tr/score-type t)) "precondition")
+    (let [t' ((kern/mh-kernel (sel/select :mu)) t (rng/fresh-key 9))]
+      (is (tr/trace? t') "kernel step runs without throwing"))
+    (let [t'' (mcmc/mh-step t (sel/select :mu) (rng/fresh-key 10))]
+      (is (tr/trace? t'') "mh-step runs without throwing"))))
+
+;; ============================================================
+;; 5. Backstop teeth — the law guarding the check itself (540f)
+;; ============================================================
+
+(deftest backstop-throws-when-strip-is-bypassed
+  ;; If the 540f strip fix ever regresses (a new entry point forgets to
+  ;; strip, or the strip is broken), trace-MH on an eliminated model must
+  ;; THROW — never silently anchor at the posterior mean.
+  (let [model (dyn/auto-key (two-gaussians))
+        {t :trace} (p/generate model [] tg-obs)]
+    (is (= #{:a :b} (get-in (:schema model)
+                            [:analytical-plan :rewrite-result :eliminated]))
+        "precondition: model is statically eliminated")
+    (is (= :marginal (tr/score-type t)) "precondition: analytical generate fired")
+    (with-redefs [dyn/strip-analytical-path identity]
+      (is (score-type-error?
+            #((kern/mh-kernel (sel/select :a)) t (rng/fresh-key 540)))
+          "mh-kernel with a bypassed strip throws instead of corrupting the chain")
+      (is (score-type-error?
+            #(mcmc/mh-step t (sel/select :a) (rng/fresh-key 541)))
+          "mh-step with a bypassed strip throws instead of corrupting the chain"))))
+
+;; ============================================================
+;; 6. Strip consolidation — importance sampling on eliminated models
+;; ============================================================
+
+(deftest importance-particles-are-joint-and-diverse
+  (let [model (dyn/auto-key (two-gaussians))
+        {:keys [traces]} (imp/importance-sampling
+                           {:samples 10 :key (rng/fresh-key 5)} model [] tg-obs)]
+    (is (every? #(= :joint (tr/score-type %)) traces)
+        "IS particles are joint-scored (analytical path stripped)")
+    (is (> (count (distinct (map #(choice-val % :a) traces))) 1)
+        "particles are diverse, not pinned at the posterior mean")))
+
+;; ============================================================
+;; 7. Serialization honesty
+;; ============================================================
+
+(deftest serialization-tags-and-reloads-honestly
+  (let [model (dyn/with-key (conjugate-model) (rng/fresh-key 7))
+        {t :trace} (p/generate model [] (cm/choicemap :y (mx/scalar 1.5)))
+        json (ser/save-trace t)
+        parsed (js->clj (js/JSON.parse json) :keywordize-keys true)]
+    (is (= :marginal (tr/score-type t)) "precondition")
+    (is (= "marginal" (:score-type parsed))
+        "saved JSON declares its score encoding (the saved score IS marginal)")
+    (testing "load-trace re-generates: reloaded trace is freshly joint-scored"
+      (let [t2 (ser/load-trace (dyn/auto-key model) json)]
+        (is (= :joint (tr/score-type t2))
+            "fully-constrained re-generate falls through to joint (b470)")))))
+
+;; ============================================================
+;; 8. GFI law registered
+;; ============================================================
+
+(deftest gfi-law-registered
+  (is (contains? (set (map :name gfi/laws)) :score-type-soundness)
+      "score-type soundness is part of the law catalog"))
+
+(cljs.test/run-tests)

--- a/test/genmlx/score_type_test.cljs
+++ b/test/genmlx/score_type_test.cljs
@@ -101,13 +101,17 @@
         (is (= 1 (:other (meta t'))))))))
 
 (deftest helpers-combine-score-types
-  (testing "lub over the joint < marginal < collapsed lattice"
+  (testing "only path-unstable tags propagate through composition"
     (is (= :joint (tr/combine-score-types)))
     (is (= :joint (tr/combine-score-types :joint :joint)))
     (is (= :marginal (tr/combine-score-types :joint :marginal)))
     (is (= :marginal (tr/combine-score-types :marginal :joint)))
-    (is (= :collapsed (tr/combine-score-types :marginal :collapsed)))
-    (is (= :collapsed (tr/combine-score-types :collapsed :joint))))
+    (is (= :marginal (tr/combine-score-types :marginal :collapsed))))
+  (testing "a :collapsed PART composes as :joint — enumerate blocks record no
+            internal choices and re-derive their exact score consistently
+            (the MCMC-around-an-enumerate-splice pattern, exact_test 41)"
+    (is (= :joint (tr/combine-score-types :collapsed :joint)))
+    (is (= :joint (tr/combine-score-types :joint :collapsed))))
   (testing "nil (untagged) counts as :joint"
     (is (= :joint (tr/combine-score-types nil nil)))
     (is (= :marginal (tr/combine-score-types nil :marginal)))))
@@ -248,6 +252,34 @@
     (testing "splice-scores metadata coexists with the tag (no meta wipe)"
       (is (some? (:genmlx.dynamic/splice-scores (meta t)))
           "parent trace still carries splice scores"))))
+
+(deftest producer-enumerate-splice-composes-joint
+  ;; The certified mixed-inference pattern (exact_test 41): a parent model
+  ;; splices an enumerate-wrapped discrete block and runs trace-MH on its
+  ;; continuous sites. The collapsed block records no internal choices and
+  ;; re-derives its exact score consistently in every op, so the PARENT is
+  ;; joint-scored — it must not inherit :collapsed (that would make the
+  ;; boundary guard reject a mathematically valid flow).
+  (let [agent-gf (dyn/auto-key (gen [] (trace :choice (dist/bernoulli 0.6))))
+        ;; laplace likelihood: keeps the parent NON-conjugate so the only
+        ;; non-joint tag source is the enumerate splice itself
+        parent (dyn/with-key
+                 (gen []
+                   (let [mu (trace :mu (dist/gaussian (mx/scalar 0) (mx/scalar 5)))]
+                     (splice :agent (exact/enumerate agent-gf))
+                     (trace :obs (dist/laplace mu (mx/scalar 1)))
+                     mu))
+                 (rng/fresh-key 41))
+        {t :trace} (p/generate parent [] (cm/choicemap :obs (mx/scalar 2.0)))]
+    (is (empty? (:auto-handlers (:schema parent)))
+        "precondition: parent itself is not analytically eliminable")
+    (is (= :joint (tr/score-type t))
+        "parent with an enumerate splice is joint-scored, not collapsed")
+    (testing "trace-MH over the continuous site flows"
+      (let [t' ((kern/mh-kernel (sel/select :mu)) t (rng/fresh-key 42))]
+        (is (tr/trace? t') "mh-kernel step runs without throwing"))
+      (let [{rt :trace} (p/regenerate parent t (sel/select :mu))]
+        (is (= :joint (tr/score-type rt)) "regenerate result stays joint")))))
 
 (deftest producer-vectorized-tags-joint
   (let [model (dyn/auto-key (conjugate-model))

--- a/test/genmlx/strip_compiled_test.cljs
+++ b/test/genmlx/strip_compiled_test.cljs
@@ -101,7 +101,7 @@
         stripped (dyn/auto-key (gfi/strip-compiled model))
         {jt :trace} (p/generate stripped [] (:choices trace))]
     (testing "precondition: analytical generate produced a marginal trace"
-      (is (= :marginal (:genmlx.dynamic/score-type (meta trace)))
+      (is (= :marginal (:genmlx.trace/score-type (meta trace)))
           "trace is analytically scored"))
     (testing "update on a marginal trace = update on the joint-rescored trace"
       (let [u-marg (p/update model trace (cm/choicemap :y 2.0))
@@ -112,8 +112,8 @@
         (is (< (js/Math.abs (- w-marg w-joint)) 1e-4)
             (str "update weights match: marginal-path " w-marg
                  " vs handler baseline " w-joint))
-        (is (nil? (:genmlx.dynamic/score-type (meta (:trace u-marg))))
-            "result trace is joint-scored")))
+        (is (= :joint (:genmlx.trace/score-type (meta (:trace u-marg))))
+            "result trace is joint-scored (explicitly tagged — genmlx-lbae)")))
     (testing "project on a marginal trace = project on the joint-rescored trace"
       (let [p-marg (p/project model trace (sel/select :mu))
             p-joint (p/project stripped jt (sel/select :mu))
@@ -125,7 +125,8 @@
         (is (some? t') "analytical regenerate works on marginal traces")))
     (testing "joint traces are passed through untouched"
       (let [upd (p/update stripped jt (cm/choicemap :y 2.0))]
-        (is (nil? (:genmlx.dynamic/score-type (meta jt))) "handler trace is joint")
+        (is (= :joint (:genmlx.trace/score-type (meta jt)))
+            "handler trace is joint (explicitly tagged — genmlx-lbae)")
         (is (some? (:trace upd)) "update on joint trace works")))))
 
 (cljs.test/run-tests)

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -293,6 +293,7 @@ slow test/genmlx/sbc_test.cljs
 fast test/genmlx/schema_test.cljs core
 fast test/genmlx/score_gradient_test.cljs core
 fast test/genmlx/score_monotonicity_property_test.cljs
+fast test/genmlx/score_type_test.cljs core
 fast test/genmlx/searchsorted_test.cljs
 fast test/genmlx/selection_algebra_test2.cljs core
 fast test/genmlx/selection_property_test.cljs


### PR DESCRIPTION
## Score-type as enforced metadata (genmlx-lbae)

ROADMAP Phase 1 item 3. ARCHITECTURE §3.3 previously admitted score-type was an
implicit convention across dual code paths — the systemic cause of the genmlx-540f
class, where analytical generate produced marginal-scored traces with mean-pinned
latents that trace-MH then treated as joint-scored, silently corrupting the chain.
This makes score-type **enforced metadata** so that class becomes structurally
impossible.

### Design
- Canonical `:genmlx.trace/score-type` metadata (`:joint` / `:marginal` / `:collapsed`),
  helpers in `trace.cljs` (Layer 1, readable by the handler): `score-type`,
  `with-score-type`, `combine-score-types`, `assert-joint!`.
- **Every producing path tags explicitly** (handler, compiled M2/M3, analytical,
  enumerate, combinators, splice). "Forgot to tag" is law-detectable.
- **Composition rule:** only path-*unstable* tags (`:marginal`, `:beam-marginal`)
  propagate from parts to composites; `:collapsed` parts compose as `:joint`
  (enumerate blocks record no internal choices and re-derive their exact score
  consistently — certified by the MCMC-around-enumerate-splice pattern in exact_test).
- **Boundaries:** the dispatcher guard converts `:marginal` (pkmx semantics kept)
  and **throws** on `:collapsed`/unknown. Combinator records get the same guard via
  `ensure-joint-self` at update/regenerate/project entries (they bypass the
  dispatcher — fixing a pre-existing 540f-class weight-mixing bug in combinator
  update over marginal element scores).
- **Trace-MH backstops** (`kern/mh-kernel`, `mcmc/mh-step`, `smc/rejuvenate-trace`)
  assert regenerate *results* are joint — teeth verified by `with-redefs`
  strip→identity → throws.

### Also
- Strips consolidated onto `dyn/strip-analytical-path` (smc + importance — closes
  the genmlx-jr90 copy-drift src side).
- `gfi.cljs` law `:score-type-soundness`.
- ARCHITECTURE §3.3 rewritten from prescription to description.

### Verification
`score_type_test` 23 tests / 81 assertions, `exact_test` 120/120, core tier 40/40,
check gate OK (364 files). The one real lbae regression found (collapsed-composition
in exact_test) was fixed in c13b03f with its own regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
