### PR TITLE
feat(gfi): update with new arguments — thesis x' (genmlx-s8e8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ src/genmlx/
   # Layer 1: Core Data (pure immutable structures)
   choicemap.cljs, trace.cljs, selection.cljs, diff.cljs
 
-  # Layer 2: GFI & Execution (10 protocols, 6+4 handler transitions)
+  # Layer 2: GFI & Execution (11 protocols, 6+4 handler transitions)
   protocols.cljs, handler.cljs, edit.cljs, tensor_trace.cljs
 
   # Layer 3: DSL + Schema (gen macro, DynamicGF, 4-level dispatcher)
@@ -268,10 +268,11 @@ direct import of dynamic.cljs).
                                       intercept) 1)))
       slope)))
 
-;; GFI operations (10 protocols)
+;; GFI operations (11 protocols)
 (p/simulate model args)                  ;; => Trace
 (p/generate model args constraints)      ;; => {:trace Trace :weight scalar}
 (p/update model trace new-constraints)   ;; => {:trace :weight :discard}
+(p/update-with-args model trace new-args argdiffs constraints) ;; thesis x'
 (p/regenerate model trace selection)     ;; => {:trace :weight}
 (p/assess model args choices)            ;; => {:retval :weight}
 (p/project model trace selection)        ;; => scalar
@@ -282,6 +283,7 @@ direct import of dynamic.cljs).
 (dyn/vsimulate model args n key)         ;; => VectorizedTrace
 (dyn/vgenerate model args obs n key)     ;; => VectorizedTrace with weights
 (dyn/vupdate model vtrace constraints key) ;; => {:vtrace :weight :discard}
+(dyn/vupdate-args model vtrace new-args constraints key) ;; batched thesis x'
 (dyn/vregenerate model vtrace selection key) ;; => {:vtrace :weight}
 
 ;; Schema introspection (Level 1)

--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -2588,6 +2588,418 @@
       (p/update this trace constraints))))
 
 ;; ---------------------------------------------------------------------------
+;; IUpdateWithArgs implementations (genmlx-s8e8)
+;; ---------------------------------------------------------------------------
+;; Sequence combinators share one weight convention with their p/update
+;; loops: accumulate `nf` (the non-fresh score under the NEW args — child
+;; thesis weights re-based by their constructed old scores, verbatim prefix
+;; steps by their recorded true scores, fresh steps by their generate
+;; weights) and return W = nf - old_total. Elements/steps dropped by the
+;; new args never enter nf, so the old-total subtraction charges them; their
+;; choices go to the discard. Exact with or without per-element metadata
+;; (the constructed old scores cancel inside the child weights).
+
+(defn- throw-update-with-args-unsupported
+  [gf]
+  (throw (ex-info (str "update-with-args is not supported by "
+                       (pr-str (type gf))
+                       " — open a bean if you need it; plain update covers"
+                       " unchanged args")
+                  {:genmlx/error :update-with-args-unsupported
+                   :gf-type (type gf)})))
+
+(extend-type MapCombinator
+  p/IUpdateWithArgs
+  (update-with-args [this trace new-args argdiffs constraints]
+    (let [trace (ensure-joint-self this :update trace)
+          kern (ensure-kernel-key (:kernel this))
+          old-args (:args trace)
+          old-choices (:choices trace)
+          old-n (count (first old-args))
+          new-n (count (first new-args))
+          old-element-scores (::element-scores (meta trace))
+          changed (when (diff/vector-diff? argdiffs) (:changed argdiffs))
+          ;; Verbatim retention is valid only when the caller asserts the
+          ;; element unchanged (vector-diff), it is unconstrained, and the
+          ;; true element score is recorded.
+          verbatim? (fn [i]
+                      (and old-element-scores changed
+                           (not (contains? changed i))
+                           (= (cm/get-submap constraints i) cm/EMPTY)))]
+      (loop [i 0
+             choices cm/EMPTY score ZERO nf ZERO
+             discard cm/EMPTY
+             retvals [] element-scores []
+             st :joint]
+        (if (>= i new-n)
+          (let [discard (reduce (fn [d j]
+                                  (cm/set-choice d [j] (cm/get-submap old-choices j)))
+                                discard (range new-n old-n))]
+            {:trace (tr/with-score-type
+                      (with-meta
+                        (tr/make-trace {:gen-fn this :args new-args
+                                        :choices choices :retval retvals :score score})
+                        {::element-scores element-scores})
+                      st)
+             :weight (mx/subtract nf (:score trace))
+             :discard discard})
+          (let [elem-args-new (mapv #(nth % i) new-args)
+                sub-constraints (cm/get-submap constraints i)]
+            (cond
+              ;; Retained verbatim
+              (and (< i old-n) (verbatim? i))
+              (let [sub (cm/get-submap old-choices i)
+                    s-i (nth old-element-scores i)]
+                (recur (inc i)
+                       (cm/set-choice choices [i] sub)
+                       (mx/add score s-i)
+                       (mx/add nf s-i)
+                       discard
+                       (conj retvals (nth (:retval trace) i))
+                       (conj element-scores s-i)
+                       st))
+
+              ;; Kept: re-execute under the new element args
+              (< i old-n)
+              (let [elem-args-old (mapv #(nth % i) old-args)
+                    c-old (if old-element-scores (nth old-element-scores i) ZERO)
+                    old-sub (tr/make-trace
+                              {:gen-fn kern :args elem-args-old
+                               :choices (cm/get-submap old-choices i)
+                               :retval nil :score c-old})
+                    result (p/update-with-args kern old-sub elem-args-new
+                                               :unknown sub-constraints)
+                    ntr (:trace result)]
+                (recur (inc i)
+                       (cm/set-choice choices [i] (:choices ntr))
+                       (mx/add score (:score ntr))
+                       (mx/add nf (mx/add (:weight result) c-old))
+                       (if (and (:discard result) (not= (:discard result) cm/EMPTY))
+                         (cm/set-choice discard [i] (:discard result))
+                         discard)
+                       (conj retvals (:retval ntr))
+                       (conj element-scores (:score ntr))
+                       (tr/combine-score-types st (tr/score-type ntr))))
+
+              ;; Fresh element
+              :else
+              (let [result (p/generate kern elem-args-new sub-constraints)
+                    ntr (:trace result)]
+                (recur (inc i)
+                       (cm/set-choice choices [i] (:choices ntr))
+                       (mx/add score (:score ntr))
+                       (mx/add nf (:weight result))
+                       discard
+                       (conj retvals (:retval ntr))
+                       (conj element-scores (:score ntr))
+                       (tr/combine-score-types st (tr/score-type ntr)))))))))))
+
+(extend-type UnfoldCombinator
+  p/IUpdateWithArgs
+  (update-with-args [this trace new-args argdiffs constraints]
+    (let [trace (ensure-joint-self this :update trace)
+          kern (ensure-kernel-key (:kernel this))
+          old-args (:args trace)
+          [old-n old-init & old-extra] old-args
+          [new-n new-init & new-extra] new-args
+          choices (:choices trace)
+          old-states (:retval trace)
+          old-step-scores (::step-scores (meta trace))
+          ;; Host = is the prefix-enabler: cheap and verifiable for numbers/
+          ;; vectors, reference-conservative for MLX arrays (same object ✓,
+          ;; numerically-equal copy → full sweep, still exact).
+          shared-config? (and (= old-init new-init) (= old-extra new-extra))
+          kept-n (min old-n new-n)
+          boundary (if (and shared-config? old-step-scores)
+                     (loop [t 0]
+                       (cond
+                         (>= t kept-n) kept-n
+                         (not= (cm/get-submap constraints t) cm/EMPTY) t
+                         :else (recur (inc t))))
+                     0)
+          prefix-choices (if (pos? boundary)
+                           (reduce (fn [cm t]
+                                     (cm/set-choice cm [t] (cm/get-submap choices t)))
+                                   cm/EMPTY (range boundary))
+                           cm/EMPTY)
+          prefix-score (if (pos? boundary)
+                         (reduce (fn [acc t] (mx/add acc (nth old-step-scores t)))
+                                 ZERO (range boundary))
+                         ZERO)
+          prefix-states (if (pos? boundary) (subvec old-states 0 boundary) [])
+          prefix-step-scores (if (pos? boundary)
+                               (subvec (vec old-step-scores) 0 boundary)
+                               [])
+          start-state (if (pos? boundary)
+                        (nth old-states (dec boundary))
+                        new-init)
+          old-state-at (fn [t threaded]
+                         (cond
+                           (zero? t) old-init
+                           (vector? old-states) (nth old-states (dec t))
+                           :else threaded))]
+      (loop [t boundary state start-state
+             new-choices prefix-choices score prefix-score nf prefix-score
+             discard cm/EMPTY
+             states prefix-states step-scores prefix-step-scores
+             st :joint]
+        (if (>= t new-n)
+          (let [discard (reduce (fn [d j]
+                                  (cm/set-choice d [j] (cm/get-submap choices j)))
+                                discard (range new-n old-n))]
+            {:trace (tr/with-score-type
+                      (with-meta
+                        (tr/make-trace {:gen-fn this :args new-args
+                                        :choices new-choices :retval states :score score})
+                        {::step-scores step-scores})
+                      st)
+             :weight (mx/subtract nf (:score trace))
+             :discard discard})
+          (let [kernel-args (into [t state] new-extra)
+                sub-constraints (cm/get-submap constraints t)]
+            (if (< t old-n)
+              ;; Kept step: child update-with-args under the new threaded state
+              (let [c-old (if old-step-scores (nth old-step-scores t) ZERO)
+                    old-sub (tr/make-trace
+                              {:gen-fn kern
+                               :args (into [t (old-state-at t state)] old-extra)
+                               :choices (cm/get-submap choices t)
+                               :retval nil :score c-old})
+                    result (p/update-with-args kern old-sub kernel-args
+                                               :unknown sub-constraints)
+                    ntr (:trace result)
+                    new-state (:retval ntr)]
+                (recur (inc t) new-state
+                       (cm/set-choice new-choices [t] (:choices ntr))
+                       (mx/add score (:score ntr))
+                       (mx/add nf (mx/add (:weight result) c-old))
+                       (if (and (:discard result) (not= (:discard result) cm/EMPTY))
+                         (cm/set-choice discard [t] (:discard result))
+                         discard)
+                       (conj states new-state)
+                       (conj step-scores (:score ntr))
+                       (tr/combine-score-types st (tr/score-type ntr))))
+              ;; Fresh step: child generate
+              (let [result (p/generate kern kernel-args sub-constraints)
+                    ntr (:trace result)
+                    new-state (:retval ntr)]
+                (recur (inc t) new-state
+                       (cm/set-choice new-choices [t] (:choices ntr))
+                       (mx/add score (:score ntr))
+                       (mx/add nf (:weight result))
+                       discard
+                       (conj states new-state)
+                       (conj step-scores (:score ntr))
+                       (tr/combine-score-types st (tr/score-type ntr)))))))))))
+
+(extend-type ScanCombinator
+  p/IUpdateWithArgs
+  (update-with-args [this trace new-args argdiffs constraints]
+    (let [trace (ensure-joint-self this :update trace)
+          kern (ensure-kernel-key (:kernel this))
+          [old-init-carry old-inputs] (:args trace)
+          [new-init-carry new-inputs] new-args
+          choices (:choices trace)
+          old-n (count old-inputs)
+          new-n (count new-inputs)
+          old-step-scores (::step-scores (meta trace))
+          old-step-carries (::step-carries (meta trace))
+          kept-n (min old-n new-n)
+          ;; Prefix-skip up to the first constrained step or first changed
+          ;; input — both verified, not asserted (host = on inputs).
+          boundary (if (and (= old-init-carry new-init-carry)
+                            old-step-scores old-step-carries)
+                     (loop [t 0]
+                       (cond
+                         (>= t kept-n) kept-n
+                         (not= (cm/get-submap constraints t) cm/EMPTY) t
+                         (not= (nth old-inputs t) (nth new-inputs t)) t
+                         :else (recur (inc t))))
+                     0)
+          prefix-choices (if (pos? boundary)
+                           (reduce (fn [cm t]
+                                     (cm/set-choice cm [t] (cm/get-submap choices t)))
+                                   cm/EMPTY (range boundary))
+                           cm/EMPTY)
+          prefix-score (if (pos? boundary)
+                         (reduce (fn [acc t] (mx/add acc (nth old-step-scores t)))
+                                 ZERO (range boundary))
+                         ZERO)
+          prefix-outputs (if (pos? boundary)
+                           (subvec (:outputs (:retval trace)) 0 boundary)
+                           [])
+          prefix-step-scores (if (pos? boundary)
+                               (subvec (vec old-step-scores) 0 boundary)
+                               [])
+          prefix-step-carries (if (pos? boundary)
+                                (subvec (vec old-step-carries) 0 boundary)
+                                [])
+          start-carry (if (pos? boundary)
+                        (nth old-step-carries (dec boundary))
+                        new-init-carry)
+          old-carry-at (fn [t threaded]
+                         (cond
+                           (zero? t) old-init-carry
+                           old-step-carries (nth old-step-carries (dec t))
+                           :else threaded))]
+      (loop [t boundary carry start-carry
+             new-choices prefix-choices score prefix-score nf prefix-score
+             discard cm/EMPTY
+             outputs prefix-outputs
+             step-scores prefix-step-scores step-carries prefix-step-carries
+             st :joint]
+        (if (>= t new-n)
+          (let [discard (reduce (fn [d j]
+                                  (cm/set-choice d [j] (cm/get-submap choices j)))
+                                discard (range new-n old-n))]
+            {:trace (tr/with-score-type
+                      (with-meta
+                        (tr/make-trace {:gen-fn this :args new-args
+                                        :choices new-choices
+                                        :retval {:carry carry :outputs outputs}
+                                        :score score})
+                        {::step-scores step-scores ::step-carries step-carries})
+                      st)
+             :weight (mx/subtract nf (:score trace))
+             :discard discard})
+          (let [kernel-args [carry (nth new-inputs t)]
+                sub-constraints (cm/get-submap constraints t)]
+            (if (< t old-n)
+              ;; Kept step
+              (let [c-old (if old-step-scores (nth old-step-scores t) ZERO)
+                    old-sub (tr/make-trace
+                              {:gen-fn kern
+                               :args [(old-carry-at t carry) (nth old-inputs t)]
+                               :choices (cm/get-submap choices t)
+                               :retval nil :score c-old})
+                    result (p/update-with-args kern old-sub kernel-args
+                                               :unknown sub-constraints)
+                    ntr (:trace result)
+                    [new-carry output] (:retval ntr)]
+                (recur (inc t) new-carry
+                       (cm/set-choice new-choices [t] (:choices ntr))
+                       (mx/add score (:score ntr))
+                       (mx/add nf (mx/add (:weight result) c-old))
+                       (if (and (:discard result) (not= (:discard result) cm/EMPTY))
+                         (cm/set-choice discard [t] (:discard result))
+                         discard)
+                       (conj outputs output)
+                       (conj step-scores (:score ntr))
+                       (conj step-carries new-carry)
+                       (tr/combine-score-types st (tr/score-type ntr))))
+              ;; Fresh step
+              (let [result (p/generate kern kernel-args sub-constraints)
+                    ntr (:trace result)
+                    [new-carry output] (:retval ntr)]
+                (recur (inc t) new-carry
+                       (cm/set-choice new-choices [t] (:choices ntr))
+                       (mx/add score (:score ntr))
+                       (mx/add nf (:weight result))
+                       discard
+                       (conj outputs output)
+                       (conj step-scores (:score ntr))
+                       (conj step-carries new-carry)
+                       (tr/combine-score-types st (tr/score-type ntr)))))))))))
+
+(extend-type SwitchCombinator
+  p/IUpdateWithArgs
+  (update-with-args [this trace new-args argdiffs constraints]
+    (let [trace (ensure-joint-self this :update trace)
+          [new-idx & new-bargs] new-args
+          old-idx (or (::switch-idx (meta trace)) (first (:args trace)))]
+      (if (= old-idx new-idx)
+        ;; Same branch: delegate with the TRUE old score, so the child's
+        ;; thesis weight is the Switch weight directly.
+        (let [branch (ensure-kernel-key (nth (:branches this) new-idx))
+              old-branch-trace (tr/make-trace
+                                 {:gen-fn branch :args (vec (rest (:args trace)))
+                                  :choices (:choices trace)
+                                  :retval (:retval trace) :score (:score trace)})
+              result (p/update-with-args branch old-branch-trace (vec new-bargs)
+                                         :unknown constraints)
+              nbt (:trace result)]
+          {:trace (tag-from-traces
+                    (with-meta
+                      (tr/make-trace {:gen-fn this :args new-args
+                                      :choices (:choices nbt)
+                                      :retval (:retval nbt)
+                                      :score (:score nbt)})
+                      {::switch-idx new-idx})
+                    [nbt])
+           :weight (:weight result) :discard (:discard result)})
+        ;; Branch flip: generate the new branch; the removed branch is
+        ;; charged via its recorded score and discarded whole.
+        (let [new-branch (ensure-kernel-key (nth (:branches this) new-idx))
+              gen-result (p/generate new-branch (vec new-bargs) constraints)
+              nbt (:trace gen-result)]
+          {:trace (tag-from-traces
+                    (with-meta
+                      (tr/make-trace {:gen-fn this :args new-args
+                                      :choices (:choices nbt)
+                                      :retval (:retval nbt)
+                                      :score (:score nbt)})
+                      {::switch-idx new-idx})
+                    [nbt])
+           :weight (mx/subtract (:weight gen-result) (:score trace))
+           :discard (:choices trace)})))))
+
+(extend-type ContramapGF
+  p/IUpdateWithArgs
+  (update-with-args [this trace new-args argdiffs constraints]
+    ;; argdiffs describe the PRE-transform args; after f they are :unknown.
+    (let [inner (ensure-kernel-key (:inner this))
+          old-inner-args ((:f this) (:args trace))
+          new-inner-args ((:f this) new-args)
+          inner-trace (tr/with-score-type
+                        (tr/make-trace {:gen-fn inner :args old-inner-args
+                                        :choices (:choices trace)
+                                        :retval (:retval trace) :score (:score trace)})
+                        (tr/score-type trace))
+          result (p/update-with-args inner inner-trace new-inner-args
+                                     :unknown constraints)]
+      {:trace (tr/with-score-type
+                (tr/make-trace {:gen-fn this :args new-args
+                                :choices (:choices (:trace result))
+                                :retval (:retval (:trace result))
+                                :score (:score (:trace result))})
+                (tr/score-type (:trace result)))
+       :weight (:weight result) :discard (:discard result)})))
+
+(extend-type MapRetvalGF
+  p/IUpdateWithArgs
+  (update-with-args [this trace new-args argdiffs constraints]
+    (let [inner (ensure-kernel-key (:inner this))
+          inner-trace (tr/with-score-type
+                        (tr/make-trace {:gen-fn inner :args (:args trace)
+                                        :choices (:choices trace)
+                                        :retval (:retval trace) :score (:score trace)})
+                        (tr/score-type trace))
+          result (p/update-with-args inner inner-trace new-args
+                                     argdiffs constraints)]
+      {:trace (tr/with-score-type
+                (tr/make-trace {:gen-fn this :args new-args
+                                :choices (:choices (:trace result))
+                                :retval ((:g this) (:retval (:trace result)))
+                                :score (:score (:trace result))})
+                (tr/score-type (:trace result)))
+       :weight (:weight result) :discard (:discard result)})))
+
+(extend-type MaskCombinator
+  p/IUpdateWithArgs
+  (update-with-args [this trace new-args argdiffs constraints]
+    (throw-update-with-args-unsupported this)))
+
+(extend-type MixCombinator
+  p/IUpdateWithArgs
+  (update-with-args [this trace new-args argdiffs constraints]
+    (throw-update-with-args-unsupported this)))
+
+(extend-type RecurseCombinator
+  p/IUpdateWithArgs
+  (update-with-args [this trace new-args argdiffs constraints]
+    (throw-update-with-args-unsupported this)))
+
+;; ---------------------------------------------------------------------------
 ;; IProject implementations
 ;; ---------------------------------------------------------------------------
 

--- a/src/genmlx/diff.cljs
+++ b/src/genmlx/diff.cljs
@@ -1,8 +1,14 @@
 (ns genmlx.diff
   "Change-tagged values for incremental computation.
-   Argdiffs and retdiffs enable `update` to skip unchanged computation,
+   Argdiffs enable update/update-with-args to skip unchanged computation,
    which is critical for MCMC performance where each MH step only changes
-   one or a few addresses.")
+   one or a few addresses, and for combinator updates over long sequences.
+
+   An argdiff is a caller ASSERTION about which arguments changed (the
+   Gen.jl trust model): :unknown (or any unrecognized value) is always
+   sound and forces full re-execution; no-change permits the identity
+   fast path; vector-diff lets Map/Scan-style combinators skip elements
+   whose indices are not in :changed.")
 
 ;; ---------------------------------------------------------------------------
 ;; Diff types
@@ -14,8 +20,9 @@
 
 (defn vector-diff
   "Argdiff for a vector argument where only the elements whose indices are
-   in `changed` (a set of ints) may differ. Map-style combinators dispatch
-   on this to update only the changed elements (update-with-diffs)."
+   in `changed` (a set of ints) may differ. Map/Scan combinators dispatch
+   on this (update-with-diffs / update-with-args) to retain unchanged
+   elements verbatim."
   [changed]
   {:diff-type :vector-diff :changed (set changed)})
 

--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -159,7 +159,11 @@
         trace (make-result-trace gf args result)]
     (make-generate-result trace (:weight result) constraints (:choices result) result)))
 
-(defn- run-update [transition gf _args key {:keys [trace constraints]}]
+(defn- run-update
+  "args is the execution-time argument vector: (:args trace) for plain
+   update, the thesis x' for update-with-args. Retained/constrained sites
+   are re-scored under it; the result trace carries it."
+  [transition gf args key {:keys [trace constraints]}]
   (let [result (rt/run-handler transition
                  {:choices cm/EMPTY :score SCORE-ZERO :weight SCORE-ZERO
                   :key key :constraints constraints
@@ -168,8 +172,8 @@
                   :old-nested-splice-scores (::nested-splice-scores (meta trace))
                   :discard cm/EMPTY
                   :executor execute-sub :param-store (param-store gf)}
-                 (fn [rt] (run-body gf rt (:args trace))))
-        new-trace (make-result-trace gf (:args trace) result)]
+                 (fn [rt] (run-body gf rt args)))
+        new-trace (make-result-trace gf args result)]
     ;; Thesis update weight: non-fresh score (handler :weight) minus the
     ;; recorded old score. Freshly sampled new addresses are drawn from the
     ;; internal proposal and cancel — score-delta would wrongly include them.
@@ -239,10 +243,14 @@
     {:trace (make-compiled-trace gf args result)
      :weight (:weight result)}))
 
-(defn- run-update-compiled [gf _args key {:keys [trace constraints]}]
+(defn- run-update-compiled
+  "Static models have a fixed address set (no fresh/removed sites), so the
+   thesis weight under execution args (x' for update-with-args) reduces to
+   score' - score."
+  [gf args key {:keys [trace constraints]}]
   (let [cfn (:compiled-update (:schema gf))
-        result (cfn key (vec (:args trace)) constraints (:choices trace))]
-    {:trace (make-compiled-trace gf (:args trace) result)
+        result (cfn key (vec args) constraints (:choices trace))]
+    {:trace (make-compiled-trace gf args result)
      :weight (mx/subtract (:score result) (:score trace))
      :discard (cm/from-flat-map (:discard result))}))
 
@@ -288,21 +296,22 @@
     (make-generate-result trace (:weight handler-result) constraints
                           (:choices handler-result) handler-result)))
 
-(defn- run-update-prefix [gf _args key {:keys [trace constraints]}]
+(defn- run-update-prefix [gf args key {:keys [trace constraints]}]
   (let [pfx (:compiled-prefix-update (:schema gf))
-        result (pfx key (vec (:args trace)) constraints (:choices trace))
+        result (pfx key (vec args) constraints (:choices trace))
         replay (cops/make-replay-update-transition (:values result))
         ;; Prefix sites never sample fresh (values come from constraints or
-        ;; old choices), so the prefix score seeds the non-fresh :weight
-        ;; accumulator as well as :score.
+        ;; old choices — the static prefix's address set is arg-independent),
+        ;; so the prefix score seeds the non-fresh :weight accumulator as
+        ;; well as :score.
         handler-result (rt/run-handler replay
                          {:choices cm/EMPTY :score (:score result)
                           :weight (:score result) :key key :constraints constraints
                           :old-choices (:choices trace) :discard (cm/from-flat-map (:discard result))
                           :old-nested-splice-scores (::nested-splice-scores (meta trace))
                           :executor execute-sub :param-store (param-store gf)}
-                         (fn [rt] (run-body gf rt (:args trace))))
-        new-trace (make-result-trace gf (:args trace) handler-result)]
+                         (fn [rt] (run-body gf rt args)))
+        new-trace (make-result-trace gf args handler-result)]
     (make-update-result new-trace
       (mx/subtract (:weight handler-result) (:score trace))
       (:discard handler-result) constraints (:choices handler-result) handler-result)))
@@ -1034,11 +1043,11 @@
       (vec/->VectorizedTrace gf args (:choices result) (:score result)
                              (:weight result) n (:retval result)))))
 
-(defn vupdate
-  "Batched update: run model body ONCE with batched update handler.
-   vtrace: VectorizedTrace with [n]-shaped choices, constraints: new observations.
-   Returns new VectorizedTrace with updated weights."
-  [gf vtrace constraints key]
+(defn- vupdate*
+  "Shared batched-update core: run the model body ONCE with the batched
+   update handler under exec-args ((:args vtrace) for vupdate, the thesis
+   x' for vupdate-args) and stamp the result vtrace with them."
+  [gf vtrace exec-args constraints key]
   (let [key (rng/ensure-key key)
 
         n (:n-particles vtrace)
@@ -1051,16 +1060,31 @@
                                 :batch-size n :batched? true
                                 :executor execute-sub
                                 :param-store (param-store gf)}
-                               (fn [rt] (run-body gf rt (:args vtrace))))
+                               (fn [rt] (run-body gf rt exec-args)))
         ;; Thesis update weight: non-fresh score minus old [N]-shaped score —
         ;; the same convention as the scalar run-update path.
         weight (mx/subtract (:weight result) (:score vtrace))]
     {:vtrace (tag-vtrace
-               (vec/->VectorizedTrace gf (:args vtrace) (:choices result)
+               (vec/->VectorizedTrace gf exec-args (:choices result)
                                       (:score result) weight
                                       n (:retval result)))
      :weight weight
      :discard (:discard result)}))
+
+(defn vupdate
+  "Batched update: run model body ONCE with batched update handler.
+   vtrace: VectorizedTrace with [n]-shaped choices, constraints: new observations.
+   Returns new VectorizedTrace with updated weights."
+  [gf vtrace constraints key]
+  (vupdate* gf vtrace (:args vtrace) constraints key))
+
+(defn vupdate-args
+  "Batched update-with-args (genmlx-s8e8): vupdate under NEW model
+   arguments. Retained [n]-shaped choices are re-scored under new-args;
+   the weight is the [n]-shaped thesis update weight. Batch size is
+   fixed — changing n is out of scope."
+  [gf vtrace new-args constraints key]
+  (vupdate* gf vtrace new-args constraints key))
 
 (defn vregenerate
   "Batched regenerate: run model body ONCE with batched regenerate handler.
@@ -1114,13 +1138,27 @@
   (edit [gf trace edit-request]
     (edit/edit-dispatch gf trace edit-request))
 
+  p/IUpdateWithArgs
+  (update-with-args [gf trace new-args argdiffs constraints]
+    (if (and (diff/no-change? argdiffs) (= constraints cm/EMPTY))
+      ;; Caller asserts no arg changes (Gen.jl trust model) and there are
+      ;; no constraints: the trace is unchanged.
+      {:trace trace :weight SCORE-ZERO :discard cm/EMPTY}
+      ;; Re-execute under x' — same dispatch as update (compiled/prefix/
+      ;; handler all thread the positional args), same lbae score-type
+      ;; boundary guard in run-dispatched*, same deleted-address discard
+      ;; post-pass.
+      (let [key (ensure-key gf)
+            result (@dispatch-fn gf :update new-args key
+                     {:trace trace :constraints constraints :argdiffs argdiffs})]
+        (mx/gfi-cleanup!)
+        (clojure.core/update result :discard
+          add-deleted-to-discard (:choices trace) (:choices (:trace result))))))
+
   p/IUpdateWithDiffs
   (update-with-diffs [gf trace constraints argdiffs]
-    (if (and (diff/no-change? argdiffs) (= constraints cm/EMPTY))
-      ;; No arg changes and no constraints: trace is unchanged
-      {:trace trace :weight SCORE-ZERO :discard cm/EMPTY}
-      ;; Otherwise delegate to regular update (body must be re-executed)
-      (p/update gf trace constraints)))
+    ;; update with change hints = update-with-args at unchanged args
+    (p/update-with-args gf trace (:args trace) argdiffs constraints))
 
   p/IHasArgumentGrads
   (has-argument-grads [_] nil))

--- a/src/genmlx/edit.cljs
+++ b/src/genmlx/edit.cljs
@@ -23,6 +23,10 @@
 ;; forward-gf proposes new choices, backward-gf scores the reverse move
 (defrecord ProposalEdit [forward-gf forward-args backward-gf backward-args])
 
+;; Equivalent to update-with-args: change model arguments and constraints
+;; (genmlx-s8e8, the thesis x' parameter)
+(defrecord ArgsUpdateEdit [new-args argdiffs constraints])
+
 ;; Constructors
 (defn constraint-edit
   "Create a ConstraintEdit (equivalent to update)."
@@ -33,6 +37,14 @@
   "Create a SelectionEdit (equivalent to regenerate)."
   [selection]
   (->SelectionEdit selection))
+
+(defn args-update-edit
+  "Create an ArgsUpdateEdit (equivalent to update-with-args).
+   argdiffs defaults to :unknown — always sound, forces full re-execution."
+  ([new-args constraints]
+   (->ArgsUpdateEdit new-args :unknown constraints))
+  ([new-args argdiffs constraints]
+   (->ArgsUpdateEdit new-args argdiffs constraints)))
 
 (defn proposal-edit
   "Create a ProposalEdit for SMCP3-style reversible kernels."
@@ -99,6 +111,31 @@
         discard (discard-of result)]
     (assoc result
            :backward-request (->ConstraintEdit discard))))
+
+(defmethod edit-dispatch ArgsUpdateEdit
+  [gf trace edit-request]
+  (let [{:keys [new-args argdiffs constraints]} edit-request
+        old-args (:args trace)
+        result (cond
+                 (satisfies? p/IUpdateWithArgs gf)
+                 (p/update-with-args gf trace new-args argdiffs constraints)
+
+                 ;; Unchanged args: plain update covers it
+                 (= new-args old-args)
+                 (p/update gf trace constraints)
+
+                 :else
+                 (throw (ex-info
+                          (str "update-with-args not supported by this"
+                               " generative function (and args changed)")
+                          {:genmlx/error :update-with-args-unsupported
+                           :gf-type (type gf)})))
+        discard (discard-of result)]
+    (assoc result
+           :discard discard
+           ;; Backward: restore the old args, re-constrain from the discard.
+           ;; argdiffs are not invertible in general; :unknown is always sound.
+           :backward-request (->ArgsUpdateEdit old-args :unknown discard))))
 
 (defmethod edit-dispatch SelectionEdit
   [gf trace edit-request]

--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -80,6 +80,15 @@
 ;; Return all leaf address paths from a choicemap.
 (def ^:private all-leaf-addrs cm/addresses)
 
+(defn- log-gauss
+  "Hand-derived gaussian log-density on JS numbers — the independent
+   oracle for the update-with-args weight laws (never computed through
+   genmlx's own dist code)."
+  [x mu sigma]
+  (- (* -0.5 (js/Math.log (* 2 js/Math.PI)))
+     (js/Math.log sigma)
+     (* 0.5 (js/Math.pow (/ (- x mu) sigma) 2))))
+
 (defn strip-compiled
   "Return a copy of model with all alternate execution paths removed from its
    schema — full-compile, prefix, and analytical — forcing the handler
@@ -698,6 +707,160 @@
                (and (approx= (ev (:weight upd)) (ev (:weight uwd)) 1e-6)
                     (approx= (ev (:score (:trace upd)))
                              (ev (:score (:trace uwd))) 1e-6))))}
+
+   ;; ===================================================================
+   ;; UPDATE-WITH-ARGS laws [T] §2.3.1 (the thesis x' parameter, genmlx-s8e8)
+   ;; ===================================================================
+
+   {:name :update-args-noop
+    :from "[T] §2.3.1 UPDATE (x' = x degenerate case)"
+    :theorem "update-with-args(P, t, x, :unknown, sigma) at the trace's own
+              args produces identical weight and score to update(P, t, sigma)."
+    :tags #{:update :update-args :core}
+    :check (fn [{:keys [model args]}]
+             (if-not (satisfies? p/IUpdateWithArgs model)
+               true
+               (let [t1 (p/simulate model args)
+                     sigma (:choices (p/simulate model args))
+                     upd (p/update model t1 sigma)
+                     uwa (p/update-with-args model t1 args :unknown sigma)]
+                 (and (approx= (ev (:weight upd)) (ev (:weight uwa)) 1e-6)
+                      (approx= (ev (:score (:trace upd)))
+                               (ev (:score (:trace uwa))) 1e-6)))))}
+
+   {:name :update-args-weight-is-density-ratio
+    :from "[T] §2.3.1 UPDATE weight, structure-preserving case"
+    :theorem "When the address set is unchanged, the update-with-args weight
+              equals log p(t'; x') - log p(t; x) — checked both against
+              assess on the same choices and against a hand-derived gaussian
+              closed form (independent oracle).
+              Self-contained: x ~ N(m,1); y ~ N(x,1), m: 0 -> 1.5."
+    :tags #{:update :update-args :core}
+    :check (fn [_]
+             (let [model (dyn/auto-key
+                          (dyn/make-gen-fn
+                           (fn [rt m]
+                             (let [trace (.-trace rt)
+                                   x (trace :x (dist/gaussian m 1))]
+                               (trace :y (dist/gaussian x 1))
+                               x))
+                           '([m] (let [x (trace :x (dist/gaussian m 1))]
+                                   (trace :y (dist/gaussian x 1))
+                                   x))))
+                   t (p/simulate model [0.0])
+                   x (choice-num (:choices t) :x)
+                   r (p/update-with-args model t [1.5] :unknown cm/EMPTY)
+                   w (ev (:weight r))
+                   a-new (ev (:weight (p/assess model [1.5] (:choices (:trace r)))))
+                   a-old (ev (:weight (p/assess model [0.0] (:choices t))))
+                   oracle (- (log-gauss x 1.5 1) (log-gauss x 0.0 1))]
+               (and (approx= w (- a-new a-old) 1e-4)
+                    (approx= w oracle 1e-4)
+                    (= [1.5] (:args (:trace r))))))}
+
+   {:name :update-args-roundtrip
+    :from "[T] §2.3.1 UPDATE invertibility (ArgsUpdateEdit backward request)"
+    :theorem "For a structure-preserving args change, applying the backward
+              ArgsUpdateEdit to the updated trace restores the original
+              choices and negates the weight."
+    :tags #{:update :update-args :edit}
+    :check (fn [_]
+             (let [model (dyn/auto-key
+                          (dyn/make-gen-fn
+                           (fn [rt m]
+                             (let [trace (.-trace rt)
+                                   x (trace :x (dist/gaussian m 1))]
+                               (trace :y (dist/gaussian x 1))
+                               x))
+                           '([m] (let [x (trace :x (dist/gaussian m 1))]
+                                   (trace :y (dist/gaussian x 1))
+                                   x))))
+                   t (p/simulate model [0.0])
+                   fwd (edit/edit model t (edit/args-update-edit [2.0] cm/EMPTY))
+                   bwd (edit/edit model (:trace fwd) (:backward-request fwd))]
+               (and (approx= (ev (:weight bwd)) (- (ev (:weight fwd))) 1e-4)
+                    (approx= (choice-num (:choices (:trace bwd)) :x)
+                             (choice-num (:choices t) :x) 1e-6)
+                    (= [0.0] (:args (:trace bwd))))))}
+
+   {:name :update-args-compiled-parity
+    :from "[T] §2.3.1; GenMLX compiled-path equivalence (handler = ground truth)"
+    :theorem "On a static (L1-compiled) model, update-with-args through the
+              compiled path produces the same weight and score as through
+              the forced handler path."
+    :tags #{:update :update-args :compiled}
+    :check (fn [_]
+             (let [mk #(dyn/auto-key
+                        (dyn/make-gen-fn
+                         (fn [rt m]
+                           (let [trace (.-trace rt)
+                                 x (trace :x (dist/gaussian m 1))]
+                             (trace :y (dist/gaussian x 1))
+                             x))
+                         '([m] (let [x (trace :x (dist/gaussian m 1))]
+                                 (trace :y (dist/gaussian x 1))
+                                 x))))
+                   compiled (mk)
+                   stripped (strip-compiled (mk))
+                   t-c (p/simulate compiled [0.0])
+                   t-h (:trace (p/generate stripped [0.0] (:choices t-c)))
+                   r-c (p/update-with-args compiled t-c [1.0] :unknown cm/EMPTY)
+                   r-h (p/update-with-args stripped t-h [1.0] :unknown cm/EMPTY)]
+               (and (approx= (ev (:weight r-c)) (ev (:weight r-h)) 1e-4)
+                    (approx= (ev (:score (:trace r-c)))
+                             (ev (:score (:trace r-h))) 1e-4))))}
+
+   {:name :unfold-extend-equivalence
+    :from "GenMLX unfold-extend contract (the n' = n+1 special case)"
+    :theorem "unfold-extend(t, sigma, k) and update-with-args(t, [n+1 init],
+              :unknown, {n: sigma}) agree on weight and extended score when
+              the new step is fully constrained (both paths deterministic)."
+    :tags #{:update :update-args :combinator}
+    :check (fn [_]
+             (let [kern (dyn/auto-key
+                         (dyn/make-gen-fn
+                          (fn [rt t prev]
+                            (let [trace (.-trace rt)]
+                              (trace :s (dist/gaussian prev 1))))
+                          '([t prev] (trace :s (dist/gaussian prev 1)))))
+                   unf (comb/unfold-combinator kern)
+                   t (p/simulate unf [3 0.0])
+                   sigma (cm/choicemap :s (mx/scalar 1.0))
+                   ext (comb/unfold-extend t sigma (rng/fresh-key 41))
+                   r (p/update-with-args unf t [4 0.0] :unknown
+                                         (cm/set-choice cm/EMPTY [3] sigma))]
+               (and (approx= (ev (:weight ext)) (ev (:weight r)) 1e-4)
+                    (approx= (ev (:score (:trace ext)))
+                             (ev (:score (:trace r))) 1e-4))))}
+
+   {:name :update-args-structure-change
+    :from "[T] §2.3.1 UPDATE weight, address set changed by x'"
+    :theorem "When new args remove an address, its value lands in the
+              discard and the weight charges exactly its old log-prob
+              (hand-derived oracle). Self-contained: mu ~ N(0,1);
+              y_i ~ N(mu,1) for i < n, n: 2 -> 1."
+    :tags #{:update :update-args :core}
+    :check (fn [_]
+             (let [model (dyn/auto-key
+                          (dyn/make-gen-fn
+                           (fn [rt n]
+                             (let [trace (.-trace rt)
+                                   mu (trace :mu (dist/gaussian 0 1))]
+                               (doseq [i (range n)]
+                                 (trace (keyword (str "y" i)) (dist/gaussian mu 1)))
+                               mu))
+                           '([n] (let [mu (trace :mu (dist/gaussian 0 1))]
+                                   (doseq [i (range n)]
+                                     (trace (keyword (str "y" i)) (dist/gaussian mu 1)))
+                                   mu))))
+                   {t :trace} (p/generate model [2]
+                                          (cm/choicemap :y0 (mx/scalar 1.0)
+                                                        :y1 (mx/scalar -1.0)))
+                   mu (choice-num (:choices t) :mu)
+                   r (p/update-with-args model t [1] :unknown cm/EMPTY)]
+               (and (approx= (ev (:weight r)) (- (log-gauss -1.0 mu 1)) 1e-4)
+                    (approx= (ev (cm/get-choice (:discard r) [:y1])) -1.0 1e-6)
+                    (nil? (cm/get-choice (:choices (:trace r)) [:y1])))))}
 
    ;; ===================================================================
    ;; GRADIENT laws [T] Eq 2.12, §2.3.1

--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -753,10 +753,22 @@
                    w (ev (:weight r))
                    a-new (ev (:weight (p/assess model [1.5] (:choices (:trace r)))))
                    a-old (ev (:weight (p/assess model [0.0] (:choices t))))
-                   oracle (- (log-gauss x 1.5 1) (log-gauss x 0.0 1))]
+                   oracle (- (log-gauss x 1.5 1) (log-gauss x 0.0 1))
+                   ;; Batched leg: vupdate-args [N] weights match the same
+                   ;; hand-derived ratio per particle.
+                   n 8
+                   vt (dyn/vsimulate model [0.0] n (rng/fresh-key 43))
+                   xs (mx/->clj (choice-val (:choices vt) :x))
+                   vw (mx/->clj (:weight (dyn/vupdate-args model vt [1.5] cm/EMPTY
+                                                           (rng/fresh-key 44))))]
                (and (approx= w (- a-new a-old) 1e-4)
                     (approx= w oracle 1e-4)
-                    (= [1.5] (:args (:trace r))))))}
+                    (= [1.5] (:args (:trace r)))
+                    (= n (count vw))
+                    (every? (fn [[xi wi]]
+                              (approx= wi (- (log-gauss xi 1.5 1)
+                                             (log-gauss xi 0.0 1)) 1e-3))
+                            (map vector xs vw)))))}
 
    {:name :update-args-roundtrip
     :from "[T] §2.3.1 UPDATE invertibility (ArgsUpdateEdit backward request)"

--- a/src/genmlx/inference/smc.cljs
+++ b/src/genmlx/inference/smc.cljs
@@ -203,11 +203,14 @@
   "Subsequent timestep: resample (if ESS low), update particles, rejuvenate.
    cfg holds the fixed per-filter config (:model :particles :ess-threshold
    :rejuvenation-steps :rejuvenation-selection :resample-method); the remaining
-   positional args are the per-step loop state.
+   positional args are the per-step loop state. step-spec (nilable) carries
+   per-step model arguments {:args :argdiffs} — when present the particle
+   advance is update-with-args under those args (genmlx-s8e8), otherwise
+   plain update at the trace's own args.
    Returns {:traces :log-weights :log-ml-increment}."
   [{:keys [model particles ess-threshold rejuvenation-steps
            rejuvenation-selection resample-method]}
-   traces log-weights obs key]
+   traces log-weights obs key step-spec]
   (let [;; Check ESS and resample if needed
         ess        (u/compute-ess log-weights)
         resample?  (< ess (* ess-threshold particles))
@@ -225,10 +228,14 @@
         update-keys   (rng/split-n-or-nils update-key particles)
         results       (mapv (fn [i ki trace]
                               (break-particle-graph!
-                               (p/update (if ki
-                                           (dyn/with-key (:gen-fn trace) ki)
-                                           (:gen-fn trace))
-                                         trace obs)
+                               (let [gf (if ki
+                                          (dyn/with-key (:gen-fn trace) ki)
+                                          (:gen-fn trace))]
+                                 (if step-spec
+                                   (p/update-with-args gf trace (:args step-spec)
+                                                       (:argdiffs step-spec :unknown)
+                                                       obs)
+                                   (p/update gf trace obs)))
                                i))
                             (range) update-keys traces')
         new-traces    (mapv :trace results)
@@ -306,11 +313,70 @@
                              :rejuvenation-steps rejuvenation-steps
                              :rejuvenation-selection rejuvenation-selection
                              :resample-method resample-method}
-                            traces log-weights obs-t step-key)]
+                            traces log-weights obs-t step-key nil)]
               (when callback
                 (callback {:step t :ess ess :resampled? resampled?}))
               (recur (inc t) traces log-weights
                      (mx/add log-ml log-ml-increment) next-key))))))))
+
+(defn smc-args
+  "SMC with changing arguments (genmlx-s8e8): a generic particle filter
+   over a sequence of {:args :constraints :argdiffs?} steps — standard
+   SMC for growing data without combinator-specific machinery.
+
+   Step 0 initializes particles by constrained generate under its args;
+   each later step advances every particle via update-with-args, so the
+   per-particle increment is the thesis update weight
+   nonfresh(t'; args_t) - score(t; args_(t-1)) — exactly the incremental
+   importance weight when the new data site is constrained.
+
+   opts: {:particles N :ess-threshold ratio :resample-method method
+          :rejuvenation-steps K :rejuvenation-selection sel :key prng-key}
+
+   Returns {:log-ml MLX-scalar :traces [Trace ...] :log-weights [...]
+            :final-ess number}; :final-ess is the post-update ESS at the
+   final step (the honest particle-collapse diagnostic). nil when steps
+   is empty."
+  [{:keys [particles ess-threshold rejuvenation-steps rejuvenation-selection
+           resample-method key]
+    :or {particles 100 ess-threshold 0.5 rejuvenation-steps 0}}
+   model steps]
+  (let [model (-> model dyn/auto-key strip-analytical)
+        steps-vec (vec steps)
+        n-steps (count steps-vec)
+        ;; Default: rejuvenate only the latents — never the observed
+        ;; addresses (genmlx-7ca0), collected across ALL steps.
+        rejuvenation-selection
+        (or rejuvenation-selection
+            (sel/complement-sel
+              (sel/from-paths
+                (mapcat (comp cm/addresses :constraints) steps-vec))))]
+    (when (pos? n-steps)
+      (loop [t 0
+             traces nil
+             log-weights nil
+             log-ml (mx/scalar 0.0)
+             rk key]
+        (if (>= t n-steps)
+          {:log-ml log-ml :traces traces :log-weights log-weights
+           :final-ess (u/compute-ess log-weights)}
+          (let [{args-t :args obs-t :constraints :as step} (nth steps-vec t)
+                obs-t (or obs-t cm/EMPTY)
+                [step-key next-key] (rng/split-or-nils rk)
+                _ (when (pos? t) (mx/sweep-dead-arrays!))
+                _ (when (and (pos? t) (zero? (mod t 5))) (mx/clear-cache!))
+                {:keys [traces log-weights log-ml-increment]}
+                (if (zero? t)
+                  (smc-init-step model args-t obs-t particles step-key)
+                  (smc-step {:model model :particles particles
+                             :ess-threshold ess-threshold
+                             :rejuvenation-steps rejuvenation-steps
+                             :rejuvenation-selection rejuvenation-selection
+                             :resample-method resample-method}
+                            traces log-weights obs-t step-key
+                            {:args args-t :argdiffs (:argdiffs step :unknown)}))]
+            (recur (inc t) traces log-weights
+                   (mx/add log-ml log-ml-increment) next-key)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Conditional SMC (cSMC) for particle MCMC / PMCMC

--- a/src/genmlx/protocols.cljs
+++ b/src/genmlx/protocols.cljs
@@ -1,6 +1,6 @@
 (ns genmlx.protocols
   "GFI (Generative Function Interface) protocol definitions.
-   Ten single-operation protocols. There are no protocol-level defaults: each
+   Eleven single-operation protocols. There are no protocol-level defaults: each
    generative function implements the operations it supports (simulate is the
    conceptual primitive; the generic run-* dispatch logic lives in the handler).")
 
@@ -40,6 +40,17 @@
   (update-with-diffs [gf trace constraints argdiffs]
     "Update a trace with change hints. argdiffs describes which arguments changed.
      Enables combinators to skip unchanged sub-computations.
+     Equivalent to update-with-args with new-args = (:args trace).
+     Returns {:trace Trace :weight MLX-scalar :discard ChoiceMap}."))
+
+(defprotocol IUpdateWithArgs
+  (update-with-args [gf trace new-args argdiffs constraints]
+    "Update a trace while the model arguments change (thesis x').
+     Retained choices are re-scored under the new arguments; fresh sites
+     cancel; removed sites are charged via the old score and discarded.
+     Weight: nonfresh-score(t'; x') - score(t; x).
+     argdiffs: genmlx.diff/no-change | genmlx.diff/vector-diff | :unknown —
+     a caller assertion about which arguments changed (trusted, Gen.jl-style).
      Returns {:trace Trace :weight MLX-scalar :discard ChoiceMap}."))
 
 (defprotocol IHasArgumentGrads

--- a/test/genmlx/update_args_test.cljs
+++ b/test/genmlx/update_args_test.cljs
@@ -1,0 +1,615 @@
+;; @tier medium
+(ns genmlx.update-args-test
+  "genmlx-s8e8: GFI update with new arguments (thesis x' on IUpdate).
+
+   update-with-args re-executes a trace's model under NEW arguments:
+   retained choices are re-scored under the new dist params, fresh sites
+   cancel (internal proposal = prior), removed sites are charged via the
+   old score and land in the discard. Weight invariant:
+
+     w = nonfresh-score(t'; x') - score(t; x)
+
+   Structure-preserving corollary (what SMC over growing data uses):
+   no fresh/removed sites => w = assess(x', t') - assess(x, t) exactly.
+
+   Every numeric assertion here is checked against a hand-derived
+   closed-form oracle (log-normal-pdf below), never against the path
+   under test (independent-oracle rule, the ke9i lesson)."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.protocols :as p]
+            [genmlx.dynamic :as dyn]
+            [genmlx.gfi :as gfi]
+            [genmlx.trace :as tr]
+            [genmlx.dist :as dist]
+            [genmlx.diff :as diff]
+            [genmlx.edit :as edit]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.choicemap :as cm]
+            [genmlx.combinators :as comb]
+            [genmlx.inference.smc :as smc])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+;; ---------------------------------------------------------------------------
+;; Oracles and helpers
+;; ---------------------------------------------------------------------------
+
+(defn- log-normal-pdf
+  "Hand-derived gaussian log-density — the independent oracle."
+  [x mu sigma]
+  (- (* -0.5 (js/Math.log (* 2 js/Math.PI)))
+     (js/Math.log sigma)
+     (* 0.5 (js/Math.pow (/ (- x mu) sigma) 2))))
+
+(defn- close? [a b tol] (< (js/Math.abs (- a b)) tol))
+
+(defn- w-item [result] (mx/item (:weight result)))
+
+(defn- choice-at
+  "JS number at path in a trace's choices."
+  [trace path]
+  (mx/item (cm/get-choice (:choices trace) path)))
+
+(defn- unsupported-error?
+  "True iff (f) throws the update-with-args-unsupported contract error."
+  [f]
+  (try (f) false
+       (catch :default e
+         (= :update-with-args-unsupported (:genmlx/error (ex-data e))))))
+
+;; ---------------------------------------------------------------------------
+;; Models
+;; ---------------------------------------------------------------------------
+
+(defn- shift-model
+  "x ~ N(m,1); y ~ N(x,1) — static, structure-preserving under m change."
+  []
+  (gen [m]
+    (let [x (trace :x (dist/gaussian m 1))]
+      (trace :y (dist/gaussian x 1))
+      x)))
+
+(defn- grow-model
+  "mu ~ N(0,1); y_i ~ N(mu,1) for i < n — address set grows with n."
+  []
+  (gen [n]
+    (let [mu (trace :mu (dist/gaussian 0 1))]
+      (doseq [i (range n)]
+        (trace (keyword (str "y" i)) (dist/gaussian mu 1)))
+      mu)))
+
+(defn- prefix-model
+  "Static prefix + dynamic loop — exercises the L1-M3 prefix update path."
+  []
+  (gen [n]
+    (let [mu (trace :mu (dist/gaussian (mx/scalar 0) (mx/scalar 1)))]
+      (doseq [i (range n)]
+        (trace (keyword (str "y" i)) (dist/gaussian mu (mx/scalar 1))))
+      mu)))
+
+(defn- uniform-model
+  "u ~ U(0, hi) — support shrinks with hi."
+  []
+  (gen [hi]
+    (trace :u (dist/uniform 0 hi))))
+
+(defn- sub-model
+  "z ~ N(m,1) — spliced child."
+  []
+  (gen [m]
+    (trace :z (dist/gaussian m 1))))
+
+(defn- splice-model
+  "Parent passes a derived arg to the splice — new parent args must
+   propagate to the child through body re-execution alone."
+  [sub]
+  (gen [m]
+    (splice :sub sub (* 2 m))))
+
+;; ============================================================
+;; 1. No-op equivalence: new-args = old args === p/update
+;; ============================================================
+
+(deftest noop-equivalence-unconstrained
+  (let [k (rng/fresh-key 1)
+        model (dyn/with-key (shift-model) k)
+        t (p/simulate model [0.5])
+        upd (p/update (dyn/with-key (shift-model) (rng/fresh-key 2)) t cm/EMPTY)
+        uwa (p/update-with-args (dyn/with-key (shift-model) (rng/fresh-key 2))
+                                t [0.5] :unknown cm/EMPTY)]
+    (is (close? (mx/item (:score (:trace upd))) (mx/item (:score (:trace uwa))) 1e-6)
+        "same score as p/update")
+    (is (close? (w-item upd) (w-item uwa) 1e-6) "same weight as p/update")
+    (is (= (choice-at (:trace upd) [:x]) (choice-at (:trace uwa) [:x]))
+        "same retained :x")
+    (is (= [0.5] (:args (:trace uwa))) "trace args unchanged")))
+
+(deftest noop-equivalence-constrained
+  (let [model (dyn/with-key (shift-model) (rng/fresh-key 3))
+        t (p/simulate model [0.5])
+        sigma (cm/choicemap :y (mx/scalar 2.0))
+        upd (p/update (dyn/with-key (shift-model) (rng/fresh-key 4)) t sigma)
+        uwa (p/update-with-args (dyn/with-key (shift-model) (rng/fresh-key 4))
+                                t [0.5] :unknown sigma)]
+    (is (close? (w-item upd) (w-item uwa) 1e-6)
+        "constrained no-op matches p/update weight")
+    (is (close? (mx/item (cm/get-choice (:discard uwa) [:y]))
+                (choice-at t [:y]) 1e-6)
+        "discard carries the overwritten :y")))
+
+(deftest no-change-fast-path
+  (let [model (dyn/with-key (shift-model) (rng/fresh-key 5))
+        t (p/simulate model [0.5])
+        r (p/update-with-args model t [0.5] diff/no-change cm/EMPTY)]
+    (is (identical? t (:trace r)) "no-change + empty constraints returns the trace")
+    (is (zero? (mx/item (:weight r))) "zero weight")
+    (is (= cm/EMPTY (:discard r)) "empty discard")))
+
+;; ============================================================
+;; 2. Weight = density ratio under new args (the payload)
+;; ============================================================
+
+(deftest weight-is-density-ratio-unconstrained
+  (let [model (dyn/with-key (shift-model) (rng/fresh-key 7))
+        t (p/simulate model [0.0])
+        x (choice-at t [:x])
+        r (p/update-with-args model t [1.5] :unknown cm/EMPTY)
+        expected (- (log-normal-pdf x 1.5 1) (log-normal-pdf x 0.0 1))]
+    (is (close? (w-item r) expected 1e-5)
+        "w = log N(x;m',1) - log N(x;m,1), hand-derived")
+    (is (= [1.5] (:args (:trace r))) "new trace carries new args")
+    (is (close? (choice-at (:trace r) [:x]) x 1e-9) "x retained verbatim")
+    (is (close? (mx/item (:score (:trace r)))
+                (+ (log-normal-pdf x 1.5 1)
+                   (log-normal-pdf (choice-at t [:y]) x 1))
+                1e-5)
+        "new score is the full joint under new args")))
+
+(deftest weight-matches-assess-ratio
+  (let [model (dyn/with-key (shift-model) (rng/fresh-key 8))
+        t (p/simulate model [0.0])
+        r (p/update-with-args model t [2.0] :unknown cm/EMPTY)
+        a-new (mx/item (:weight (p/assess model [2.0] (:choices (:trace r)))))
+        a-old (mx/item (:weight (p/assess model [0.0] (:choices t))))]
+    (is (close? (w-item r) (- a-new a-old) 1e-5)
+        "structure-preserving: w = assess(x',t') - assess(x,t)")))
+
+(deftest weight-with-constraint-and-new-args
+  (let [model (dyn/with-key (shift-model) (rng/fresh-key 9))
+        t (p/simulate model [0.0])
+        x (choice-at t [:x])
+        y-old (choice-at t [:y])
+        r (p/update-with-args model t [1.0] :unknown
+                              (cm/choicemap :y (mx/scalar 3.0)))
+        nonfresh (+ (log-normal-pdf x 1.0 1) (log-normal-pdf 3.0 x 1))
+        old-score (+ (log-normal-pdf x 0.0 1) (log-normal-pdf y-old x 1))]
+    (is (close? (w-item r) (- nonfresh old-score) 1e-5)
+        "w = nonfresh(x') - score(t;x), both terms hand-derived")
+    (is (close? (choice-at (:trace r) [:y]) 3.0 1e-9) "constraint applied")
+    (is (close? (mx/item (cm/get-choice (:discard r) [:y])) y-old 1e-9)
+        "old :y in discard")))
+
+;; ============================================================
+;; 3. Fresh and removed sites (address set changes with args)
+;; ============================================================
+
+(deftest fresh-site-constrained
+  (let [model (dyn/with-key (grow-model) (rng/fresh-key 11))
+        {t :trace} (p/generate model [2] (cm/choicemap :y0 (mx/scalar 1.0)
+                                                       :y1 (mx/scalar -1.0)))
+        mu (choice-at t [:mu])
+        r (p/update-with-args model t [3] :unknown
+                              (cm/choicemap :y2 (mx/scalar 0.5)))]
+    (is (close? (w-item r) (log-normal-pdf 0.5 mu 1) 1e-5)
+        "constrained fresh site contributes exactly its new log-prob")
+    (is (close? (choice-at (:trace r) [:y2]) 0.5 1e-9) "new site present")))
+
+(deftest fresh-site-unconstrained-cancels
+  (let [model (dyn/with-key (grow-model) (rng/fresh-key 12))
+        {t :trace} (p/generate model [1] (cm/choicemap :y0 (mx/scalar 1.0)))
+        r (p/update-with-args model t [2] :unknown cm/EMPTY)]
+    (is (close? (w-item r) 0.0 1e-5)
+        "unconstrained fresh site cancels: retained dists unchanged => w = 0")
+    (is (some? (cm/get-choice (:choices (:trace r)) [:y1]))
+        "fresh :y1 was sampled")))
+
+(deftest removed-site-charged-and-discarded
+  (let [model (dyn/with-key (grow-model) (rng/fresh-key 13))
+        {t :trace} (p/generate model [2] (cm/choicemap :y0 (mx/scalar 1.0)
+                                                       :y1 (mx/scalar -1.0)))
+        mu (choice-at t [:mu])
+        r (p/update-with-args model t [1] :unknown cm/EMPTY)]
+    (is (close? (w-item r) (- (log-normal-pdf -1.0 mu 1)) 1e-5)
+        "removed site charged via the old score: w = -lp(y1)")
+    (is (close? (mx/item (cm/get-choice (:discard r) [:y1])) -1.0 1e-9)
+        "removed :y1 value lands in the discard")
+    (is (nil? (cm/get-choice (:choices (:trace r)) [:y1]))
+        "removed site absent from new choices")))
+
+(deftest retained-value-out-of-support
+  (let [model (dyn/with-key (uniform-model) (rng/fresh-key 14))
+        {t :trace} (p/generate model [10.0] (cm/choicemap :u (mx/scalar 5.0)))
+        r (p/update-with-args model t [1.0] :unknown cm/EMPTY)]
+    (is (= js/Number.NEGATIVE_INFINITY (w-item r))
+        "retained value outside new support => -inf weight, not an error")))
+
+;; ============================================================
+;; 4. Splice propagation (no executor change — body re-execution)
+;; ============================================================
+
+(deftest splice-new-args-propagate
+  (let [sub (sub-model)
+        model (dyn/with-key (splice-model sub) (rng/fresh-key 15))
+        t (p/simulate model [1.0])
+        z (choice-at t [:sub :z])
+        r (p/update-with-args model t [2.0] :unknown cm/EMPTY)
+        expected (- (log-normal-pdf z 4.0 1) (log-normal-pdf z 2.0 1))]
+    (is (close? (w-item r) expected 1e-5)
+        "child :z re-scored under the NEW derived sub-arg (2m)")
+    (is (close? (choice-at (:trace r) [:sub :z]) z 1e-9)
+        "child choice retained verbatim")))
+
+;; ============================================================
+;; 5. Prefix-compiled path (L1-M3) threads new args
+;; ============================================================
+
+(deftest prefix-path-new-args
+  (let [model (dyn/with-key (prefix-model) (rng/fresh-key 16))
+        {t :trace} (p/generate model [1] (cm/choicemap :y0 (mx/scalar 1.0)))
+        mu (choice-at t [:mu])
+        r (p/update-with-args model t [2] :unknown
+                              (cm/choicemap :y1 (mx/scalar 0.0)))]
+    (is (close? (w-item r) (log-normal-pdf 0.0 mu 1) 1e-5)
+        "prefix model: growing the dynamic suffix adds the new site's lp")))
+
+;; ============================================================
+;; 6. Compiled parity (L1-M2): compiled === handler under new args
+;; ============================================================
+
+(deftest compiled-parity-static-model
+  (let [mk #(dyn/with-key (shift-model) (rng/fresh-key 17))
+        compiled (mk)
+        stripped (gfi/strip-compiled (mk))
+        t-c (p/simulate compiled [0.0])
+        ;; same choices into the stripped model via fully-constrained generate
+        t-h (:trace (p/generate stripped [0.0] (:choices t-c)))
+        r-c (p/update-with-args compiled t-c [1.0] :unknown cm/EMPTY)
+        r-h (p/update-with-args stripped t-h [1.0] :unknown cm/EMPTY)]
+    (is (close? (w-item r-c) (w-item r-h) 1e-5)
+        "compiled and handler paths agree on the weight")
+    (is (close? (mx/item (:score (:trace r-c)))
+                (mx/item (:score (:trace r-h))) 1e-5)
+        "and on the new score")))
+
+;; ============================================================
+;; 7. Score-type boundary (lbae guard runs on the new entry)
+;; ============================================================
+
+(deftest marginal-trace-converts-before-update-with-args
+  (let [model (dyn/with-key
+                (gen []
+                  (let [mu (trace :mu (dist/gaussian (mx/scalar 0) (mx/scalar 1)))]
+                    (trace :y (dist/gaussian mu (mx/scalar 1)))
+                    mu))
+                (rng/fresh-key 18))
+        {t :trace} (p/generate model [] (cm/choicemap :y (mx/scalar 1.5)))]
+    (when (= :marginal (tr/score-type t))
+      (let [r (p/update-with-args model t [] :unknown cm/EMPTY)]
+        (is (= :joint (tr/score-type (:trace r)))
+            "marginal input converted: result is joint-scored")
+        (is (js/isFinite (w-item r)) "finite weight after conversion")))))
+
+;; ============================================================
+;; 8. Map combinator
+;; ============================================================
+
+(defn- map-kernel [] (gen [m] (trace :v (dist/gaussian m 1))))
+
+(deftest map-element-change-vector-diff-and-unknown
+  (let [mapped (dyn/with-key (comb/map-combinator (map-kernel)) (rng/fresh-key 21))
+        t (p/simulate mapped [[0.0 1.0]])
+        v1 (choice-at t [1 :v])
+        expected (- (log-normal-pdf v1 2.0 1) (log-normal-pdf v1 1.0 1))
+        r-vd (p/update-with-args mapped t [[0.0 2.0]]
+                                 (diff/vector-diff #{1}) cm/EMPTY)
+        r-uk (p/update-with-args mapped t [[0.0 2.0]] :unknown cm/EMPTY)]
+    (is (close? (w-item r-vd) expected 1e-5) "vector-diff fast path: exact ratio")
+    (is (close? (w-item r-uk) expected 1e-5) "full sweep: same exact ratio")
+    (is (close? (choice-at (:trace r-vd) [0 :v]) (choice-at t [0 :v]) 1e-9)
+        "untouched element retained")))
+
+(deftest map-grow-constrained
+  (let [mapped (dyn/with-key (comb/map-combinator (map-kernel)) (rng/fresh-key 22))
+        t (p/simulate mapped [[0.0 1.0]])
+        r (p/update-with-args mapped t [[0.0 1.0 2.0]] :unknown
+                              (cm/set-choice cm/EMPTY [2 :v] (mx/scalar 2.5)))]
+    (is (close? (w-item r) (log-normal-pdf 2.5 2.0 1) 1e-5)
+        "constrained new element contributes its log-prob")
+    (is (close? (choice-at (:trace r) [2 :v]) 2.5 1e-9) "element present")))
+
+(deftest map-shrink-discards
+  (let [mapped (dyn/with-key (comb/map-combinator (map-kernel)) (rng/fresh-key 23))
+        t (p/simulate mapped [[0.0 1.0]])
+        v1 (choice-at t [1 :v])
+        r (p/update-with-args mapped t [[0.0]] :unknown cm/EMPTY)]
+    (is (close? (w-item r) (- (log-normal-pdf v1 1.0 1)) 1e-5)
+        "dropped element charged via old score")
+    (is (close? (mx/item (cm/get-choice (:discard r) [1 :v])) v1 1e-9)
+        "dropped element's choices in discard")))
+
+;; ============================================================
+;; 9. Unfold combinator
+;; ============================================================
+
+(defn- unfold-kernel [] (gen [t prev] (trace :s (dist/gaussian prev 1))))
+
+(deftest unfold-extend-equivalence
+  (let [unf (dyn/with-key (comb/unfold-combinator (unfold-kernel)) (rng/fresh-key 24))
+        t (p/simulate unf [3 0.0])
+        sigma (cm/choicemap :s (mx/scalar 1.0))
+        ;; fully-constrained new step: both paths are deterministic
+        ext (comb/unfold-extend t sigma (rng/fresh-key 25))
+        r (p/update-with-args unf t [4 0.0] :unknown
+                              (cm/set-choice cm/EMPTY [3] sigma))]
+    (is (close? (w-item ext) (w-item r) 1e-5)
+        "unfold-extend is the n'=n+1 special case (same weight)")
+    (is (close? (mx/item (:score (:trace ext))) (mx/item (:score (:trace r))) 1e-5)
+        "same extended score")
+    (is (close? (choice-at (:trace r) [3 :s]) 1.0 1e-9) "new step constrained")))
+
+(deftest unfold-truncate
+  (let [unf (dyn/with-key (comb/unfold-combinator (unfold-kernel)) (rng/fresh-key 26))
+        t (p/simulate unf [3 0.0])
+        s1 (choice-at t [1 :s])
+        s2 (choice-at t [2 :s])
+        r (p/update-with-args unf t [2 0.0] :unknown cm/EMPTY)]
+    (is (close? (w-item r) (- (log-normal-pdf s2 s1 1)) 1e-5)
+        "truncated step charged via old score")
+    (is (close? (mx/item (cm/get-choice (:discard r) [2 :s])) s2 1e-9)
+        "truncated step in discard")
+    (is (nil? (cm/get-choice (:choices (:trace r)) [2 :s]))
+        "step absent from new choices")))
+
+(deftest unfold-init-state-change-full-sweep
+  (let [unf (dyn/with-key (comb/unfold-combinator (unfold-kernel)) (rng/fresh-key 27))
+        t (p/simulate unf [2 0.0])
+        s0 (choice-at t [0 :s])
+        r (p/update-with-args unf t [2 5.0] :unknown cm/EMPTY)
+        expected (- (log-normal-pdf s0 5.0 1) (log-normal-pdf s0 0.0 1))]
+    (is (close? (w-item r) expected 1e-5)
+        "only step 0 depends on init: w is its hand-derived ratio")
+    (is (close? (choice-at (:trace r) [1 :s]) (choice-at t [1 :s]) 1e-9)
+        "downstream step retained (its dist depends on s0, unchanged)")))
+
+;; ============================================================
+;; 10. Scan combinator
+;; ============================================================
+
+(defn- scan-kernel []
+  (gen [carry x]
+    (let [v (trace :v (dist/gaussian (+ carry x) 1))]
+      [v v])))
+
+(deftest scan-grow-constrained
+  (let [sc (dyn/with-key (comb/scan-combinator (scan-kernel)) (rng/fresh-key 28))
+        t (p/simulate sc [0.0 [1.0 2.0]])
+        v1 (choice-at t [1 :v])             ;; carry after step 1 = v1
+        r (p/update-with-args sc t [0.0 [1.0 2.0 3.0]] :unknown
+                              (cm/set-choice cm/EMPTY [2 :v] (mx/scalar 0.0)))]
+    (is (close? (w-item r) (log-normal-pdf 0.0 (+ v1 3.0) 1) 1e-5)
+        "new step scored at carry+input, hand-derived")))
+
+(deftest scan-input-change-full-sweep
+  (let [sc (dyn/with-key (comb/scan-combinator (scan-kernel)) (rng/fresh-key 29))
+        t (p/simulate sc [0.0 [1.0 2.0]])
+        v0 (choice-at t [0 :v])
+        v1 (choice-at t [1 :v])
+        r (p/update-with-args sc t [0.0 [4.0 2.0]] :unknown cm/EMPTY)
+        ;; step 0: mean 0+4 (was 0+1); step 1: carry v0 unchanged, mean v0+2
+        expected (- (log-normal-pdf v0 4.0 1) (log-normal-pdf v0 1.0 1))]
+    (is (close? (w-item r) expected 1e-5)
+        "changed input re-scores step 0; step 1's carry is the retained v0")))
+
+;; ============================================================
+;; 11. Switch combinator
+;; ============================================================
+
+(deftest switch-same-branch-delegates
+  (let [b0 (gen [m] (trace :a (dist/gaussian m 1)))
+        b1 (gen [m] (trace :b (dist/gaussian m 2)))
+        sw (dyn/with-key (comb/switch-combinator b0 b1) (rng/fresh-key 31))
+        t (p/simulate sw [0 0.0])
+        a (choice-at t [:a])
+        r (p/update-with-args sw t [0 1.0] :unknown cm/EMPTY)
+        expected (- (log-normal-pdf a 1.0 1) (log-normal-pdf a 0.0 1))]
+    (is (close? (w-item r) expected 1e-5) "same branch: delegated ratio")))
+
+(deftest switch-branch-flip
+  (let [b0 (gen [m] (trace :a (dist/gaussian m 1)))
+        b1 (gen [m] (trace :b (dist/gaussian m 2)))
+        sw (dyn/with-key (comb/switch-combinator b0 b1) (rng/fresh-key 32))
+        t (p/simulate sw [0 0.0])
+        a (choice-at t [:a])
+        r (p/update-with-args sw t [1 0.0] :unknown
+                              (cm/choicemap :b (mx/scalar 1.0)))]
+    (is (close? (w-item r)
+                (- (log-normal-pdf 1.0 0.0 2) (log-normal-pdf a 0.0 1))
+                1e-5)
+        "flip: new branch nonfresh minus old branch score")
+    (is (close? (mx/item (cm/get-choice (:discard r) [:a])) a 1e-9)
+        "old branch choices discarded")))
+
+;; ============================================================
+;; 12. Contramap / MapRetval delegation; unsupported combinators throw
+;; ============================================================
+
+(deftest contramap-delegates
+  (let [inner (dyn/with-key (shift-model) (rng/fresh-key 33))
+        cgf (comb/contramap-gf inner (fn [[m]] [(* 2 m)]))
+        t (p/simulate cgf [0.5])             ;; inner sees m=1.0
+        x (choice-at t [:x])
+        r (p/update-with-args cgf t [1.0] :unknown cm/EMPTY)  ;; inner sees 2.0
+        expected (- (log-normal-pdf x 2.0 1) (log-normal-pdf x 1.0 1))]
+    (is (close? (w-item r) expected 1e-5) "f applied to new args before inner")))
+
+(deftest map-retval-delegates
+  (let [inner (dyn/with-key (shift-model) (rng/fresh-key 34))
+        mgf (comb/map-retval inner (fn [x] (mx/multiply x (mx/scalar 10))))
+        t (p/simulate mgf [0.0])
+        r (p/update-with-args mgf t [1.0] :unknown cm/EMPTY)]
+    (is (js/isFinite (w-item r)) "delegates and produces a finite weight")
+    (is (close? (mx/item (:retval (:trace r)))
+                (* 10 (choice-at (:trace r) [:x])) 1e-4)
+        "retval re-mapped on the updated trace")))
+
+(deftest unsupported-combinators-throw
+  (let [inner (dyn/auto-key (gen [] (trace :x (dist/gaussian 0 1))))
+        masked (comb/mask-combinator inner)
+        t (p/simulate masked [true])]
+    (is (unsupported-error?
+          #(p/update-with-args masked t [false] :unknown cm/EMPTY))
+        "Mask throws the informative unsupported error (not silence)")))
+
+;; ============================================================
+;; 13. Edit flavor: ArgsUpdateEdit forward/backward roundtrip
+;; ============================================================
+
+(deftest args-update-edit-roundtrip
+  (let [model (dyn/with-key (shift-model) (rng/fresh-key 35))
+        t (p/simulate model [0.0])
+        fwd (edit/edit model t (edit/args-update-edit [1.0] cm/EMPTY))
+        bwd-req (:backward-request fwd)
+        bwd (edit/edit model (:trace fwd) bwd-req)]
+    (is (instance? edit/ArgsUpdateEdit bwd-req) "backward request is an ArgsUpdateEdit")
+    (is (= [0.0] (:new-args bwd-req)) "backward carries the old args")
+    (is (close? (w-item bwd) (- (w-item fwd)) 1e-5)
+        "structure-preserving roundtrip: w_back = -w_fwd")
+    (is (close? (choice-at (:trace bwd) [:x]) (choice-at t [:x]) 1e-9)
+        "roundtrip restores choices")))
+
+;; ============================================================
+;; 14. Vectorized path: vupdate-args
+;; ============================================================
+
+(deftest vupdate-args-matches-scalar-oracle
+  (let [n 8
+        model (dyn/with-key (shift-model) (rng/fresh-key 36))
+        vt (dyn/vsimulate model [0.0] n (rng/fresh-key 37))
+        xs (mx/->clj (cm/get-value (cm/get-submap (:choices vt) :x)))
+        {w :weight vt' :vtrace} (dyn/vupdate-args model vt [1.0] cm/EMPTY
+                                                  (rng/fresh-key 38))
+        ws (mx/->clj w)]
+    (is (= n (count ws)) "weight is [N]-shaped")
+    (doseq [[x w-i] (map vector xs ws)]
+      (is (close? w-i (- (log-normal-pdf x 1.0 1) (log-normal-pdf x 0.0 1)) 1e-4)
+          "each particle's weight matches the hand-derived ratio"))
+    (is (= [1.0] (:args vt')) "vtrace carries new args")))
+
+;; ============================================================
+;; 15. SMC with changing arguments, end-to-end (growing data)
+;; ============================================================
+
+(deftest smc-args-growing-data-log-ml
+  ;; mu ~ N(0,1); y_i ~ N(mu,1). Closed-form sequential predictive:
+  ;; after i obs, posterior mu | y_<i ~ N(m_i, s_i^2), s_i^2 = 1/(1+i),
+  ;; m_i = s_i^2 * sum(y_<i); predictive y_i ~ N(m_i, sqrt(s_i^2 + 1)).
+  (let [ys [1.0 -0.5 0.8 0.2]
+        closed-form (loop [i 0 sum-y 0.0 acc 0.0]
+                      (if (= i (count ys))
+                        acc
+                        (let [s2 (/ 1.0 (+ 1 i))
+                              m (* s2 sum-y)
+                              y (nth ys i)]
+                          (recur (inc i) (+ sum-y y)
+                                 (+ acc (log-normal-pdf y m (js/Math.sqrt (+ s2 1.0))))))))
+        steps (map-indexed
+                (fn [t y]
+                  {:args [(inc t)]
+                   :constraints (cm/choicemap (keyword (str "y" t)) (mx/scalar y))})
+                ys)
+        {:keys [log-ml traces final-ess]}
+        (smc/smc-args {:particles 300 :key (rng/fresh-key 39)}
+                      (grow-model) steps)]
+    (is (close? (mx/item log-ml) closed-form 0.25)
+        (str "SMC log-ML " (mx/item log-ml) " within MC tolerance of closed form " closed-form))
+    (is (= 300 (count traces)) "all particles survive")
+    (is (pos? final-ess) "honest pre-resample final ESS reported")
+    (is (every? #(= [4] (:args %)) traces) "final traces carry the final args")))
+
+(defn- linreg-model
+  "slope ~ N(0,1); intercept ~ N(0,1); y_i ~ N(slope*x_i + intercept, 1)
+   for i < (count xs) — stable y_i addresses, args grow with the data."
+  []
+  (gen [xs]
+    (let [slope (trace :slope (dist/gaussian 0 1))
+          intercept (trace :intercept (dist/gaussian 0 1))]
+      (doseq [[i x] (map-indexed vector xs)]
+        (trace (keyword (str "y" i))
+               (dist/gaussian (mx/add (mx/multiply slope (mx/scalar x))
+                                      intercept)
+                              1)))
+      slope)))
+
+(defn- linreg-log-ml
+  "Hand-derived sequential log-ML for Bayesian linear regression with
+   prior N(0, I) on [slope intercept] and unit observation noise:
+   log p(y) = sum_t log N(y_t; phi_t . m_(t-1), sqrt(phi_t . S_(t-1) phi_t + 1))
+   with S = inv(I + sum phi phi^T), m = S (sum phi y) — 2x2 algebra inline,
+   independent of all genmlx code."
+  [xs ys]
+  (loop [t 0
+         ;; precision Lambda = I + sum phi phi^T, b = sum phi y
+         l00 1.0 l01 0.0 l11 1.0 b0 0.0 b1 0.0
+         acc 0.0]
+    (if (= t (count ys))
+      acc
+      (let [x (nth xs t) y (nth ys t)
+            det (- (* l00 l11) (* l01 l01))
+            ;; S = inv(Lambda)
+            s00 (/ l11 det) s01 (- (/ l01 det)) s11 (/ l00 det)
+            ;; posterior mean m = S b
+            m0 (+ (* s00 b0) (* s01 b1))
+            m1 (+ (* s01 b0) (* s11 b1))
+            ;; predictive: mean phi.m, var phi.S.phi + 1, phi = [x 1]
+            mean (+ (* x m0) m1)
+            var (+ (* x (+ (* s00 x) s01))
+                   (+ (* s01 x) s11)
+                   1.0)]
+        (recur (inc t)
+               (+ l00 (* x x)) (+ l01 x) (+ l11 1.0)
+               (+ b0 (* x y)) (+ b1 y)
+               (+ acc (log-normal-pdf y mean (js/Math.sqrt var))))))))
+
+(deftest smc-args-growing-linreg-log-ml
+  (let [xs [0.0 1.0 2.0 3.0]
+        ys [0.5 1.8 2.9 4.4]
+        closed-form (linreg-log-ml xs ys)
+        steps (map-indexed
+                (fn [t y]
+                  {:args [(subvec (vec xs) 0 (inc t))]
+                   :constraints (cm/choicemap (keyword (str "y" t)) (mx/scalar y))})
+                ys)
+        {:keys [log-ml traces]}
+        (smc/smc-args {:particles 400 :key (rng/fresh-key 42)}
+                      (linreg-model) steps)]
+    (is (close? (mx/item log-ml) closed-form 0.3)
+        (str "growing-data linreg SMC log-ML " (mx/item log-ml)
+             " within MC tolerance of hand-derived closed form " closed-form))
+    (is (every? #(= [[0.0 1.0 2.0 3.0]] (:args %)) traces)
+        "final traces carry the full xs")))
+
+;; ============================================================
+;; 16. Laws registered
+;; ============================================================
+
+(deftest update-args-laws-registered
+  (let [names (set (map :name gfi/laws))]
+    (doseq [law [:update-args-noop
+                 :update-args-weight-is-density-ratio
+                 :update-args-roundtrip
+                 :update-args-compiled-parity
+                 :unfold-extend-equivalence
+                 :update-args-structure-change]]
+      (is (contains? names law) (str law " is in the law catalog")))))
+
+(cljs.test/run-tests)

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -335,6 +335,7 @@ fast test/genmlx/tutorial/ch09_test.cljs
 fast test/genmlx/tutorial/ch10_test.cljs
 fast test/genmlx/unfold_splice_test.cljs
 medium test/genmlx/untested_features_test.cljs
+medium test/genmlx/update_args_test.cljs
 fast test/genmlx/update_discard_branch_test.cljs
 fast test/genmlx/update_weight_test.cljs core
 fast test/genmlx/validation_test.cljs


### PR DESCRIPTION
## GFI update with new arguments — thesis x' (genmlx-s8e8)

ROADMAP Phase 1 item 1. The thesis `update` takes new arguments x' alongside new
constraints; GenMLX `IUpdate` lacked it, so a trace could not be updated while the model
arguments change — blocking SMC over growing data. This adds it **additively** (existing GFI
protocol signatures untouched).

### Design
- New protocol `IUpdateWithArgs` (`update-with-args [gf trace new-args argdiffs constraints]`),
  Gen.jl arg order; new `ArgsUpdateEdit` edit flavor for SMCP3/reversible-kernel compatibility.
- **handler.cljs needed ZERO changes** — transitions never read model args; dist params arrive
  via body re-execution. `run-update`/`-compiled`/`-prefix` switch from `(:args trace)` to their
  previously-ignored positional args; all existing call sites pass `(:args trace)`, so old
  behavior is provably unchanged.
- Weight = nonfresh-score(t'; x') − score(t; x). Structure-preserving corollary (what SMC uses):
  `w = assess(x', t') − assess(x, t)`, pinned with a hand-derived closed-form oracle.
- Combinators: Map/Unfold/Scan/Switch propagate arg diffs (argdiffs are trusted caller
  assertions, Gen.jl model; Unfold/Scan prefix-skip additionally verified by host `=`).
- `smc/smc-args`: SMC with changing arguments, end-to-end on growing-data linreg + normal-normal,
  validated against hand-derived sequential predictive closed forms.

### Tests / laws
`update_args_test.cljs` (new, @tier medium): 32 tests / 82 assertions — protocol basics, density-
ratio weight oracle (scalar + batched), structure change, splice propagation, −inf out-of-support,
marginal→joint conversion on the new entry, edit roundtrip, vupdate-args vs per-particle oracle,
growing-data SMC log-ML vs closed form. 6 new gfi laws.

### Verification
Stacked on genmlx-lbae (now merged, #103) and rebased onto current main (one trivial `diff.cljs`
docstring merge). Green: update_args 32/82 · combinators 21/67 · combinator_compile 26/92 · core
40/40 · exact 120/120 · score_type 23/81 · smc {scoring 41, property 7, evidence 17}.

Full medium tier (133 files) vs a main baseline (132 files): **zero new deterministic failures**.
The two s8e8-only medium failures (`audit_gaps_test`, `compiled_optimizer_test`) both pass when
run serially — TEST_JOBS=2 GPU-contention false positives. The shared failures are pre-existing /
known-flaky (`gfi_combinator_invariants` switch cross-branch = pre-existing on 303fe22, captured as
genmlx-qm7m; `gfi_laws` vgenerate = x93e flake; `fused_mcmc` = 5ucd Metal resource; `gen_jl_speed`
= timing benchmark). Main itself carries more flaky failures than s8e8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
