### PR TITLE
feat(gfi): encapsulated randomness via unbiased density estimators (qbaa §4.5)

### DIFF
--- a/src/genmlx/encapsulated.cljs
+++ b/src/genmlx/encapsulated.cljs
@@ -1,0 +1,458 @@
+(ns genmlx.encapsulated
+  "Encapsulated randomness — Cusumano-Towner 2020 PhD thesis, Chapter 4.5.
+
+   ## What this is
+
+   A generative function normally exposes an EXACT density: the trace's score
+   is log p(tau; x). §4.5 relaxes this. A generative function with encapsulated
+   randomness owns internal randomness omega (NOT part of the choice dictionary
+   tau), and its realized score is a value of an unbiased density ESTIMATOR
+
+       xi(x, tau, omega),   with   E_omega[ xi(x, tau, omega) ] = p(tau; x)
+                                                                       (Eq 4.3)
+
+   The trace carries omega alongside tau (the optional `omega` field on
+   genmlx.trace/Trace), so the realized score is reproducible: re-evaluating the
+   estimator at the recorded omega yields the same xi. Reproducibility is what
+   makes identity update/project return weight 0 exactly, while a genuine move
+   (changed value or args) resamples omega and pays the pseudo-marginal ratio
+   log xi' − log xi_old.
+
+   ## Why it matters (the three §4.5 use cases)
+
+   - Models that call black-box stochastic code whose density is intractable but
+     unbiasedly estimable (here: `marginalized-gaussian`, a latent-variable
+     likelihood estimated by importance sampling over the nuisance).
+   - Finite mixtures whose normalizer is integrated by Monte Carlo over an
+     encapsulated component index (`mixture-density`).
+   - Pseudo-marginal MCMC: the score becomes an unbiased estimator, and the
+     chain still targets the exact posterior (`pseudo-marginal-mh`,
+     Andrieu-Roberts 2009; the auxiliary-variable argument is Eq 4.3-4.4).
+
+   ## Contract on the caller-supplied estimator (the §4.5 obligation)
+
+   `encapsulated` takes a single observed address and three closures:
+     :sample-value          (fn [key args] -> v)        draws v ~ p(.; args)
+     :sample-omega          (fn [key args v] -> omega)  draws encapsulated randomness
+     :log-density-estimate  (fn [args v omega] -> logxi-scalar)
+   Obligations:
+     (1) E_omega[ exp(log-density-estimate args v omega) ] = p(v; args)  (Eq 4.3)
+     (2) log-density-estimate is DETERMINISTIC given omega (reproducibility)
+     (3) xi >= 0 (the estimate is a non-negative density; logxi finite)
+
+   ## NOTE on score-type
+
+   An encapsulated trace is tagged :joint (the default). Its score is an
+   estimate, but it is a REPRODUCIBLE function of the recorded omega and every
+   GFI op re-derives it consistently — so, unlike an L3 :marginal trace (which
+   pins latents at posterior means and switches decomposition between ops), it
+   composes like an ordinary joint density and is safe for trace-MH ratios.
+   See genmlx.trace score-type notes and ARCHITECTURE §3.3.
+
+   ## Limitation (scope)
+
+   An EncapsulatedGF is a STANDALONE / top-level generative function (and the
+   likelihood in pseudo-marginal MCMC). It is NOT a combinator/vmap kernel:
+   shape-batched combinators (genmlx.vmap, Map/Unfold/Scan) reconstruct
+   per-element traces via make-trace WITHOUT the omega field, which would break
+   the estimator's reproducibility (identity ops would no longer cost weight 0).
+   Use it directly, not wrapped in a combinator."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.mlx.constants :refer [ZERO]]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.protocols :as p]
+            [genmlx.trace :as tr]
+            [genmlx.diff :as diff]))
+
+;; ---------------------------------------------------------------------------
+;; Key handling
+;;
+;; EncapsulatedGF honours the SAME metadata key dynamic.cljs uses
+;; (:genmlx.dynamic/key), so dyn/with-key and dyn/auto-key work transparently
+;; on it. The keyword literal is referenced as data — no namespace dependency,
+;; no circular-require risk. A real PRNG key is an MLX array; the auto-key
+;; sentinel is a keyword; absent => fresh per call (REPL/test convenience).
+;; ---------------------------------------------------------------------------
+
+(defn- enc-key [gf]
+  (let [k (:genmlx.dynamic/key (meta gf))]
+    (if (or (nil? k) (keyword? k)) (rng/fresh-key) k)))
+
+;; ---------------------------------------------------------------------------
+;; Internal helpers
+;; ---------------------------------------------------------------------------
+
+(defn- addr-value
+  "Leaf value stored at the GF's single observed address in a choicemap, or nil."
+  [choices addr]
+  (cm/get-value (cm/get-submap choices addr)))
+
+(defn- same-value?
+  "True if MLX values a and b are equal (identity fast-path, else elementwise).
+   Used to decide whether an update at the observed address is a genuine move
+   (resample omega) or a no-op (reuse omega → weight 0)."
+  [a b]
+  (or (identical? a b)
+      (and (some? a) (some? b)
+           (= (mx/realize-clj a) (mx/realize-clj b)))))
+
+(defn- same-args?
+  "True if argument vectors a and b are element-wise equal (MLX-aware)."
+  [a b]
+  (and (= (count a) (count b))
+       (every? true?
+               (map (fn [x y]
+                      (if (or (mx/array? x) (mx/array? y))
+                        (same-value? x y)
+                        (= x y)))
+                    a b))))
+
+(defn- make-enc-trace
+  "Build an encapsulated Trace: choices = {addr v}, score = logxi, omega stored,
+   retval = v. Tagged :joint (see ns docstring)."
+  [gf args addr v logxi omega]
+  (tr/with-score-type
+    (tr/make-trace {:gen-fn gf :args args
+                    :choices (cm/set-value cm/EMPTY addr v)
+                    :retval v :score logxi :omega omega})
+    :joint))
+
+(defn- resample-result
+  "Build the {:trace :weight :discard} result for a genuine move at new value
+   `v` under `args`: draw fresh omega with `key`, recompute logxi', weight is
+   logxi' minus the OLD trace's stored score (the pseudo-marginal ratio). The
+   old score is the auxiliary variable being reused as the move's denominator."
+  [gf args addr v old-score discard key]
+  (let [{:keys [sample-omega log-density-estimate]} gf
+        omega' (sample-omega key args v)
+        logxi' (log-density-estimate args v omega')]
+    {:trace (make-enc-trace gf args addr v logxi' omega')
+     :weight (mx/subtract logxi' old-score)
+     :discard discard}))
+
+;; ---------------------------------------------------------------------------
+;; EncapsulatedGF — full GFI over a single observed address
+;; ---------------------------------------------------------------------------
+
+(defrecord EncapsulatedGF [addr sample-value sample-omega log-density-estimate]
+  p/IGenerativeFunction
+  (simulate [gf args]
+    (let [[k1 k2] (rng/split (enc-key gf))
+          v (sample-value k1 args)
+          omega (sample-omega k2 args v)
+          logxi (log-density-estimate args v omega)]
+      (make-enc-trace gf args addr v logxi omega)))
+
+  p/IGenerate
+  (generate [gf args constraints]
+    (let [constraint (cm/get-submap constraints addr)]
+      (if (cm/has-value? constraint)
+        ;; Observed value constrained: draw fresh omega, weight = score = logxi.
+        (let [v (cm/get-value constraint)
+              [_ k2] (rng/split (enc-key gf))
+              omega (sample-omega k2 args v)
+              logxi (log-density-estimate args v omega)]
+          {:trace (make-enc-trace gf args addr v logxi omega) :weight logxi})
+        ;; Unconstrained: equivalent to simulate, weight 0.
+        {:trace (p/simulate gf args) :weight ZERO})))
+
+  p/IAssess
+  (assess [gf args choices]
+    (let [v (addr-value choices addr)]
+      (when (nil? v)
+        (throw (ex-info (str "assess: encapsulated address " addr
+                             " not found in provided choices.")
+                        {:addr addr})))
+      (let [[_ k2] (rng/split (enc-key gf))
+            omega (sample-omega k2 args v)
+            logxi (log-density-estimate args v omega)]
+        {:retval v :weight logxi})))
+
+  p/IPropose
+  (propose [gf args]
+    (let [trace (p/simulate gf args)]
+      {:choices (:choices trace) :weight (:score trace) :retval (:retval trace)}))
+
+  p/IProject
+  (project [gf trace selection]
+    ;; The whole estimated density lives at the single address; reuse the
+    ;; stored score (= logxi at the recorded omega). project-all = score,
+    ;; project-none = 0.
+    (if (and selection (sel/selected? selection addr))
+      (:score trace)
+      ZERO))
+
+  p/IUpdate
+  (update [gf trace constraints]
+    (let [args (:args trace)
+          old-v (addr-value (:choices trace) addr)
+          constraint (cm/get-submap constraints addr)]
+      (if (and (cm/has-value? constraint)
+               (not (same-value? (cm/get-value constraint) old-v)))
+        ;; Genuine move: new observed value → resample omega, pay logxi'−old.
+        (let [new-v (cm/get-value constraint)
+              [_ k2] (rng/split (enc-key gf))]
+          (resample-result gf args addr new-v (:score trace)
+                           (cm/set-value cm/EMPTY addr old-v) k2))
+        ;; No change at the observed address: reuse omega → weight 0.
+        {:trace trace :weight ZERO :discard cm/EMPTY})))
+
+  p/IRegenerate
+  (regenerate [gf trace selection]
+    (let [args (:args trace)]
+      (if (and selection (sel/selected? selection addr))
+        ;; Selected: propose a fresh observed value from the marginal, with a
+        ;; fresh estimate. The §4.5 estimator regenerate ratio logxi'−logxi_old
+        ;; replaces the exact-density "resample-from-prior ⇒ weight 0" because
+        ;; the marginal proposal density is itself only estimated.
+        (let [[k1 k2] (rng/split (enc-key gf))
+              new-v (sample-value k1 args)]
+          (dissoc (resample-result gf args addr new-v (:score trace) cm/EMPTY k2)
+                  :discard))
+        ;; Unselected: reuse omega → weight 0.
+        {:trace trace :weight ZERO})))
+
+  p/IUpdateWithArgs
+  (update-with-args [gf trace new-args argdiffs constraints]
+    (let [old-args (:args trace)
+          old-v (addr-value (:choices trace) addr)
+          constraint (cm/get-submap constraints addr)
+          value-changed (and (cm/has-value? constraint)
+                             (not (same-value? (cm/get-value constraint) old-v)))
+          new-v (if (cm/has-value? constraint) (cm/get-value constraint) old-v)
+          ;; The argdiff is a trusted caller hint (Gen.jl model): no-change ⇒
+          ;; trust unchanged. Otherwise compare the ACTUAL args, so a
+          ;; conservative :unknown at genuinely-unchanged args stays a no-op
+          ;; (weight 0) rather than paying spurious estimator noise — i.e.
+          ;; update-with-args at x'=x reduces to update.
+          args-changed (and (not (diff/no-change? argdiffs))
+                            (not (same-args? old-args new-args)))]
+      (if (or args-changed value-changed)
+        ;; Pseudo-marginal move generator: resample omega under new args at the
+        ;; (possibly new) value, weight = logxi'(new-args) − old-score.
+        (let [[_ k2] (rng/split (enc-key gf))
+              discard (if value-changed (cm/set-value cm/EMPTY addr old-v) cm/EMPTY)]
+          (resample-result gf new-args addr new-v (:score trace) discard k2))
+        ;; Caller asserts no arg change and the value is unchanged: reuse omega.
+        {:trace trace :weight ZERO :discard cm/EMPTY})))
+
+  p/IUpdateWithDiffs
+  (update-with-diffs [gf trace constraints argdiffs]
+    (p/update-with-args gf trace (:args trace) argdiffs constraints))
+
+  p/IHasArgumentGrads
+  (has-argument-grads [_] nil))
+
+(defn encapsulated
+  "Construct a generative function with encapsulated randomness (§4.5).
+
+   opts:
+     :addr                  keyword — the single observed address.
+     :sample-value          (fn [key args] -> v)        draws v ~ p(.; args).
+     :sample-omega          (fn [key args v] -> omega)  draws encapsulated randomness.
+     :log-density-estimate  (fn [args v omega] -> logxi) DETERMINISTIC given omega;
+                            unbiased: E_omega[exp logxi] = p(v; args).
+
+   Returns an EncapsulatedGF implementing the full GFI with score = log xi and
+   trace.omega = omega. Use dyn/with-key / dyn/auto-key for PRNG control."
+  [{:keys [addr sample-value sample-omega log-density-estimate]}]
+  (assert (keyword? addr) "encapsulated: :addr must be a keyword")
+  (assert (fn? sample-value) "encapsulated: :sample-value must be a fn")
+  (assert (fn? sample-omega) "encapsulated: :sample-omega must be a fn")
+  (assert (fn? log-density-estimate) "encapsulated: :log-density-estimate must be a fn")
+  (->EncapsulatedGF addr sample-value sample-omega log-density-estimate))
+
+;; ---------------------------------------------------------------------------
+;; Gaussian log-density helper (estimator-internal; the TEST oracle is an
+;; independent JS implementation, never this).
+;; ---------------------------------------------------------------------------
+
+(def ^:private LOG-2PI (js/Math.log (* 2 js/Math.PI)))
+
+(defn- gauss-logpdf
+  "logN(x; mu, sigma), elementwise over MLX arrays. sigma is an MLX scalar."
+  [x mu sigma]
+  (mx/subtract
+   (mx/subtract (mx/scalar (* -0.5 LOG-2PI)) (mx/log sigma))
+   (mx/multiply (mx/scalar 0.5)
+                (mx/square (mx/divide (mx/subtract x mu) sigma)))))
+
+;; ---------------------------------------------------------------------------
+;; Estimator library 1 — marginalized Gaussian (black-box stochastic code)
+;;
+;; The observed datum vector y of length n is generated as y_i = z_i + noise_i
+;; with z_i ~ N(theta, tau^2), noise_i ~ N(0, sigma^2). The marginal density
+;;   p(y_i; theta) = N(y_i; theta, sqrt(tau^2 + sigma^2))
+;; is treated as a black box: it is estimated, per factor independently, by
+;; K-sample importance sampling over the nuisance z with the prior N(theta,tau)
+;; as the proposal (so weights reduce to the likelihood N(y_i; z, sigma)):
+;;   xi_i = (1/K) sum_k N(y_i; z_{i,k}, sigma),   z_{i,k} ~iid N(theta, tau)
+;;   log xi = sum_i logmeanexp_k logN(y_i; z_{i,k}, sigma)
+;; INDEPENDENT z per factor i (shape [n,K]) is essential: a shared nuisance
+;; correlates the factors and biases the product (Andrieu-Roberts pitfall).
+;; ---------------------------------------------------------------------------
+
+(defn marginalized-gaussian
+  "Encapsulated marginalized-Gaussian likelihood (§4.5 black-box example).
+
+   opts: {:addr kw, :n int, :tau num, :sigma num, :k int (IS samples)}
+   args to the returned GF: [theta] (an MLX scalar — the inferred location).
+
+   Returns {:gf EncapsulatedGF
+            :exact-log-density (fn [args y] -> logp scalar)  ;; the true marginal
+            :marginal-sigma S}                               ;; sqrt(tau^2+sigma^2)"
+  [{:keys [addr n tau sigma k] :or {addr :y k 16}}]
+  (let [tau-mx (mx/scalar (double tau))
+        sigma-mx (mx/scalar (double sigma))
+        S (js/Math.sqrt (+ (* tau tau) (* sigma sigma)))
+        S-mx (mx/scalar S)
+        log-k (mx/scalar (js/Math.log k))
+        theta-of (fn [args] (let [t (first args)]
+                              (if (mx/array? t) t (mx/scalar (double t)))))
+        sample-value
+        (fn [key args]
+          (mx/add (theta-of args) (mx/multiply S-mx (rng/normal key [n]))))
+        sample-omega
+        (fn [key args _v]
+          ;; z[n,K] ~ N(theta, tau): independent nuisance per (factor, sample).
+          (mx/add (theta-of args) (mx/multiply tau-mx (rng/normal key [n k]))))
+        log-density-estimate
+        (fn [_args y z]
+          (let [y2 (mx/reshape y [n 1])
+                lp (gauss-logpdf y2 z sigma-mx)            ;; [n,K]
+                per-i (mx/subtract (mx/logsumexp lp [1]) log-k)] ;; [n]
+            (mx/sum per-i)))
+        exact-log-density
+        (fn [args y] (mx/sum (gauss-logpdf y (theta-of args) S-mx)))]
+    {:gf (encapsulated {:addr addr
+                        :sample-value sample-value
+                        :sample-omega sample-omega
+                        :log-density-estimate log-density-estimate})
+     :exact-log-density exact-log-density
+     :marginal-sigma S}))
+
+;; ---------------------------------------------------------------------------
+;; Estimator library 2 — finite mixture with Monte-Carlo-integrated index
+;; ("finite mixture with unknown Z": the normalizing sum over the component
+;; index is estimated by sampling the index rather than summing it).
+;;
+;;   p(y) = sum_k pi_k N(y; mu_k, sigma_k)
+;;   xi   = (1/K) sum_i N(y; mu_{k_i}, sigma_{k_i}),  k_i ~iid Categorical(pi)
+;; ---------------------------------------------------------------------------
+
+(defn mixture-density
+  "Encapsulated finite-mixture density (§4.5 unknown-Z example).
+
+   opts: {:addr kw, :weights [num...], :means [num...], :sigmas [num...], :k int}
+   args to the returned GF: [] (a fixed mixture; the value y is a scalar).
+
+   Returns {:gf EncapsulatedGF
+            :exact-log-density (fn [args y] -> logp scalar)}"
+  [{:keys [addr weights means sigmas k] :or {addr :y k 32}}]
+  (let [m (count weights)
+        wsum (reduce + weights)
+        log-pi (mx/array (mapv #(js/Math.log (/ % wsum)) weights))  ;; normalized [m]
+        logits (mx/array (mapv #(js/Math.log %) weights))           ;; categorical logits [m]
+        mu (mx/array (mapv double means))                           ;; [m]
+        sig (mx/array (mapv double sigmas))                         ;; [m]
+        log-k (mx/scalar (js/Math.log k))
+        cat-rows (fn [key rows]
+                   ;; sample `rows` iid category indices: broadcast logits to
+                   ;; [rows,m], categorical samples along last axis → [rows].
+                   (rng/categorical key (mx/broadcast-to (mx/reshape logits [1 m]) [rows m])))
+        ensure-y (fn [v] (if (mx/array? v) v (mx/scalar (double v))))
+        sample-value
+        (fn [key _args]
+          (let [[k1 k2] (rng/split key)
+                idx (cat-rows k1 1)                       ;; [1]
+                mu-i (mx/take-idx mu idx)                 ;; [1]
+                sig-i (mx/take-idx sig idx)]              ;; [1]
+            (mx/reshape (mx/add mu-i (mx/multiply sig-i (rng/normal k2 [1]))) [])))
+        sample-omega
+        (fn [key _args _v] (cat-rows key k))             ;; K indices [K]
+        log-density-estimate
+        (fn [_args y idx]
+          (let [yv (ensure-y y)
+                mu-k (mx/take-idx mu idx)                 ;; [K]
+                sig-k (mx/take-idx sig idx)               ;; [K]
+                lp (gauss-logpdf yv mu-k sig-k)]          ;; [K]
+            (mx/subtract (mx/logsumexp lp [0]) log-k)))
+        exact-log-density
+        (fn [_args y]
+          (let [yv (ensure-y y)
+                lp (mx/add log-pi (gauss-logpdf yv mu sig))]  ;; [m]
+            (mx/logsumexp lp [0])))]
+    {:gf (encapsulated {:addr addr
+                        :sample-value sample-value
+                        :sample-omega sample-omega
+                        :log-density-estimate log-density-estimate})
+     :exact-log-density exact-log-density}))
+
+;; ---------------------------------------------------------------------------
+;; Pseudo-marginal Metropolis-Hastings (§4.5 / Andrieu-Roberts 2009)
+;;
+;; Infers a parameter theta whose likelihood p(y | theta) is available only as
+;; an unbiased estimate xi from an EncapsulatedGF (y constrained, theta = arg).
+;; Each proposed theta' draws a fresh xi'; the CURRENT state reuses its stored
+;; xi (the trace score + omega) as the acceptance denominator. The extended
+;; (theta, omega) chain is reversible and the theta-marginal is the exact
+;; posterior because E_omega[xi] = p(y|theta) (Eq 4.3).
+;; ---------------------------------------------------------------------------
+
+(defn pseudo-marginal-mh
+  "Pseudo-marginal random-walk MH on a scalar parameter theta.
+
+   opts:
+     :enc-gf       EncapsulatedGF likelihood (args = [theta], observed value y).
+     :y            observed value (MLX array) constrained at the GF's address.
+     :theta0       initial theta (number).
+     :log-prior    (fn [theta-num] -> log p(theta)) host-side prior log-density.
+     :step         random-walk std (number).
+     :samples      number of post-burn samples to collect.
+     :burn         burn-in steps (default 0).
+     :key          PRNG key (default fresh).
+
+   Returns {:samples [theta-num ...] :accept-rate r}. The likelihood is never
+   computed exactly — only the encapsulated estimator is used."
+  [{:keys [enc-gf y theta0 log-prior step samples burn key]
+    :or {burn 0}}]
+  (assert (instance? EncapsulatedGF enc-gf)
+          "pseudo-marginal-mh: :enc-gf must be an EncapsulatedGF (see `encapsulated`)")
+  (let [addr (:addr enc-gf)
+        rk (rng/ensure-key (or key (rng/fresh-key)))
+        obs (cm/set-value cm/EMPTY addr y)
+        ;; Initialise the trace at theta0 (draws the initial stored xi/omega).
+        keyed (fn [k] (vary-meta enc-gf assoc :genmlx.dynamic/key k))
+        [k0 rk0] (rng/split rk)
+        init-trace (:trace (p/generate (keyed k0) [(mx/scalar (double theta0))] obs))
+        n-total (+ burn samples)]
+    (loop [cur-trace init-trace
+           theta theta0
+           i 0
+           rk rk0
+           acc (transient [])
+           n-acc 0]
+      (if (>= i n-total)
+        {:samples (persistent! acc)
+         :accept-rate (/ n-acc (double n-total))}
+        (let [[k-prop k-move k-acc rk'] (rng/split-n rk 4)
+              ;; Random-walk proposal theta' = theta + step * N(0,1).
+              theta' (+ theta (* step (mx/item (rng/normal k-prop []))))
+              ;; Pseudo-marginal move: change the arg theta→theta', redraw omega.
+              ;; weight = logxi'(theta') − logxi_old (the stored auxiliary).
+              {prop-trace :trace weight :weight}
+              (p/update-with-args (keyed k-move) cur-trace
+                                  [(mx/scalar theta')] :unknown cm/EMPTY)
+              log-alpha (+ (mx/item weight)
+                           (- (log-prior theta') (log-prior theta)))
+              u (mx/item (rng/uniform k-acc []))
+              accept? (< (js/Math.log u) log-alpha)
+              ;; On reject KEEP the old trace (with its stored old xi); on accept
+              ;; carry the proposed trace forward (its xi' becomes the next aux).
+              next-trace (if accept? prop-trace cur-trace)
+              next-theta (if accept? theta' theta)]
+          (recur next-trace next-theta (inc i) rk'
+                 (if (>= i burn) (conj! acc next-theta) acc)
+                 (+ n-acc (if accept? 1 0))))))))

--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -32,8 +32,10 @@
             [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
             [genmlx.trace :as tr]
+            [genmlx.diff :as diff]
             [genmlx.dynamic :as dyn]
             [genmlx.dist :as dist]
+            [genmlx.encapsulated :as enc]
             [genmlx.gradients :as grad]
             [genmlx.verify :as verify]
             [genmlx.inference.mcmc :as mcmc]
@@ -1509,6 +1511,89 @@
                ;; Both kernels converge to the same analytical posterior
                (and (approx= mean-mix analytical-mean 0.25)
                     (approx= mean-cycle analytical-mean 0.25))))}
+
+   ;; ===================================================================
+   ;; ENCAPSULATED RANDOMNESS laws [T] §4.5 (genmlx-qbaa)
+   ;;
+   ;; A generative function whose realized score is an unbiased density
+   ;; ESTIMATOR xi(x, tau, omega), not the exact density p(tau; x). omega
+   ;; lives in the trace; reuse makes identity ops cost weight 0, resample
+   ;; drives pseudo-marginal MCMC. These laws are SELF-CONTAINED (they build
+   ;; their own encapsulated models and ignore the passed model/args) and
+   ;; seeded for reproducibility, like :mixture-kernel-stationarity. Tagged
+   ;; #{:encapsulated} so they run only when explicitly requested.
+   ;; ===================================================================
+
+   {:name :encapsulated-estimator-unbiased
+    :from "[T] §4.5 Eq 4.3 — E_omega[xi(x,tau,omega)] = p(tau;x)"
+    :theorem "The Monte-Carlo average over omega of the realized density
+              estimate xi converges to the exact marginal density p(y),
+              checked on a 3-component Gaussian mixture whose exact density is
+              an independent closed form."
+    :tags #{:encapsulated :inference}
+    :check (fn [{:keys [_model _args]}]
+             (let [w [0.3 0.5 0.2] mu [-2 0 3] sg [1 0.5 2]
+                   {:keys [gf]} (enc/mixture-density
+                                 {:weights w :means mu :sigmas sg :k 32})
+                   y 0.0
+                   wsum (reduce + w)
+                   ;; independent oracle: exact mixture density at y
+                   p-exact (reduce + (map (fn [wk m s]
+                                            (* (/ wk wsum)
+                                               (js/Math.exp (log-gauss y m s))))
+                                          w mu sg))
+                   obs (cm/choicemap :y (mx/scalar y))
+                   r 300
+                   xis (mapv (fn [i]
+                               (js/Math.exp
+                                (ev (:weight (p/assess
+                                              (dyn/with-key gf (rng/fresh-key (+ 7000 i)))
+                                              [] obs)))))
+                             (range r))
+                   mc (/ (reduce + xis) r)
+                   sd (js/Math.sqrt (/ (reduce + (map #(let [d (- % mc)] (* d d)) xis)) r))
+                   band (max (* 5.0 (/ sd (js/Math.sqrt r))) 0.01)]
+               (approx= mc p-exact band)))}
+
+   {:name :encapsulated-identity-update-zero
+    :from "[T] §4.5 — stored omega makes a no-op move reproducible"
+    :theorem "update / update-with-args / regenerate that change nothing reuse
+              the recorded omega, so the realized xi is unchanged and the
+              weight is EXACTLY 0. Without stored omega a fresh xi would inject
+              nonzero weight into SMC/MH."
+    :tags #{:encapsulated :inference}
+    :check (fn [{:keys [_model _args]}]
+             (let [{:keys [gf]} (enc/marginalized-gaussian
+                                 {:n 2 :tau 1.0 :sigma 1.0 :k 16})
+                   theta (mx/scalar 0.4)
+                   y (mx/array [1.0 2.0])
+                   obs (cm/choicemap :y y)
+                   t (:trace (p/generate (dyn/with-key gf (rng/fresh-key 31)) [theta] obs))
+                   w-upd (ev (:weight (p/update gf t obs)))
+                   w-uwa (ev (:weight (p/update-with-args gf t [theta]
+                                                          diff/no-change cm/EMPTY)))
+                   w-reg (ev (:weight (p/regenerate gf t sel/none)))]
+               (and (= 0.0 w-upd) (= 0.0 w-uwa) (= 0.0 w-reg))))}
+
+   {:name :pseudo-marginal-stationarity
+    :from "[T] §4.5 / Andrieu-Roberts 2009 — unbiased likelihood ⇒ exact target"
+    :theorem "Pseudo-marginal MH on theta using an unbiased ESTIMATE of the
+              likelihood (never the exact density), reusing the stored old xi as
+              the auxiliary variable, has the exact posterior as its stationary
+              distribution. Normal-Normal conjugate: posterior mean recovered to
+              tolerance (independent closed form 24/13)."
+    :tags #{:encapsulated :mcmc :inference}
+    :check (fn [{:keys [_model _args]}]
+             (let [{:keys [gf]} (enc/marginalized-gaussian
+                                 {:n 3 :tau 0.6 :sigma 0.8 :k 8})
+                   y (mx/array [1.0 2.0 3.0])
+                   log-prior (fn [th] (log-gauss th 0.0 2.0))
+                   {:keys [samples]} (enc/pseudo-marginal-mh
+                                      {:enc-gf gf :y y :theta0 0.0 :log-prior log-prior
+                                       :step 0.7 :samples 3000 :burn 800
+                                       :key (rng/fresh-key 4242)})
+                   m (/ (reduce + samples) (count samples))]
+               (approx= m (/ 24.0 13.0) 0.1)))}
 
    ;; ===================================================================
    ;; WELL-FORMEDNESS laws [T] §2.2.1 (DML restrictions)

--- a/src/genmlx/serialize.cljs
+++ b/src/genmlx/serialize.cljs
@@ -222,6 +222,10 @@
 (defn save-trace
   "Serialize a full trace to a JSON string.
    Includes choices, args, and retval (best-effort for retval).
+   The optional :omega field (encapsulated randomness, genmlx-qbaa §4.5) is
+   intentionally NOT persisted: it is internal randomness, and load-trace
+   reconstructs via p/generate, which redraws a fresh omega for an
+   EncapsulatedGF (the saved :score is reproduced in expectation, not exactly).
    Options:
      :gen-fn-id - optional string identifier for the gen-fn"
   [trace & {:keys [gen-fn-id]}]

--- a/src/genmlx/trace.cljs
+++ b/src/genmlx/trace.cljs
@@ -10,11 +10,28 @@
    by TensorTrace and VectorizedTrace at their definition sites, so
    predicates (e.g. genmlx.schemas) accept every trace representation.")
 
-(defrecord Trace [gen-fn args choices retval score]
+(defrecord Trace [gen-fn args choices retval score omega]
   ITrace)
 
+;; ---------------------------------------------------------------------------
+;; Encapsulated randomness (genmlx-qbaa, thesis §4.5)
+;;
+;; The 6th field `omega` is optional (default nil). It holds the *encapsulated
+;; randomness* a generative function used to realize its score when the score
+;; is an unbiased density ESTIMATOR ξ(x, τ, ω) rather than the exact density
+;; p(τ; x) (Def 4.5.1, Eq 4.2). Ordinary exact-density traces leave it nil.
+;;
+;; Storing ω makes the realized score reproducible: re-evaluating the
+;; estimator at the recorded ω yields the same ξ, so identity update/project
+;; over an encapsulated trace return weight 0 exactly, while a genuine move
+;; (changed value or args) resamples ω and pays the pseudo-marginal ratio
+;; log ξ' − log ξ_old. See genmlx.encapsulated.
+;; ---------------------------------------------------------------------------
+
 (defn make-trace
-  "Create a trace from a map of {:gen-fn :args :choices :retval :score}."
+  "Create a trace from a map of {:gen-fn :args :choices :retval :score} and the
+   optional :omega (encapsulated randomness, genmlx-qbaa §4.5; nil for ordinary
+   exact-density traces)."
   [m]
   (map->Trace m))
 

--- a/test/genmlx/encapsulated_test.cljs
+++ b/test/genmlx/encapsulated_test.cljs
@@ -1,0 +1,361 @@
+;; @tier medium
+(ns genmlx.encapsulated-test
+  "genmlx-qbaa: encapsulated randomness (Cusumano-Towner 2020 thesis §4.5).
+
+   Verifies that a generative function whose realized score is an unbiased
+   density ESTIMATOR xi(x, tau, omega) (not the exact density) behaves
+   correctly under the full GFI, that omega is resampled/reused correctly so
+   identity operations cost weight 0, and that pseudo-marginal MCMC built on
+   it targets the EXACT posterior.
+
+   INDEPENDENT ORACLE discipline ([[feedback-independent-oracle-tests]]): every
+   numeric expectation is a closed form derived by hand below (`o-log-gauss`,
+   `o-mixture-logp`, `o-conv-logp`, the Normal-Normal posterior 24/13 & 4/13),
+   never computed through the function under test."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.encapsulated :as enc]
+            [genmlx.dynamic :as dyn]
+            [genmlx.diff :as diff]
+            [genmlx.protocols :as p]
+            [genmlx.trace :as tr]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.gfi :as gfi]
+            [genmlx.serialize :as ser]))
+
+;; ---------------------------------------------------------------------------
+;; Independent JS oracles (NEVER call the implementation)
+;; ---------------------------------------------------------------------------
+
+(defn- o-log-gauss [x mu sigma]
+  (- (* -0.5 (js/Math.log (* 2 js/Math.PI)))
+     (js/Math.log sigma)
+     (* 0.5 (js/Math.pow (/ (- x mu) sigma) 2))))
+
+(defn- o-logsumexp [xs]
+  (let [m (reduce max xs)]
+    (+ m (js/Math.log (reduce + (map #(js/Math.exp (- % m)) xs))))))
+
+(defn- o-mixture-logp [y weights means sigmas]
+  (let [wsum (reduce + weights)
+        lpi (mapv #(js/Math.log (/ % wsum)) weights)]
+    (o-logsumexp (mapv (fn [lp mu s] (+ lp (o-log-gauss y mu s)))
+                       lpi means sigmas))))
+
+(defn- o-conv-logp
+  "Marginal of y_i = z + noise, z~N(theta,tau), noise~N(0,sigma): N(theta, sqrt(tau^2+sigma^2))."
+  [ys theta tau sigma]
+  (let [s (js/Math.sqrt (+ (* tau tau) (* sigma sigma)))]
+    (reduce + (map #(o-log-gauss % theta s) ys))))
+
+(defn- mean [xs] (/ (reduce + xs) (double (count xs))))
+(defn- variance [xs]
+  (let [m (mean xs)] (/ (reduce + (map #(* (- % m) (- % m)) xs)) (double (count xs)))))
+(defn- it [a] (mx/item a))
+
+;; ===========================================================================
+;; 1. The omega field
+;; ===========================================================================
+
+(deftest omega-field-roundtrips
+  (testing "Trace gains an optional omega field, default nil"
+    (let [t0 (tr/make-trace {:gen-fn :g :args [] :choices cm/EMPTY :retval nil
+                             :score (mx/scalar 0.0)})]
+      (is (nil? (:omega t0)) "ordinary trace has nil omega")
+      (is (= 6 (count (keys (into {} t0)))) "Trace now has 6 fields"))
+    (let [om (mx/array [1.0 2.0 3.0])
+          t (tr/make-trace {:gen-fn :g :args [] :choices cm/EMPTY :retval nil
+                            :score (mx/scalar 0.0) :omega om})]
+      (is (identical? om (:omega t)) "omega round-trips through make-trace")))
+  (testing "encapsulated simulate stores omega and tags :joint"
+    (let [{:keys [gf]} (enc/mixture-density {:weights [0.3 0.5 0.2] :means [-2 0 3]
+                                             :sigmas [1 0.5 2] :k 16})
+          t (p/simulate (dyn/with-key gf (rng/fresh-key 1)) [])]
+      (is (some? (:omega t)) "encapsulated trace carries omega")
+      (is (= :joint (tr/score-type t)) "encapsulated traces are :joint (see ns docstring)")
+      (is (js/Number.isFinite (it (:score t))) "score is a finite log-xi"))))
+
+;; ===========================================================================
+;; 2. Estimator exactness vs independent oracle  (the EXACT marginal helper)
+;; ===========================================================================
+
+(deftest exact-marginal-matches-oracle
+  (testing "mixture exact-log-density == hand oracle"
+    (let [{:keys [exact-log-density]} (enc/mixture-density
+                                       {:weights [0.3 0.5 0.2] :means [-2 0 3]
+                                        :sigmas [1 0.5 2] :k 8})]
+      (is (< (js/Math.abs (- (it (exact-log-density [] (mx/scalar 0.0)))
+                             (o-mixture-logp 0.0 [0.3 0.5 0.2] [-2 0 3] [1 0.5 2]))) 1e-4)
+          "logp(0) matches oracle -0.848418718")
+      (is (< (js/Math.abs (- (it (exact-log-density [] (mx/scalar 1.0)))
+                             (o-mixture-logp 1.0 [0.3 0.5 0.2] [-2 0 3] [1 0.5 2]))) 1e-4)
+          "logp(1) matches oracle -2.531776980")))
+  (testing "marginalized-gaussian exact-log-density == convolution oracle"
+    (let [{:keys [exact-log-density marginal-sigma]} (enc/marginalized-gaussian
+                                                      {:n 3 :tau 2.0 :sigma 0.5 :k 8})
+          y (mx/array [1.5 1.0 2.0])]
+      (is (< (js/Math.abs (- marginal-sigma (js/Math.sqrt 4.25))) 1e-6) "S=sqrt(4.25)")
+      (is (< (js/Math.abs (- (it (exact-log-density [(mx/scalar 1.0)] y))
+                             (o-conv-logp [1.5 1.0 2.0] 1.0 2.0 0.5))) 1e-4)
+          "convolution marginal matches oracle"))))
+
+;; ===========================================================================
+;; 3. Eq 4.3 — unbiasedness of the density estimator:  E_omega[xi] = p(tau;x)
+;; ===========================================================================
+
+(defn- mc-estimates
+  "R independent realized log-xi values for `gf` at value v under args, via assess."
+  [gf args v addr R seed0]
+  (let [obs (cm/set-value cm/EMPTY addr v)]
+    (mapv (fn [i]
+            (it (:weight (p/assess (dyn/with-key gf (rng/fresh-key (+ seed0 i)))
+                                   args obs))))
+          (range R))))
+
+(deftest eq43-estimator-unbiased
+  (testing "mixture: MC-average of xi over omega converges to the exact density"
+    (let [w [0.3 0.5 0.2] mu [-2 0 3] sg [1 0.5 2]
+          {:keys [gf]} (enc/mixture-density {:weights w :means mu :sigmas sg :k 64})
+          y 0.0
+          exact-logp (o-mixture-logp y w mu sg)
+          R 600
+          log-xis (mc-estimates gf [] (mx/scalar y) :y R 1000)
+          xis (mapv js/Math.exp log-xis)
+          mc-density (mean xis)
+          ;; derived tolerance band 4*sd/sqrt(R) (math-verifier guidance)
+          band (* 4.0 (/ (js/Math.sqrt (variance xis)) (js/Math.sqrt R)))]
+      (is (< (js/Math.abs (- mc-density (js/Math.exp exact-logp))) (max band 1e-3))
+          (str "E[xi]=" mc-density " ~ p(y)=" (js/Math.exp exact-logp) " band=" band))))
+  (testing "marginalized-gaussian: MC-average of xi converges to the convolution marginal"
+    (let [{:keys [gf]} (enc/marginalized-gaussian {:n 1 :tau 1.0 :sigma 1.0 :k 64})
+          theta (mx/scalar 0.5) y (mx/array [1.3])
+          exact-logp (o-conv-logp [1.3] 0.5 1.0 1.0)
+          R 600
+          log-xis (mc-estimates gf [theta] y :y R 5000)
+          xis (mapv js/Math.exp log-xis)
+          mc-density (mean xis)
+          band (* 4.0 (/ (js/Math.sqrt (variance xis)) (js/Math.sqrt R)))]
+      (is (< (js/Math.abs (- mc-density (js/Math.exp exact-logp))) (max band 1e-3))
+          (str "E[xi]=" mc-density " ~ p(y)=" (js/Math.exp exact-logp))))))
+
+(deftest eq43-variance-decreases-with-K
+  (testing "more importance samples => lower estimator variance (same unbiased mean)"
+    (let [w [0.3 0.5 0.2] mu [-2 0 3] sg [1 0.5 2]
+          mk (fn [k] (:gf (enc/mixture-density {:weights w :means mu :sigmas sg :k k})))
+          xis-k4  (mapv js/Math.exp (mc-estimates (mk 4)  [] (mx/scalar 0.0) :y 300 2000))
+          xis-k64 (mapv js/Math.exp (mc-estimates (mk 64) [] (mx/scalar 0.0) :y 300 3000))]
+      (is (< (variance xis-k64) (variance xis-k4))
+          (str "Var(K=64)=" (variance xis-k64) " < Var(K=4)=" (variance xis-k4))))))
+
+(deftest eq43-unbalanced-mixture
+  (testing "unbiasedness holds for a heavily-unbalanced mixture (rare-component regime)"
+    (let [w [0.95 0.05] mu [0 4] sg [0.5 0.5]
+          {:keys [gf]} (enc/mixture-density {:weights w :means mu :sigmas sg :k 512})
+          y 4.0  ;; rare-component-dominated: stresses the importance estimator + K-adequacy
+          exact (js/Math.exp (o-mixture-logp y w mu sg))
+          R 600
+          xis (mapv js/Math.exp (mc-estimates gf [] (mx/scalar y) :y R 8000))
+          mc (mean xis)
+          band (* 4.0 (/ (js/Math.sqrt (variance xis)) (js/Math.sqrt R)))]
+      (is (< (js/Math.abs (- mc exact)) (max band 1e-3))
+          (str "E[xi]=" mc " ~ p(y)=" exact " band=" band " (unbalanced [0.95,0.05] at rare mode)")))))
+
+;; ===========================================================================
+;; 4. Eq 4.4 — the reciprocal is NOT 1/p for the naive estimator (Jensen guard)
+;; ===========================================================================
+
+(deftest eq44-naive-reciprocal-is-biased
+  (testing "E[1/xi] > 1/p(y) for a finite-variance estimator (Jensen) — never invert xi"
+    (let [w [0.3 0.5 0.2] mu [-2 0 3] sg [1 0.5 2]
+          {:keys [gf]} (enc/mixture-density {:weights w :means mu :sigmas sg :k 4})
+          y 0.0
+          p (js/Math.exp (o-mixture-logp y w mu sg))
+          log-xis (mc-estimates gf [] (mx/scalar y) :y 800 7000)
+          mc-recip (mean (mapv #(/ 1.0 (js/Math.exp %)) log-xis))]
+      (is (> mc-recip (/ 1.0 p))
+          (str "E[1/xi]=" mc-recip " >= 1/p=" (/ 1.0 p)
+               " (Jensen: inverting xi over-estimates 1/p — must use a "
+               "meta-inference proposal for reciprocal unbiasedness)")))))
+
+;; ===========================================================================
+;; 5. Full GFI op semantics
+;; ===========================================================================
+
+(deftest gfi-op-semantics
+  (let [{:keys [gf]} (enc/marginalized-gaussian {:n 2 :tau 1.0 :sigma 1.0 :k 32})
+        y  (mx/array [1.0 2.0])
+        y2 (mx/array [0.5 2.5])
+        theta (mx/scalar 0.3)
+        obs (cm/set-value cm/EMPTY :y y)]
+    (testing "generate: fully-constrained weight == trace score (= log xi)"
+      (let [{:keys [trace weight]} (p/generate (dyn/with-key gf (rng/fresh-key 11)) [theta] obs)]
+        (is (< (js/Math.abs (- (it weight) (it (:score trace)))) 1e-6)
+            "generate weight equals stored score")
+        (is (some? (:omega trace)) "generate stores omega")))
+    (testing "generate empty constraints == simulate, weight 0"
+      (let [{:keys [weight]} (p/generate (dyn/with-key gf (rng/fresh-key 12)) [theta] cm/EMPTY)]
+        (is (= 0.0 (it weight)) "unconstrained generate has weight 0")))
+    (testing "assess: weight is a finite log-xi; retval is the value"
+      (let [{:keys [retval weight]} (p/assess (dyn/with-key gf (rng/fresh-key 13)) [theta] obs)]
+        (is (js/Number.isFinite (it weight)))
+        (is (= (mx/realize-clj y) (mx/realize-clj retval))
+            "observed value vector round-trips as retval")))
+    (testing "project: all-selected == score, none == 0"
+      (let [t (:trace (p/generate (dyn/with-key gf (rng/fresh-key 14)) [theta] obs))]
+        (is (< (js/Math.abs (- (it (p/project gf t (sel/select :y))) (it (:score t)))) 1e-9)
+            "project of the observed addr == score")
+        (is (= 0.0 (it (p/project gf t sel/none))) "project of nothing == 0")))
+    (testing "update identity (same value) => weight EXACTLY 0, omega reused"
+      (let [t (:trace (p/generate (dyn/with-key gf (rng/fresh-key 15)) [theta] obs))
+            {:keys [trace weight]} (p/update gf t obs)]
+        (is (= 0.0 (it weight)) "identity update weight is exactly 0")
+        (is (identical? (:omega t) (:omega trace)) "omega reused (same object)")))
+    (testing "update changed value => weight == log xi' - old score, discard old"
+      (let [t (:trace (p/generate (dyn/with-key gf (rng/fresh-key 16)) [theta] obs))
+            {:keys [trace weight discard]} (p/update (dyn/with-key gf (rng/fresh-key 17))
+                                                     t (cm/set-value cm/EMPTY :y y2))]
+        (is (< (js/Math.abs (- (it weight) (- (it (:score trace)) (it (:score t))))) 1e-5)
+            "weight = new score - old score")
+        (is (= (mx/realize-clj y) (mx/realize-clj (cm/get-value (cm/get-submap discard :y))))
+            "discard holds the old value")
+        (is (not (identical? (:omega t) (:omega trace))) "omega resampled on a genuine move")))
+    (testing "update-with-args: no-change & empty => weight 0; arg change => move"
+      (let [t (:trace (p/generate (dyn/with-key gf (rng/fresh-key 18)) [theta] obs))
+            {w0 :weight} (p/update-with-args gf t [theta] diff/no-change cm/EMPTY)
+            {trace :trace w1 :weight} (p/update-with-args (dyn/with-key gf (rng/fresh-key 19))
+                                                          t [(mx/scalar 0.9)] :unknown cm/EMPTY)]
+        (is (= 0.0 (it w0)) "no-change update-with-args is exactly 0")
+        (is (< (js/Math.abs (- (it w1) (- (it (:score trace)) (it (:score t))))) 1e-5)
+            "arg-change weight = log xi'(theta') - old score")
+        (is (= [(it (mx/scalar 0.9))] (mapv it (:args trace))) "args updated to theta'")))
+    (testing "regenerate: empty selection => weight 0; selected => fresh value + finite weight"
+      (let [t (:trace (p/generate (dyn/with-key gf (rng/fresh-key 20)) [theta] obs))
+            {w0 :weight} (p/regenerate gf t sel/none)
+            {trace :trace w1 :weight} (p/regenerate (dyn/with-key gf (rng/fresh-key 21))
+                                                    t (sel/select :y))]
+        (is (= 0.0 (it w0)) "unselected regenerate weight 0")
+        (is (js/Number.isFinite (it w1)) "selected regenerate weight finite")
+        (is (not (identical? (cm/get-value (cm/get-submap (:choices t) :y))
+                             (cm/get-value (cm/get-submap (:choices trace) :y))))
+            "selected regenerate proposes a fresh value")))))
+
+;; ===========================================================================
+;; 5b. Robustness & edge cases (adversarial-review hardening)
+;; ===========================================================================
+
+(deftest encapsulated-robustness
+  (testing "update-with-args at x'=x with a conservative :unknown argdiff is a no-op"
+    ;; The argdiff is a trusted hint; :unknown at genuinely-unchanged args must
+    ;; NOT pay spurious estimator noise — it reduces to update (weight 0).
+    (let [{:keys [gf]} (enc/marginalized-gaussian {:n 2 :tau 1.0 :sigma 1.0 :k 16})
+          theta (mx/scalar 0.4) y (mx/array [1.0 2.0])
+          t (:trace (p/generate (dyn/with-key gf (rng/fresh-key 60)) [theta]
+                                (cm/set-value cm/EMPTY :y y)))
+          {w :weight tr :trace} (p/update-with-args (dyn/with-key gf (rng/fresh-key 61))
+                                                    t [theta] :unknown cm/EMPTY)]
+      (is (= 0.0 (it w)) ":unknown at unchanged args is exactly 0")
+      (is (identical? (:omega t) (:omega tr)) "omega reused (no spurious resample)")))
+  (testing "robust to a hand-built trace with nil omega (uses the stored score as old xi)"
+    (let [{:keys [gf]} (enc/marginalized-gaussian {:n 1 :tau 1.0 :sigma 1.0 :k 16})
+          theta (mx/scalar 0.2) y (mx/array [1.0])
+          t0 (:trace (p/generate (dyn/with-key gf (rng/fresh-key 50)) [theta]
+                                 (cm/set-value cm/EMPTY :y y)))
+          t (assoc t0 :omega nil)]          ;; mimic a deserialized / hand-built trace
+      (is (nil? (:omega t)) "precondition: omega cleared")
+      (let [{trace :trace w :weight} (p/update (dyn/with-key gf (rng/fresh-key 51))
+                                               t (cm/set-value cm/EMPTY :y (mx/array [1.7])))]
+        (is (some? (:omega trace)) "update draws fresh omega")
+        (is (js/Number.isFinite (it w)) "weight finite"))
+      (let [{trace :trace w :weight} (p/regenerate (dyn/with-key gf (rng/fresh-key 52))
+                                                   t (sel/select :y))]
+        (is (some? (:omega trace)) "regenerate draws fresh omega")
+        (is (js/Number.isFinite (it w)) "weight finite"))))
+  (testing "EncapsulatedGF satisfies the generic project laws (via the law framework)"
+    (let [g (dyn/auto-key (:gf (enc/marginalized-gaussian {:n 1 :tau 1.0 :sigma 1.0 :k 8})))]
+      (doseq [law-name [:project-all-equals-score :project-none-equals-zero]]
+        (is (:pass? (gfi/check-law law-name g [(mx/scalar 0.0)]))
+            (str law-name " holds on EncapsulatedGF")))))
+  (testing "pseudo-marginal-mh rejects a non-encapsulated gf"
+    (is (thrown? js/Error
+                 (enc/pseudo-marginal-mh {:enc-gf {:not :encapsulated} :y (mx/array [1.0])
+                                          :theta0 0.0 :log-prior (fn [_] 0.0)
+                                          :step 0.5 :samples 1})))))
+
+;; ===========================================================================
+;; 6. Pseudo-marginal MCMC stationarity (THE headline)
+;; ===========================================================================
+
+(defn- normal-logprior [m0 s0]
+  (fn [th] (o-log-gauss th m0 s0)))
+
+(defn- exact-marginal-mh
+  "Vanilla RW-MH on theta using the EXACT marginal likelihood (no estimator).
+   The control that pseudo-marginal MH must match."
+  [exact-log-density y log-prior theta0 step samples burn key]
+  (let [rk (rng/ensure-key key)]
+    (loop [theta theta0 i 0 rk rk acc (transient [])]
+      (if (>= i (+ burn samples))
+        (persistent! acc)
+        (let [[kp ka rk'] (rng/split-n rk 3)
+              theta' (+ theta (* step (it (rng/normal kp []))))
+              ll  (it (exact-log-density [(mx/scalar theta)]  y))
+              ll' (it (exact-log-density [(mx/scalar theta')] y))
+              la (+ (- ll' ll) (- (log-prior theta') (log-prior theta)))
+              accept? (< (js/Math.log (it (rng/uniform ka []))) la)
+              nt (if accept? theta' theta)]
+          (recur nt (inc i) rk' (if (>= i burn) (conj! acc nt) acc)))))))
+
+(deftest pseudo-marginal-stationarity
+  ;; Normal-Normal conjugate: theta ~ N(0,2); y_i ~ N(theta, S=1) via tau=0.6,sigma=0.8.
+  ;; data = [1,2,3] => posterior N(24/13, 4/13) = N(1.846154, 0.307692).  [oracle]
+  (let [{:keys [gf exact-log-density]} (enc/marginalized-gaussian {:n 3 :tau 0.6 :sigma 0.8 :k 8})
+        y (mx/array [1.0 2.0 3.0])
+        log-prior (normal-logprior 0.0 2.0)
+        post-mean (/ 24.0 13.0)
+        post-var  (/ 4.0 13.0)]
+    (testing "PM-MH posterior mean & variance match the exact conjugate posterior"
+      (let [{:keys [samples accept-rate]}
+            (enc/pseudo-marginal-mh {:enc-gf gf :y y :theta0 0.0 :log-prior log-prior
+                                     :step 0.7 :samples 8000 :burn 2000
+                                     :key (rng/fresh-key 4242)})
+            m (mean samples) v (variance samples)]
+        (is (> accept-rate 0.2) (str "chain mixes (accept-rate " accept-rate ")"))
+        (is (< (js/Math.abs (- m post-mean)) 0.06)
+            (str "PM-MH mean " m " ~ 24/13=" post-mean " (estimated likelihood, K=8)"))
+        (is (< (js/Math.abs (- v post-var)) 0.06)
+            (str "PM-MH var " v " ~ 4/13=" post-var))))
+    (testing "PM-MH (estimated likelihood) matches exact-marginal MH (closed form)"
+      (let [exact-samples (exact-marginal-mh exact-log-density y log-prior
+                                             0.0 0.7 8000 2000 (rng/fresh-key 99))
+            {:keys [samples]} (enc/pseudo-marginal-mh
+                               {:enc-gf gf :y y :theta0 0.0 :log-prior log-prior
+                                :step 0.7 :samples 8000 :burn 2000 :key (rng/fresh-key 7)})]
+        (is (< (js/Math.abs (- (mean samples) (mean exact-samples))) 0.06)
+            (str "PM mean " (mean samples) " ~ exact-MH mean " (mean exact-samples)))))))
+
+;; ===========================================================================
+;; 7. GFI laws registered
+;; ===========================================================================
+
+(deftest gfi-laws-registered
+  (let [names (set (map :name gfi/laws))]
+    (is (contains? names :encapsulated-estimator-unbiased) "Eq 4.3 law present")
+    (is (contains? names :encapsulated-identity-update-zero) "identity-zero law present")
+    (is (contains? names :pseudo-marginal-stationarity) "pseudo-marginal law present")))
+
+(deftest gfi-laws-hold
+  (testing "the three §4.5 laws pass when run directly"
+    (doseq [law-name [:encapsulated-estimator-unbiased
+                      :encapsulated-identity-update-zero
+                      :pseudo-marginal-stationarity]]
+      (let [{:keys [pass? error]} (gfi/check-law law-name
+                                                 (dyn/auto-key
+                                                  (:gf (enc/mixture-density
+                                                        {:weights [0.5 0.5] :means [0 1]
+                                                         :sigmas [1 1] :k 8})))
+                                                 [])]
+        (is pass? (str law-name " holds" (when error (str " — ERROR: " error))))))))
+
+(cljs.test/run-tests)

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -95,6 +95,7 @@ medium test/genmlx/differentiable_hard2_test.cljs
 medium test/genmlx/differentiable_resample_test.cljs
 medium test/genmlx/differentiable_test.cljs
 medium test/genmlx/directional_dist_test.cljs
+medium test/genmlx/dirichlet_categorical_test.cljs
 fast test/genmlx/dist_batch_test.cljs
 fast test/genmlx/dist_boundary_test.cljs core
 fast test/genmlx/dist_boundary2_test.cljs
@@ -113,6 +114,7 @@ fast test/genmlx/edit_purity_test.cljs
 medium test/genmlx/ekf_nd_test.cljs
 medium test/genmlx/ekf_test.cljs
 medium test/genmlx/elliptical_slice_test.cljs
+medium test/genmlx/encapsulated_test.cljs
 fast test/genmlx/entropy_property_test.cljs
 medium test/genmlx/enumerate_test.cljs
 fast test/genmlx/error_message_test.cljs
@@ -317,6 +319,7 @@ fast test/genmlx/strip_compiled_test.cljs core
 medium test/genmlx/support_property_test.cljs
 medium test/genmlx/synthesis_exact_test.cljs
 fast test/genmlx/temperature_sampling_test.cljs
+fast test/genmlx/tensor_trace_property_test.cljs
 medium test/genmlx/tensor_trace_test.cljs
 exclude test/genmlx/test_helpers.cljs
 exclude test/genmlx/test_models.cljs


### PR DESCRIPTION
Implements **encapsulated randomness** — Chapter 4.5 of the Cusumano-Towner 2020 PhD thesis (bean `genmlx-qbaa`). A generative function's realized score becomes an unbiased density **estimator** ξ(x,τ,ω) instead of the exact density p(τ;x), with the encapsulated randomness ω stored in the trace.

## What's new
- **`trace.cljs`** — optional 6th `omega` field (default nil; backward-compatible, no positional `->Trace` exists).
- **`encapsulated.cljs`** (NEW, +445) — `EncapsulatedGF` implementing the full GFI over one observed address. Score = log ξ; ω stored so:
  - identity `update`/`project` reuse ω → weight **exactly 0**;
  - a genuine move (changed value **or** args) resamples ω and pays the pseudo-marginal ratio `log ξ′ − log ξ_old`.
  - `update-with-args` compares actual args so a conservative `:unknown` at unchanged args reduces to a no-op.
  - Two §4.5 estimators with closed-form oracles: `marginalized-gaussian` (black-box stochastic code; importance sampling over an independent nuisance per factor) and `mixture-density` (unknown-Z finite mixture; Monte Carlo over the component index).
  - `pseudo-marginal-mh` (Andrieu-Roberts 2009): MH on a parameter θ using the **estimated** likelihood, reusing the stored old ξ as the auxiliary variable; targets the exact posterior.
- **`gfi.cljs`** — 3 self-contained laws: `:encapsulated-estimator-unbiased` (Eq 4.3), `:encapsulated-identity-update-zero`, `:pseudo-marginal-stationarity`.
- **`encapsulated_test.cljs`** (NEW) — 11 tests / 53 assertions, independent JS oracles.

## Validation
- Pseudo-marginal MH recovers the exact Normal-Normal posterior (mean 1.848 vs 24/13=1.846; var 0.296 vs 4/13=0.308) using **K=8 estimated** likelihoods — never the exact density.
- Eq 4.3 unbiasedness confirmed by Monte Carlo + K-scaling (variance ↓ with K); Eq 4.4 reciprocal documented (Jensen — never invert ξ).
- Independent math-verifier confirmed every oracle; adversarial review (3 lenses, 7 confirmed findings) all addressed.
- **Zero regressions**: core suite, L0 certification 68/68, gfi-laws, well-formedness, score-type, serialize, mutation-boundary all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)