### PR TITLE
feat(gfi): analytical update mode for linear-Gaussian blocks + scalar conjugate (genmlx-6hcu)

### DIFF
--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -532,6 +532,41 @@
       (clojure.core/update regen-result :trace tr/with-score-type :marginal)
       regen-result)))
 
+(defn- run-update-analytical
+  "Analytical :update for eliminated linear-Gaussian blocks + scalar conjugate
+   pairs (genmlx-6hcu). Runs the :auto-update-transition: each eliminated
+   structure re-folds its marginal LL under the merged (new-over-old) obs into
+   BOTH :score and :weight, sets its latent choices to the NEW posterior mean,
+   and charges changed-obs old values into :discard. The thesis update weight
+   ((:weight result) − old score) then collapses to the Δ marginal-LL of the
+   changed structure(s): untouched blocks/pairs and retained residual sites
+   contribute identically to both sides and cancel. The result trace stays
+   :marginal. Gated to value-only obs updates (no re-opening latent constraint,
+   no Kalman/MVN) by the analytical-dispatcher; otherwise the joint handler path
+   runs via joint-rescore-marginal."
+  [gf _args key {:keys [trace constraints]}]
+  (let [schema (:schema gf)
+        result (rt/run-handler (:auto-update-transition schema)
+                 {:choices cm/EMPTY :score SCORE-ZERO :weight SCORE-ZERO
+                  :key key :constraints constraints
+                  :old-choices (:choices trace)
+                  ;; LG block update handlers recover the design matrix by probing
+                  ;; the obs mean forms against the model args.
+                  :model-args (:args trace)
+                  :auto-posteriors {} :auto-kalman-beliefs {} :auto-kalman-noise-vars {}
+                  :old-splice-scores (::splice-scores (meta trace))
+                  :old-nested-splice-scores (::nested-splice-scores (meta trace))
+                  :discard cm/EMPTY
+                  :executor execute-sub :param-store (param-store gf)}
+                 (fn [rt] (run-body gf rt (:args trace))))
+        new-trace (make-result-trace gf (:args trace) result)
+        update-result (make-update-result new-trace
+                        (mx/subtract (:weight result) (:score trace))
+                        (:discard result) constraints (:choices result) result)]
+    (if (analytical-fired? result)
+      (clojure.core/update update-result :trace tr/with-score-type :marginal)
+      update-result)))
+
 ;; -- Utility --
 
 (defn- add-deleted-to-discard
@@ -596,7 +631,8 @@
 (def ^:private analytical-table
   {:generate run-generate-analytical
    :assess   run-assess-analytical
-   :regenerate run-regen-analytical})
+   :regenerate run-regen-analytical
+   :update   run-update-analytical})
 
 (def ^:private compiled-keys
   {:simulate :compiled-simulate,   :generate :compiled-generate
@@ -656,6 +692,23 @@
       (and selection
            (some (fn [addr] (sel/selected? selection addr)) (keys handlers))))))
 
+(defn- update-reopens-analytical?
+  "True when the update CONSTRAINTS pin an eliminated LATENT (a conjugate prior
+   or linear-Gaussian block latent) or a block noise latent (genmlx-4q9d).
+   Pinning a latent re-opens its marginalisation (it must be scored jointly under
+   the pinned value); changing a block's noise latent alters every obs variance,
+   breaking the closed-form Δ marginal-LL. In either case the analytical update
+   declines so the joint handler path + joint-rescore-marginal runs (correct, no
+   Rao-Blackwell). Constraining only block OBS is the normal value-update case and
+   does NOT re-open (genmlx-6hcu)."
+  [schema constraints]
+  (let [elim  (get-in schema [:analytical-plan :rewrite-result :eliminated])
+        noise (into #{} (mapcat :noise-latents (:linear-gaussian-blocks schema)))
+        reopen (into (set elim) noise)]
+    (boolean
+      (and (seq reopen)
+           (some (fn [addr] (cm/has-value? (cm/get-submap constraints addr))) reopen)))))
+
 (def ^:private analytical-dispatcher
   (reify dispatch/IDispatcher
     (resolve-transition [_ op schema opts]
@@ -680,6 +733,22 @@
           (when (and (:auto-regenerate-transition schema)
                      (= :marginal (tr/score-type (:trace opts)))
                      (not (regen-reopens-analytical? schema (:selection opts))))
+            {:run run-fn :score-type :marginal :label :analytical})
+
+          :update
+          ;; First analytical :update path (genmlx-6hcu). Same decomposition-
+          ;; consistency rule as regenerate: the marginal old-score is a valid
+          ;; subtrahend only when THIS pass also scores every eliminated structure
+          ;; marginally. :auto-update-transition is built ONLY for fully-supported
+          ;; models (scalar conjugate + LG blocks, no Kalman/MVN); a constraint that
+          ;; pins an eliminated latent re-opens it (decline). Otherwise → joint path.
+          ;; PLAIN update only: update-with-args (op :update + :argdiffs in opts,
+          ;; genmlx-s8e8) re-executes under NEW args x' — a changed design X breaks
+          ;; the closed-form Δ marginal-LL — so it keeps its joint-conversion path.
+          (when (and (:auto-update-transition schema)
+                     (not (contains? opts :argdiffs))
+                     (= :marginal (tr/score-type (:trace opts)))
+                     (not (update-reopens-analytical? schema (:constraints opts))))
             {:run run-fn :score-type :marginal :label :analytical})
 
           nil)))))
@@ -862,7 +931,7 @@
    likelihoods, corrupting for particle diversity (smc) and trace-MH chains
    (genmlx-540f)."
   [:auto-handlers :conjugate-pairs :has-conjugate? :analytical-plan
-   :auto-regenerate-transition])
+   :auto-regenerate-transition :auto-update-transition :auto-update-handlers])
 
 (def alternate-path-schema-keys
   "Every schema key the dispatcher stack consults for a non-handler execution
@@ -1126,11 +1195,32 @@
                            ;; Opt 1: precompute dispatch transition once at construction
                            regen-transition (when (seq regen-handlers)
                                               (auto/make-address-dispatch
-                                               h/regenerate-transition regen-handlers))]
+                                               h/regenerate-transition regen-handlers))
+                           ;; Analytical UPDATE handlers (genmlx-6hcu): scalar
+                           ;; conjugate pairs + LG blocks. MVN and Kalman analytical
+                           ;; update are unimplemented, so a model containing EITHER
+                           ;; gets NO :auto-update-transition and its update falls to
+                           ;; the joint handler path (correct, just no Rao-Blackwell)
+                           ;; — never a mixed marginal/joint score (cf genmlx-wl1y).
+                           update-supported? (and (empty? (:kalman-chains plan))
+                                                  (not-any? #(= :mvn-normal (:family %)) regen-pairs))
+                           scalar-update-handlers (if update-supported?
+                                                    (auto/build-update-handlers regen-pairs)
+                                                    {})
+                           block-update-handlers (reduce
+                                                  (fn [m blk]
+                                                    (merge m (lg/make-lg-handlers blk :update)))
+                                                  {} lg-blocks)
+                           update-handlers (merge scalar-update-handlers block-update-handlers)
+                           update-transition (when (and update-supported? (seq update-handlers))
+                                               (auto/make-address-dispatch
+                                                h/update-transition update-handlers))]
                        (-> augmented
                            (assoc :auto-handlers (get-in plan [:rewrite-result :handlers]))
                            (assoc :auto-regenerate-handlers regen-handlers)
                            (assoc :auto-regenerate-transition regen-transition)
+                           (assoc :auto-update-handlers (when update-transition update-handlers))
+                           (assoc :auto-update-transition update-transition)
                            (assoc :linear-gaussian-blocks (:lg-blocks plan))
                            (assoc :analytical-plan plan)))
                      augmented))

--- a/src/genmlx/inference/auto_analytical.cljs
+++ b/src/genmlx/inference/auto_analytical.cljs
@@ -164,16 +164,30 @@
    :regenerate — prior returns the old value and falls through (nil) when the
      site is selected; obs reads :old-choices, requires an initialized posterior,
      skips selected obs, ll → :score only.
+   :update (genmlx-6hcu) — prior marginalizes when UNCONSTRAINED (a constrained
+     prior re-opens the pair → fall through to the base transition, mirroring
+     regenerate Case A); obs reads :constraints with fallback to :old-choices
+     (new-over-old) so the full marginal LL is refolded over the merged obs,
+     ll → :score + :weight; a CHANGED obs charges its old value into :discard.
 
    Returns {addr handler-fn} for prior + all obs addresses."
   [prior-addr obs-addrs init-posterior posterior-mean update-step mode]
   (let [regenerate? (= mode :regenerate)
+        update? (= mode :update)
         prior-handler
         (fn [state addr dist]
           (let [proceed?
-                (if regenerate?
+                (cond
+                  regenerate?
                   (not (and (:selection state)
                             (sel/selected? (:selection state) addr)))
+                  ;; Update (genmlx-6hcu): marginalize unless the prior latent is
+                  ;; itself constrained — pinning it re-opens the pair (scored
+                  ;; jointly), so fall through to the base transition. (The
+                  ;; dispatcher also declines the whole analytical-update for such
+                  ;; constraints; this is the per-pair backstop.)
+                  update?
+                  (not (cm/has-value? (cm/get-submap (:constraints state) prior-addr)))
                   ;; Generate/assess (genmlx-b470): the pair group marginalizes
                   ;; only when the prior itself is UNCONSTRAINED and EVERY obs
                   ;; is constrained. A constrained prior must keep its value
@@ -181,6 +195,7 @@
                   ;; obs set would otherwise produce a score that is neither
                   ;; joint nor marginal. Declining here leaves no posterior in
                   ;; state, so the obs handlers below fall through too.
+                  :else
                   (let [cs (:constraints state)]
                     (and (not (cm/has-value? (cm/get-submap cs prior-addr)))
                          (every? #(cm/has-value? (cm/get-submap cs %)) obs-addrs))))]
@@ -203,18 +218,27 @@
             ;; Regenerate: skip obs that are themselves being resampled.
             (when-not (and regenerate? (:selection state)
                            (sel/selected? (:selection state) addr))
-              (let [constraint (if regenerate?
-                                 (cm/get-submap (:old-choices state) addr)
-                                 (cm/get-submap (:constraints state) addr))]
+              (let [old-sub (cm/get-submap (:old-choices state) addr)
+                    new-sub (cm/get-submap (:constraints state) addr)
+                    ;; new-over-old: update reads the CHANGED obs from :constraints
+                    ;; and UNCHANGED obs from :old-choices, so the full marginal LL
+                    ;; is refolded; regenerate reads old, generate reads constraints.
+                    constraint (cond
+                                 regenerate? old-sub
+                                 update?     (if (cm/has-value? new-sub) new-sub old-sub)
+                                 :else       new-sub)]
                 (when (cm/has-value? constraint)
                   (let [obs-value (cm/get-value constraint)
                         {:keys [posterior ll]} (update-step current-posterior obs-value (:params dist))
-                        post-mean (posterior-mean posterior)]
+                        post-mean (posterior-mean posterior)
+                        ;; update: a changed obs charges its old value to :discard
+                        changed? (and update? (cm/has-value? new-sub) (cm/has-value? old-sub))]
                     [obs-value (cond-> state
                                  true (assoc-in [:auto-posteriors prior-addr] posterior)
                                  true (update :choices cm/set-value addr obs-value)
                                  true (update :score mx/add ll)
                                  (not regenerate?) (update :weight mx/add ll)
+                                 changed? (update :discard cm/set-value addr (cm/get-value old-sub))
                                  ;; Update prior's value to posterior mean
                                  true (update :choices cm/set-value prior-addr post-mean))]))))))]
     (assoc (zipmap obs-addrs (repeat obs-handler)) prior-addr prior-handler)))
@@ -714,6 +738,46 @@
                           conjugate-pairs)
         non-chain-handlers (build-regenerate-handlers remaining)]
     (merge kalman-handlers non-chain-handlers)))
+
+;; ---------------------------------------------------------------------------
+;; Update-specific handlers (genmlx-6hcu) — SCALAR conjugate families only.
+;; MVN and Kalman analytical UPDATE are not implemented; models containing them
+;; decline the analytical-update path entirely (at schema construction) and use
+;; the joint handler path, so no factory is registered for those families here.
+;; ---------------------------------------------------------------------------
+
+(defn- make-update-handlers-for
+  "Update-mode handler factory for `family`: a (fn [prior-addr obs-addrs])."
+  [family]
+  (fn [prior-addr obs-addrs] (make-family-handlers family :update prior-addr obs-addrs)))
+
+(def update-family->handler-factory
+  "Map from conjugate family keyword to update-specific handler factory.
+   No :mvn-normal — MVN analytical update is unimplemented (decline to joint)."
+  {:normal-normal     (make-update-handlers-for :normal-normal)
+   :normal-iid-normal (make-update-handlers-for :normal-iid-normal)
+   :beta-bernoulli    (make-update-handlers-for :beta-bernoulli)
+   :gamma-poisson     (make-update-handlers-for :gamma-poisson)
+   :gamma-exponential (make-update-handlers-for :gamma-exponential)})
+
+(defn build-update-handlers
+  "Build update-specific address-based handlers from conjugate pairs (scalar
+   families only). Multi-parent obs pairs are dropped first (see
+   build-auto-handlers). Pairs whose family has no update factory (e.g. MVN)
+   are skipped — callers must decline the analytical-update path for models that
+   contain them. Returns a merged map of {addr handler-fn}."
+  [conjugate-pairs]
+  (let [grouped (conj/group-by-prior (conj/drop-multi-parent-pairs conjugate-pairs))]
+    (reduce
+     (fn [handlers [prior-addr pairs]]
+       (let [family (:family (first pairs))
+             factory (get update-family->handler-factory family)
+             obs-addrs (mapv :obs-addr pairs)]
+         (if factory
+           (merge handlers (factory prior-addr obs-addrs))
+           handlers)))
+     {}
+     grouped)))
 
 ;; ---------------------------------------------------------------------------
 ;; Utility: check if any conjugate obs is constrained

--- a/src/genmlx/linear_gaussian.cljs
+++ b/src/genmlx/linear_gaussian.cljs
@@ -28,10 +28,12 @@
    which is algebraically identical to the batch marginal/posterior (chain rule
    of the joint Gaussian density) and fits the per-address handler structure.
 
-   Scope: generate + assess (exact), and regenerate (genmlx-m3tn: the block stays
+   Scope: generate + assess (exact), regenerate (genmlx-m3tn: the block stays
    Rao-Blackwellised under MH moves over unrelated residual latents; selecting a
-   block latent re-opens the whole block). UPDATE still declines (no analytical
-   :update path yet — genmlx-6hcu).
+   block latent re-opens the whole block), and UPDATE (genmlx-6hcu: a value-only
+   obs change re-folds the block marginal LL — weight = Δ marginal-LL, latents →
+   new posterior mean, changed-obs old values to the discard; constraining a block
+   latent re-opens it → the joint handler path).
 
    Partial conjugacy (genmlx-4q9d): when the obs noise depends on a RESIDUAL
    (non-block) latent — e.g. y_j ~ N(slope·x_j+intercept, sigma) with sigma ~ Gamma
@@ -399,15 +401,25 @@
          noise-latents (or noise-latents #{})
          obs-addrs (or obs-addrs (mapv :addr obs))
          regenerate? (= mode :regenerate)
+         update? (= mode :update)
          block-reopened?
          (fn [state]
-           ;; Selecting ANY block address — latent OR obs — re-opens the whole
-           ;; block (genmlx-b470: a selected obs must be resampled by the base
-           ;; transition, not Kalman-conditioned on its old value).
-           (and regenerate?
-                (:selection state)
-                (boolean (some #(sel/selected? (:selection state) %)
-                               (concat latents obs-addrs)))))
+           (cond
+             ;; Regenerate: selecting ANY block address — latent OR obs — re-opens
+             ;; the whole block (genmlx-b470: a selected obs must be resampled by
+             ;; the base transition, not Kalman-conditioned on its old value).
+             regenerate?
+             (and (:selection state)
+                  (boolean (some #(sel/selected? (:selection state) %)
+                                 (concat latents obs-addrs))))
+             ;; Update (genmlx-6hcu): pinning a block LATENT in the constraints
+             ;; re-opens the block (it can no longer be marginalised — score it
+             ;; jointly). Constraining an OBS is the normal update (re-eliminate).
+             ;; The dispatcher also declines the whole analytical-update for latent
+             ;; constraints; this is the per-block backstop.
+             update?
+             (boolean (some #(cm/has-value? (cm/get-submap (:constraints state) %)) latents))
+             :else false))
          block-ok?
          ;; Runtime eligibility gate (genmlx-b470), consulted by EVERY block
          ;; handler before committing and cached under [:lg-ok id] once a
@@ -425,9 +437,13 @@
              (let [args (:model-args state)
                    cs (:constraints state)
                    constraints-ok?
-                   (or regenerate?
-                       (and (not-any? #(cm/has-value? (cm/get-submap cs %)) latents)
-                            (every? #(cm/has-value? (cm/get-submap cs %)) obs-addrs)))]
+                   (cond
+                     regenerate? true
+                     ;; Update: ok as long as no block latent is pinned (obs are
+                     ;; read new-over-old, so they need not all be in :constraints).
+                     update? (not-any? #(cm/has-value? (cm/get-submap cs %)) latents)
+                     :else (and (not-any? #(cm/has-value? (cm/get-submap cs %)) latents)
+                                (every? #(cm/has-value? (cm/get-submap cs %)) obs-addrs)))]
                (boolean
                 (and args constraints-ok?
                      (every? (fn [{:keys [mean-fn]}]
@@ -442,7 +458,7 @@
                            (when (block-ok? state)
                              (let [{:keys [mu sigma]} (:params dist)
                                    var (mx/multiply sigma sigma)
-                                   value (if regenerate?
+                                   value (if (or regenerate? update?)
                                            (cm/get-value (cm/get-submap (:old-choices state) la))
                                            mu)
                                    st (-> state
@@ -467,9 +483,15 @@
                                     (block-ok? state))
                            (let [belief (get-in state [:lg-belief id])
                                  args (:model-args state)
-                                 constraint (if regenerate?
-                                              (cm/get-submap (:old-choices state) addr)
-                                              (cm/get-submap (:constraints state) addr))
+                                 old-sub (cm/get-submap (:old-choices state) addr)
+                                 new-sub (cm/get-submap (:constraints state) addr)
+                                 ;; new-over-old: update reads a CHANGED obs from
+                                 ;; :constraints, an UNCHANGED obs from :old-choices,
+                                 ;; so the full marginal LL is refolded.
+                                 constraint (cond
+                                              regenerate? old-sub
+                                              update?     (if (cm/has-value? new-sub) new-sub old-sub)
+                                              :else       new-sub)
                                  ;; Residual noise latents (genmlx-4q9d): their sampled
                                  ;; values, read live from :choices (set before the obs by
                                  ;; dep-order). Empty for v1 constant/block-free noise.
@@ -495,6 +517,9 @@
                                                 (assoc-in [:lg-belief id] {:mean mean :cov cov})
                                                 (update :choices cm/set-value addr y)
                                                 (update :score mx/add ll))
-                                      (not regenerate?) (update :weight mx/add ll))])))))]))
+                                      (not regenerate?) (update :weight mx/add ll)
+                                      ;; update: a changed obs charges its old value to :discard
+                                      (and update? (cm/has-value? new-sub) (cm/has-value? old-sub))
+                                      (update :discard cm/set-value addr (cm/get-value old-sub)))])))))]))
                obs)]
      (merge latent-handlers obs-handlers))))

--- a/test/genmlx/linear_gaussian_elim_test.cljs
+++ b/test/genmlx/linear_gaussian_elim_test.cljs
@@ -20,6 +20,7 @@
             [genmlx.selection :as sel]
             [genmlx.mlx.random :as rng]
             [genmlx.method-selection :as ms]
+            [genmlx.trace :as tr]
             [genmlx.linear-gaussian :as lg])
   (:require-macros [genmlx.gen :refer [gen]]))
 
@@ -528,6 +529,106 @@
                 (< (js/Math.abs (- sig-mean oracle-sigma-mean)) 0.35))
   (assert-close "block re-eliminated conditional on current sigma"
                 fem-slope (choice-val final :slope) 2e-2))
+
+;; ===========================================================================
+;; SECTION 6 — analytical UPDATE (genmlx-6hcu)
+;; ===========================================================================
+;; p/update over an eliminated structure with a value-only obs change: the
+;; weight is the Δ block-marginal-LL (logZ_new − logZ_old, the FULL-vector
+;; correlated Gaussian evidence — NOT a per-obs sum, the ke9i trap), the block
+;; latent choices move to the NEW posterior mean, and the discard carries the
+;; changed obs's old value. Re-opening the block (constraining a latent) declines
+;; to the joint handler path. Oracle is an INDEPENDENT float64 quadrature /
+;; closed-form marginal, never lg-eliminate.
+
+(println "\n== Section 6: analytical UPDATE (genmlx-6hcu) ==")
+
+(def BR-X [1.0 2.0 3.0 4.0 5.0])
+
+(defn br-quad
+  "Independent float64 2D quadrature for br-model: the block marginal evidence
+   logZ(y) = log ∫∫ N(s;0,10) N(i;0,10) ∏_j N(y_j; s·x_j+i, 1) ds di, plus the
+   posterior means E[slope|y], E[intercept|y]. Pure model density — does NOT use
+   the Kalman eliminator under test. (Grid discretisation largely cancels in the
+   logZ DIFFERENCE that the weight test checks.)"
+  [ys]
+  (let [log2pi (js/Math.log (* 2 js/Math.PI))
+        c0 (- (* -0.5 log2pi) (js/Math.log 10.0))      ; N(·;0,10) log-norm const
+        ds 0.0125 di 0.025
+        cells (for [k (range 160) m (range 200)]
+                (let [s (+ 1.0 (* ds k)) i (+ -2.0 (* di m))
+                      lik (reduce + (map (fn [xj yj]
+                                           (let [r (- yj (+ (* s xj) i))]
+                                             (+ (* -0.5 log2pi) (* -0.5 r r))))
+                                         BR-X ys))
+                      lp (+ c0 (/ (* s s) -200.0) c0 (/ (* i i) -200.0) lik)]
+                  [s i lp]))
+        mxlp (reduce max (map #(nth % 2) cells))
+        ws   (mapv (fn [[s i lp]] [s i (js/Math.exp (- lp mxlp))]) cells)
+        z    (reduce + (map #(nth % 2) ws))]
+    {:logZ (+ mxlp (js/Math.log z) (js/Math.log (* ds di)))
+     :slope-mean (/ (reduce + (map (fn [[s _ w]] (* s w)) ws)) z)
+     :intercept-mean (/ (reduce + (map (fn [[_ i w]] (* i w)) ws)) z)}))
+
+(defn br-post-mean
+  "Closed-form analytic posterior mean E[β|y] for br-model — independent of the
+   Kalman eliminator (batch normal equations, float64): m1 = (XᵀX + S0⁻¹)⁻¹ Xᵀy
+   with prior N(0,100·I), R=I, so Λ1 = [[Σx²+1/100, Σx],[Σx, n+1/100]]. Exact (no
+   grid error), unlike the quadrature mean."
+  [ys]
+  (let [a (+ 55.0 0.01) b 15.0 d (+ 5.0 0.01)        ; Λ1 = [[a,b],[b,d]]
+        det (- (* a d) (* b b))
+        sxy (reduce + (map * BR-X ys)) sy (reduce + ys)]
+    {:slope     (/ (- (* d sxy) (* b sy)) det)
+     :intercept (/ (- (* a sy) (* b sxy)) det)}))
+
+;; -- U1: update a block obs (:y3); weight = Δ marginal-LL (independent quadrature),
+;;    posterior mean vs the exact closed form.
+(println "-- U1 (update :y3): weight = Δ block-marginal-LL (independent quadrature)")
+(let [{otrace :trace} (p/generate br-model br-xs br-obs)
+      new-y3 7.5
+      y-old [2.3 4.7 6.1 8.9 10.2]
+      y-new [2.3 4.7 7.5 8.9 10.2]
+      new-constraints (cm/set-choice cm/EMPTY [:y3] (mx/scalar new-y3))
+      {rtrace :trace weight :weight discard :discard} (p/update br-model otrace new-constraints)
+      w-oracle (- (:logZ (br-quad y-new)) (:logZ (br-quad y-old)))
+      pm (br-post-mean y-new)]
+  (assert-true  "U1 result trace is :marginal (analytical update fired)"
+                (= :marginal (tr/score-type rtrace)))
+  (assert-close "U1 weight = Δ block-marginal-LL (independent quadrature)" w-oracle (mx/item weight) 5e-3)
+  (assert-close "U1 slope → new posterior mean (closed form)" (:slope pm) (choice-val rtrace :slope) 1e-3)
+  (assert-close "U1 intercept → new posterior mean (closed form)" (:intercept pm) (choice-val rtrace :intercept) 1e-3)
+  (assert-close "U1 discard carries old y3" 6.1 (mx/item (cm/get-value (cm/get-submap discard :y3))) 1e-5))
+
+;; -- U2: constrain a block LATENT (:slope) → re-open → joint handler path
+(println "-- U2 (constrain :slope): re-opens block → analytical declines → joint path")
+(let [{otrace :trace} (p/generate br-model br-xs br-obs)
+      new-constraints (cm/set-choice cm/EMPTY [:slope] (mx/scalar 2.5))
+      {rtrace :trace weight :weight} (p/update br-model otrace new-constraints)]
+  (assert-true "U2 weight finite (re-open → joint path, no marginal/joint mixing)"
+               (js/isFinite (mx/item weight)))
+  (assert-true "U2 result trace is :joint (joint-rescore conversion, not anchored)"
+               (= :joint (tr/score-type rtrace))))
+
+;; -- U3: scalar conjugate (normal-normal) update vs closed-form marginal
+(println "-- U3 (scalar conjugate normal-normal): update :y, weight vs closed-form marginal")
+(def nn-model
+  (dyn/auto-key
+    (gen [] (let [mu (trace :mu (dist/gaussian 0 2))]
+              (trace :y (dist/gaussian mu 1))
+              mu))))
+(let [{otrace :trace} (p/generate nn-model [] (cm/set-choice cm/EMPTY [:y] (mx/scalar 1.0)))
+      {rtrace :trace weight :weight discard :discard}
+      (p/update nn-model otrace (cm/set-choice cm/EMPTY [:y] (mx/scalar 2.5)))
+      ;; marginal y ~ N(0, prior-var + obs-var) = N(0, 5); closed form, exact.
+      mvar 5.0
+      lz (fn [y] (- (* -0.5 (js/Math.log (* 2 js/Math.PI mvar))) (/ (* y y) (* 2 mvar))))
+      w-oracle (- (lz 2.5) (lz 1.0))]
+  (assert-true  "U3 result trace is :marginal (scalar analytical update fired)"
+                (= :marginal (tr/score-type rtrace)))
+  (assert-close "U3 scalar-conjugate update weight = Δ marginal-LL" w-oracle (mx/item weight) 2e-4)
+  (assert-close "U3 mu → new posterior mean (4y/5)" (/ (* 4 2.5) 5.0) (choice-val rtrace :mu) 1e-4)
+  (assert-close "U3 discard carries old y" 1.0 (mx/item (cm/get-value (cm/get-submap discard :y))) 1e-9))
 
 ;; ===========================================================================
 ;; Summary


### PR DESCRIPTION
## What

Adds the **first analytical `:update` path** in the engine — `genmlx-6hcu`, the last missing L3 eliminator op (parent `genmlx-2s3n` / ROADMAP Phase 1).

`p/update` on a `:marginal` trace with a value-only obs change now keeps the eliminated structure **marginalised (Rao-Blackwell)** instead of converting to joint via `joint-rescore-marginal`.

## Weight semantics

`W = Δ block-marginal-LL = logZ_new − logZ_old` — the **full-vector correlated** Gaussian evidence difference, *not* a per-obs `Σ Δlp` (the ke9i trap; obs sharing latents are correlated). The `:update` handlers accumulate the refolded marginal LL into **both `:score` and `:weight`**, so the standard `run-update` weight `((:weight result) − old score)` collapses to the Δ of the changed structure: untouched blocks/pairs and retained residual sites cancel automatically.

- Block/pair latent choices → **new posterior mean** (covariance unchanged → RB preserved).
- Discard carries the **changed obs's old values** (Gen.jl).

## Scope & gating

- **Supported:** scalar conjugate families (`normal-normal`, `normal-iid-normal`, `beta-bernoulli`, `gamma-poisson`, `gamma-exponential`) + linear-Gaussian regression blocks.
- **Declines to the joint path (correct, no RB):** models with Kalman chains or MVN priors (no `:auto-update-transition` built) — a clean follow-up; `update-with-args` (changed args `x'`, `genmlx-s8e8`) since a changed design `X` breaks the closed form (gated on `:argdiffs` absence); and constraints that **re-open** an eliminated/noise latent (`update-reopens-analytical?`, mirroring the `genmlx-wl1y` regenerate decline).

## Verification (independent oracles, never the eliminator)

- **LG block** (`linear_gaussian_elim_test` Section 6): weight = Δ marginal-LL vs a float64 2D quadrature (|Δ|=2.7e-3); posterior mean vs the **closed-form normal equations** (exact, |Δ|=1.3e-7); discard = old obs value.
- **Scalar conjugate** (normal-normal): weight + posterior mean (4y/5) + discard vs closed form.
- **Re-open** (constrain `:slope`) → analytical declines → joint path, trace `:joint`.
- **No regressions:** `gfi_update`, `update_weight`, `update_discard_branch`, `update_args`, `vupdate`, `score_type`, `conjugate_posterior`, `conjugacy`, `auto_analytical`, `l3_5_gate`, `iid_conjugacy`, `wp8_combinator_update`, GFI-law p5/p7/p8, `smc_evidence` — all green.

## Files

4 files, +301/−23: `auto_analytical.cljs` (`:update` mode + `build-update-handlers`), `linear_gaussian.cljs` (block `:update` mode), `dynamic.cljs` (`run-update-analytical` + dispatcher gating + construction wiring), `linear_gaussian_elim_test.cljs` (Section 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
