### PR TITLE
fix(gfi): analytical regenerate declines on block re-open — decomposition-consistent MH weight (genmlx-wl1y)

### DIFF
--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -635,6 +635,27 @@
              :score-type (or (:score-type (meta (if (map? t) tf t))) :joint)
              :label :custom}))))))
 
+(defn- regen-reopens-analytical?
+  "True when the regenerate selection selects any address that carries an analytical
+   regenerate handler — an eliminated conjugate prior, a linear-Gaussian block
+   latent/obs, or a Kalman state/obs. Selecting such an address RE-OPENS the
+   marginalisation: the analytical handler declines and the site is scored JOINTLY
+   this pass (genmlx-b470's block-reopened? / Case-A fallthrough, and the scalar
+   conjugate \"prior selected → nil\" path). The incoming trace is :marginal, so the
+   fast (new-score − old-score) difference in make-regen-result would subtract a
+   marginal old score from a now-joint new score — not a valid MH weight
+   (genmlx-wl1y). When this holds the analytical regenerate declines; the joint
+   handler path then runs through joint-rescore-marginal, which converts the old
+   trace to a joint score so BOTH sides share one decomposition. When it does NOT
+   hold (e.g. an MH move over an unrelated residual) the block re-marginalises
+   identically to the old trace, so the fast analytical path stays exact and
+   Rao-Blackwellised (genmlx-m3tn / genmlx-4q9d)."
+  [schema selection]
+  (boolean
+    (when-let [handlers (:auto-regenerate-handlers schema)]
+      (and selection
+           (some (fn [addr] (sel/selected? selection addr)) (keys handlers))))))
+
 (def ^:private analytical-dispatcher
   (reify dispatch/IDispatcher
     (resolve-transition [_ op schema opts]
@@ -651,8 +672,14 @@
             {:run run-fn :score-type :marginal :label :analytical})
 
           :regenerate
+          ;; The marginal old-score is only a valid subtrahend when THIS pass also
+          ;; scores every eliminated structure marginally. A selection that re-opens
+          ;; a block (genmlx-wl1y) flips it to joint scoring this pass — decline so
+          ;; the joint handler path + joint-rescore-marginal differences two joint
+          ;; scores consistently. Stable (no-reopen) moves keep the fast path.
           (when (and (:auto-regenerate-transition schema)
-                     (= :marginal (tr/score-type (:trace opts))))
+                     (= :marginal (tr/score-type (:trace opts)))
+                     (not (regen-reopens-analytical? schema (:selection opts))))
             {:run run-fn :score-type :marginal :label :analytical})
 
           nil)))))

--- a/test/genmlx/linear_gaussian_elim_test.cljs
+++ b/test/genmlx/linear_gaussian_elim_test.cljs
@@ -301,6 +301,50 @@
   (assert-close "intercept (unselected) kept at posterior mean"
                 0.441145 (choice-val rtrace :intercept) POST-TOL))
 
+;; -- Case A weight vs INDEPENDENT oracle (genmlx-wl1y): re-opening the block by
+;;    selecting :slope must yield the model-density-only MH regenerate weight
+;;    W = Σ_retained [lp(v;new) − lp(v;old)]. retained = every site but :slope;
+;;    only the y_j depend on slope (intercept is retained at its old value, tau & w
+;;    are slope-independent), so the closed form collapses to the Gaussian residual
+;;    difference below — computed in float64 JS from the model density, NOT via the
+;;    Kalman eliminator or the GFI weight machinery. The new/old slope are read back
+;;    from the actual traces so the oracle scores the move that really happened.
+;;    Pre-fix the analytical regenerate differenced a JOINT new-score against the
+;;    MARGINAL old-score (the block re-marginalised differently across passes), so
+;;    the weight carried a spurious (block-joint − block-marginal) term and this
+;;    assertion failed.
+(println "-- Case A (select :slope): regen weight == independent closed-form oracle (wl1y)")
+(let [xs        [1.0 2.0 3.0 4.0 5.0]
+      ys        [2.3 4.7 6.1 8.9 10.2]
+      {otrace :trace} (p/generate (dyn/with-key br-model (rng/fresh-key 7)) br-xs br-obs)
+      old-slope (choice-val otrace :slope)
+      {rtrace :trace rweight :weight}
+      (p/regenerate (dyn/with-key br-model (rng/fresh-key 13)) otrace (sel/select :slope))
+      w-analytical (mx/item rweight)
+      new-slope (choice-val rtrace :slope)
+      intercept (choice-val rtrace :intercept)             ; retained at old value
+      ;; W = Σ_j [logN(y_j; new-slope·x_j+intercept, 1) − logN(y_j; old-slope·x_j+intercept, 1)]
+      ;;   = Σ_j [ −½(y_j−μ_new)² + ½(y_j−μ_old)² ]   (the −½log2π and σ=1 terms cancel)
+      w-oracle  (reduce + (map (fn [xj yj]
+                                 (let [rn (- yj (+ (* new-slope xj) intercept))
+                                       ro (- yj (+ (* old-slope xj) intercept))]
+                                   (+ (* -0.5 rn rn) (* 0.5 ro ro))))
+                               xs ys))
+      ;; Ground-truth cross-check: regenerate the SAME old trace with the SAME key via
+      ;; the stripped (handler-only) model. Post-fix the analytical path declines on a
+      ;; block-reopening selection and takes that very handler path, so the two weights
+      ;; are bit-identical regardless of magnitude; pre-fix they differed by the bug
+      ;; term. This is magnitude-robust where the float64 oracle is float32-floor-bound.
+      w-stripped (mx/item (:weight (p/regenerate
+                                     (dyn/with-key (strip-analytical br-model) (rng/fresh-key 13))
+                                     otrace (sel/select :slope))))]
+  ;; tol scaled to the float32 floor at this weight magnitude (|w|≈2400 ⇒ ~1 ulp ≈ 3e-4);
+  ;; the bug it guards against is ~0.12 nat, two orders larger.
+  (assert-close "Case A regen weight = closed-form MH weight (independent oracle)"
+                w-oracle w-analytical 3e-3)
+  (assert-close "Case A analytical regen weight = handler ground truth (stripped)"
+                w-stripped w-analytical 1e-4))
+
 ;; -- MH over tau (analytical): converges to the oracle, AND the eliminated block
 ;;    stays at the EXACT posterior mean every step (zero MC variance = Rao-Blackwell).
 (println "-- MH over tau (analytical): oracle convergence + zero-variance block")

--- a/test/genmlx/score_type_test.cljs
+++ b/test/genmlx/score_type_test.cljs
@@ -74,6 +74,19 @@
       (trace :obs-b (dist/gaussian b 1))
       [a b])))
 
+;; Eliminated conjugate latent :mu (normal-normal via :y) PLUS a residual :tau
+;; (Gamma prior, non-conjugate scale obs :w). Trace is :marginal; selecting :mu
+;; RE-OPENS the eliminated pair (a wl1y decline → joint conversion), while
+;; selecting the residual :tau does NOT re-open it (the analytical regenerate
+;; still fires and returns a :marginal result).
+(defn- conj+residual []
+  (gen []
+    (let [mu  (trace :mu (dist/gaussian 0 1))
+          tau (trace :tau (dist/gamma-dist 2 1))]
+      (trace :y (dist/gaussian mu 1))
+      (trace :w (dist/gaussian 0 tau))
+      mu)))
+
 (def ^:private tg-obs
   (-> cm/EMPTY
       (cm/set-choice [:obs-a] (mx/scalar 1.0))
@@ -365,23 +378,61 @@
 ;; 5. Backstop teeth — the law guarding the check itself (540f)
 ;; ============================================================
 
-(deftest backstop-throws-when-strip-is-bypassed
-  ;; If the 540f strip fix ever regresses (a new entry point forgets to
-  ;; strip, or the strip is broken), trace-MH on an eliminated model must
-  ;; THROW — never silently anchor at the posterior mean.
-  (let [model (dyn/auto-key (two-gaussians))
-        {t :trace} (p/generate model [] tg-obs)]
-    (is (= #{:a :b} (get-in (:schema model)
-                            [:analytical-plan :rewrite-result :eliminated]))
+(deftest backstop-protects-eliminated-model-when-strip-bypassed
+  ;; The 540f safety GOAL: if the trace-MH analytical strip ever regresses, an
+  ;; eliminated model must NOT silently anchor chains at the posterior mean
+  ;; (chi2 290.9 vs crit 21.67). Two protections now hold that line, both
+  ;; exercised here with the strip forced to identity (the regressed-strip case):
+  ;;
+  ;;  (1) wl1y re-opening decline — selecting an eliminated latent makes the
+  ;;      analytical regenerate dispatcher DECLINE (the selection re-opens the
+  ;;      block), routing to the joint handler + joint-rescore-marginal. The
+  ;;      latent is resampled, not pinned: a CORRECT joint move, so the result is
+  ;;      :joint and no throw is needed — the chain is not corrupted. (Pre-wl1y
+  ;;      this case threw; the throw was the only protection. The decline is the
+  ;;      stronger one: it makes the move correct, not merely loud.)
+  ;;  (2) assert-joint! teeth — see backstop-throws-on-marginal-residual-move:
+  ;;      any :marginal result that still reaches trace-MH throws loudly.
+  (let [tg (dyn/auto-key (two-gaussians))
+        {t :trace} (p/generate tg [] tg-obs)]
+    (is (= #{:a :b} (get-in (:schema tg) [:analytical-plan :rewrite-result :eliminated]))
         "precondition: model is statically eliminated")
     (is (= :marginal (tr/score-type t)) "precondition: analytical generate fired")
+    ;; Direct regenerate of an eliminated latent (the move mh-kernel runs after the
+    ;; — here bypassed — strip): the wl1y decline routes it to the joint handler +
+    ;; conversion, so the RESULT trace is :joint (not a marginal anchor) with a
+    ;; finite weight.
+    (let [{rt :trace rw :weight}
+          (p/regenerate (dyn/auto-key (:gen-fn t)) t (sel/select :a))]
+      (is (= :joint (tr/score-type rt))
+          "regenerate result is joint — wl1y decline → conversion, not a marginal anchor")
+      (is (js/isFinite (mx/item rw)) "regenerate weight is finite"))
+    ;; Backstop: with the strip forced to identity, mh-kernel/mh-step therefore do
+    ;; NOT trip assert-joint! — the regenerate result they assert on is joint. (A
+    ;; :marginal result would still throw; see the residual-move test below.) The
+    ;; returned trace is the accept/reject outcome, so it may be the old :marginal
+    ;; trace on rejection — the point is only that no corruption-guard fired.
+    (with-redefs [dyn/strip-analytical-path identity]
+      (is (tr/trace? ((kern/mh-kernel (sel/select :a)) t (rng/fresh-key 540)))
+          "mh-kernel runs without throwing (joint regenerate result)")
+      (is (tr/trace? (mcmc/mh-step t (sel/select :a) (rng/fresh-key 541)))
+          "mh-step runs without throwing (joint regenerate result)"))))
+
+(deftest backstop-throws-on-marginal-residual-move-when-strip-bypassed
+  ;; The assert-joint! teeth are intact: with the strip bypassed, a residual MH
+  ;; move on a model with an eliminated block does NOT re-open it, so the
+  ;; analytical regenerate fires and returns a :marginal result — trace-MH must
+  ;; THROW, never silently accept a marginal-scored step (genmlx-540f / wl1y).
+  (let [m (dyn/auto-key (conj+residual))
+        {t :trace} (p/generate m [] (cm/choicemap :y (mx/scalar 1.5)))]
+    (is (= :marginal (tr/score-type t)) "precondition: analytical generate fired (mu eliminated)")
     (with-redefs [dyn/strip-analytical-path identity]
       (is (score-type-error?
-            #((kern/mh-kernel (sel/select :a)) t (rng/fresh-key 540)))
-          "mh-kernel with a bypassed strip throws instead of corrupting the chain")
+            #((kern/mh-kernel (sel/select :tau)) t (rng/fresh-key 542)))
+          "mh-kernel throws on a marginal residual move when the strip is bypassed")
       (is (score-type-error?
-            #(mcmc/mh-step t (sel/select :a) (rng/fresh-key 541)))
-          "mh-step with a bypassed strip throws instead of corrupting the chain"))))
+            #(mcmc/mh-step t (sel/select :tau) (rng/fresh-key 543)))
+          "mh-step throws on a marginal residual move when the strip is bypassed"))))
 
 ;; ============================================================
 ;; 6. Strip consolidation — importance sampling on eliminated models


### PR DESCRIPTION
## What

Fixes `genmlx-wl1y` — the lone open thread in the 2026-06-09 audit epic (`genmlx-hqo2`) and the **last residual in the ROADMAP.md "Phase 0 — Correctness floor."** Closing it empties the floor completely.

## The bug

`run-regen-analytical` used the fast `make-regen-result` (`W = new-score − old-score − proposal-ratio`), differencing **this pass's** score against the old `:marginal` trace's stored `:score`. When a regenerate selection **re-opens** an analytically-eliminated block (selects a block latent/obs → `block-reopened?`), that block is scored **jointly** this pass but was **marginal** in the old trace — so the weight carried a spurious `(block-joint − block-marginal)` term, which is not a valid MH log-acceptance ratio (measured **0.124 nats** off on the `br-model` Case A).

## The fix

`regen-reopens-analytical?` — the analytical-dispatcher `:regenerate` branch now **declines** when the selection touches any `:auto-regenerate-handlers` key (re-opens an eliminated conjugate prior / LG block / Kalman chain). The move then routes to the joint handler path, where the existing `joint-rescore-marginal` chokepoint (`genmlx-pkmx`/`lbae`) converts the old `:marginal` trace to joint so **both sides share one decomposition**.

Stable moves (e.g. MH over an unrelated residual) keep the fast marginal path — **Rao-Blackwellization preserved** (`genmlx-m3tn` / `genmlx-4q9d`). This is the same root cause as `genmlx-540f`; the decline is a stronger second layer — it makes the move *correct*, not merely *loud*.

## Verification

- **Independent float64 oracle** (`linear_gaussian_elim_test` Case A): weight discrepancy collapses **0.124 → 3.8e-4** (float32 floor); **bit-identical (Δ=0)** to the handler ground truth (`strip-analytical`).
- **540f backstop revised faithfully** (`score_type_test`): `backstop-protects-eliminated-model-when-strip-bypassed` verifies the eliminated-latent move is now *correct* (joint conversion, no anchoring); the `assert-joint!` throw teeth are preserved via the new `backstop-throws-on-marginal-residual-move-when-strip-bypassed`.
- **No regressions:** 12 targeted analytical/regenerate files + 6 GFI law parts (p2/p4/p5/p7/p8/p9) all green. The one law failure (`law:vgenerate-shape-and-finiteness`) is the pre-existing `genmlx-fgb6` bug — baseline-confirmed *identical on clean main* across two runs (mechanistically disjoint from this change).

## Diff

3 files, +135/−13: `src/genmlx/dynamic.cljs` (the fix), `test/genmlx/linear_gaussian_elim_test.cljs` (independent-oracle reproduction), `test/genmlx/score_type_test.cljs` (faithful 540f backstop revision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
