### PR TITLE
test(core): property-based merge associativity + trace/TensorTrace roundtrips (ota8)

### DIFF
--- a/test/genmlx/choicemap_property_test.cljs
+++ b/test/genmlx/choicemap_property_test.cljs
@@ -126,4 +126,52 @@
       (and (= val-a (cm/get-choice merged path-a))
            (= val-b (cm/get-choice merged path-b))))))
 
+;; ---------------------------------------------------------------------------
+;; Merge associativity (genmlx-ota8)
+;;
+;; merge-cm is a RIGHT-biased deep merge: on a leaf-vs-node conflict, b replaces
+;; a's entire subtree (documented). That makes it associative ONLY over
+;; PREFIX-FREE address sets (no path is a proper prefix of another) — which is
+;; exactly the invariant real GFI choicemaps satisfy (a model's trace addresses
+;; are prefix-free). Counterexample WITH a prefix conflict, to show the
+;; constraint is load-bearing, not incidental:
+;;   a={:x {:y 1}}, b={:x 2}, c={:x {:z 3}}
+;;   (merge (merge a b) c) = {:x {:z 3}}      (b's leaf wiped a's :y subtree)
+;;   (merge a (merge b c)) = {:x {:y 1 :z 3}} (a's :y survived)
+;; So the generators below are deliberately prefix-free: flat (depth 1) and
+;; fixed-depth-2 (all leaves at depth 2, all nodes at depth 1 — never a
+;; leaf-vs-node clash). Over those, last-write-wins is associative.
+
+(def gen-path2
+  "Generator for a path of EXACTLY 2 keywords (prefix-free w.r.t. other depth-2
+   paths: no depth-2 path is a prefix of another)."
+  (gen/vector gen-addr 2 2))
+
+(def gen-path2-value
+  (gen/tuple gen-path2 gen-value))
+
+(defn gen-choicemap2
+  "Generator for a prefix-free nested choicemap from 1-5 depth-2 path-value pairs."
+  []
+  (gen/fmap
+    (fn [pvs]
+      (reduce (fn [cm [path val]] (cm/set-choice cm path val))
+              cm/EMPTY pvs))
+    (gen/not-empty (gen/vector gen-path2-value 1 5))))
+
+(defspec merge-cm-associative-flat 100
+  (prop/for-all [a gen-flat-map
+                 b gen-flat-map
+                 c gen-flat-map]
+    (let [ca (cm/from-map a) cb (cm/from-map b) cc (cm/from-map c)]
+      (= (cm/to-map (cm/merge-cm (cm/merge-cm ca cb) cc))
+         (cm/to-map (cm/merge-cm ca (cm/merge-cm cb cc)))))))
+
+(defspec merge-cm-associative-nested-prefix-free 100
+  (prop/for-all [a (gen-choicemap2)
+                 b (gen-choicemap2)
+                 c (gen-choicemap2)]
+    (= (cm/to-map (cm/merge-cm (cm/merge-cm a b) c))
+       (cm/to-map (cm/merge-cm a (cm/merge-cm b c))))))
+
 (t/run-tests)

--- a/test/genmlx/tensor_trace_property_test.cljs
+++ b/test/genmlx/tensor_trace_property_test.cljs
@@ -1,0 +1,93 @@
+;; @tier fast
+(ns genmlx.tensor-trace-property-test
+  "Property-based TensorTrace round-trip tests (genmlx-ota8) using test.check.
+
+   Complements the deterministic examples in tensor_trace_test.cljs with
+   generated value maps / address indices:
+     1. pack-values then unpack-values is the identity on values.
+     2. trace -> tensor-trace -> trace preserves choices and all scalar fields.
+
+   Run: bun run --bun nbb test/genmlx/tensor_trace_property_test.cljs"
+  (:require [cljs.test :as t]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [genmlx.mlx :as mx]
+            [genmlx.choicemap :as cm]
+            [genmlx.trace :as tr]
+            [genmlx.tensor-trace :as tt])
+  (:require-macros [clojure.test.check.clojure-test :refer [defspec]]))
+
+;; ---------------------------------------------------------------------------
+;; Generators
+;; ---------------------------------------------------------------------------
+
+(def addr-pool [:a :b :c :d :e :f :g :h])
+
+(def gen-num
+  (gen/double* {:min -50.0 :max 50.0 :NaN? false :infinite? false}))
+
+(def gen-addr-num-map
+  "Non-empty {addr -> number} map with DISTINCT addresses (into {} dedups by
+   key, last-wins). 1-8 entries drawn from the pool."
+  (gen/such-that seq
+    (gen/fmap (fn [pairs] (into {} pairs))
+              (gen/vector (gen/tuple (gen/elements addr-pool) gen-num) 1 8))
+    100))
+
+(defn- close? [a b tol]
+  (and (number? a) (number? b) (js/isFinite a) (js/isFinite b)
+       (<= (js/Math.abs (- a b)) tol)))
+
+(defn- ->scalars [m] (into {} (map (fn [[a v]] [a (mx/scalar v)]) m)))
+
+(defn- contiguous-index
+  "addr-index {addr -> 0..K-1} in key order (a bijection onto the [K] tensor
+   positions, exactly as make-addr-index assigns)."
+  [addrs]
+  (zipmap addrs (range (count addrs))))
+
+;; ---------------------------------------------------------------------------
+;; Property 1: pack-values then unpack-values is the identity
+;; ---------------------------------------------------------------------------
+
+(defspec pack-unpack-roundtrips-values 100
+  (prop/for-all [m gen-addr-num-map]
+    (let [addrs (vec (keys m))
+          ai (contiguous-index addrs)
+          packed (tt/pack-values (->scalars m) ai)
+          unpacked (tt/unpack-values packed ai)]
+      (and (= [(count addrs)] (mx/shape packed))
+           (every? (fn [a] (close? (get m a) (mx/item (get unpacked a)) 1e-5))
+                   addrs)))))
+
+;; ---------------------------------------------------------------------------
+;; Property 2: trace -> tensor-trace -> trace preserves choices + fields
+;; ---------------------------------------------------------------------------
+
+(defspec tensor-trace->trace-roundtrips 100
+  (prop/for-all [m       gen-addr-num-map
+                 score-n gen-num
+                 retval-n gen-num]
+    (let [addrs   (vec (keys m))
+          ai      (contiguous-index addrs)
+          choices (cm/from-flat-map (->scalars m))
+          trace   (tr/make-trace {:gen-fn :test-gfn
+                                  :args   [1.0 2.0]
+                                  :choices choices
+                                  :retval (mx/scalar retval-n)
+                                  :score  (mx/scalar score-n)})
+          tt-trace (tt/trace->tensor-trace trace ai)
+          back     (tt/tensor-trace->trace tt-trace)]
+      (and (instance? tt/TensorTrace tt-trace)
+           (instance? tr/Trace back)
+           (= :test-gfn (:gen-fn back))
+           (= [1.0 2.0] (:args back))
+           (close? score-n  (mx/item (:score back)) 1e-5)
+           (close? retval-n (mx/item (:retval back)) 1e-5)
+           (every? (fn [a]
+                     (close? (get m a)
+                             (mx/item (cm/get-value (cm/get-submap (:choices back) a)))
+                             1e-5))
+                   addrs)))))
+
+(t/run-tests)

--- a/test/genmlx/trace_immutability_property_test.cljs
+++ b/test/genmlx/trace_immutability_property_test.cljs
@@ -11,6 +11,7 @@
             [genmlx.dynamic :as dyn]
             [genmlx.protocols :as p]
             [genmlx.choicemap :as cm]
+            [genmlx.trace :as tr]
             [genmlx.selection :as sel]
             [genmlx.combinators :as comb])
   (:require-macros [genmlx.gen :refer [gen]]
@@ -302,5 +303,58 @@
       (every? (fn [a]
                 (close? (get orig-unsel a) (get new-unsel a) 1e-6))
               unselected))))
+
+;; ---------------------------------------------------------------------------
+;; Property 10: make-trace preserves every field, and the record is immutable
+;; (genmlx-ota8). make-trace is map->Trace; field access must return exactly
+;; what was put in, and assoc must yield a NEW trace without touching the
+;; original.
+;; ---------------------------------------------------------------------------
+
+(def gen-field-num
+  (gen/double* {:min -1e6 :max 1e6 :NaN? false :infinite? false}))
+
+(def gen-flat-choice-map
+  "Generator for a flat {addr -> number} map (0-5 distinct addrs)."
+  (gen/fmap (fn [kvs] (into {} kvs))
+            (gen/vector (gen/tuple (gen/elements [:a :b :c :d :e]) gen-field-num) 0 5)))
+
+(defspec make-trace-preserves-all-fields 50
+  (prop/for-all [gfn    (gen/elements [:gfn-x :gfn-y nil])
+                 args   (gen/vector gen-field-num 0 3)
+                 retval gen-field-num
+                 score  gen-field-num
+                 cmap   gen-flat-choice-map]
+    (let [choices (cm/from-flat-map (into {} (map (fn [[a v]] [a (mx/scalar v)]) cmap)))
+          fields {:gen-fn gfn :args args :choices choices :retval retval :score score}
+          t (tr/make-trace fields)]
+      (and (tr/trace? t)
+           (= gfn (:gen-fn t))
+           (= args (:args t))
+           (identical? choices (:choices t))
+           (= retval (:retval t))
+           (= score (:score t))
+           ;; immutability: assoc returns a NEW trace, original untouched
+           (let [t2 (assoc t :score (inc score))]
+             (and (= (inc score) (:score t2))
+                  (= score (:score t))
+                  (not (identical? t2 t))))))))
+
+;; Across the real model pool + generated args: snapshot a simulated trace's
+;; fields and confirm make-trace reconstructs an identical-field trace.
+(defspec make-trace-roundtrips-simulated-fields 50
+  (prop/for-all [m gen-model]
+    (let [orig    (p/simulate (:model m) (:args m))
+          rebuilt (tr/make-trace {:gen-fn  (:gen-fn orig)
+                                  :args    (:args orig)
+                                  :choices (:choices orig)
+                                  :retval  (:retval orig)
+                                  :score   (:score orig)})]
+      (and (tr/trace? rebuilt)
+           (identical? (:gen-fn orig)  (:gen-fn rebuilt))
+           (=          (:args orig)    (:args rebuilt))
+           (identical? (:choices orig) (:choices rebuilt))
+           (identical? (:retval orig)  (:retval rebuilt))
+           (identical? (:score orig)   (:score rebuilt))))))
 
 (t/run-tests)


### PR DESCRIPTION
Closes the property-test gaps for core data structures (ROADMAP Phase 1, genmlx-ota8): algebraic laws that existed only as single-example `deftest`s are promoted to `test.check` `defspec`s (≥50 trials each).

## What's added

**`choicemap_property_test.cljs` — merge associativity**
`merge-cm` is a **right-biased deep merge**: on a leaf-vs-node conflict, `b` replaces `a`'s entire subtree (documented). That makes it associative **only over prefix-free address sets** (no path is a proper prefix of another) — which is exactly the invariant real GFI choicemaps satisfy. The generators are therefore deliberately prefix-free (flat depth-1 + fixed depth-2), and a comment records the leaf-vs-node counterexample so the constraint is explicit rather than incidental:
```
a={:x {:y 1}}, b={:x 2}, c={:x {:z 3}}
(merge (merge a b) c) = {:x {:z 3}}        ; b's leaf wiped a's :y
(merge a (merge b c)) = {:x {:y 1 :z 3}}   ; a's :y survived
```
Two defspecs (flat + nested), 100 trials each.

**`trace_immutability_property_test.cljs` — make-trace field preservation**
`make-trace` preserves every field via keyword access and the record is immutable (`assoc` yields a new trace, original untouched); plus a roundtrip that reconstructs fields from real simulated traces across the model pool. 50 + 50 trials.

**`tensor_trace_property_test.cljs` (NEW) — TensorTrace roundtrips**
- `pack-values` then `unpack-values` is the identity on values (generated value maps + contiguous addr-indices).
- `trace → tensor-trace → trace` preserves choices and all scalar fields.
100 trials each.

## Done-means

- [x] Merge associativity defspec in `choicemap_property_test.cljs`
- [x] Trace field-preservation defspec in `trace_immutability_property_test.cljs`
- [x] TensorTrace pack/unpack defspec
- [x] TensorTrace conversion-roundtrip defspec
- [x] All new defspecs ≥50 trials
- [x] All pass via `bun run --bun nbb` — choicemap 13/13, trace 11/11, tensor_trace 2/2 (0 failures, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)