### PR TITLE
feat(l3): dirichlet-categorical conjugate family via log-link elimination (cf0d)

### DIFF
--- a/src/genmlx/conjugacy.cljs
+++ b/src/genmlx/conjugacy.cljs
@@ -95,12 +95,29 @@
   (and (symbol? sym)
        (= (name sym) (name addr))))
 
+(defn- log-link?
+  "True when `arg` is (mx/log <sym>) where <sym> resolves to prior-addr.
+
+   This is the canonical link for Dirichlet–Categorical: GenMLX's categorical is
+   logit-parameterized, so passing log(theta) as its logits makes
+   softmax(log theta) = theta — i.e. (dist/categorical (mx/log theta)) is exactly
+   Categorical(theta) over the simplex theta, with log p(x=k) = log theta_k. The
+   head is matched namespace-agnostically (mx/log, genmlx.mlx/log both qualify)."
+  [arg prior-addr]
+  (and (seq? arg) (seq arg)
+       (symbol? (first arg))
+       (= "log" (name (first arg)))
+       (= 2 (count arg))
+       (symbol-resolves-to-addr? (second arg) prior-addr)))
+
 (defn- classify-dependency
   "Classify how an obs site depends on a prior site's value.
-   Returns {:type :direct|:affine|:nonlinear} with metadata.
+   Returns {:type :direct|:log-link|:affine|:nonlinear} with metadata.
 
    :direct — the prior's value appears directly as the natural parameter
              argument (e.g., mu is position 0 in (dist/gaussian mu sigma))
+   :log-link — the natural parameter is (mx/log prior); the Dirichlet–Categorical
+             link (see log-link?)
    :affine — the natural parameter is an affine function of the prior
              (e.g., (mx/multiply 0.9 mu)), with :coefficient and :offset
    :nonlinear — dependency exists but through a non-trivial expression"
@@ -109,6 +126,18 @@
         dist-args (:dist-args obs-site)
         natural-arg (nth dist-args natural-idx nil)]
     (cond
+      ;; Dirichlet–Categorical is conjugate ONLY through the log link
+      ;; (dist/categorical (mx/log theta)). Bare (dist/categorical theta) is raw
+      ;; logit space and NOT conjugate to a Dirichlet prior — its marginal
+      ;; E[softmax(theta)_k] has no closed form — so it must classify as
+      ;; :nonlinear and be declined. This closes the health-audit over-promise
+      ;; (the table advertised the pair with no handler) without admitting a
+      ;; ke9i-class wrong-math false positive (genmlx-cf0d).
+      (= :dirichlet-categorical (:family family-info))
+      (if (log-link? natural-arg prior-addr)
+        {:type :log-link}
+        {:type :nonlinear})
+
       ;; Direct: the natural parameter arg IS the prior symbol
       (symbol-resolves-to-addr? natural-arg prior-addr)
       {:type :direct}
@@ -139,7 +168,8 @@
    2. obs depends on prior (prior-addr is in obs's :deps)
    3. [prior-dist-type, obs-dist-type] is in conjugacy-table with non-nil value
    4. The dependency is through the natural parameter position: :direct for
-      any family, :affine only for affine-capable families (normal-normal)
+      any family, :log-link for Dirichlet–Categorical (which is conjugate ONLY
+      through the log link), :affine only for affine-capable families (normal-normal)
 
    Returns vector of {:prior-addr :obs-addr :family :prior-site :obs-site
                        :dependency-type :family-info}"
@@ -157,9 +187,12 @@
             ;; Must be in table AND non-nil (nil = explicitly not conjugate)
             :when (and (not= family-info ::not-found) (some? family-info))
             :let [dep-type (classify-dependency prior-addr obs-site family-info)]
-            ;; :direct for all families; :affine only where a path exists that
-            ;; recovers the coefficients (see affine-capable-families)
+            ;; :direct for all families; :log-link only ever produced for
+            ;; Dirichlet–Categorical (classify-dependency gates it by family);
+            ;; :affine only where a path exists that recovers the coefficients
+            ;; (see affine-capable-families)
             :when (or (= :direct (:type dep-type))
+                      (= :log-link (:type dep-type))
                       (and (= :affine (:type dep-type))
                            (contains? affine-capable-families
                                       (:family family-info))))]

--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -1197,13 +1197,18 @@
                                               (auto/make-address-dispatch
                                                h/regenerate-transition regen-handlers))
                            ;; Analytical UPDATE handlers (genmlx-6hcu): scalar
-                           ;; conjugate pairs + LG blocks. MVN and Kalman analytical
-                           ;; update are unimplemented, so a model containing EITHER
-                           ;; gets NO :auto-update-transition and its update falls to
-                           ;; the joint handler path (correct, just no Rao-Blackwell)
-                           ;; — never a mixed marginal/joint score (cf genmlx-wl1y).
+                           ;; conjugate pairs + LG blocks. MVN, Kalman, and
+                           ;; Dirichlet–Categorical (genmlx-cf0d) analytical update
+                           ;; are unimplemented, so a model containing ANY of them
+                           ;; gets NO :auto-update-transition and its update falls
+                           ;; to the joint handler path (correct, just no
+                           ;; Rao-Blackwell) — never a mixed marginal/joint score
+                           ;; (cf genmlx-wl1y). Declining the WHOLE update (not just
+                           ;; the unsupported pair) is what prevents the mix.
                            update-supported? (and (empty? (:kalman-chains plan))
-                                                  (not-any? #(= :mvn-normal (:family %)) regen-pairs))
+                                                  (not-any? #(#{:mvn-normal :dirichlet-categorical}
+                                                              (:family %))
+                                                            regen-pairs))
                            scalar-update-handlers (if update-supported?
                                                     (auto/build-update-handlers regen-pairs)
                                                     {})

--- a/src/genmlx/inference/auto_analytical.cljs
+++ b/src/genmlx/inference/auto_analytical.cljs
@@ -284,7 +284,33 @@
     :posterior-mean (fn [{:keys [shape rate]}] (mx/divide shape rate))
     :update-step (fn [posterior obs-value _params]
                    (let [{:keys [shape rate ll]} (ge-update-step posterior obs-value)]
-                     {:posterior {:shape shape :rate rate} :ll ll}))}})
+                     {:posterior {:shape shape :rate rate} :ll ll}))}
+   ;; Dirichlet–Categorical (genmlx-cf0d). Prior theta ~ Dirichlet(alpha), obs
+   ;; x ~ Categorical(theta) — written (dist/categorical (mx/log theta)) so the
+   ;; logit-parameterized categorical scores log p(x=k)=log theta_k (conjugacy
+   ;; detection accepts ONLY this log-link form). The latent value is the VECTOR
+   ;; posterior mean alpha/sum(alpha). Per-obs predictive log-evidence is
+   ;; log alpha_k - log(sum alpha); the posterior folds alpha <- alpha + e_k, so
+   ;; the generic core's sequential fold of N obs yields the exact ordered
+   ;; Dirichlet-multinomial sequence marginal.
+   :dirichlet-categorical
+   ;; Force float32: a synthesized model may pass an INT vector literal
+   ;; (dist/dirichlet [1 2 3]); log/divide downstream need a float dtype.
+   {:init-posterior (fn [{:keys [alpha]}] {:alpha (mx/ensure-array alpha mx/float32)})
+    :posterior-mean (fn [{:keys [alpha]}] (mx/divide alpha (mx/sum alpha)))
+    :update-step
+    (fn [{:keys [alpha]} obs-value _params]
+      (let [d (first (mx/shape alpha))
+            dt (mx/dtype alpha)
+            ;; one-hot indicator for the observed category, built at graph level
+            ;; so it works for a JS-int OR an MLX-scalar obs-value:
+            ;; (arange D == k) cast to alpha's dtype.
+            onehot (mx/astype (mx/equal (mx/astype (mx/arange d) dt) obs-value) dt)
+            sum-alpha (mx/sum alpha)
+            alpha-k (mx/sum (mx/multiply alpha onehot))   ;; gather alpha_k
+            ll (mx/subtract (mx/log alpha-k) (mx/log sum-alpha))
+            alpha' (mx/add alpha onehot)]                 ;; alpha <- alpha + e_k
+        {:posterior {:alpha alpha'} :ll ll}))}})
 
 (defn- make-family-handlers
   "Build conjugate handlers for `family` from conjugate-family-specs, in `mode`."
@@ -633,6 +659,7 @@
    :beta-bernoulli (make-auto-handlers-for :beta-bernoulli)
    :gamma-poisson (make-auto-handlers-for :gamma-poisson)
    :gamma-exponential (make-auto-handlers-for :gamma-exponential)
+   :dirichlet-categorical (make-auto-handlers-for :dirichlet-categorical)
    :mvn-normal (make-auto-handlers-for :mvn-normal)})
 
 (defn build-auto-handlers
@@ -682,6 +709,7 @@
    :beta-bernoulli (make-regenerate-handlers-for :beta-bernoulli)
    :gamma-poisson (make-regenerate-handlers-for :gamma-poisson)
    :gamma-exponential (make-regenerate-handlers-for :gamma-exponential)
+   :dirichlet-categorical (make-regenerate-handlers-for :dirichlet-categorical)
    :mvn-normal (make-regenerate-handlers-for :mvn-normal)})
 
 (defn build-regenerate-handlers

--- a/src/genmlx/llm/msa.cljs
+++ b/src/genmlx/llm/msa.cljs
@@ -59,6 +59,7 @@
            'exponential dist/exponential
            'poisson dist/poisson
            'categorical dist/categorical
+           'dirichlet dist/dirichlet
            'multivariate-normal dist/multivariate-normal
            'delta dist/delta}
     'mx {'add mx/add

--- a/src/genmlx/rewrite.cljs
+++ b/src/genmlx/rewrite.cljs
@@ -47,10 +47,12 @@
 (defrecord ConjugacyRule [family prior-addr obs-addrs]
   IRewriteRule
   (-applicable? [this graph schema]
-    ;; A family present in the conjugacy table but absent from the handler
-    ;; factory map (e.g. dirichlet-categorical) has NO runtime elimination —
-    ;; applying the rule anyway would prune a still-stochastic latent from the
-    ;; graph and let method-selection claim an exact marginal (genmlx-b470).
+    ;; Defensive guard: a family present in the conjugacy table but absent from
+    ;; the handler factory map has NO runtime elimination — applying the rule
+    ;; anyway would prune a still-stochastic latent from the graph and let
+    ;; method-selection claim an exact marginal (genmlx-b470). Every table family
+    ;; is currently wired (dirichlet-categorical since genmlx-cf0d); this keeps
+    ;; any future detection-only entry from silently mis-eliminating.
     (and (some? (get auto/family->handler-factory family))
          (contains? (:nodes graph) prior-addr)
          (every? #(contains? (:nodes graph) %) obs-addrs)))

--- a/test/genmlx/dirichlet_categorical_test.cljs
+++ b/test/genmlx/dirichlet_categorical_test.cljs
@@ -1,0 +1,263 @@
+;; @tier medium
+(ns genmlx.dirichlet-categorical-test
+  "Dirichlet–Categorical exact analytical evidence (genmlx-cf0d).
+
+   theta ~ Dirichlet(alpha), x ~ Categorical(theta). GenMLX's categorical is
+   LOGIT-parameterized, so the conjugate obs is written with the log link
+   (dist/categorical (mx/log theta)): softmax(log theta) = theta over the
+   simplex, hence log p(x=k) = log theta_k. Bare (dist/categorical theta) is raw
+   logit space and NOT conjugate — it is declined (covered in
+   l3_false_positive_test Section 4).
+
+   Ground truth here is THREE independent sources that must all agree:
+     1. closed form    — host-side lgamma Dirichlet-multinomial sequence marginal
+     2. exact          — the analytical handler (function under test)
+     3. IS             — a self-written SHARED-theta importance sampler that
+                         draws one theta per particle and scores all obs against
+                         it (captures the obs correlation; NOT the ke9i trap of
+                         summing independent per-obs marginals)
+   Numbers were independently confirmed by the math-verifier (Lanczos lgamma).
+
+   Run: bun run --bun nbb test/genmlx/dirichlet_categorical_test.cljs"
+  (:require [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.dist.core :as dc]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.mlx.random :as rng])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+;; ---------------------------------------------------------------------------
+;; Assertion harness
+;; ---------------------------------------------------------------------------
+
+(def ^:private pass (volatile! 0))
+(def ^:private fail (volatile! 0))
+
+(defn- assert-true [desc pred]
+  (if pred
+    (do (vswap! pass inc) (println (str "  PASS: " desc)))
+    (do (vswap! fail inc) (println (str "  FAIL: " desc)))))
+
+(defn- assert-close [desc expected actual tol]
+  (let [ok (and (number? actual) (js/isFinite actual)
+                (<= (js/Math.abs (- expected actual)) tol))]
+    (if ok
+      (do (vswap! pass inc)
+          (println (str "  PASS: " desc " (" (.toFixed actual 6) " ~ " (.toFixed expected 6)
+                        ", |Δ|=" (.toExponential (js/Math.abs (- expected actual)) 2) ")")))
+      (do (vswap! fail inc)
+          (println (str "  FAIL: " desc " expected " expected " got " actual))))))
+
+;; ---------------------------------------------------------------------------
+;; Independent host-side oracles (never the function under test)
+;; ---------------------------------------------------------------------------
+
+(defn- lgamma [x] (mx/item (mx/lgamma (mx/scalar (double x)))))
+
+(defn- closed-form-log-marginal
+  "Ordered Dirichlet-multinomial sequence marginal (NO multinomial coefficient):
+   sum_k [lgamma(a_k + n_k) - lgamma(a_k)] + lgamma(sum a) - lgamma(sum a + n).
+   alpha: vector of concentrations; obs: ordered seq of category indices."
+  [alpha obs]
+  (let [d (count alpha)
+        counts (reduce (fn [c k] (update c k inc)) (vec (repeat d 0)) obs)
+        n (count obs)
+        sum-a (reduce + alpha)
+        per-k (reduce + (map (fn [a nk] (- (lgamma (+ a nk)) (lgamma a))) alpha counts))]
+    (+ per-k (lgamma sum-a) (- (lgamma (+ sum-a n))))))
+
+(defn- counts-of [alpha obs]
+  (let [d (count alpha)]
+    (reduce (fn [c k] (update c k inc)) (vec (repeat d 0)) obs)))
+
+(defn- is-log-marginal
+  "Self-written SHARED-theta importance estimate of log P(obs). Draws N
+   theta ~ Dirichlet(alpha) ([N,D]); each particle's weight is
+   prod_i theta[k_i] = sum_k counts_k * log theta[:,k]; returns
+   logsumexp(log w) - log N. One theta per particle scores ALL obs jointly,
+   so the shared-theta correlation is preserved (this is the discriminating,
+   non-circular oracle for the multi-obs case)."
+  [alpha obs n key]
+  (let [counts (mapv double (counts-of alpha obs))
+        theta (dc/dist-sample-n (dist/dirichlet (mx/array (mapv double alpha))) key n) ;; [N,D]
+        log-w (mx/sum (mx/multiply (mx/log theta) (mx/array counts)) [-1])             ;; [N]
+        lse (mx/logsumexp log-w)]
+    (mx/item (mx/subtract lse (mx/log (mx/scalar (double n)))))))
+
+;; ---------------------------------------------------------------------------
+;; Models + GFI helpers
+;; ---------------------------------------------------------------------------
+
+(defn- obs-cm [m]
+  (reduce-kv (fn [c k v] (cm/set-value c k v)) cm/EMPTY m))
+
+(defn- exact-weight [model obs key]
+  (mx/item (:weight (p/generate (dyn/with-key model key) [] (obs-cm obs)))))
+
+(defn- exact-trace [model obs key]
+  (:trace (p/generate (dyn/with-key model key) [] (obs-cm obs))))
+
+;; Single-obs models
+(def ^:private m-123
+  (gen [] (let [th (trace :th (dist/dirichlet (mx/array [1.0 2.0 3.0])))]
+            (trace :x (dist/categorical (mx/log th))) th)))
+(def ^:private m-22
+  (gen [] (let [th (trace :th (dist/dirichlet (mx/array [2.0 2.0])))]
+            (trace :x (dist/categorical (mx/log th))) th)))
+
+;; Multi-obs (ordered) models — three / five iid obs sharing one theta.
+(def ^:private m-D
+  (gen [] (let [th (trace :th (dist/dirichlet (mx/array [1.0 1.0 1.0])))]
+            (trace :x0 (dist/categorical (mx/log th)))
+            (trace :x1 (dist/categorical (mx/log th)))
+            (trace :x2 (dist/categorical (mx/log th)))
+            th)))
+(def ^:private m-E
+  (gen [] (let [th (trace :th (dist/dirichlet (mx/array [2.0 1.0 1.0 1.0])))]
+            (trace :x0 (dist/categorical (mx/log th)))
+            (trace :x1 (dist/categorical (mx/log th)))
+            (trace :x2 (dist/categorical (mx/log th)))
+            (trace :x3 (dist/categorical (mx/log th)))
+            (trace :x4 (dist/categorical (mx/log th)))
+            th)))
+
+(def TOL 2e-4)   ;; analytical vs closed-form: float32 lgamma floor
+
+;; ===========================================================================
+;; 1 — detection fires on the log link
+;; ===========================================================================
+
+(println "\n== 1: detection (log link fires, family is :dirichlet-categorical) ==")
+
+(doseq [[nm model n] [["single" m-123 1] ["multi-D" m-D 3] ["multi-E" m-E 5]]]
+  (let [pairs (:conjugate-pairs (:schema model))]
+    (assert-true (str nm ": one pair per obs (" n ")") (= n (count pairs)))
+    (assert-true (str nm ": every pair is :dirichlet-categorical")
+                 (every? #(= :dirichlet-categorical (:family %)) pairs))
+    (assert-true (str nm ": every pair via :log-link dependency")
+                 (every? #(= :log-link (:type (:dependency-type %))) pairs))))
+
+;; ===========================================================================
+;; 2 — single-obs marginal: exact == closed form  (A, B, C)
+;; ===========================================================================
+
+(println "\n== 2: single-obs marginal == closed form (independent lgamma) ==")
+
+(let [k (rng/fresh-key 1)]
+  ;; A: alpha=[1,2,3], x=2  -> log(3/6) = log(1/2)
+  (assert-close "A: alpha=[1,2,3] x=2 exact == closed form"
+                (closed-form-log-marginal [1.0 2.0 3.0] [2]) (exact-weight m-123 {:x 2} k) TOL)
+  (assert-close "A: == hand value -0.693147" -0.693147 (exact-weight m-123 {:x 2} k) TOL)
+  ;; B: alpha=[1,2,3], x=0  -> log(1/6)
+  (assert-close "B: alpha=[1,2,3] x=0 exact == closed form"
+                (closed-form-log-marginal [1.0 2.0 3.0] [0]) (exact-weight m-123 {:x 0} k) TOL)
+  (assert-close "B: == hand value -1.791759" -1.791759 (exact-weight m-123 {:x 0} k) TOL)
+  ;; C: alpha=[2,2], x=1  -> log(2/4) = log(1/2)
+  (assert-close "C: alpha=[2,2] x=1 exact == closed form"
+                (closed-form-log-marginal [2.0 2.0] [1]) (exact-weight m-22 {:x 1} k) TOL)
+  (assert-close "C: == hand value -0.693147" -0.693147 (exact-weight m-22 {:x 1} k) TOL))
+
+;; ===========================================================================
+;; 3 — multi-obs (ordered) marginal == closed form  (D, E)
+;;     This is the chain-rule fold over shared theta; correlation matters.
+;; ===========================================================================
+
+(println "\n== 3: multi-obs marginal == closed form (Dirichlet-multinomial) ==")
+
+(let [k (rng/fresh-key 2)
+      wD (exact-weight m-D {:x0 0 :x1 0 :x2 1} k)
+      wE (exact-weight m-E {:x0 0 :x1 1 :x2 0 :x3 2 :x4 0} k)]
+  (assert-close "D: alpha=[1,1,1] seq[0,0,1] exact == closed form"
+                (closed-form-log-marginal [1.0 1.0 1.0] [0 0 1]) wD TOL)
+  (assert-close "D: == hand value -3.401197" -3.401197 wD TOL)
+  (assert-close "E: alpha=[2,1,1,1] seq[0,1,0,2,0] exact == closed form"
+                (closed-form-log-marginal [2.0 1.0 1.0 1.0] [0 1 0 2 0]) wE TOL)
+  (assert-close "E: == hand value -6.445720" -6.445720 wE TOL))
+
+;; ===========================================================================
+;; 4 — posterior mean of theta is stored on the latent site
+;; ===========================================================================
+
+(println "\n== 4: latent :th holds the posterior mean (alpha+counts)/(sum+n) ==")
+
+(let [k (rng/fresh-key 3)
+      thD (mx/->clj (cm/get-value (cm/get-submap (:choices (exact-trace m-D {:x0 0 :x1 0 :x2 1} k)) :th)))
+      thE (mx/->clj (cm/get-value (cm/get-submap (:choices (exact-trace m-E {:x0 0 :x1 1 :x2 0 :x3 2 :x4 0} k)) :th)))]
+  ;; D posterior alpha=[3,2,1], sum=6 -> mean [0.5, 0.3333, 0.1667]
+  (assert-close "D: theta[0] == 0.5" 0.5 (nth thD 0) 1e-4)
+  (assert-close "D: theta[1] == 0.3333" (/ 1.0 3.0) (nth thD 1) 1e-4)
+  (assert-close "D: theta[2] == 0.1667" (/ 1.0 6.0) (nth thD 2) 1e-4)
+  ;; E posterior alpha=[5,2,2,1], sum=10 -> mean [0.5, 0.2, 0.2, 0.1]
+  (assert-close "E: theta[0] == 0.5" 0.5 (nth thE 0) 1e-4)
+  (assert-close "E: theta[1] == 0.2" 0.2 (nth thE 1) 1e-4)
+  (assert-close "E: theta[3] == 0.1" 0.1 (nth thE 3) 1e-4))
+
+;; ===========================================================================
+;; 5 — exact == IS  (independent shared-theta Monte Carlo), and the IS
+;;     DISCRIMINATES the correct marginal from the ke9i independence trap.
+;; ===========================================================================
+
+(println "\n== 5: exact == IS (shared-theta), discriminates the independence trap ==")
+
+(let [k (rng/fresh-key 12345)
+      n 200000
+      ;; single obs A: IS over 1 obs
+      isA (is-log-marginal [1.0 2.0 3.0] [2] n k)
+      exactA (exact-weight m-123 {:x 2} (rng/fresh-key 1))
+      ;; multi obs D: 3 correlated obs
+      isD (is-log-marginal [1.0 1.0 1.0] [0 0 1] n (rng/fresh-key 999))
+      exactD (exact-weight m-D {:x0 0 :x1 0 :x2 1} (rng/fresh-key 2))
+      ;; the WRONG independent-per-obs estimate (ke9i trap): sum of marginals
+      ;; treating each obs as independent => 3 * log(1/3) = -3.295837
+      trapD -3.295837
+      trueD -3.401197]
+  (assert-close "A: IS == exact (single obs)" exactA isA 0.03)
+  (assert-close "D: IS == exact (3 shared-theta obs)" exactD isD 0.03)
+  (assert-true (str "D: IS (" (.toFixed isD 4) ") closer to true marginal ("
+                    trueD ") than to independence trap (" trapD ")")
+               (< (js/Math.abs (- isD trueD)) (js/Math.abs (- isD trapD)))))
+
+;; ===========================================================================
+;; 6 — regenerate is wired: analytical regenerate parity with handler path
+;; ===========================================================================
+
+(println "\n== 6: regenerate wired — analytical == handler (same key) ==")
+
+(defn- strip-analytical [model]
+  (dyn/->DynamicGF (:body-fn model) (:source model)
+                   (dissoc (:schema model)
+                           :auto-handlers :auto-regenerate-transition
+                           :auto-regenerate-handlers :analytical-plan
+                           :conjugate-pairs :has-conjugate?)))
+
+(let [k (rng/fresh-key 4)
+      ;; ONE marginal base trace; regenerate it via BOTH the analytical model and
+      ;; the stripped (pure-handler) model, selecting the latent :th. Selecting
+      ;; :th re-opens the pair, so the analytical regenerate falls through to the
+      ;; handler path — with the SAME base + SAME key the retained-only weights
+      ;; must coincide. (Same base trace is essential: the retained weight depends
+      ;; on the OLD :th value, so a different base would legitimately differ.)
+      base (exact-trace m-D {:x0 0 :x1 0 :x2 1} k)
+      seln (sel/select :th)
+      ra (p/regenerate (dyn/with-key m-D k) base seln)
+      rh (p/regenerate (dyn/with-key (strip-analytical m-D) k) base seln)
+      thA (mx/->clj (cm/get-value (cm/get-submap (:choices (:trace ra)) :th)))
+      thBase (mx/->clj (cm/get-value (cm/get-submap (:choices base) :th)))]
+  (assert-true "regen: analytical path returns a trace" (some? (:trace ra)))
+  (assert-true "regen: analytical weight finite" (js/isFinite (mx/item (:weight ra))))
+  (assert-true "regen: :th actually resampled (changed from posterior mean)"
+               (> (js/Math.abs (- (first thA) (first thBase))) 1e-6))
+  (assert-close "regen: analytical weight == handler weight (same base+key)"
+                (mx/item (:weight rh)) (mx/item (:weight ra)) TOL))
+
+;; ---------------------------------------------------------------------------
+;; Summary
+;; ---------------------------------------------------------------------------
+
+(println (str "\n==========================================\n"
+              "  dirichlet-categorical: " @pass " passed, " @fail " failed\n"
+              "=========================================="))
+(when (pos? @fail) (js/process.exit 1))

--- a/test/genmlx/l3_false_positive_test.cljs
+++ b/test/genmlx/l3_false_positive_test.cljs
@@ -343,36 +343,72 @@
                (pos? (count (:conjugate-pairs schema)))))
 
 ;; ===========================================================================
-;; SECTION 4 — Family without runtime factory: not eliminated, no :exact claim
+;; SECTION 4 — Dirichlet–Categorical: bare logits NOT conjugate; log-link IS
+;; (genmlx-cf0d). GenMLX's categorical is logit-parameterized, so ONLY the log
+;; link (dist/categorical (mx/log theta)) equals Categorical(theta) over the
+;; simplex and is conjugate to a Dirichlet prior. Bare (dist/categorical theta)
+;; is raw logit space — its marginal E[softmax(theta)_k] has no closed form, so
+;; it must be DECLINED (the false-positive guard this file is about). The
+;; log-link form is the genuine pair and routes to exact.
 ;; ===========================================================================
 
-(println "\n== Section 4: dirichlet-categorical has no factory ==")
+(println "\n== Section 4: dirichlet-categorical — bare declined, log-link exact ==")
 
-(def dc-model
+;; (a) BARE logits — NOT conjugate to Dirichlet; detection must NOT fire.
+(def dc-bare-model
   (gen []
     (let [th (trace :th (dist/dirichlet (mx/array [1.0 1.0 1.0])))]
       (trace :c (dist/categorical th))
       th)))
 
-(let [schema (:schema dc-model)
-      eliminated (get-in schema [:analytical-plan :rewrite-result :eliminated])
-      sel-result (ms/select-method dc-model (cmv {:c 1.0}))]
-  (assert-true "DC: pair detected (in conjugacy table)"
-               (pos? (count (:conjugate-pairs schema))))
-  (assert-true "DC: prior NOT counted as eliminated"
-               (not (contains? (or eliminated #{}) :th)))
-  (assert-true "DC: no analytical handlers installed"
+(let [schema (:schema dc-bare-model)
+      sel-result (ms/select-method dc-bare-model (cmv {:c 1.0}))]
+  (assert-true "DC bare: NO conjugate pair (logit space is not conjugate)"
+               (empty? (:conjugate-pairs schema)))
+  (assert-true "DC bare: no analytical handlers installed"
                (empty? (:auto-handlers schema)))
-  (assert-true "DC: method selection does NOT claim :exact"
+  (assert-true "DC bare: method selection does NOT claim :exact"
                (not= :exact (:method sel-result))))
 
 (let [k (rng/fresh-key 10)
       obs (cmv {:c 1.0})
-      w (gen-weight dc-model obs k)
-      w-handler (gen-weight (strip-l3 dc-model) obs k)
-      tr (gen-trace dc-model obs k)]
-  (assert-true "DC: trace NOT labeled :marginal" (not (marginal-trace? tr)))
-  (assert-close "DC: weight matches handler path (same key)" w-handler w TOL))
+      w (gen-weight dc-bare-model obs k)
+      w-handler (gen-weight (strip-l3 dc-bare-model) obs k)
+      tr (gen-trace dc-bare-model obs k)]
+  (assert-true "DC bare: trace NOT labeled :marginal" (not (marginal-trace? tr)))
+  (assert-close "DC bare: weight matches handler path (same key)" w-handler w TOL))
+
+;; (b) LOG-LINK — the genuine Dirichlet–Categorical: fires, eliminates, exact.
+(def dc-loglink-model
+  (gen []
+    (let [th (trace :th (dist/dirichlet (mx/array [1.0 1.0 1.0])))]
+      (trace :c (dist/categorical (mx/log th)))
+      th)))
+
+(let [schema (:schema dc-loglink-model)
+      eliminated (get-in schema [:analytical-plan :rewrite-result :eliminated])
+      sel-result (ms/select-method dc-loglink-model (cmv {:c 1.0}))]
+  (assert-true "DC log-link: conjugate pair detected"
+               (pos? (count (:conjugate-pairs schema))))
+  (assert-true "DC log-link: family is :dirichlet-categorical"
+               (= :dirichlet-categorical (:family (first (:conjugate-pairs schema)))))
+  (assert-true "DC log-link: prior :th eliminated"
+               (contains? (or eliminated #{}) :th))
+  (assert-true "DC log-link: analytical handlers installed for :th and :c"
+               (and (contains? (:auto-handlers schema) :th)
+                    (contains? (:auto-handlers schema) :c)))
+  (assert-true "DC log-link: method selection claims :exact"
+               (= :exact (:method sel-result))))
+
+;; Single-obs marginal: P(c=1) = alpha_1 / sum(alpha) = 1/3  ->  log(1/3).
+;; Independent closed-form oracle (host-side), exact path matches to float floor.
+(let [k (rng/fresh-key 10)
+      obs (cmv {:c 1.0})
+      w (gen-weight dc-loglink-model obs k)
+      tr (gen-trace dc-loglink-model obs k)]
+  (assert-true "DC log-link: trace labeled :marginal" (marginal-trace? tr))
+  (assert-close "DC log-link: exact weight == closed form log(1/3)"
+                (js/Math.log (/ 1.0 3.0)) w TOL))
 
 ;; ===========================================================================
 ;; SECTION 5 — Constraint checks: constrained prior, partial obs

--- a/test/genmlx/synthesis_exact_test.cljs
+++ b/test/genmlx/synthesis_exact_test.cljs
@@ -104,6 +104,32 @@
   (let [d 2.0 log-det (* 2.0 (js/Math.log 3.0)) mahal (/ 2.0 3.0)]
     (* -0.5 (+ (* d (js/Math.log (* 2.0 js/Math.PI))) log-det mahal))))
 
+;; Dirichlet-Categorical (single obs): theta ~ Dir([1,2,3]), x ~ Cat(theta) via
+;; the log link (categorical is logit-parameterized; softmax(log theta)=theta).
+;; Marginal P(x=2) = alpha_2/sum(alpha) = 3/6 = 1/2 -> log(1/2).
+(def ^:private dc-gf
+  (synth [:theta :x] {:theta "(dist/dirichlet [1 2 3])"
+                      :x     "(dist/categorical (mx/log theta))"}))
+(def ^:private dc-obs {:x 2})
+(def ^:private dc-exact-truth (js/Math.log 0.5))
+
+;; Dirichlet-Categorical (multi-obs, shared theta): theta ~ Dir([1,1,1]),
+;; x0,x1,x2 ~ Cat(theta). Ordered seq [0,0,1], counts [2,1,0] ->
+;; Dirichlet-multinomial sequence marginal = -3.401197 (math-verified).
+(def ^:private dcm-gf
+  (synth [:theta :x0 :x1 :x2]
+         {:theta "(dist/dirichlet [1 1 1])"
+          :x0    "(dist/categorical (mx/log theta))"
+          :x1    "(dist/categorical (mx/log theta))"
+          :x2    "(dist/categorical (mx/log theta))"}))
+(def ^:private dcm-obs {:x0 0 :x1 0 :x2 1})
+(def ^:private dcm-exact-truth
+  (+ (- (lgamma 3.0) (lgamma 1.0))   ;; cat 0: n=2 -> lgamma(1+2)-lgamma(1)
+     (- (lgamma 2.0) (lgamma 1.0))   ;; cat 1: n=1 -> lgamma(1+1)-lgamma(1)
+     (- (lgamma 1.0) (lgamma 1.0))   ;; cat 2: n=0
+     (lgamma 3.0)                    ;; + lgamma(sum alpha = 3)
+     (- (lgamma 6.0))))              ;; - lgamma(sum alpha + n = 6)
+
 (defn- strip-analytical
   "Return a copy of gf with the L3 analytical plan removed from its schema, so
    p/generate uses the handler/compiled path (genuine importance sampling)
@@ -153,6 +179,17 @@
   (assert-true "MVN-Normal: family is :mvn-normal"
                (boolean (some #(= :mvn-normal (:family %)) pairs))))
 
+(let [pairs (:conjugate-pairs (:schema dc-gf))]
+  (assert-true "Dirichlet-Categorical: :conjugate-pairs non-empty" (boolean (seq pairs)))
+  (assert-true "Dirichlet-Categorical: family is :dirichlet-categorical"
+               (boolean (some #(= :dirichlet-categorical (:family %)) pairs))))
+
+(let [pairs (:conjugate-pairs (:schema dcm-gf))]
+  (assert-true "Dirichlet-Categorical (multi-obs): one pair per obs (3)"
+               (= 3 (count pairs)))
+  (assert-true "Dirichlet-Categorical (multi-obs): all :dirichlet-categorical"
+               (every? #(= :dirichlet-categorical (:family %)) pairs)))
+
 (let [pairs (:conjugate-pairs (:schema nonconj-gf))]
   (assert-true "Non-conjugate (a^2 dep): no conjugate pairs" (empty? pairs)))
 
@@ -181,6 +218,14 @@
 (let [{:keys [method log-ml]} (msa/score-model* mvn-gf mvn-obs)]
   (assert-true "MVN-Normal routed to :exact" (= :exact method))
   (assert-true "MVN-Normal exact log-ml finite" (js/isFinite log-ml)))
+
+(let [{:keys [method log-ml]} (msa/score-model* dc-gf dc-obs)]
+  (assert-true "Dirichlet-Categorical routed to :exact" (= :exact method))
+  (assert-true "Dirichlet-Categorical exact log-ml finite" (js/isFinite log-ml)))
+
+(let [{:keys [method log-ml]} (msa/score-model* dcm-gf dcm-obs)]
+  (assert-true "Dirichlet-Categorical (multi-obs) routed to :exact" (= :exact method))
+  (assert-true "Dirichlet-Categorical (multi-obs) exact log-ml finite" (js/isFinite log-ml)))
 
 (let [{:keys [method log-ml]} (msa/score-model* nonconj-gf nonconj-obs {:n-particles 100})]
   (assert-true "Non-conjugate NOT routed to exact"
@@ -229,6 +274,20 @@
       is    (msa/score-model (strip-analytical mvn-gf) mvn-obs {:n-particles 6000})]
   (assert-close "MVN-Normal exact == closed-form" mvn-exact-truth exact 0.05)
   (assert-close "MVN-Normal exact == IS estimate" exact is 0.5))
+
+;; Dirichlet-Categorical (single obs): exact, closed-form log(1/2), and IS agree.
+(let [exact (msa/score-model dc-gf dc-obs)
+      is    (msa/score-model (strip-analytical dc-gf) dc-obs {:n-particles 4000})]
+  (assert-close "Dirichlet-Categorical exact == closed-form log(1/2)" dc-exact-truth exact 0.05)
+  (assert-close "Dirichlet-Categorical exact == IS estimate" exact is 0.2))
+
+;; Dirichlet-Categorical (multi-obs): exact == Dirichlet-multinomial closed form,
+;; and the SHARED-theta IS agrees (one theta per particle scores all 3 obs — the
+;; non-circular ke9i-safe check; the independence trap would land at -3.296).
+(let [exact (msa/score-model dcm-gf dcm-obs)
+      is    (msa/score-model (strip-analytical dcm-gf) dcm-obs {:n-particles 12000})]
+  (assert-close "Dirichlet-Categorical multi-obs exact == closed-form" dcm-exact-truth exact 0.05)
+  (assert-close "Dirichlet-Categorical multi-obs exact == shared-theta IS" exact is 0.2))
 
 ;; ===========================================================================
 ;; Regression — synthesized GFs still simulate; score-model number contract


### PR DESCRIPTION
Closes the last conjugacy-table family that had **no analytical implementation** — the detection table advertised `[:dirichlet :categorical]` but `build-auto-handlers` had no factory, so introspection over-promised an elimination that never fired (health-audit defect).

## The "done right" call: the log link

GenMLX's `dist/categorical` is **logit-parameterized**. Dirichlet is conjugate to the **probability**-parameterized categorical, so the genuine conjugate obs is the log link:

```clojure
theta ~ Dirichlet(alpha)
x     ~ (dist/categorical (mx/log theta))   ;; softmax(log theta) = theta
```

This makes `log p(x=k) = log theta_k`, single-obs marginal `alpha_k / sum(alpha)`, and the ordered multi-obs marginal the Dirichlet-multinomial sequence evidence.

**Bare `(dist/categorical theta)` is now correctly DECLINED** — it is raw logit space (`E[softmax(theta)_k]` has no closed form). Detection fires *only* on the log-link form, closing the over-promise **without** admitting a ke9i-class wrong-math false positive. The handler path is ground truth; the analytical path matches it to the float32 floor.

## Changes

- **conjugacy.cljs** — `log-link?` helper + family-aware `classify-dependency` (`:dirichlet-categorical` → `:log-link` only; bare → `:nonlinear`); `detect-conjugate-pairs` accepts `:log-link`.
- **auto_analytical.cljs** — `:dirichlet-categorical` family spec: float32 init-posterior; posterior-mean `alpha/sum` is the **vector** latent value; update-step gathers `alpha_k` via a graph-level one-hot, `ll = log alpha_k - log sum alpha`, folds `alpha ← alpha + e_k`. The generic core's sequential fold then yields the exact ordered Dirichlet-multinomial marginal. Wired into **generate + regenerate** factories.
- **dynamic.cljs** — `:dirichlet-categorical` joins MVN/Kalman in the `update-supported?` exclusion, so a *mixed* model never produces a partial marginal/joint update score (analytical UPDATE for this family is intentionally unimplemented).
- **msa.cljs** — `dirichlet` added to the SCI sandbox. **rewrite.cljs** — stale "no runtime elimination" comment refreshed.

## Verification

Ground truth independently derived by the math-verifier (Lanczos lgamma). The IS oracle is **non-circular and discriminating**: it draws one `theta` per particle and scores all obs jointly (shared-theta correlation), so it lands at the true marginal **−3.401** and not the independence trap **−3.296**.

- **NEW `dirichlet_categorical_test.cljs` 32/32** — detection; single + multi-obs `exact == closed-form` (cases A–E, float floor); posterior-mean theta; shared-theta IS `== exact` + trap discrimination; regenerate parity (`analytical == handler`, same base+key).
- **`synthesis_exact_test.cljs` 59/59** — fires, routes to `:exact`, `exact == closed-form == IS`.
- **`l3_false_positive_test.cljs` 68/68** — Section 4 rewritten: bare logits declined, log-link exact.
- **Regression green** — conjugacy, auto_analytical, iid_conjugacy, conjugate(_bb/_gp/_posterior), analytical_posterior_referee, l3_5_{assess,combinator_conjugacy,gate,multivariate,regenerate,score_fn}, linear_gaussian_elim 73/73, score_type.

Part of ROADMAP Phase 1 (engine contract). One bean → one branch → PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)