### PR TITLE
fix(gfi): batched retained-only regenerate (8xia) + cross-branch update-weight test fixes (qm7m)

### DIFF
--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -1224,49 +1224,105 @@
   [gf vtrace new-args constraints key]
   (vupdate* gf vtrace new-args constraints key))
 
-(defn vregenerate
-  "Batched regenerate: run model body ONCE with batched regenerate handler.
-   vtrace: VectorizedTrace with [n]-shaped choices, selection: addresses to resample.
-   Returns new VectorizedTrace with resampled selected addresses.
-
-   Uses the per-site batched convention, which is exact ONLY for fast-eligible
-   selections (single-site / mutually-independent, no structure change). A
-   DEPENDENT JOINT batched selection would carry the genmlx-yep2 residual, and
-   a structure-changing batched flip is ill-posed under shape-batching (host
-   control flow must be uniform across particles — math-verifier §7 on
-   genmlx-hmch). Rather than silently miscalibrate, those are rejected loudly;
-   the full batched retained-only path is the genmlx-8xia follow-up. The scalar
-   p/regenerate handles all these cases correctly."
+(defn vproject
+  "Batched project (genmlx-8xia): replay the vtrace's [N]-shaped choices and
+   return the [N]-shaped sum of log-probs at the selected addresses. The
+   batched counterpart of p/project, used to compute the retained-only batched
+   regenerate weight."
   [gf vtrace selection key]
-  (when-not (regen-fast-eligible? gf selection)
-    (throw (ex-info
-             (str "vregenerate: this selection is not fast-eligible (dependent "
-                  "joint move or structure change). The batched per-site "
-                  "convention would carry the genmlx-yep2 weight residual or be "
-                  "ill-posed under shape-batching. Use scalar p/regenerate "
-                  "per particle, or restrict to single-site / independent "
-                  "selections. Full batched retained-only: genmlx-8xia.")
-             {:genmlx/error :batched-regenerate-not-fast-eligible})))
-  (let [key (rng/ensure-key key)
+  (let [n (:n-particles vtrace)
+        result (rt/run-handler h/batched-project-transition
+                 {:choices cm/EMPTY :score SCORE-ZERO :weight SCORE-ZERO
+                  :key (rng/ensure-key key) :selection selection
+                  :old-choices (:choices vtrace) :constraints cm/EMPTY
+                  :batch-size n :batched? true
+                  :executor execute-sub-project :param-store (param-store gf)}
+                 (fn [rt] (run-body gf rt (:args vtrace))))]
+    (:weight result)))
 
-        n (:n-particles vtrace)
-        old-score (:score vtrace)
-        result (rt/run-handler h/batched-regenerate-transition
-                               {:choices cm/EMPTY :score SCORE-ZERO
-                                :weight SCORE-ZERO :key key
-                                :selection selection
-                                :old-choices (:choices vtrace)
-                                :batch-size n :batched? true
-                                :executor execute-sub
-                                :param-store (param-store gf)}
-                               (fn [rt] (run-body gf rt (:args vtrace))))
+(defn- make-vregen-result-general
+  "Batched retained-only regenerate (genmlx-8xia, batched counterpart of
+   make-regen-result-general). Builds the new [N] trace, then
+   W = vproject(new, retained) - vproject(old, retained), where retained =
+   leaf addresses present in both minus the selection. For non-structure-change
+   dependent-joint selections (the batched yep2 case); the [N] weight is exact
+   per particle because the per-site residual cancels in the two project passes."
+  [gf vtrace selection key]
+  (let [n (:n-particles vtrace)
+        [k1 k2] (rng/split (rng/ensure-key key))
+        result (rt/run-handler h/batched-regenerate-transition-general
+                 {:choices cm/EMPTY :score SCORE-ZERO :key k1 :selection selection
+                  :old-choices (:choices vtrace) :batch-size n :batched? true
+                  :executor execute-sub :param-store (param-store gf)}
+                 (fn [rt] (run-body gf rt (:args vtrace))))
         new-score (:score result)
-        proposal-ratio (:weight result)
-        weight (mx/subtract (mx/subtract new-score old-score) proposal-ratio)]
-    {:vtrace (tag-vtrace
-               (vec/->VectorizedTrace gf (:args vtrace) (:choices result)
-                                      new-score weight n (:retval result)))
+        new-vtrace (vec/->VectorizedTrace gf (:args vtrace) (:choices result)
+                                          new-score nil n (:retval result))
+        retained-sel (regen-retained-selection (:choices result) (:choices vtrace) selection)
+        weight (if retained-sel
+                 (mx/subtract (vproject gf new-vtrace retained-sel k2)
+                              (vproject gf vtrace retained-sel k2))
+                 (mx/subtract new-score new-score))]  ; [N]-shaped zero (select-all)
+    {:vtrace (tag-vtrace (vec/->VectorizedTrace gf (:args vtrace) (:choices result)
+                                                new-score weight n (:retval result)))
      :weight weight}))
+
+(defn vregenerate
+  "Batched regenerate (genmlx-hmch / yep2 / 8xia). Returns {:vtrace :weight}.
+
+   Routing (cond order matters):
+   1. Fast-eligible at the PARENT (single-site / mutually-independent direct
+      sites, no structure change) → the per-site batched convention.
+   2. Otherwise, a structure-changing (has-branches?) or splice-bearing model
+      whose PARENT selection is not fast-eligible → throw (host control flow
+      cannot shape-batch coherently — math-verifier §7).
+   3. Otherwise (dependent-joint over the parent's own sites, no structure
+      change) → the batched retained-only general path (two batched project
+      passes — exact, no residual).
+
+   KNOWN GAP (genmlx-8xia, batched splice recursion): a model that only SPLICES
+   a sub-GF and selects no direct parent site is fast-eligible at the parent and
+   takes path 1. Inside the splice the per-site batched convention is used; this
+   is exact for fast-eligible sub-selections (single-site / independent, and the
+   prior-resample case → weight 0), but a DEPENDENT-JOINT selection INSIDE a
+   spliced sub-GF would carry the yep2 residual. Batched splice recursion routed
+   through the executor (so the sub-GF re-gates) is unimplemented — the sub-GF is
+   only a runtime value, not resolvable from the schema at gate time, and the
+   runtime splice handler is below the dynamic layer. For a dependent-joint
+   selection inside a spliced sub-GF, use scalar p/regenerate, which is exact."
+  [gf vtrace selection key]
+  (cond
+    (regen-fast-eligible? gf selection)
+    (let [key (rng/ensure-key key)
+          n (:n-particles vtrace)
+          old-score (:score vtrace)
+          result (rt/run-handler h/batched-regenerate-transition
+                                 {:choices cm/EMPTY :score SCORE-ZERO
+                                  :weight SCORE-ZERO :key key
+                                  :selection selection
+                                  :old-choices (:choices vtrace)
+                                  :batch-size n :batched? true
+                                  :executor execute-sub
+                                  :param-store (param-store gf)}
+                                 (fn [rt] (run-body gf rt (:args vtrace))))
+          new-score (:score result)
+          proposal-ratio (:weight result)
+          weight (mx/subtract (mx/subtract new-score old-score) proposal-ratio)]
+      {:vtrace (tag-vtrace
+                 (vec/->VectorizedTrace gf (:args vtrace) (:choices result)
+                                        new-score weight n (:retval result)))
+       :weight weight})
+
+    (or (:has-branches? (:schema gf)) (seq (:splice-sites (:schema gf))))
+    (throw (ex-info
+             (str "vregenerate: structure-changing or spliced batched regenerate "
+                  "is not supported — host control flow cannot shape-batch "
+                  "coherently across particles, and batched splice recursion is "
+                  "unimplemented. Use scalar p/regenerate per particle.")
+             {:genmlx/error :batched-regenerate-unsupported}))
+
+    :else
+    (make-vregen-result-general gf vtrace selection key)))
 
 (defn loop-obs
   "Create flat constraints from prefix + values sequence.

--- a/src/genmlx/handler.cljs
+++ b/src/genmlx/handler.cljs
@@ -332,6 +332,55 @@
                  (update :choices cm/set-value addr val)
                  (update :score mx/add lp))]))))
 
+(defn batched-project-transition
+  "Pure: batched project — replay the [N]-shaped old value, accumulate its
+   [N] log-prob into :score, and into :weight when the address is selected.
+   The batched counterpart of project-transition (genmlx-8xia)."
+  [state addr dist]
+  (let [n (:batch-size state)
+        old-choice (cm/get-submap (:old-choices state) addr)
+        val (when (cm/has-value? old-choice) (cm/get-value old-choice))]
+    (when (nil? val)
+      (throw (ex-info (str "batched project: address " addr
+                           " not found in previous trace choices.")
+                      {:addr addr})))
+    (let [lp (dc/dist-log-prob dist val)
+          sel (:selection state)]
+      (check-batched-lp! addr n lp)
+      [val (-> state
+               (update :choices cm/set-value addr val)
+               (update :score mx/add lp)
+               (cond-> (and sel (sel/selected? sel addr))
+                 (update :weight mx/add lp)))])))
+
+(defn batched-regenerate-transition-general
+  "Pure: batched retained-only regenerate transition (genmlx-8xia) — the
+   batched counterpart of regenerate-transition-general. Builds the new [N]
+   trace (selected sites resample [N]; unselected sites are retained) and
+   accumulates NO weight; make-vregen-result-general computes the [N]-shaped
+   W via two batched project passes. Only used for non-structure-change
+   selections (the address set is fixed across the batch), so there are no
+   fresh/removed sites — this is the dependent-joint (yep2) batched case."
+  [state addr dist]
+  (let [n (:batch-size state)
+        sel (:selection state)
+        old-choice (cm/get-submap (:old-choices state) addr)]
+    (if (and sel (sel/selected? sel addr))
+      (let [[k1 k2] (rng/split (:key state))
+            new-val (dc/dist-sample-n dist k2 n)
+            new-lp (dc/dist-log-prob dist new-val)]
+        (check-batched-lp! addr n new-lp)
+        [new-val (-> state
+                     (assoc :key k1)
+                     (update :choices cm/set-value addr new-val)
+                     (update :score mx/add new-lp))])
+      (let [val (cm/get-value old-choice)
+            lp (dc/dist-log-prob dist val)]
+        (check-batched-lp! addr n lp)
+        [val (-> state
+                 (update :choices cm/set-value addr val)
+                 (update :score mx/add lp))]))))
+
 ;; ---------------------------------------------------------------------------
 ;; Pure helpers used by runtime.cljs
 ;; ---------------------------------------------------------------------------

--- a/test/genmlx/branching_property_test.cljs
+++ b/test/genmlx/branching_property_test.cljs
@@ -189,7 +189,7 @@
           w (eval-weight weight)]
       (finite? w))))
 
-(defspec branching-update-flip-coin-weight-equals-new-score-minus-old-score 50
+(defspec branching-update-flip-coin-weight-cancels-fresh-arm 50
   (prop/for-all [_k gen-key]
     (let [tr (p/simulate branch-model [])
           old-score (trace-score tr)
@@ -197,12 +197,15 @@
           flipped (if (> coin 0.5) 0.0 1.0)
           constraint (cm/choicemap :coin (mx/scalar flipped))
           {:keys [trace weight]} (p/update branch-model tr constraint)
-          w (eval-weight weight)
-          new-score (trace-score trace)]
-      ;; Fundamental GFI update weight identity:
-      ;; weight = new_score - old_score (for address-changing updates
-      ;; where new addresses are freshly sampled)
-      (close? w (- new-score old-score) 0.1))))
+          w (eval-weight weight)]
+      ;; CORRECTED 2026-06-13 (genmlx-qm7m): previously asserted
+      ;; new_score - old_score, which wrongly includes the FRESH new-arm latent
+      ;; (:heads/:tails) density. Under the thesis update identity that fresh
+      ;; density cancels (it is in both log p(t') and -log q(fresh)). Only the
+      ;; CONSTRAINED :coin contributes: w = lp(coin_new) - old_score, and since
+      ;; :coin ~ Bernoulli(0.5), lp(coin_new) = log(0.5) regardless of value.
+      ;; (Independent derivation: math-verifier §3 on genmlx-qm7m.)
+      (close? w (- (js/Math.log 0.5) old-score) 0.1))))
 
 (defspec branching-update-flip-coin-discard-contains-old-coin 50
   (prop/for-all [_k gen-key]

--- a/test/genmlx/gfi_combinator_invariants_test.cljs
+++ b/test/genmlx/gfi_combinator_invariants_test.cljs
@@ -362,10 +362,20 @@
                              (tr/make-trace (assoc old-trace :args [1]))
                              (meta old-trace))
             {:keys [trace weight discard]} (p/update switch-model modified-trace cm/EMPTY)
-            new-score (realize (:score trace))]
-        ;; Assertion #19 — weight = new_score - old_score
-        (is (th/close? (realize weight) (- new-score old-score) 1e-4)
-            "cross-branch no-constraint weight = new_score - old_score")
+            _new-score (realize (:score trace))]
+        ;; Assertion #19 — weight = -old_score (genmlx-qm7m).
+        ;; CORRECTED 2026-06-13: previously asserted new_score - old_score (the
+        ;; assess-delta). For a cross-branch update with NO constraints the new
+        ;; arm is entirely FRESH (sampled from its prior); under the thesis
+        ;; update identity the fresh-site density cancels (it is in both
+        ;; log p(t') and -log q(fresh)), leaving w = -old_score. The combinator
+        ;; already computes this — the old assertion was the stale party.
+        ;; (Independent derivation: math-verifier on genmlx-qm7m. This is a
+        ;; cross-branch instance of the universal gfi law
+        ;; :update-fresh-cancellation: w = (new-old) - project(t',fresh), and
+        ;; here the whole new arm is fresh so project(t',fresh)=new_score.)
+        (is (th/close? (realize weight) (- old-score) 1e-4)
+            "cross-branch no-constraint weight = -old_score (fresh new arm cancels)")
         ;; Assertion #20 — discard contains old branch choices
         (is (some? (cm/get-value (cm/get-submap discard :x)))
             "discard contains old branch choices")))))
@@ -405,19 +415,21 @@
             (str "independent full-selection weight = " w ", expected 0"))))))
 
 (deftest regenerate-full-selection-dependent
-  (testing "Full selection on dependent model: weight = downstream correction (20 trials)"
+  (testing "Full selection on dependent model: weight = 0 (full-prior resample)"
+    ;; CORRECTED 2026-06-13 (genmlx-yep2): previously asserted the nonzero
+    ;; "downstream correction" gaussian-lp(y_old;x_new) - gaussian-lp(y_old;x_old),
+    ;; which treats :y as RETAINED. Under sel/all BOTH :x and :y are selected
+    ;; (resampled), so there is no retained site and no "old y": a full-prior
+    ;; regenerate is its own proposal, giving weight 0 identically. The old
+    ;; assertion was derived from the buggy per-site convention (yep2). Pinned
+    ;; universally by gfi law :regenerate-select-all-zero.
     (doseq [_ (range 20)]
       (let [tr (p/simulate dependent-model [])
-            x-old (choice-val (:choices tr) [:x])
-            y-old (choice-val (:choices tr) [:y])
-            {:keys [trace weight]} (p/regenerate dependent-model tr sel/all)
-            x-new (choice-val (:choices trace) [:x])
-            actual (realize weight)
-            expected (- (th/gaussian-lp y-old x-new 1)
-                        (th/gaussian-lp y-old x-old 1))]
+            {:keys [weight]} (p/regenerate dependent-model tr sel/all)
+            actual (realize weight)]
         ;; Assertion #25
-        (is (th/close? expected actual 1e-4)
-            (str "dependent full-selection weight " actual " = expected " expected))))))
+        (is (th/close? 0.0 actual 1e-4)
+            (str "dependent full-selection weight " actual " = 0"))))))
 
 (deftest regenerate-partial-selection-dependent
   (testing "Partial selection {:x} on dependent model: downstream weight (20 trials)"

--- a/test/genmlx/regen_structure_test.cljs
+++ b/test/genmlx/regen_structure_test.cljs
@@ -397,20 +397,33 @@
 ;; 9. Batched: uniform flip coherent; divergent flip throws
 ;; ---------------------------------------------------------------------------
 
-(deftest batched-regenerate-fast-eligibility-gate
-  ;; The batched per-site convention is exact only for fast-eligible
-  ;; selections; a dependent JOINT batched move would carry the yep2 residual,
-  ;; and a structure-changing batched flip is ill-posed under shape-batching
-  ;; (math-verifier §7). vregenerate rejects both loudly rather than silently
-  ;; miscalibrate. The full batched retained-only path is genmlx-8xia.
-  (testing "dependent joint batched regenerate is rejected (no silent yep2)"
-    (let [vt (dyn/vsimulate dep-pair [] 8 (rng/fresh-key 3000))]
-      (is (thrown? :default
-            (dyn/vregenerate dep-pair vt (sel/from-paths [[:a] [:b]]) (rng/fresh-key 3100)))
-          "dependent joint batched regenerate throws, not silently miscalibrated")))
+(deftest batched-retained-only-regenerate
+  ;; genmlx-8xia: the batched retained-only general path. Dependent-joint
+  ;; batched moves (no structure change) take two batched project passes —
+  ;; exact per particle, no yep2 residual. Single-site/independent use the fast
+  ;; path. Structure-change/spliced batched regenerate is still rejected.
+  (testing "dependent select-all => per-particle weight 0 (batched yep2 fix)"
+    (let [vt (dyn/vsimulate dep-pair [] 8 (rng/fresh-key 3000))
+          {:keys [weight]} (dyn/vregenerate dep-pair vt (sel/from-paths [[:a] [:b]]) (rng/fresh-key 3100))
+          ws (mx/->clj weight)]
+      (is (= 8 (count ws)) "weight is [N]-shaped")
+      (is (every? #(< (js/Math.abs %) 1e-4) ws) "every particle weight is 0")))
+  (testing "dependent joint {a,b}, y retained: per-particle closed-form oracle"
+    (let [sigma 0.7
+          vt (dyn/vsimulate cascade [sigma] 8 (rng/fresh-key 3200))
+          y-old (mx/->clj (cm/get-value (cm/get-submap (:choices vt) :y)))
+          b-old (mx/->clj (cm/get-value (cm/get-submap (:choices vt) :b)))
+          {:keys [vtrace weight]} (dyn/vregenerate cascade vt (sel/from-paths [[:a] [:b]]) (rng/fresh-key 3300))
+          b-new (mx/->clj (cm/get-value (cm/get-submap (:choices vtrace) :b)))
+          ws (mx/->clj weight)
+          oracle (mapv (fn [yi bn bo] (- (h/gaussian-lp yi bn sigma) (h/gaussian-lp yi bo sigma)))
+                       y-old b-new b-old)]
+      (is (= 8 (count ws)) "weight is [N]-shaped")
+      (is (every? (fn [[w o]] (< (js/Math.abs (- w o)) 1e-3)) (map vector ws oracle))
+          "each particle weight = retained-y log-density delta (batched yep2-exact)")))
   (testing "single-site batched regenerate is fast-eligible and succeeds"
-    (let [vt (dyn/vsimulate dep-pair [] 8 (rng/fresh-key 3200))
-          {:keys [vtrace]} (dyn/vregenerate dep-pair vt (sel/select :b) (rng/fresh-key 3300))]
-      (is (some? vtrace) "single-site batched regenerate is allowed (fast-eligible)"))))
+    (let [vt (dyn/vsimulate dep-pair [] 8 (rng/fresh-key 3400))
+          {:keys [vtrace]} (dyn/vregenerate dep-pair vt (sel/select :b) (rng/fresh-key 3500))]
+      (is (some? vtrace) "single-site batched regenerate uses the fast path"))))
 
 (cljs.test/run-tests)


### PR DESCRIPTION
## Batched retained-only regenerate (genmlx-8xia) + cross-branch update-weight test fixes (genmlx-qm7m)

Two follow-ups to the regenerate/update weight work (PRs #103–#105).

### genmlx-8xia — batched retained-only regenerate
Extends the scalar retained-only fix to the batched path (`vregenerate`).
- `handler.cljs`: `batched-project-transition`, `batched-regenerate-transition-general`.
- `dynamic.cljs`: `vproject` + `make-vregen-result-general`; `vregenerate` now routes
  - **fast-eligible** (single-site / independent, no structure change) → per-site batched convention;
  - **structure-change / non-fast-eligible splice** → throw (host control flow can't shape-batch coherently);
  - **else** (dependent-joint, no structure change) → batched retained-only general path:
    `W[i] = vproject(new, retained) − vproject(old, retained)` — exact per particle, no yep2 residual.
- Tests (`regen_structure_test`): batched dependent select-all → `[N]` zeros; batched dependent `{a,b}` with retained `:y` → per-particle closed-form gaussian-lp delta.

**Known gap (`genmlx-20p7`, follow-up):** a dependent-joint selection *inside a spliced sub-GF* still takes the per-site path (exact for the prior-resample/single-site sub-cases all existing tests exercise, but residual-bearing for dependent joints). Proper fix needs batched splice-regenerate routed through the executor so the sub-GF re-gates; the sub-GF is a runtime value (schema only has `:gf-form`) and `runtime.cljs` is below the dynamic layer, so gate-time recursion isn't possible. Scalar `p/regenerate` is exact there today. Pre-existing (predates 8xia).

### genmlx-qm7m — cross-branch UPDATE-weight tests were stale
A math-verifier independently confirmed the **combinator/handler were already correct**: for a no-constraint cross-branch update the fresh new-arm density cancels, so `w = −old_score`, **not** `new_score − old_score`. This is a cross-branch instance of the existing universal law `:update-fresh-cancellation`. Corrected:
- `gfi_combinator_invariants` `switch-cross-branch-update-no-constraints` → `−old_score`.
- `branching_property` flip-coin (`:coin` constrained, Bernoulli(0.5)) → `log(0.5) − old_score`.
- `gfi_combinator_invariants` `regenerate-full-selection-dependent` → `0` — a **stale regenerate test PR #105 had left red on main**: the retained-only fix correctly turns select-all-dependent to 0, but the test still asserted the old buggy nonzero value (missed earlier because a file-granularity baseline diff hid the new sub-failure inside an already-failing file).

### Verification
regen_structure 11/335 · gfi_combinator_invariants 17/334 · branching_property 11/11 · gfi_regenerate 15/23 · vectorized_equivalence 15/59 · splice_weight 8/11 · phase_a 18/36 · gfi_universal (laws) 14/14 · core 40/40. Full medium tier vs main baseline: **zero new deterministic regressions** (the one new-vs-baseline file, `pmcmc_test`, passes serially — a TEST_JOBS=2 contention flake); `gfi_combinator_invariants` now fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
