### PR TITLE
feat(gfi): regenerate through structure change + retained-only weight (genmlx-hmch, genmlx-yep2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,6 +347,24 @@ Batched variants add `:batch-size` (int) and `:batched?` (true).
 The handler never inspects value shapes — MLX broadcasting handles
 `[N]`-shaped arrays transparently.
 
+**Regenerate has two transitions (genmlx-hmch, genmlx-yep2).** The *fast*
+`regenerate-transition` (per-site convention) is used when the selection is
+proven equivalent to the general path — no structure change (`has-branches?`
+false) and the selected sites are mutually independent (no selected site feeds
+another's distribution parameters). Otherwise `regenerate-transition-general`
+builds the new trace (selected sites resample; unselected-&-absent sites sample
+fresh — a structure change replacing the old throw, enabling branch flips;
+unselected-&-present sites are retained), and `make-regen-result-general`
+computes the retained-only weight `W = Σ_retained [lp(v; new ctx) − lp(v; old
+ctx)]` with two project passes — `project(new-trace, retained) −
+project(old-trace, retained)` — where `retained` = leaf addresses present in
+both traces minus the selection. Selected, fresh, and removed sites cancel to
+0; the project passes recurse through splices, so dependent joint moves and
+spliced sub-models compose with no weight bookkeeping in the parent. The
+compiled/prefix/branch-rewrite regen paths are skipped (deferred to the handler
+general path) for non-fast-eligible selections; the analytical path is
+unaffected.
+
 **Dispatcher stack (4-level priority, first non-nil wins):**
 
 1. **custom-dispatcher** — `::custom-dispatch` or `::custom-transition` metadata

--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -112,6 +112,13 @@
        :discard discard}
       (attach-unused constraints result-choices)))
 
+(def ^:dynamic *force-general-regen*
+  "When true, regenerate always takes the retained-only GENERAL path (the
+   project-pass algebra), never the fast path. Used by the fast≡general law
+   test to pin equivalence on fast-eligible models. Default false (the fast
+   path is auto-selected when provably equivalent)."
+  false)
+
 (defn- make-regen-result
   "Build the regenerate return map from handler result, computing the MH weight."
   [gf trace result old-score]
@@ -126,6 +133,90 @@
                     (or (:score-type result) :joint))]
     {:trace (attach-splice-scores new-trace result)
      :weight weight}))
+
+(defn- selected-path?
+  "Does selection `sel` select the full leaf path `path` (a vector of
+   addresses)? Descends sub-selections for all but the last address, so it
+   handles hierarchical selections over spliced sub-models."
+  [sel path]
+  (cond
+    (nil? sel) false
+    (empty? path) false
+    (= 1 (count path)) (sel/selected? sel (first path))
+    :else (selected-path? (sel/get-subselection sel (first path)) (rest path))))
+
+(defn- regen-retained-selection
+  "Selection of the RETAINED leaf addresses of a regenerate move: leaf paths
+   present in BOTH the new and old choices, minus the selected ones. Returns
+   nil when nothing is retained (weight is then 0)."
+  [new-choices old-choices selection]
+  (let [old-set (set (cm/addresses old-choices))
+        retained (into [] (comp (filter old-set)
+                                (remove #(selected-path? selection %)))
+                       (cm/addresses new-choices))]
+    (when (seq retained)
+      (sel/from-paths retained))))
+
+(defn- make-regen-result-general
+  "Build the regenerate return for the retained-only GENERAL path
+   (genmlx-hmch, genmlx-yep2).
+
+   W = project(new-trace, retained) - project(old-trace, retained)
+     = Σ_retained [lp(v; new ctx) - lp(v; old ctx)],
+   where retained = leaf addresses present in BOTH executions and unselected.
+   Selected, fresh (structure change), and removed sites are excluded and
+   contribute 0. Each project pass restores the corresponding execution context
+   (args + values of that trace) and recurses through splices, so dependent
+   retained sites — whose parameters moved because a selected upstream site was
+   resampled — are scored correctly under both contexts (the yep2 fix), and
+   spliced sub-models compose with no weight bookkeeping in the parent."
+  [gf trace result selection]
+  (let [new-trace (-> (tr/make-trace {:gen-fn gf :args (:args trace)
+                                      :choices (:choices result)
+                                      :retval (:retval result)
+                                      :score (:score result)})
+                      (tr/with-score-type (or (:score-type result) :joint))
+                      (attach-splice-scores result))
+        retained-sel (regen-retained-selection (:choices result) (:choices trace) selection)
+        weight (if retained-sel
+                 (mx/subtract (p/project gf new-trace retained-sel)
+                              (p/project gf trace retained-sel))
+                 SCORE-ZERO)]
+    {:trace new-trace :weight weight}))
+
+(defn- regen-fast-eligible?
+  "The fast regenerate path (per-site convention, no project pass) is provably
+   equivalent to the general retained-only path iff (a) no structure change can
+   occur and (b) the selected sites are mutually independent (no selected site
+   feeds another selected site's distribution parameters). Otherwise the
+   general path is required for correctness.
+
+   (a) holds when the model has no branches (the address set is fixed).
+   (b) holds when, for every selected static site, none of its dependency set
+       contains another selected site.
+   Returns false conservatively whenever the schema lacks the static info
+   needed to prove eligibility (dynamic addresses, loops, missing trace-sites)."
+  [gf selection]
+  (let [schema (:schema gf)
+        sites (or (:trace-sites schema) [])]
+    (cond
+      *force-general-regen* false
+      (:has-branches? schema) false
+      (:dynamic-addresses? schema) false
+      (:has-loops? schema) false
+      :else
+      ;; Only the parent's DIRECT trace sites are checked here. Spliced
+      ;; sub-gfs recurse through p/regenerate and gate themselves; a parent
+      ;; with no directly-selected sites (e.g. one that only splices children
+      ;; and retains its own observations) is fast-eligible — the existing
+      ;; execute-sub composition handles the child weights exactly.
+      (let [selected (into #{} (comp (map :addr)
+                                     (filter #(sel/selected? selection %)))
+                           sites)]
+        (every? (fn [s]
+                  (or (not (contains? selected (:addr s)))
+                      (empty? (set/intersection selected (set (:deps s))))))
+                sites)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Execution helpers — each takes [gf args key opts] and returns a GFI result.
@@ -192,6 +283,35 @@
                   :executor execute-sub :param-store (param-store gf)}
                  (fn [rt] (run-body gf rt (:args trace))))]
     (make-regen-result gf trace result old-score)))
+
+(defn- run-regen-general
+  "Retained-only regenerate via the handler (genmlx-hmch, genmlx-yep2).
+   Builds the new trace with regenerate-transition-general (selected sites
+   resample, unselected-absent sites sample fresh — a structure change instead
+   of the old throw, unselected-present sites are retained); the weight is then
+   two project passes over the retained selection (new-context minus
+   old-context), which is exact for dependent joint moves (yep2) and recurses
+   through splices."
+  [gf _args key {:keys [trace selection]}]
+  (let [result (rt/run-handler h/regenerate-transition-general
+                 {:choices cm/EMPTY :score SCORE-ZERO :weight SCORE-ZERO
+                  :key key :selection selection
+                  :old-choices (:choices trace)
+                  :old-splice-scores (::splice-scores (meta trace))
+                  :old-nested-splice-scores (::nested-splice-scores (meta trace))
+                  :executor execute-sub :param-store (param-store gf)}
+                 (fn [rt] (run-body gf rt (:args trace))))]
+    (make-regen-result-general gf trace result selection)))
+
+(defn- run-regen-handler
+  "Handler-path regenerate dispatcher: take the fast per-site convention when
+   it is provably equivalent (regen-fast-eligible?), else the general
+   retained-only path. The fast path keeps the MCMC hot loop (single-site
+   mh-cycle) free of the extra project pass."
+  [gf args key {:keys [selection] :as opts}]
+  (if (regen-fast-eligible? gf selection)
+    (run-regen h/regenerate-transition gf args key opts)
+    (run-regen-general gf args key opts)))
 
 (defn- run-assess [transition gf args key {:keys [constraints]}]
   (let [result (rt/run-handler transition
@@ -453,10 +573,15 @@
    :propose h/simulate-transition})
 
 ;; Handler table: each entry is (partial run-* standard-transition).
+;; :regenerate is overridden with the fast/general gating dispatcher
+;; (run-regen-handler) — the retained-only general path is selected when the
+;; fast per-site convention is not provably equivalent (genmlx-hmch/yep2).
+;; transition-run-fns keeps the plain run-regen for custom with-handler use.
 (def ^:private handler-table
-  (into {} (map (fn [[op run-fn]]
-                  [op (partial run-fn (get standard-transitions op))]))
-        transition-run-fns))
+  (assoc (into {} (map (fn [[op run-fn]]
+                         [op (partial run-fn (get standard-transitions op))]))
+                 transition-run-fns)
+         :regenerate run-regen-handler))
 
 (def ^:private compiled-table
   {:simulate run-simulate-compiled, :generate run-generate-compiled
@@ -534,8 +659,21 @@
 
 (def ^:private compiled-dispatcher
   (reify dispatch/IDispatcher
-    (resolve-transition [_ op schema _opts]
+    (resolve-transition [_ op schema opts]
       (cond
+        ;; Non-fast-eligible regenerate (dependent joint moves / structure
+        ;; change) must take the handler general retained-only path: the
+        ;; compiled, prefix, and branch-rewrite per-site regen conventions are
+        ;; exact ONLY for fast-eligible selections (genmlx-hmch / genmlx-yep2).
+        ;; Returning nil falls through to the handler-dispatcher, whose
+        ;; run-regen-handler then takes the general path. The analytical
+        ;; dispatcher sits EARLIER in the stack, so conjugate-posterior
+        ;; regenerate is never bypassed by this.
+        (and (= op :regenerate)
+             (:selection opts)               ; absent for introspective resolve (inspect)
+             (not (regen-fast-eligible? (:gf opts) (:selection opts))))
+        nil
+
         (get schema (get compiled-keys op))
         {:run (get compiled-table op) :score-type :joint :label :compiled}
 
@@ -1089,8 +1227,26 @@
 (defn vregenerate
   "Batched regenerate: run model body ONCE with batched regenerate handler.
    vtrace: VectorizedTrace with [n]-shaped choices, selection: addresses to resample.
-   Returns new VectorizedTrace with resampled selected addresses."
+   Returns new VectorizedTrace with resampled selected addresses.
+
+   Uses the per-site batched convention, which is exact ONLY for fast-eligible
+   selections (single-site / mutually-independent, no structure change). A
+   DEPENDENT JOINT batched selection would carry the genmlx-yep2 residual, and
+   a structure-changing batched flip is ill-posed under shape-batching (host
+   control flow must be uniform across particles — math-verifier §7 on
+   genmlx-hmch). Rather than silently miscalibrate, those are rejected loudly;
+   the full batched retained-only path is the genmlx-8xia follow-up. The scalar
+   p/regenerate handles all these cases correctly."
   [gf vtrace selection key]
+  (when-not (regen-fast-eligible? gf selection)
+    (throw (ex-info
+             (str "vregenerate: this selection is not fast-eligible (dependent "
+                  "joint move or structure change). The batched per-site "
+                  "convention would carry the genmlx-yep2 weight residual or be "
+                  "ill-posed under shape-batching. Use scalar p/regenerate "
+                  "per particle, or restrict to single-site / independent "
+                  "selections. Full batched retained-only: genmlx-8xia.")
+             {:genmlx/error :batched-regenerate-not-fast-eligible})))
   (let [key (rng/ensure-key key)
 
         n (:n-particles vtrace)

--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -367,6 +367,43 @@
                    (and (check-addr first-addr)
                         (check-addr last-addr))))))}
 
+   {:name :regenerate-select-all-zero
+    :from "[T] §3.4.2 retained-only weight (genmlx-hmch, genmlx-yep2)"
+    :theorem "regenerate(t, all).weight = 0 for ANY model. A full-prior
+              resample is its own proposal: q(t→t') = p(t';x) and
+              q(t'→t) = p(t;x), so the MH weight is identically 0. This holds
+              even for DEPENDENT latents (e.g. b ~ N(a,1) with {a,b} both
+              selected) and for branch-flipping selections (the new-arm sites
+              are fresh, the old-arm sites removed — both cancel). The
+              per-site fast convention leaked a nonzero residual here by
+              scoring a selected site's backward proposal under the NEW parent
+              values (genmlx-yep2); the retained-only general path fixes it."
+    :tags #{:regenerate :inference :mcmc :consistency}
+    :check (fn [{:keys [model args]}]
+             (let [t (p/simulate model args)
+                   {:keys [weight]} (p/regenerate model t sel/all)]
+               (approx= 0.0 (ev weight) 0.01)))}
+
+   {:name :regenerate-fast-general-equivalence
+    :from "[D] fast ≡ general retained-only path (genmlx-hmch)"
+    :theorem "On a fast-eligible selection, the fast per-site regenerate
+              convention and the forced general retained-only path (the
+              project-pass algebra) produce identical weights when seeded with
+              the same PRNG key. Pins the hot-loop fast path so it can never
+              silently diverge from the always-correct general path."
+    :tags #{:regenerate :inference :mcmc :consistency}
+    :check (fn [{:keys [model args]}]
+             (let [t (p/simulate model args)
+                   addrs (all-leaf-addrs (:choices t))]
+               (if (empty? addrs)
+                 true
+                 (let [k (rng/fresh-key 7)
+                       sel (sel/select (first (first addrs)))
+                       fast (p/regenerate (dyn/with-key model k) t sel)
+                       general (binding [dyn/*force-general-regen* true]
+                                 (p/regenerate (dyn/with-key model k) t sel))]
+                   (approx= (ev (:weight fast)) (ev (:weight general)) 0.01)))))}
+
    {:name :mh-acceptance-correctness
     :from "[T] Alg 5, §3.4.2"
     :theorem "MH with regenerate weight produces a chain whose

--- a/src/genmlx/handler.cljs
+++ b/src/genmlx/handler.cljs
@@ -154,6 +154,46 @@
                    (update :choices cm/set-value addr val)
                    (update :score mx/add lp))])))))
 
+(defn regenerate-transition-general
+  "Pure: the retained-only regenerate transition (genmlx-hmch, genmlx-yep2).
+
+   The MH weight for a DML regenerate is
+     W = Σ over RETAINED sites of [lp(v; new ctx) - lp(v; old ctx)],
+   where retained = unselected AND present in BOTH executions; selected,
+   freshly-appearing (structure change), and removed sites all cancel to 0.
+
+   This transition only builds the new trace and its :score — it does NOT
+   accumulate the weight. make-regen-result-general computes W with two
+   project passes over the retained selection (new-context minus old-context),
+   which recurses correctly through spliced sub-models and never double-counts.
+
+   - selected (resample) and unselected-&-ABSENT (fresh — a structure change
+     replacing the old throw): draw from the NEW context, add lp to :score,
+     split the key. These behave identically; the only difference from the
+     fast transition is that fresh sites are sampled instead of throwing.
+   - unselected & present (RETAINED): keep the old value, add lp to :score,
+     no key split.
+   Removed sites are simply never visited in the new execution."
+  [state addr dist]
+  (let [sel (:selection state)
+        old-choice (cm/get-submap (:old-choices state) addr)]
+    (if (or (and sel (sel/selected? sel addr))
+            (not (cm/has-value? old-choice)))
+      ;; Selected resample OR fresh structure-change draw: sample, score, split
+      (let [[k1 k2] (rng/split (:key state))
+            new-val (dc/dist-sample dist k2)
+            new-lp (dc/dist-log-prob dist new-val)]
+        [new-val (-> state
+                     (assoc :key k1)
+                     (update :choices cm/set-value addr new-val)
+                     (update :score mx/add new-lp))])
+      ;; Retained: keep old value, score, no key split
+      (let [val (cm/get-value old-choice)
+            lp (dc/dist-log-prob dist val)]
+        [val (-> state
+                 (update :choices cm/set-value addr val)
+                 (update :score mx/add lp))]))))
+
 (defn project-transition
   "Pure: replay old value, accumulate log-prob for selected addresses."
   [state addr dist]

--- a/test/genmlx/gfi_regenerate_test.cljs
+++ b/test/genmlx/gfi_regenerate_test.cljs
@@ -203,31 +203,27 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest regenerate-dependent-select-all-stale-child
-  (testing "Dependent model, select-all: weight = lp(y_old;x',1) - lp(y_old;x,1)"
-    ;; Derivation: x ~ N(0,1), y ~ N(x,1), S = {:x,:y}
-    ;; handler for :x: lp(x';0,1) - lp(x;0,1)
-    ;; handler for :y: lp(y';x',1) - lp(y;x',1)
-    ;;   [old_lp for y evaluated under NEW x' because x was already replayed]
-    ;; handler_weight = [lp(x';0,1)-lp(x;0,1)] + [lp(y';x',1)-lp(y;x',1)]
+  (testing "Dependent model, select-all: weight = 0 (full-prior resample)"
+    ;; x ~ N(0,1), y ~ N(x,1), S = {:x,:y}.
     ;;
-    ;; weight = new_score - old_score - handler_weight
-    ;; = [lp(x';0,1)+lp(y';x',1)] - [lp(x;0,1)+lp(y;x,1)]
-    ;;   - [lp(x';0,1)-lp(x;0,1)] - [lp(y';x',1)-lp(y;x',1)]
-    ;; Cancel lp(x';0,1), lp(x;0,1), lp(y';x',1):
-    ;; = lp(y;x',1) - lp(y;x,1)
+    ;; CORRECTED 2026-06-13 (genmlx-yep2): this test previously asserted the
+    ;; nonzero value lp(y_old;x',1) - lp(y_old;x,1), DERIVED FROM the buggy
+    ;; per-site handler convention (it scored the SELECTED site :y's backward
+    ;; proposal under the NEW parent x'). That is the yep2 bug, baked into a
+    ;; test via implementation arithmetic rather than independent theory.
     ;;
-    ;; This is the "stale child" correction: old y's density changes
-    ;; because its parent changed. Weight != 0 in general.
-    ;; Tolerance: 1e-4 (float32 accumulation)
+    ;; Correct semantics: selecting ALL sites is a full-prior resample, so the
+    ;; internal proposal IS the prior — q(t->t') = p(t';x), q(t'->t) = p(t;x) —
+    ;; and the MH weight is identically 0. There is no "old y" in the new trace:
+    ;; y is SELECTED, hence resampled to a fresh y'. (Independent derivation:
+    ;; math-verifier §2 on genmlx-hmch; gfi law :regenerate-select-all-zero.)
     (let [x-old 1.0
           y-old 2.0
           constraints (cm/choicemap :x (mx/scalar x-old) :y (mx/scalar y-old))
           {:keys [trace]} (p/generate models/dependent-model [] constraints)
-          {:keys [trace weight]} (p/regenerate models/dependent-model trace sel/all)
-          x-new (h/realize (cm/get-value (cm/get-submap (:choices trace) :x)))
-          expected (- (h/gaussian-lp y-old x-new 1) (h/gaussian-lp y-old x-old 1))]
-      (is (h/close? expected (h/realize weight) 1e-4)
-          "weight is stale-child correction for old y under new x"))))
+          {:keys [weight]} (p/regenerate models/dependent-model trace sel/all)]
+      (is (h/close? 0.0 (h/realize weight) 1e-4)
+          "dependent select-all weight is 0 (yep2 fix)"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Case 5: Empty selection — identity operation

--- a/test/genmlx/regen_structure_test.cljs
+++ b/test/genmlx/regen_structure_test.cljs
@@ -1,0 +1,416 @@
+;; @tier medium
+(ns genmlx.regen-structure-test
+  "genmlx-hmch + genmlx-yep2: regenerate through structure change, and the
+   retained-only MH weight algebra.
+
+   The DML regenerate weight is, for selection S with the internal prior
+   proposal, W = Σ over RETAINED sites of [lp(v; new ctx) - lp(v; old ctx)],
+   where retained = unselected AND present in BOTH executions; selected,
+   freshly-appearing, and removed sites all cancel to 0 (proven in the
+   math-verifier derivation on genmlx-hmch).
+
+   Every oracle here is an INDEPENDENT closed form (h/gaussian-lp, Bayes'
+   rule) — never computed via the regenerate code under test. See
+   feedback_independent_oracle_tests."
+  (:require-macros [genmlx.gen :refer [gen]])
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.test-helpers :as h]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.dist :as dist]
+            [genmlx.choicemap :as cm]
+            [genmlx.trace :as tr]
+            [genmlx.selection :as sel]))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn force-handler
+  "Strip all compiled/analytical paths so a gen-fn runs through the handler."
+  [gf]
+  (assoc gf :schema
+         (dissoc (:schema gf)
+                 :compiled-simulate :compiled-generate :compiled-update
+                 :compiled-assess :compiled-project :compiled-regenerate
+                 :compiled-prefix :compiled-prefix-addrs :compiled-prefix-generate
+                 :compiled-prefix-update :compiled-prefix-assess
+                 :compiled-prefix-project :compiled-prefix-regenerate
+                 :auto-handlers :conjugate-pairs :has-conjugate?
+                 :analytical-plan :auto-regenerate-transition)))
+
+(defn cval
+  "Realize a scalar choice value at address."
+  [choices addr]
+  (mx/item (cm/get-value (cm/get-submap choices addr))))
+
+(defn has-addr? [choices addr]
+  (cm/has-value? (cm/get-submap choices addr)))
+
+(defn gen-trace
+  "Deterministic trace via generate with the given constraints."
+  [gf args constraints key]
+  (:trace (p/generate (dyn/with-key (force-handler gf) key) args constraints)))
+
+;; ---------------------------------------------------------------------------
+;; Models
+;; ---------------------------------------------------------------------------
+
+;; yep2: dependent pair — b's params depend on a.
+(def dep-pair
+  (gen []
+    (let [a (trace :a (dist/gaussian 0 1))
+          b (trace :b (dist/gaussian a 1))]
+      b)))
+
+;; yep2 cascade: a -> b -> y, y observed/retained.
+(def cascade
+  (gen [sigma]
+    (let [a (trace :a (dist/gaussian 0 1))
+          b (trace :b (dist/gaussian a 1))
+          y (trace :y (dist/gaussian b sigma))]
+      y)))
+
+;; Independent pair — fast-path-eligible (no dependency between selected sites).
+(def indep-pair
+  (gen []
+    (let [a (trace :a (dist/gaussian 0 1))
+          b (trace :b (dist/gaussian 3 2))]
+      (mx/add a b))))
+
+;; Branch flip, SHARED :y address (no structure change), per-arm params.
+(def branch-shared-y
+  (gen [p mu1 s1 mu0 s0]
+    (let [bb (trace :branch (dist/bernoulli p))]
+      (if (pos? (mx/item bb))
+        (trace :y (dist/gaussian mu1 s1))
+        (trace :y (dist/gaussian mu0 s0))))))
+
+;; Prior-only flip — DIFFERENT latent addresses per arm (structure change),
+;; no observation.  Flipping :branch makes one arm's latent fresh and the
+;; other's removed.
+(def prior-flip
+  (gen []
+    (let [bb (trace :branch (dist/bernoulli 0.5))]
+      (if (pos? (mx/item bb))
+        (trace :xa (dist/gaussian 0 1))
+        (trace :xb (dist/gaussian 5 1))))))
+
+;; Structure-change WITH a shared observation: flipping :branch swaps the
+;; latent address (:ya <-> :yb, structure change) AND the mean of the shared
+;; :obs leaf.  The latent does not feed :obs, so it integrates out and the
+;; posterior over :branch is plain Bayes on the two obs-means.
+(def struct-obs
+  (gen [obs]
+    (let [bb (trace :branch (dist/bernoulli 0.5))]
+      (if (pos? (mx/item bb))
+        (do (trace :ya (dist/gaussian 0 1))
+            (trace :obs (dist/gaussian 2.0 1.0)))
+        (do (trace :yb (dist/gaussian 5 1))
+            (trace :obs (dist/gaussian -2.0 1.0)))))))
+
+;; Splice: parent splices the dependent cascade child, plus a parent-direct
+;; retained observation.
+(def child-cascade
+  (gen [sigma]
+    (let [a (trace :a (dist/gaussian 0 1))
+          b (trace :b (dist/gaussian a 1))]
+      b)))
+
+(def parent-splice
+  (gen [sigma]
+    (let [b (splice :child child-cascade [sigma])
+          y (trace :y (dist/gaussian b sigma))]
+      y)))
+
+;; ---------------------------------------------------------------------------
+;; 1. yep2 — select-all on a DEPENDENT pair: W = 0 (every draw)
+;; ---------------------------------------------------------------------------
+
+(deftest select-all-dependent-zero
+  (testing "handler: select {a,b} on b~N(a,1) => weight 0"
+    (dotimes [i 25]
+      (let [t  (gen-trace dep-pair [] (cm/choicemap :a (mx/scalar 0.7) :b (mx/scalar 1.3))
+                          (rng/fresh-key (+ 100 i)))
+            {:keys [weight]} (p/regenerate (dyn/with-key (force-handler dep-pair) (rng/fresh-key (+ 500 i)))
+                                           t (sel/from-paths [[:a] [:b]]))]
+        (is (h/close? 0.0 (mx/item weight) 1e-4)
+            "dependent select-all weight is exactly 0"))))
+  (testing "auto-dispatched (compilable model): dependent select-all routes to general, weight 0"
+    ;; dep-pair is static/compilable, but a dependent JOINT selection is not
+    ;; fast-eligible, so the dispatcher defers the compiled per-site regen to
+    ;; the handler general path. This pins that the dispatched (non-forced)
+    ;; result is the correct 0, never the buggy per-site residual.
+    (dotimes [i 15]
+      (let [t  (gen-trace dep-pair [] (cm/choicemap :a (mx/scalar 0.7) :b (mx/scalar 1.3))
+                          (rng/fresh-key (+ 200 i)))
+            {:keys [weight]} (p/regenerate (dyn/with-key dep-pair (rng/fresh-key (+ 600 i)))
+                                           t (sel/from-paths [[:a] [:b]]))]
+        (is (h/close? 0.0 (mx/item weight) 1e-4)
+            "dispatched dependent select-all weight is 0")))))
+
+;; ---------------------------------------------------------------------------
+;; 2. yep2 — cascading pair {a,b} selected, y retained: closed-form W
+;; ---------------------------------------------------------------------------
+
+(deftest cascading-pair-oracle
+  (testing "handler: W = logN(y;b_new,σ) - logN(y;b_old,σ)"
+    (let [sigma 0.7
+          y     1.1]
+      (dotimes [i 25]
+        (let [t (gen-trace cascade [sigma]
+                           (cm/choicemap :a (mx/scalar 0.3) :b (mx/scalar 0.9) :y (mx/scalar y))
+                           (rng/fresh-key (+ 700 i)))
+              b-old (cval (:choices t) :b)
+              {:keys [trace weight]} (p/regenerate
+                                       (dyn/with-key (force-handler cascade) (rng/fresh-key (+ 800 i)))
+                                       t (sel/from-paths [[:a] [:b]]))
+              b-new  (cval (:choices trace) :b)
+              oracle (- (h/gaussian-lp y b-new sigma) (h/gaussian-lp y b-old sigma))]
+          (is (h/close? oracle (mx/item weight) 1e-4)
+              "cascade weight matches retained-y log-density delta")))))
+  (testing "auto-dispatched (compilable model): dependent joint routes to general, same closed form"
+    (let [sigma 0.7 y 1.1]
+      (dotimes [i 15]
+        (let [t (gen-trace cascade [sigma]
+                           (cm/choicemap :a (mx/scalar 0.3) :b (mx/scalar 0.9) :y (mx/scalar y))
+                           (rng/fresh-key (+ 900 i)))
+              b-old (cval (:choices t) :b)
+              {:keys [trace weight]} (p/regenerate (dyn/with-key cascade (rng/fresh-key (+ 1000 i)))
+                                                   t (sel/from-paths [[:a] [:b]]))
+              b-new (cval (:choices trace) :b)
+              oracle (- (h/gaussian-lp y b-new sigma) (h/gaussian-lp y b-old sigma))]
+          (is (h/close? oracle (mx/item weight) 1e-4)
+              "compiled cascade weight matches oracle"))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. fast ≡ general path equivalence (single-site & independent selections)
+;; ---------------------------------------------------------------------------
+
+(deftest fast-general-equivalence
+  (testing "single-site selection: fast path == forced-general path"
+    (dotimes [i 20]
+      (let [t (gen-trace cascade [0.7]
+                         (cm/choicemap :a (mx/scalar 0.3) :b (mx/scalar 0.9) :y (mx/scalar 1.1))
+                         (rng/fresh-key (+ 1100 i)))
+            k (rng/fresh-key (+ 1200 i))
+            fast    (p/regenerate (dyn/with-key (force-handler cascade) k) t (sel/select :b))
+            general (binding [dyn/*force-general-regen* true]
+                      (p/regenerate (dyn/with-key (force-handler cascade) k) t (sel/select :b)))]
+        (is (h/close? (mx/item (:weight fast)) (mx/item (:weight general)) 1e-5)
+            "single-site fast == general weight")
+        (is (h/close? (mx/item (:score (:trace fast))) (mx/item (:score (:trace general))) 1e-5)
+            "single-site fast == general score"))))
+  (testing "independent joint selection: fast path == forced-general path, both 0"
+    (dotimes [i 20]
+      (let [t (gen-trace indep-pair [] (cm/choicemap :a (mx/scalar 0.5) :b (mx/scalar 4.0))
+                         (rng/fresh-key (+ 1300 i)))
+            k (rng/fresh-key (+ 1400 i))
+            fast    (p/regenerate (dyn/with-key (force-handler indep-pair) k) t (sel/from-paths [[:a] [:b]]))
+            general (binding [dyn/*force-general-regen* true]
+                      (p/regenerate (dyn/with-key (force-handler indep-pair) k) t (sel/from-paths [[:a] [:b]])))]
+        (is (h/close? (mx/item (:weight fast)) (mx/item (:weight general)) 1e-5)
+            "independent fast == general")
+        (is (h/close? 0.0 (mx/item (:weight general)) 1e-4)
+            "independent select-all weight 0")))))
+
+;; ---------------------------------------------------------------------------
+;; 4. Branch flip with SHARED :y — weight oracle + MH posterior
+;; ---------------------------------------------------------------------------
+
+(defn- normal-pdf [x mu s]
+  (js/Math.exp (h/gaussian-lp x mu s)))
+
+(deftest branch-flip-shared-weight-oracle
+  (testing "flip 0->1 weight = logN(y;mu1,s1) - logN(y;mu0,s0)"
+    (let [args [0.5 2.0 1.0 -2.0 1.0]  ; p mu1 s1 mu0 s0
+          yv   0.4]
+      (dotimes [i 20]
+        ;; force branch=0 old trace
+        (let [t (gen-trace branch-shared-y args
+                           (cm/choicemap :branch (mx/scalar 0.0) :y (mx/scalar yv))
+                           (rng/fresh-key (+ 1500 i)))
+              {:keys [trace weight]} (p/regenerate
+                                       (dyn/with-key (force-handler branch-shared-y) (rng/fresh-key (+ 1600 i)))
+                                       t (sel/select :branch))
+              b-new (cval (:choices trace) :branch)
+              oracle (if (pos? b-new)
+                       (- (h/gaussian-lp yv 2.0 1.0) (h/gaussian-lp yv -2.0 1.0))   ; flipped 0->1
+                       0.0)]                                                          ; stayed 0
+          (is (h/close? oracle (mx/item weight) 1e-4)
+              "shared-y branch flip weight matches likelihood log-ratio"))))))
+
+(deftest branch-flip-mh-posterior
+  (testing "MH selecting :branch converges to Bayes posterior p(branch=1|y)"
+    (let [p 0.5 mu1 2.0 s1 1.0 mu0 -2.0 s0 1.0
+          yv 0.7
+          L1 (normal-pdf yv mu1 s1)
+          L0 (normal-pdf yv mu0 s0)
+          post (/ (* p L1) (+ (* p L1) (* (- 1 p) L0)))   ; closed-form oracle
+          gf  (force-handler branch-shared-y)
+          args [p mu1 s1 mu0 s0]
+          t0  (gen-trace branch-shared-y args
+                         (cm/choicemap :branch (mx/scalar 0.0) :y (mx/scalar yv))
+                         (rng/fresh-key 1700))
+          n   4000
+          ones (loop [i 0, t t0, acc 0]
+                 (if (>= i n)
+                   acc
+                   (let [{:keys [trace weight]} (p/regenerate
+                                                  (dyn/with-key gf (rng/fresh-key (+ 2000 i)))
+                                                  t (sel/select :branch))
+                         w (mx/item weight)
+                         [_ uk] (rng/split (rng/fresh-key (+ 30000 i)))
+                         u (mx/item (rng/uniform uk []))
+                         accept? (< (js/Math.log u) w)
+                         t' (if accept? trace t)
+                         b  (cval (:choices t') :branch)]
+                     (recur (inc i) t' (+ acc (if (pos? b) 1 0))))))
+          emp (/ ones n)]
+      (is (h/close? post emp 0.03)
+          (str "empirical p(branch=1)=" emp " vs oracle " post)))))
+
+;; ---------------------------------------------------------------------------
+;; 5. Prior-only flip (DIFFERENT addresses) — no throw, W = 0
+;; ---------------------------------------------------------------------------
+
+(deftest prior-only-flip-structure-change
+  (testing "selecting :branch flips arms (xa<->xb) without throwing; W = 0"
+    (let [n-flips (atom 0)]
+      (dotimes [i 40]
+        (let [;; old trace in arm 0 (has :xb)
+              t (gen-trace prior-flip [] (cm/choicemap :branch (mx/scalar 0.0) :xb (mx/scalar 4.2))
+                           (rng/fresh-key (+ 1800 i)))
+              {:keys [trace weight]} (p/regenerate
+                                       (dyn/with-key (force-handler prior-flip) (rng/fresh-key (+ 1900 i)))
+                                       t (sel/select :branch))
+              b-new (cval (:choices trace) :branch)]
+          (when (pos? b-new) (swap! n-flips inc))
+          (is (h/close? 0.0 (mx/item weight) 1e-4)
+              "prior-only flip weight is 0 (fresh/removed cancel)")
+          ;; structure invariant: exactly one of xa/xb present, matching branch
+          (is (if (pos? b-new)
+                (and (has-addr? (:choices trace) :xa) (not (has-addr? (:choices trace) :xb)))
+                (and (has-addr? (:choices trace) :xb) (not (has-addr? (:choices trace) :xa))))
+              "exactly the active arm's latent is present")))
+      (is (pos? @n-flips) "at least one actual branch flip occurred (structure changed)"))))
+
+;; ---------------------------------------------------------------------------
+;; 6. Structure change WITH observation — weight oracle + MH posterior
+;; ---------------------------------------------------------------------------
+
+(deftest struct-change-obs-weight-oracle
+  (testing "flip swaps latent address AND obs-mean; W depends only on retained :obs"
+    (let [obsv -0.3]
+      (dotimes [i 25]
+        (let [t (gen-trace struct-obs [obsv]
+                           (cm/choicemap :branch (mx/scalar 0.0) :yb (mx/scalar 5.1) :obs (mx/scalar obsv))
+                           (rng/fresh-key (+ 2100 i)))
+              {:keys [trace weight]} (p/regenerate
+                                       (dyn/with-key (force-handler struct-obs) (rng/fresh-key (+ 2200 i)))
+                                       t (sel/select :branch))
+              b-new (cval (:choices trace) :branch)
+              oracle (if (pos? b-new)
+                       (- (h/gaussian-lp obsv 2.0 1.0) (h/gaussian-lp obsv -2.0 1.0))  ; 0->1
+                       0.0)]
+          ;; fresh latent must be present, removed latent gone
+          (is (if (pos? b-new)
+                (and (has-addr? (:choices trace) :ya) (not (has-addr? (:choices trace) :yb)))
+                (and (has-addr? (:choices trace) :yb) (not (has-addr? (:choices trace) :ya)))
+                )
+              "active-arm latent present, other removed")
+          (is (h/close? oracle (mx/item weight) 1e-4)
+              "structure-change weight depends only on retained :obs"))))))
+
+(deftest struct-change-mh-posterior
+  (testing "MH over :branch with structure change converges to Bayes posterior"
+    (let [obsv 0.2
+          L1 (normal-pdf obsv 2.0 1.0)
+          L0 (normal-pdf obsv -2.0 1.0)
+          post (/ (* 0.5 L1) (+ (* 0.5 L1) (* 0.5 L0)))
+          gf  (force-handler struct-obs)
+          t0  (gen-trace struct-obs [obsv]
+                         (cm/choicemap :branch (mx/scalar 0.0) :yb (mx/scalar 5.0) :obs (mx/scalar obsv))
+                         (rng/fresh-key 2300))
+          n   4000
+          ones (loop [i 0, t t0, acc 0]
+                 (if (>= i n)
+                   acc
+                   (let [{:keys [trace weight]} (p/regenerate
+                                                  (dyn/with-key gf (rng/fresh-key (+ 2500 i)))
+                                                  t (sel/select :branch))
+                         w (mx/item weight)
+                         u (mx/item (rng/uniform (rng/fresh-key (+ 40000 i)) []))
+                         t' (if (< (js/Math.log u) w) trace t)
+                         b  (cval (:choices t') :branch)]
+                     (recur (inc i) t' (+ acc (if (pos? b) 1 0))))))
+          emp (/ ones n)]
+      (is (h/close? post emp 0.03)
+          (str "structure-change MH empirical p=" emp " vs oracle " post)))))
+
+;; ---------------------------------------------------------------------------
+;; 7. Reversibility — flipping back restores the address set
+;; ---------------------------------------------------------------------------
+
+(deftest structure-change-reversibility
+  (testing "flip then flip back restores original branch address set"
+    (let [t0 (gen-trace prior-flip [] (cm/choicemap :branch (mx/scalar 1.0) :xa (mx/scalar 0.1))
+                        (rng/fresh-key 2600))
+          ;; force a flip by regenerating until branch becomes 0
+          flip-to-0 (loop [i 0]
+                      (let [{:keys [trace]} (p/regenerate
+                                              (dyn/with-key (force-handler prior-flip) (rng/fresh-key (+ 2700 i)))
+                                              t0 (sel/select :branch))]
+                        (if (or (not (pos? (cval (:choices trace) :branch))) (> i 50))
+                          trace
+                          (recur (inc i)))))]
+      (is (has-addr? (:choices flip-to-0) :xb) "after flip to 0, :xb present")
+      (is (not (has-addr? (:choices flip-to-0) :xa)) "after flip to 0, :xa gone"))))
+
+;; ---------------------------------------------------------------------------
+;; 8. Splice composition — regenerate through a spliced dependent child
+;; ---------------------------------------------------------------------------
+
+(deftest splice-regenerate-composition
+  (testing "select child {a,b}: parent W = retained :y delta only (child contributes 0)"
+    (let [sigma 0.7]
+      (dotimes [i 15]
+        (let [t (gen-trace parent-splice [sigma]
+                           (cm/choicemap :child (cm/choicemap :a (mx/scalar 0.2) :b (mx/scalar 0.8))
+                                         :y (mx/scalar 1.0))
+                           (rng/fresh-key (+ 2800 i)))
+              y-old (cval (:choices t) :y)
+              b-old (mx/item (cm/get-choice (:choices t) [:child :b]))
+              ;; select both child latents; :y (parent-direct) retained
+              {:keys [trace weight]} (p/regenerate
+                                       (dyn/with-key (force-handler parent-splice) (rng/fresh-key (+ 2900 i)))
+                                       t (sel/from-paths [[:child :a] [:child :b]]))
+              b-new (mx/item (cm/get-choice (:choices trace) [:child :b]))
+              ;; retained :y depends on child :b via the parent dist N(b, sigma)
+              oracle (- (h/gaussian-lp y-old b-new sigma) (h/gaussian-lp y-old b-old sigma))]
+          (is (h/close? oracle (mx/item weight) 1e-4)
+              "spliced regenerate weight = retained parent-direct :y delta"))))))
+
+;; ---------------------------------------------------------------------------
+;; 9. Batched: uniform flip coherent; divergent flip throws
+;; ---------------------------------------------------------------------------
+
+(deftest batched-regenerate-fast-eligibility-gate
+  ;; The batched per-site convention is exact only for fast-eligible
+  ;; selections; a dependent JOINT batched move would carry the yep2 residual,
+  ;; and a structure-changing batched flip is ill-posed under shape-batching
+  ;; (math-verifier §7). vregenerate rejects both loudly rather than silently
+  ;; miscalibrate. The full batched retained-only path is genmlx-8xia.
+  (testing "dependent joint batched regenerate is rejected (no silent yep2)"
+    (let [vt (dyn/vsimulate dep-pair [] 8 (rng/fresh-key 3000))]
+      (is (thrown? :default
+            (dyn/vregenerate dep-pair vt (sel/from-paths [[:a] [:b]]) (rng/fresh-key 3100)))
+          "dependent joint batched regenerate throws, not silently miscalibrated")))
+  (testing "single-site batched regenerate is fast-eligible and succeeds"
+    (let [vt (dyn/vsimulate dep-pair [] 8 (rng/fresh-key 3200))
+          {:keys [vtrace]} (dyn/vregenerate dep-pair vt (sel/select :b) (rng/fresh-key 3300))]
+      (is (some? vtrace) "single-site batched regenerate is allowed (fast-eligible)"))))
+
+(cljs.test/run-tests)

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -277,6 +277,7 @@ fast test/genmlx/project_test.cljs
 medium test/genmlx/proposal_edit_test.cljs
 slow test/genmlx/qwen2_coder_test.cljs
 fast test/genmlx/recurse_test.cljs
+medium test/genmlx/regen_structure_test.cljs
 fast test/genmlx/remaining_fixes_test.cljs
 slow test/genmlx/resource_recovery_test.cljs
 medium test/genmlx/resource_test.cljs


### PR DESCRIPTION
## Regenerate through structure change + retained-only weight (genmlx-hmch, genmlx-yep2)

ROADMAP Phase 1 item 2 (hmch) + the dependent-selection weight bug (yep2) it
surfaced. Both ship together — one weight algebra fixes both.

### The algebra
The DML `regenerate(t, S)` MH weight, derived independently (math-verifier) and
confirmed against the thesis identity:

```
W = Σ over RETAINED sites of [ lp(v; new ctx) − lp(v; old ctx) ]
```

retained = unselected **and** present in both executions; **selected, fresh
(structure change), and removed sites all cancel to 0**.

- **hmch (structure change):** the handler used to *throw* when an unselected
  address was absent from the old trace (a branch flip changing the address
  set). It now **samples fresh** there, enabling branch-flipping MH.
- **yep2 (dependent joint):** the per-site convention scored a *selected*
  site's backward proposal under the **new** parent values, leaking a spurious
  residual for dependent joint moves (`a~N(0,1); b~N(a,1)`, select `{a,b}` →
  nonzero where theory demands exactly 0). The retained-only weight has no such
  term.

### Mechanism
- `handler.cljs` `regenerate-transition-general`: builds the new trace
  (selected resample; unselected-&-absent sample fresh; unselected-&-present
  retained), accumulates no weight.
- `dynamic.cljs` `make-regen-result-general`: `W = project(new-trace, retained)
  − project(old-trace, retained)`, where `retained` = leaf addresses in both
  traces minus the selection. Two project passes restore each execution context
  and **recurse through splices**, so dependent joint moves and spliced
  sub-models compose with no parent-side bookkeeping.
- `regen-fast-eligible?` gates the fast per-site path (single-site mh-cycle hot
  loop) vs the general path (no structure change + mutually-independent selected
  sites). The compiled/prefix/branch-rewrite regen paths **defer** to the
  handler general path for non-fast-eligible selections; the analytical and
  custom dispatchers are untouched.
- `vregenerate` (batched) **rejects** non-fast-eligible selections loudly rather
  than silently carry the residual; the full batched retained-only path is the
  `genmlx-8xia` follow-up.

### Tests / laws (independent oracles)
- new `test/genmlx/regen_structure_test.cljs` — 11 tests / 332 assertions:
  select-all-dependent = 0, cascading-pair closed form, fast≡general
  equivalence, branch-flip MH posterior vs Bayes, prior-only / structure-change
  flip = 0 (no throw), splice composition, reversibility, batched gate.
- gfi laws `:regenerate-select-all-zero`, `:regenerate-fast-general-equivalence`.
- A **stale circular test** was corrected: `gfi_regenerate_test`
  `regenerate-dependent-select-all-stale-child` had asserted the yep2-buggy
  nonzero weight (derived from implementation arithmetic, not theory); now 0.

### Verification
core 40/40 · regen_structure 11/332 · wp6_regenerate 9/62 · gfi_regenerate
15/23 · splice_weight 8/11 · combinator_regen_weight 11/25 · plate_generate
8/73 · gfi_universal (laws) 14/14 · exact 120/120 · smc {scoring 41, property 7,
evidence 17}. Full medium tier vs a main baseline: **zero new deterministic
regressions** — the 3 new-vs-baseline files (audit_gaps, l3_5_gate, vimco) all
pass serially (TEST_JOBS=2 contention/timing flakes).

Pre-existing cross-branch **update**-weight convention failures (switch + gen-if)
are captured as `genmlx-qm7m` (confirmed identical on main — not introduced here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
