### PR TITLE
fix(gfi): batched splice recursion — dependent-joint regenerate inside a spliced sub-GF (genmlx-20p7)

### DIFF
--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -1267,6 +1267,52 @@
                                                 new-score weight n (:retval result)))
      :weight weight}))
 
+(defn batched-sub-regen
+  "Executor for a spliced DynamicGF sub-GF during BATCHED regenerate
+   (genmlx-20p7). Threaded into the batched handler state as :batched-sub-regen
+   and invoked by the runtime splice handler for the regenerate sub-case.
+
+   Returns nil when the sub-selection is FAST-ELIGIBLE for the sub-GF — the
+   caller then uses the per-site batched transition, which is exact there
+   (single-site / independent / prior-resample). Otherwise (a dependent-joint
+   selection inside the sub) runs the sub's batched retained-only general path
+   and returns a batched sub-result whose :weight is the parent-fast-formula
+   proposal ratio (child_new_score - child_old_score - w_child), so the parent's
+   (new_score - old_score) - proposal_ratio yields the child's exact retained-
+   only w_child. Throws if the sub ITSELF splices (deeper batched recursion is
+   unimplemented — scalar p/regenerate is exact there)."
+  [sub-gf sub-args sub-selection sub-old-choices n key param-store]
+  (when-not (regen-fast-eligible? sub-gf sub-selection)
+    (when (seq (:splice-sites (:schema sub-gf)))
+      (throw (ex-info (str "batched regenerate: a dependent-joint selection inside a "
+                           "spliced sub-GF that itself splices is unsupported "
+                           "(genmlx-20p7). Use scalar p/regenerate per particle.")
+                      {:genmlx/error :batched-nested-splice-regenerate :addr sub-args})))
+    (let [sub-gf (propagate-meta sub-gf nil param-store)
+          [k1 k2] (rng/split key)
+          old-vt (vec/->VectorizedTrace sub-gf sub-args sub-old-choices SCORE-ZERO nil n nil)
+          result (rt/run-handler h/batched-regenerate-transition-general
+                   {:choices cm/EMPTY :score SCORE-ZERO :key k1 :selection sub-selection
+                    :old-choices sub-old-choices :batch-size n :batched? true
+                    :executor execute-sub :param-store param-store}
+                   (fn [rt] (run-body sub-gf rt sub-args)))
+          child-new-score (:score result)
+          new-vt (vec/->VectorizedTrace sub-gf sub-args (:choices result)
+                                        child-new-score nil n (:retval result))
+          retained-sel (regen-retained-selection (:choices result) sub-old-choices sub-selection)
+          w-child (if retained-sel
+                    (mx/subtract (vproject sub-gf new-vt retained-sel k2)
+                                 (vproject sub-gf old-vt retained-sel k2))
+                    (mx/subtract child-new-score child-new-score))
+          ;; child's full OLD joint score (re-scored under old choices) — the
+          ;; parent's recorded old score already includes it, so the conversion
+          ;; below makes the parent fast formula reproduce w_child exactly.
+          child-old-score (vproject sub-gf old-vt
+                                    (sel/from-paths (cm/addresses sub-old-choices)) k2)
+          proposal-ratio (mx/subtract (mx/subtract child-new-score child-old-score) w-child)]
+      {:choices (:choices result) :score child-new-score
+       :weight proposal-ratio :retval (:retval result) :score-type :joint})))
+
 (defn vregenerate
   "Batched regenerate (genmlx-hmch / yep2 / 8xia). Returns {:vtrace :weight}.
 
@@ -1303,6 +1349,7 @@
                                   :old-choices (:choices vtrace)
                                   :batch-size n :batched? true
                                   :executor execute-sub
+                                  :batched-sub-regen batched-sub-regen
                                   :param-store (param-store gf)}
                                  (fn [rt] (run-body gf rt (:args vtrace))))
           new-score (:score result)

--- a/src/genmlx/runtime.cljs
+++ b/src/genmlx/runtime.cljs
@@ -112,9 +112,20 @@
                       sub-init-state (if-let [ps (:param-store state)]
                                        (assoc sub-init-state :param-store ps)
                                        sub-init-state)
-                      ;; Recursive call to run-handler
-                      sub-result (run-handler sub-transition sub-init-state
-                                              (fn [rt] (apply sub-body-fn rt (vec args))))
+                      ;; genmlx-20p7: gate the REGENERATE sub-case via the
+                      ;; batched-sub-regen executor (threaded from dynamic.cljs).
+                      ;; A dependent-joint selection inside the sub takes the
+                      ;; retained-only general path instead of the residual-
+                      ;; bearing per-site convention. nil => fast-eligible (or no
+                      ;; executor) => fall through to the per-site run-handler.
+                      gated-sub (when (and sub-selection (:batched-sub-regen state))
+                                  ((:batched-sub-regen state)
+                                   gf (vec args) sub-selection
+                                   (or sub-old-choices cm/EMPTY) n k2 (:param-store state)))
+                      ;; Recursive call to run-handler (per-site path)
+                      sub-result (or gated-sub
+                                     (run-handler sub-transition sub-init-state
+                                                  (fn [rt] (apply sub-body-fn rt (vec args)))))
                       ;; Merge into parent state
                       _ (@validate-fn :sub-result sub-result
                           (str "splice sub-result at " addr))

--- a/test/genmlx/regen_structure_test.cljs
+++ b/test/genmlx/regen_structure_test.cljs
@@ -426,4 +426,32 @@
           {:keys [vtrace]} (dyn/vregenerate dep-pair vt (sel/select :b) (rng/fresh-key 3500))]
       (is (some? vtrace) "single-site batched regenerate uses the fast path"))))
 
+;; ---------------------------------------------------------------------------
+;; 10. Batched dependent-joint selection INSIDE a spliced sub-GF (genmlx-20p7)
+;; ---------------------------------------------------------------------------
+
+(deftest batched-regenerate-through-splice-dependent-joint
+  (testing "select {child:a, child:b} (dependent, inside splice), :y retained: per-particle oracle"
+    ;; parent-splice splices child-cascade (a~N(0,1), b~N(a,1) -> b), then
+    ;; y ~ N(b, sigma). Selecting BOTH child latents is a dependent-joint move
+    ;; INSIDE the spliced sub-GF; :y (parent-direct) is retained. The batched
+    ;; per-site convention would carry the yep2 residual through the splice;
+    ;; the executor-gated sub general path makes W exact per particle:
+    ;;   W[i] = logN(y_i; b_new_i, sigma) - logN(y_i; b_old_i, sigma).
+    (let [sigma 0.7
+          n 8
+          vt (dyn/vsimulate parent-splice [sigma] n (rng/fresh-key 3600))
+          y-old (mx/->clj (cm/get-value (cm/get-submap (:choices vt) :y)))
+          b-old (mx/->clj (cm/get-choice (:choices vt) [:child :b]))
+          {:keys [vtrace weight]} (dyn/vregenerate parent-splice vt
+                                                   (sel/from-paths [[:child :a] [:child :b]])
+                                                   (rng/fresh-key 3700))
+          b-new (mx/->clj (cm/get-choice (:choices vtrace) [:child :b]))
+          ws (mx/->clj weight)
+          oracle (mapv (fn [yi bn bo] (- (h/gaussian-lp yi bn sigma) (h/gaussian-lp yi bo sigma)))
+                       y-old b-new b-old)]
+      (is (= n (count ws)) "weight is [N]-shaped")
+      (is (every? (fn [[w o]] (< (js/Math.abs (- w o)) 1e-3)) (map vector ws oracle))
+          "each particle weight = retained-:y delta only (sub residual cancels)"))))
+
 (cljs.test/run-tests)


### PR DESCRIPTION
## Batched splice recursion: dependent-joint regenerate inside a spliced sub-GF (genmlx-20p7)

Closes the gap the genmlx-8xia adversarial review flagged. A parent that *only splices* a sub-GF (selects no direct site) is **fast-eligible at the parent**, so batched `vregenerate` took the per-site path; a **dependent-joint selection inside the spliced sub-GF** then silently carried the yep2 residual.

### Fix (executor pattern)
`runtime.cljs` (Layer 0) can't call the dynamic-layer gating (circular dep), so the gating logic is threaded in as a closure:
- `dynamic.cljs/batched-sub-regen` → added to the batched handler state as `:batched-sub-regen`, invoked by the runtime splice handler for the regenerate sub-case.
- Returns `nil` when the sub-selection is **fast-eligible** → caller keeps the exact per-site path (single-site / independent / prior-resample — all existing splice batched tests).
- Otherwise runs the sub's **batched retained-only general path** and returns a sub-result whose `:weight` is the parent-fast-formula proposal ratio `child_new − child_old − w_child`, so the parent's `(new − old) − proposal_ratio` reproduces the child's exact retained-only `w_child`.
- A sub that **itself splices** → throws (deeper batched recursion unimplemented; scalar `p/regenerate` is exact there).

### Test
`regen_structure` adds `batched-regenerate-through-splice-dependent-joint`: parent splices a cascade sub (`a~N(0,1); b~N(a,1)`), select `{child:a, child:b}` (dependent-joint *inside* the splice) with retained `:y~N(b,σ)` → each particle weight = `logN(y;b_new,σ) − logN(y;b_old,σ)`; the sub residual cancels. (Confirmed red before the fix, green after.)

### Verification
regen_structure 12/337 · splice_weight 8/11 · vectorized_equivalence 15/59 · phase_a 18/36 · gfi_laws_p9 9/23 · all `batched_*` / `vectorized_*` / `combinator_*` suites green · core 40/40 (serial). **Blast radius is batched-DynamicGF-splice regenerate only** — non-splice and non-batched paths are untouched (the `:batched-sub-regen` closure is consulted only when a splice is encountered during a batched regenerate).

With this, the retained-only regenerate weight is exact across **all** paths: scalar, compiled, batched, and now batched-through-splices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
