### PR TITLE
feat(inference): general trace translators §3.6-3.7 + RJMCMC + coarse-to-fine SMC (oen5)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -101,10 +101,12 @@ The GFI operates on three data structures. Each exists for a precise reason, and
 A **trace** is an immutable record:
 
 ```
-Trace = {gen-fn, args, choices, retval, score}
+Trace = {gen-fn, args, choices, retval, score, omega?}
 ```
 
 A trace is one complete execution. It records not just *what* happened (the choices) but *in what context* (the generative function and arguments) and *at what probability* (the score). Inference algorithms need to re-enter the computation at any point, and the trace carries everything needed to do so. `update` takes a trace and produces a new trace. `regenerate` takes a trace and produces a new trace. The generative function reference inside the trace tells these operations which model to re-execute.
+
+The optional `omega` field carries **encapsulated randomness** (thesis §4.5; nil for ordinary exact-density traces). When a generative function's score is an unbiased density *estimator* rather than an exact density, `omega` records the internal randomness that realized that estimate, making the score reproducible — see Part IV §4.1.
 
 Traces are immutable. An `update` does not mutate the old trace; it produces a new one. Clojure's persistent data structures make this efficient through structural sharing.
 
@@ -459,6 +461,68 @@ guard the convention.
 
 ---
 
+# Part IV -- Extended Thesis Mechanisms
+
+Two mechanisms from later chapters of the Cusumano-Towner thesis extend the
+engine beyond the seven core operations. Both compose on the existing GFI; the
+handler remains ground truth.
+
+## 4.1 Encapsulated Randomness (§4.5)
+
+A generative function may own internal randomness *ω* that is not part of its
+choice dictionary *τ*. Its realized score is then a value of an unbiased density
+*estimator* *ξ*(*x*, *τ*, *ω*) rather than the exact density *p*(*τ*; *x*):
+
+> E_*ω*[ *ξ*(*x*, *τ*, *ω*) ] = *p*(*τ*; *x*)     (Eq 4.3)
+
+The `Trace` record carries the optional `omega` field so the realized score is
+reproducible: re-evaluating the estimator at the recorded *ω* yields the same
+*ξ*. This makes identity `update`/`project` cost weight 0 exactly, while a genuine
+move (changed value or arguments) resamples *ω* and pays the pseudo-marginal
+ratio log *ξ'* − log *ξ*_old.
+
+`genmlx.encapsulated` provides `EncapsulatedGF` (the full GFI over one observed
+address), two estimator families with closed-form oracles — `marginalized-gaussian`
+(black-box stochastic code, importance sampling over a nuisance) and
+`mixture-density` (a finite mixture whose component index is integrated by Monte
+Carlo) — and `pseudo-marginal-mh` (Andrieu-Roberts), which infers a parameter
+whose likelihood is available only as an unbiased estimate and still targets the
+exact posterior. The laws `:encapsulated-estimator-unbiased`,
+`:encapsulated-identity-update-zero`, and `:pseudo-marginal-stationarity` in
+`gfi.cljs` pin the contract.
+
+## 4.2 Trace Translators (§3.6-3.7)
+
+A **trace translator** maps a trace of model *P₁* to a trace of model *P₂* whose
+choice dictionaries live in different spaces. It is built from forward/backward
+auxiliary proposals *Q₁*, *Q₂* and a bijection *h* between (*τ₁*, *ρ₁*) and
+(*τ₂*, *ρ₂*) (Def 3.6.1), with importance weight (Eq 3.12):
+
+> log *w* = (log *p₂* − log *p₁*) + (log *q₂* − log *q₁*) + log|det *J_h*|
+
+The forward auxiliary density is the denominator, the backward the numerator, and
+the Jacobian is taken over the continuous coordinates only (discrete coordinates
+contribute no column). The involutive-MCMC kernel in `inference/mcmc.cljs` is the
+symmetric special case (*P₁*=*P₂*, *Q₁*=*Q₂*, *h* an involution, §3.7).
+
+`genmlx.inference.translator` provides `trace-translator` (the constructor),
+`apply-translator`/`translator-weight` (Eq 3.12), an AD Jacobian
+(`jacobian-logdet`, via `mx/grad`; the log|det| is computed on the host because
+the native determinant is unreliable for non-diagonal matrices) with a
+sparsity-aware variant (`sparse-jacobian-logdet`, §3.6.2: coordinates *h* copies
+unchanged are identity columns excluded from the determinant block), a
+`read`/`write`/`copy` introspection API for writing bijections,
+`reversible-jump-mh` (structure-changing split/merge moves, §3.7.4), and
+`coarse-to-fine-smc` (a model sequence bridged by translators, §3.6.4). Because
+translators drive sampling-based methods, `apply-translator` strips the L3
+analytical path before scoring so a conjugate target yields joint scores, not
+posterior-mean-pinned marginals (the genmlx-540f failure class). Five laws
+(`:translator-weight-formula`, `:translator-jacobian-ad`,
+`:translator-sparsity-equiv`, `:translator-bijection-roundtrip`,
+`:reversible-jump-detailed-balance`) pin the contract.
+
+---
+
 # Part V -- Separation of Concerns
 
 The previous sections argued that GenMLX's architecture embodies the right abstractions: pure transitions, immutable traces, composable protocols. The remaining concern is where the dispatch logic lives. The naive design puts a `cond` ladder in every GFI method of `dynamic.cljs` — each checking schema flags to select between handler, compiled, analytical, and prefix paths. Those ladders are structurally identical: same priority order, operation-specific wiring. Adding an execution strategy would mean updating every ladder in lockstep.
@@ -571,6 +635,7 @@ src/genmlx/
     conjugate.cljs, kalman.cljs, ekf.cljs, ekf_nd.cljs, hmm_forward.cljs
     compiled_smc.cljs, compiled_optimizer.cljs, compiled_gradient.cljs
     differentiable.cljs, differentiable_resample.cljs, amortized.cljs
+    translator.cljs            ;; General trace translators (§3.6-3.7): Eq 3.12, RJMCMC, coarse-to-fine
 
   ;; Layer 8: LLM Integration
   llm/
@@ -593,6 +658,7 @@ src/genmlx/
   ;; Support
   edit.cljs, diff.cljs, gradients.cljs, learning.cljs
   custom_gradient.cljs, nn.cljs, vectorized.cljs, serialize.cljs
+  encapsulated.cljs           ;; Encapsulated randomness (§4.5): EncapsulatedGF, estimators, pseudo-marginal-mh
 ```
 
 

--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -39,6 +39,7 @@
             [genmlx.gradients :as grad]
             [genmlx.verify :as verify]
             [genmlx.inference.mcmc :as mcmc]
+            [genmlx.inference.translator :as transl]
             [genmlx.inference.smc :as smc]
             [genmlx.inference.util :as u]
             [genmlx.learning :as learn]
@@ -2147,7 +2148,135 @@
                                         (if (>= i 500) (conj acc x-val) acc)
                                         k2))))
                    mean-x (/ (reduce + samples) (count samples))]
-               (approx= mean-x 1.6 0.2)))}])
+               (approx= mean-x 1.6 0.2)))}
+
+   ;; ===================================================================
+   ;; GENERAL TRACE TRANSLATOR laws [T] §3.6-3.7 (genmlx-oen5)
+   ;;
+   ;; The general case of the involutive kernel above: translators between
+   ;; models with different latent spaces (Def 3.6.1; Eq 3.12 importance weight
+   ;; + Jacobian; reversible-jump MCMC §3.7.4). Self-contained, seeded, tagged
+   ;; #{:translator} so they run only on request.
+   ;; ===================================================================
+
+   {:name :translator-jacobian-ad
+    :from "[T] §3.6 — Jacobian of the bijection via automatic differentiation"
+    :theorem "jacobian-logdet (AD, mx/grad) computes log|det J|: g(x)=2x => log 2,
+              the split map (mu,u)->(mu-u,mu+u) => log 2."
+    :tags #{:translator}
+    :check (fn [_]
+             (and (approx= (ev (transl/jacobian-logdet #(mx/multiply % (mx/scalar 2.0))
+                                                       (mx/array [3.0]) 1)) (js/Math.log 2) 1e-4)
+                  (approx= (ev (transl/jacobian-logdet
+                                (fn [x] (let [m (mx/index x 0) u (mx/index x 1)]
+                                          (mx/stack [(mx/subtract m u) (mx/add m u)])))
+                                (mx/array [1.0 0.5]) 2))
+                           (js/Math.log 2) 1e-4)))}
+
+   {:name :translator-sparsity-equiv
+    :from "[T] §3.6.2 — sparsity-aware Jacobian (copied coords are identity cols)"
+    :theorem "sparse-jacobian-logdet over the transformed coordinates equals the
+              full jacobian-logdet when the remaining coordinates are copied
+              (identity columns, determinant 1)."
+    :tags #{:translator}
+    :check (fn [_]
+             (let [g (fn [x] (let [a (mx/index x 0) b (mx/index x 1) c (mx/index x 2)]
+                               (mx/stack [(mx/subtract a b) (mx/add a b) c])))
+                   x (mx/array [1.0 0.5 9.0])]
+               (approx= (ev (transl/jacobian-logdet g x 3))
+                        (ev (transl/sparse-jacobian-logdet g x [0 1])) 1e-5)))}
+
+   {:name :translator-weight-formula
+    :from "[T] Eq 3.12 — trace-translator importance weight"
+    :theorem "A translator over a pure reparameterization (x ~ N(0,1) vs
+              u ~ N(0,0.5) with x=2u — the same law in different coordinates)
+              has importance weight 0 by change of variables."
+    :tags #{:translator}
+    :check (fn [_]
+             (let [P1 (dyn/auto-key (dyn/make-gen-fn
+                                     (fn [rt] ((.-trace rt) :x (dist/gaussian 0 1)))
+                                     '([] (trace :x (dist/gaussian 0 1)))))
+                   P2 (dyn/make-gen-fn
+                       (fn [rt] ((.-trace rt) :u (dist/gaussian 0 0.5)))
+                       '([] (trace :u (dist/gaussian 0 0.5))))
+                   h (fn [in _aux] {:trace (cm/set-value cm/EMPTY :u
+                                                         (mx/divide (transl/read-choice in :x) (mx/scalar 2.0)))
+                                    :aux cm/EMPTY :log-det-jacobian (mx/scalar (- (js/Math.log 2)))})
+                   ttr (transl/trace-translator {:p2 P2 :h h})]
+               (every? true?
+                       (for [seed (range 6)]
+                         (let [in-tr (p/simulate (dyn/with-key P1 (rng/fresh-key seed)) [])
+                               {:keys [weight]} (transl/apply-translator ttr in-tr [] (rng/fresh-key (+ 50 seed)))]
+                           (approx= (ev weight) 0.0 1e-4))))))}
+
+   {:name :translator-bijection-roundtrip
+    :from "[T] §3.7 — the split/merge bijection is invertible"
+    :theorem "Split (mu,u)->(mu-u,mu+u) then merge ->((m1+m2)/2,(m2-m1)/2)
+              recovers (mu,u); the split/merge log-Jacobians (+log2,-log2) are
+              exact negatives."
+    :tags #{:translator}
+    :check (fn [_]
+             (every? true?
+                     (for [[mu u] [[1.0 0.5] [-0.3 0.2] [2.7 -1.1]]]
+                       (let [m1 (- mu u) m2 (+ mu u)
+                             mu' (/ (+ m1 m2) 2.0) u' (/ (- m2 m1) 2.0)]
+                         (and (approx= mu mu' 1e-9) (approx= u u' 1e-9)
+                              (approx= (+ (js/Math.log 2) (- (js/Math.log 2))) 0.0 1e-12))))))}
+
+   {:name :reversible-jump-detailed-balance
+    :from "[T] §3.7.4, Eq 3.12 — split/merge reversible-jump weights are reciprocal"
+    :theorem "For a dimension-changing split/merge move, the split translator
+              weight and the merge translator weight on the round-tripped trace
+              sum to 0 (detailed balance): model-score, auxiliary-proposal, and
+              Jacobian terms each cancel between the two directions."
+    :tags #{:translator :mcmc}
+    :check (fn [_]
+             (let [su 1.5
+                   model (dyn/auto-key
+                          (dyn/make-gen-fn
+                           (fn [rt]
+                             (let [trace (.-trace rt)
+                                   k (trace :k (dist/bernoulli 0.5))]
+                               (if (> (mx/item k) 0.5)
+                                 (let [mu1 (trace :mu1 (dist/gaussian 0 10))
+                                       mu2 (trace :mu2 (dist/gaussian 0 10))]
+                                   (trace :y0 (dist/gaussian mu1 1))
+                                   (trace :y1 (dist/gaussian mu2 1)))
+                                 (let [mu (trace :mu (dist/gaussian 0 10))]
+                                   (trace :y0 (dist/gaussian mu 1))
+                                   (trace :y1 (dist/gaussian mu 1))))))
+                           '([] nil)))
+                   uprop (dyn/make-gen-fn
+                          (fn [rt] ((.-trace rt) :u (dist/gaussian 0 su)))
+                          '([_in] (trace :u (dist/gaussian 0 su))))
+                   split (transl/trace-translator
+                          {:p2 model :q1 uprop
+                           :h (fn [in aux]
+                                (let [m (transl/read-choice in :mu) uu (transl/read-aux aux :u)]
+                                  {:trace (-> cm/EMPTY
+                                              (cm/set-value :k (mx/scalar 1.0))
+                                              (cm/set-value :mu1 (mx/subtract m uu))
+                                              (cm/set-value :mu2 (mx/add m uu))
+                                              (cm/set-value :y0 (transl/read-choice in :y0))
+                                              (cm/set-value :y1 (transl/read-choice in :y1)))
+                                   :aux cm/EMPTY :log-det-jacobian (mx/scalar (js/Math.log 2))}))})
+                   mrg (transl/trace-translator
+                        {:p2 model :q2 uprop
+                         :h (fn [in _aux]
+                              (let [m1 (transl/read-choice in :mu1) m2 (transl/read-choice in :mu2)]
+                                {:trace (-> cm/EMPTY
+                                            (cm/set-value :k (mx/scalar 0.0))
+                                            (cm/set-value :mu (mx/divide (mx/add m1 m2) (mx/scalar 2.0)))
+                                            (cm/set-value :y0 (transl/read-choice in :y0))
+                                            (cm/set-value :y1 (transl/read-choice in :y1)))
+                                 :aux (cm/set-value cm/EMPTY :u (mx/divide (mx/subtract m2 m1) (mx/scalar 2.0)))
+                                 :log-det-jacobian (mx/scalar (- (js/Math.log 2)))}))})
+                   init (:trace (p/generate (dyn/with-key model (rng/fresh-key 3)) []
+                                            (cm/choicemap :k (mx/scalar 0.0)
+                                                          :y0 (mx/scalar -2.0) :y1 (mx/scalar 2.0))))
+                   {t2 :trace w-split :weight} (transl/apply-translator split init [] (rng/fresh-key 4))
+                   {w-merge :weight} (transl/apply-translator mrg t2 [] (rng/fresh-key 5))]
+               (approx= (+ (ev w-split) (ev w-merge)) 0.0 1e-4)))}])
 
 ;; ---------------------------------------------------------------------------
 ;; Law index (for fast lookup)

--- a/src/genmlx/inference/translator.cljs
+++ b/src/genmlx/inference/translator.cljs
@@ -1,0 +1,358 @@
+(ns genmlx.inference.translator
+  "General trace translators — Cusumano-Towner 2020 PhD thesis, §3.6-3.7.
+
+   A trace translator maps a trace of model P1 to a trace of model P2 whose
+   choice dictionaries live in different spaces. It is the machinery behind
+   reversible-jump MCMC, coarse-to-fine SMC, and bridging between discrete and
+   continuous representations. The involutive-MCMC kernel in genmlx.inference.mcmc
+   is the SYMMETRIC special case (P1=P2, Q1=Q2, h an involution, §3.7); this
+   namespace is the general case (Def 3.6.1, Eq 3.12).
+
+   ## Structure (Def 3.6.1)
+
+   A deterministic trace translator is built from
+     - p2  : the target generative function,
+     - q1  : a forward auxiliary proposal (a GF taking [in-choices] -> rho1),
+     - q2  : a backward auxiliary proposal (a GF taking [out-choices] -> rho2),
+     - h   : a bijection (tau1, rho1) <-> (tau2, rho2).
+   The bijection uses the same convention as the involutive kernel:
+     h : (fn [in-choices aux-choices]
+            -> {:trace out-choices :aux out-aux :log-det-jacobian (optional)})
+
+   ## Importance weight (Eq 3.12)
+
+     w = [ p2(tau2) q2(rho2; tau2) ] / [ p1(tau1) q1(rho1; tau1) ] * |det J_h|
+
+   In log space (what apply-translator computes):
+
+     log w = (score2 - score1) + (q2-score - q1-score) + log|det J_h|
+
+   where score1 is the input trace's score, score2 is generate(p2, args2,
+   tau2).score, q1-score is the forward proposal log-density (DENOMINATOR), and
+   q2-score is the backward proposal log-density (NUMERATOR). log|det J_h| is the
+   Jacobian of the bijection over the CONTINUOUS coordinates; discrete
+   coordinates contribute no Jacobian column. It comes from h (:log-det-jacobian),
+   else from the translator's :jacobian-fn (typically built with jacobian-logdet,
+   AD via mx/grad), else 0 (a volume-preserving move — discrete/copy moves)."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.mlx.constants :refer [ZERO]]
+            [genmlx.choicemap :as cm]
+            [genmlx.protocols :as p]
+            [genmlx.trace :as tr]
+            [genmlx.dynamic :as dyn]
+            [genmlx.inference.util :as u]))
+
+;; ---------------------------------------------------------------------------
+;; Jacobian via automatic differentiation (mx/grad)
+;;
+;; NOTE on the determinant: the native mx/det is unreliable for non-diagonal
+;; matrices (genmlx-det-bug: [[1,2],[3,4]] -> 25 not -2) and mx/logdet is
+;; cholesky-based (SPD only). Jacobians of trace-translator bijections are
+;; LOW-dimensional (1-4 coords), so we realize the AD Jacobian and take its
+;; log|det| on the HOST via LU with partial pivoting — exact and bug-free.
+;; (The host-geometry / GPU-linalg split.)
+;; ---------------------------------------------------------------------------
+
+(defn- host-log-abs-det
+  "log|det| of a small square matrix (clj nested-vector `rows`) via Gaussian
+   elimination with partial pivoting. -Infinity for a singular matrix."
+  [rows]
+  (let [n (count rows)]
+    (loop [a (mapv #(mapv double %) rows), k 0, acc 0.0]
+      (if (>= k n)
+        acc
+        (let [p (apply max-key #(js/Math.abs (get-in a [% k])) (range k n))
+              a (if (= p k) a (assoc a k (a p) p (a k)))
+              piv (get-in a [k k])]
+          (if (zero? piv)
+            ##-Inf
+            (let [a (reduce
+                     (fn [a i]
+                       (let [f (/ (get-in a [i k]) piv)]
+                         (reduce (fn [a j] (update-in a [i j] - (* f (get-in a [k j]))))
+                                 a (range k n))))
+                     a (range (inc k) n))]
+              (recur a (inc k) (+ acc (js/Math.log (js/Math.abs piv)))))))))))
+
+(defn jacobian-matrix
+  "The n x n Jacobian of g : R^n -> R^n at point x ([n]-shaped MLX vector),
+   row i = d g_i / d x (computed by mx/grad on the scalar component g_i)."
+  [g x n]
+  (mx/stack
+   (mapv (fn [i] ((mx/grad (fn [xv] (mx/index (g xv) i))) x))
+         (range n))))
+
+(defn jacobian-logdet
+  "log|det J_g(x)| (MLX scalar) for a bijective numeric transform
+   g : R^n -> R^n at x. The AD Jacobian (mx/grad on g) is realized and its
+   log|det| taken on the host (orientation-sign-safe).
+
+   SPARSITY (thesis §3.6.2): pass g and x restricted to the TRANSFORMED
+   continuous coordinates only. Coordinates that h copies unchanged contribute
+   identity columns (determinant 1), so excluding them leaves log|det| unchanged
+   while reducing the matrix from m x m to (m-c) x (m-c) — O((m-c)^3) instead of
+   O(m^3). sparse-jacobian-logdet packages this from the full transform."
+  [g x n]
+  (mx/scalar (host-log-abs-det (mx/->clj (jacobian-matrix g x n)))))
+
+(defn sparse-jacobian-logdet
+  "Sparsity-aware (thesis §3.6.2) log|det J| (MLX scalar). `g-full` : R^m -> R^m
+   is the full transform and `x` the full input point [m]; `transformed-idxs`
+   lists the c' indices of the coordinates h actually transforms. The
+   determinant is taken over the (c' x c') submatrix of the Jacobian at those
+   indices (the copied coordinates are identity rows/cols, determinant 1).
+   Equals jacobian-logdet on the full matrix but over the smaller block."
+  [g-full x transformed-idxs]
+  (let [m (first (mx/shape x))           ;; vector length (not rank)
+        full-j (mx/->clj (jacobian-matrix g-full x m))
+        idxs (vec transformed-idxs)
+        sub (mapv (fn [i] (mapv (fn [j] (get-in full-j [i j])) idxs)) idxs)]
+    (mx/scalar (host-log-abs-det sub))))
+
+;; ---------------------------------------------------------------------------
+;; read / write / copy — introspection API for writing bijections h
+;; ---------------------------------------------------------------------------
+
+(defn read-choice
+  "Value at addr in a choicemap (the bijection's input side)."
+  [choices addr]
+  (cm/get-value (cm/get-submap choices addr)))
+
+(def read-aux
+  "Value at addr in an auxiliary choicemap. Alias of read-choice (same shape)."
+  read-choice)
+
+(defn write-choice
+  "Set a TRANSFORMED output choice at addr. (Conceptually @write — its value
+   is a function of the inputs, so it contributes a Jacobian column.)"
+  [choices addr value]
+  (cm/set-value choices addr value))
+
+(defn copy-choice
+  "Copy the value at `from-addr` of `src` into `to-addr` of `dst` UNCHANGED.
+   (Conceptually @copy — an identity column, excluded from the Jacobian by
+   sparse-jacobian-logdet.) from-addr defaults to to-addr."
+  ([dst src addr] (copy-choice dst src addr addr))
+  ([dst src to-addr from-addr]
+   (cm/set-value dst to-addr (read-choice src from-addr))))
+
+(def write-aux
+  "Set a backward-auxiliary choice. Alias of write-choice."
+  write-choice)
+
+;; ---------------------------------------------------------------------------
+;; The translator
+;; ---------------------------------------------------------------------------
+
+(defrecord DeterministicTraceTranslator [p2 q1 q2 h jacobian-fn volume-preserving?])
+
+(defn trace-translator
+  "Construct a general (deterministic) trace translator (Def 3.6.1).
+
+   opts:
+     :p2                target generative function (required).
+     :q1                forward auxiliary proposal GF [in-choices]->rho1 (nil ok).
+     :q2                backward auxiliary proposal GF [out-choices]->rho2 (nil ok).
+     :h                 bijection (fn [in-choices aux-choices]
+                          -> {:trace out-choices :aux out-aux
+                              :log-det-jacobian (optional)}) (required).
+     :jacobian-fn       optional (fn [in-choices aux-choices] -> log|det J|)
+                        used when h omits :log-det-jacobian (e.g. via
+                        jacobian-logdet).
+     :volume-preserving? when true, default log|det J| = 0 silently (discrete /
+                        copy-only moves). Otherwise a missing Jacobian also
+                        defaults to 0 but is the caller's responsibility."
+  [{:keys [p2 q1 q2 h jacobian-fn volume-preserving?]}]
+  (assert (some? p2) "trace-translator: :p2 (target model) is required")
+  (assert (fn? h) "trace-translator: :h (bijection) must be a fn")
+  (->DeterministicTraceTranslator p2 q1 q2 h jacobian-fn (boolean volume-preserving?)))
+
+(defn- log-det-of
+  "Resolve log|det J| for one application: h's value, else the translator's
+   :jacobian-fn, else 0."
+  [tt h-result in-choices aux-choices]
+  (cond
+    (contains? h-result :log-det-jacobian)
+    (let [j (:log-det-jacobian h-result)] (if (mx/array? j) j (mx/scalar j)))
+    (:jacobian-fn tt)
+    (let [j ((:jacobian-fn tt) in-choices aux-choices)] (if (mx/array? j) j (mx/scalar j)))
+    :else ZERO))
+
+(defn apply-translator
+  "Apply trace translator `tt` to input trace `in-trace`, producing a trace of
+   the target model p2 with new args `args2`. Returns
+     {:trace out-trace :weight log-w :aux rho2 :log-det-jacobian ldj}
+   where log-w is the Eq 3.12 importance weight (log domain). `key` supplies
+   entropy for the forward auxiliary proposal."
+  [tt in-trace args2 key]
+  (let [{:keys [p2 q1 q2 h]} tt
+        in-choices (:choices in-trace)
+        [k1 k2] (rng/split (rng/ensure-key key))
+        ;; 1. forward auxiliary rho1 ~ q1(in-choices)   (denominator)
+        fwd (if q1 (p/propose (dyn/with-key q1 k1) [in-choices])
+                   {:choices cm/EMPTY :weight ZERO})
+        rho1 (:choices fwd)
+        q1-score (:weight fwd)
+        ;; 2. apply the bijection h
+        hres (h in-choices rho1)
+        out-choices (:trace hres)
+        rho2 (or (:aux hres) cm/EMPTY)
+        ;; 3. target trace, fully constrained -> score2 (= generate weight).
+        ;; Strip the L3 analytical path: a conjugate p2 would otherwise return a
+        ;; :marginal score with latents pinned at the posterior mean, corrupting
+        ;; the importance weight (genmlx-540f). Translators need joint scores.
+        gen (p/generate (dyn/with-key (dyn/strip-analytical-path p2) k2) args2 out-choices)
+        out-trace (:trace gen)
+        score2 (:score out-trace)
+        ;; 4. backward auxiliary density q2(rho2; out-choices)   (numerator)
+        q2-score (if q2 (:weight (p/assess (dyn/auto-key q2) [out-choices] rho2)) ZERO)
+        ;; 5. Jacobian of the continuous part of h
+        ldj (log-det-of tt hres in-choices rho1)
+        ;; 6. Eq 3.12 weight in log domain
+        score1 (:score in-trace)
+        log-w (mx/add (mx/subtract score2 score1)
+                      (mx/subtract q2-score q1-score)
+                      ldj)]
+    {:trace out-trace :weight log-w :aux rho2 :log-det-jacobian ldj}))
+
+(defn translator-weight
+  "The Eq 3.12 importance weight (an MLX scalar) of applying `tt` to `in-trace`
+   at target args `args2`. Convenience wrapper over apply-translator."
+  [tt in-trace args2 key]
+  (:weight (apply-translator tt in-trace args2 key)))
+
+;; ---------------------------------------------------------------------------
+;; Reversible-jump MCMC (§3.7.4) — structure-changing moves via translators
+;; ---------------------------------------------------------------------------
+
+(defn- applicable-moves
+  "Indices of moves whose :applicable? predicate accepts `trace` (a move with no
+   predicate is always applicable)."
+  [moves trace]
+  (filterv (fn [i] (let [pred (:applicable? (nth moves i))]
+                     (or (nil? pred) (pred trace))))
+           (range (count moves))))
+
+(defn reversible-jump-mh-step
+  "One reversible-jump MH step. `moves` is a vector of maps
+     {:translator tt :args2 args :applicable? (fn [trace] -> bool, optional)}
+   each a translator from the current model P to P (possibly changing
+   structure). An APPLICABLE move is chosen uniformly, the translator applied,
+   and the proposed trace accepted with probability min(1, exp(log-w + corr))
+   where log-w is the Eq 3.12 weight (auxiliary proposals + Jacobian) and corr =
+   log(#applicable-at-current) - log(#applicable-at-proposed) corrects for the
+   discrete move-selection probability (0 for split/merge, where exactly one
+   move is applicable in each state). Returns {:trace t' :accepted? bool :move i}."
+  [current-trace moves key]
+  (let [[k-sel k-app k-acc] (rng/split-n (rng/ensure-key key) 3)
+        appl (applicable-moves moves current-trace)
+        n-cur (count appl)]
+    (if (zero? n-cur)
+      {:trace current-trace :accepted? false :move nil}
+      (let [i (nth appl (int (mx/realize (rng/randint k-sel 0 n-cur []))))
+            {:keys [translator args2]} (nth moves i)
+            {:keys [trace weight]} (apply-translator translator current-trace
+                                                     (or args2 (:args current-trace)) k-app)
+            n-prop (count (applicable-moves moves trace))
+            corr (if (pos? n-prop) (- (js/Math.log n-cur) (js/Math.log n-prop)) 0.0)
+            log-w (+ (mx/realize weight) corr)
+            accept? (u/accept-mh? log-w k-acc)]
+        {:trace (if accept? trace current-trace) :accepted? accept? :move i}))))
+
+(defn reversible-jump-mh
+  "Reversible-jump MCMC. Returns {:samples [trace ...] :accept-rate r}.
+
+   opts: {:moves [{:translator tt :args2 args} ...] :samples N :burn B
+          :thin T :key prng-key}
+   init-trace: the starting model trace (e.g. from p/generate with observations)."
+  [{:keys [moves samples burn thin key] :or {burn 0 thin 1}} init-trace]
+  (let [rk (rng/ensure-key (or key (rng/fresh-key)))]
+    (loop [t init-trace i 0 rk rk acc (transient []) n-acc 0 n-steps 0]
+      (if (>= i (+ burn (* samples thin)))
+        {:samples (persistent! acc)
+         :accept-rate (if (pos? n-steps) (/ n-acc (double n-steps)) 0.0)}
+        (let [[k rk'] (rng/split rk)
+              {:keys [trace accepted?]} (reversible-jump-mh-step t moves k)
+              keep? (and (>= i burn) (zero? (mod (- i burn) thin)))]
+          (recur trace (inc i) rk'
+                 (if keep? (conj! acc trace) acc)
+                 (+ n-acc (if accepted? 1 0))
+                 (inc n-steps)))))))
+
+;; ---------------------------------------------------------------------------
+;; Coarse-to-fine SMC (§3.6.4) — bridge a sequence of models with translators
+;; ---------------------------------------------------------------------------
+
+(defn- logmeanexp-js
+  "log( mean( exp xs ) ) over a JS vector of log-values (numerically stable)."
+  [xs]
+  (let [m (reduce max xs)]
+    (+ m (js/Math.log (/ (reduce + (map #(js/Math.exp (- % m)) xs))
+                         (double (count xs)))))))
+
+(defn coarse-to-fine-smc
+  "SMC over a sequence of models P_0 (coarse) -> ... -> P_T (fine) bridged by
+   trace translators (thesis §3.6.4).
+
+   opts:
+     :models       [P_0 ... P_T]                  (T+1 generative functions)
+     :stage-args   [args_0 ... args_T]            (args per model; default [] each)
+     :stage-obs    [obs_0 ... obs_T]              (constraints per stage; default EMPTY)
+     :translators  [T_{0->1} ... T_{(T-1)->T}]    (T translators)
+     :n-particles  N
+     :key          prng-key
+     :resample?    resample between stages (default true)
+
+   Returns {:particles [trace ...] :log-weights [scalar ...] :log-ml number}.
+   log-ml is the accumulated unbiased marginal-likelihood estimate for the fine
+   model: at stage 0 the importance weights are P_0.generate weights; each
+   translator application multiplies in its Eq 3.12 weight; resampling adds the
+   usual logmeanexp normaliser increments."
+  [{:keys [models stage-args stage-obs translators n-particles key resample?]
+    :or {resample? true}}]
+  (let [n n-particles
+        T (dec (count models))
+        args-of (fn [s] (nth stage-args s []))
+        obs-of (fn [s] (or (nth stage-obs s nil) cm/EMPTY))
+        rk (rng/ensure-key (or key (rng/fresh-key)))
+        ;; Stage 0: import N particles from the coarse model.
+        [k0 rk] (rng/split rk)
+        keys0 (rng/split-n k0 n)
+        ;; strip the L3 analytical path so a conjugate coarse model imports true
+        ;; joint-scored particles (not posterior-mean-pinned :marginal traces).
+        p0 (dyn/strip-analytical-path (nth models 0))
+        init (mapv (fn [kk]
+                     (let [{:keys [trace weight]} (p/generate (dyn/with-key p0 kk)
+                                                              (args-of 0) (obs-of 0))]
+                       {:trace trace :lw (mx/realize weight)}))
+                   keys0)]
+    (loop [stage 0
+           parts init
+           log-ml 0.0
+           rk rk]
+      (if (>= stage T)
+        {:particles (mapv :trace parts)
+         :log-weights (mapv :lw parts)
+         :log-ml (+ log-ml (logmeanexp-js (mapv :lw parts)))}
+        (let [;; normalise + (optionally) resample before bridging to the next model
+              lws (mapv :lw parts)
+              lme (logmeanexp-js lws)
+              [k-res rk1] (rng/split rk)
+              parts' (if resample?
+                       ;; systematic-resample takes MLX log-weight scalars; our
+                       ;; lws are realized JS numbers, so box them.
+                       (let [idxs (u/systematic-resample (mapv mx/scalar lws) n k-res)]
+                         (mapv (fn [j] {:trace (:trace (nth parts j)) :lw 0.0}) idxs))
+                       parts)
+              ;; bridge every particle to the next model via the translator
+              tt (nth translators stage)
+              keysT (rng/split-n rk1 (inc n))
+              bridged (mapv (fn [j]
+                              (let [{:keys [trace lw]} (nth parts' j)
+                                    {t2 :trace w :weight}
+                                    (apply-translator tt trace (args-of (inc stage))
+                                                      (nth keysT j))]
+                                {:trace t2 :lw (+ lw (mx/realize w))}))
+                            (range n))]
+          (recur (inc stage) bridged (+ log-ml lme) (nth keysT n)))))))

--- a/test/genmlx/trace_translator_test.cljs
+++ b/test/genmlx/trace_translator_test.cljs
@@ -1,0 +1,350 @@
+;; @tier medium
+(ns genmlx.trace-translator-test
+  "genmlx-oen5: general trace translators (Cusumano-Towner 2020 thesis §3.6-3.7).
+
+   Verifies the Eq 3.12 importance weight, the AD Jacobian (with sparsity),
+   bijection round-trips, reversible-jump MCMC (split/merge recovering the exact
+   model posterior), coarse-to-fine SMC, and the discrete<->continuous bridge.
+
+   INDEPENDENT ORACLE discipline: every numeric expectation is a closed form
+   derived by hand here (o-log-gauss, o-cat, the change-of-variables identities,
+   the split/merge log-Jacobians +/- log 2, and the Normal-Normal marginal
+   likelihoods giving P(k=2|y)=0.8804741734), never via the code under test."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.inference.translator :as tt]
+            [genmlx.inference.mcmc :as mcmc]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.trace :as tr]
+            [genmlx.dist :as dist]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.gfi :as gfi]
+            [genmlx.inference.util :as u])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(defn- it [a] (mx/item a))
+(defn- o-log-gauss [x mu sigma]
+  (- (* -0.5 (js/Math.log (* 2 js/Math.PI))) (js/Math.log sigma)
+     (* 0.5 (js/Math.pow (/ (- x mu) sigma) 2))))
+(def ^:private LOG2 (js/Math.log 2))
+
+;; ===========================================================================
+;; 1. AD Jacobian (mx/grad) + sparsity (§3.6.2)
+;; ===========================================================================
+
+(deftest jacobian-ad
+  (testing "1-D: log|d(x/2)/dx| = -log 2, log|d(2x)/dx| = +log 2"
+    (is (< (js/Math.abs (- (it (tt/jacobian-logdet #(mx/divide % (mx/scalar 2.0))
+                                                   (mx/array [3.0]) 1)) (- LOG2))) 1e-5))
+    (is (< (js/Math.abs (- (it (tt/jacobian-logdet #(mx/multiply % (mx/scalar 2.0))
+                                                   (mx/array [3.0]) 1)) LOG2)) 1e-5)))
+  (testing "2-D split (mu,u)->(mu-u,mu+u): log|det J| = log 2 (orientation-safe)"
+    (let [g (fn [x] (let [m (mx/index x 0) u (mx/index x 1)]
+                      (mx/stack [(mx/subtract m u) (mx/add m u)])))]
+      (is (< (js/Math.abs (- (it (tt/jacobian-logdet g (mx/array [1.0 0.5]) 2)) LOG2)) 1e-5))))
+  (testing "sparsity (§3.6.2): copied coordinate excluded => sparse == dense logdet"
+    (let [g (fn [x] (let [a (mx/index x 0) b (mx/index x 1) c (mx/index x 2)]
+                      (mx/stack [(mx/subtract a b) (mx/add a b) c])))   ;; c copied
+          x (mx/array [1.0 0.5 9.0])]
+      (is (< (js/Math.abs (- (it (tt/jacobian-logdet g x 3)) LOG2)) 1e-5) "dense = log 2")
+      (is (< (js/Math.abs (- (it (tt/sparse-jacobian-logdet g x [0 1])) LOG2)) 1e-5)
+          "sparse over {0,1} = log 2 (copied coord 2 is identity, det 1)"))))
+
+;; ===========================================================================
+;; 2. read / write / copy introspection API
+;; ===========================================================================
+
+(deftest read-write-copy
+  (let [in (cm/choicemap :mu (mx/scalar 3.0) :y0 (mx/scalar -2.0) :y1 (mx/scalar 2.0))
+        aux (cm/choicemap :u (mx/scalar 0.5))]
+    (is (= 3.0 (it (tt/read-choice in :mu))) "read-choice")
+    (is (= 0.5 (it (tt/read-aux aux :u))) "read-aux")
+    (let [out (-> cm/EMPTY
+                  (tt/write-choice :mu1 (mx/subtract (tt/read-choice in :mu) (tt/read-aux aux :u)))
+                  (tt/copy-choice in :y0)
+                  (tt/copy-choice in :y1))]
+      (is (= 2.5 (it (tt/read-choice out :mu1))) "write-choice transformed value")
+      (is (= -2.0 (it (tt/read-choice out :y0))) "copy-choice copies unchanged")
+      (is (= 2.0 (it (tt/read-choice out :y1))) "copy-choice copies unchanged"))))
+
+;; ===========================================================================
+;; 3. Eq 3.12 weight — pure reparameterization => weight 0
+;; ===========================================================================
+
+(defn- reparam-p1 [] (gen [] (trace :x (dist/gaussian 0 1))))
+;; x = 2u with u ~ N(0, sd=0.5) => pushforward N(0, 4*0.25)=N(0,1) = P1 (same law).
+(defn- reparam-p2 [] (gen [] (trace :u (dist/gaussian 0 0.5))))
+
+(deftest reparam-weight-zero
+  (testing "translator over a pure reparameterization has weight 0 (Eq 3.12)"
+    (let [P1 (reparam-p1) P2 (reparam-p2)
+          h (fn [in _aux] {:trace (tt/write-choice cm/EMPTY :u
+                                                   (mx/divide (tt/read-choice in :x) (mx/scalar 2.0)))
+                           :aux cm/EMPTY
+                           :log-det-jacobian (mx/scalar (- LOG2))})  ;; |du/dx| = 1/2
+          translator (tt/trace-translator {:p2 P2 :h h})]
+      (doseq [seed [1 2 3 4 5]]
+        (let [in-tr (p/simulate (dyn/with-key P1 (rng/fresh-key seed)) [])
+              {:keys [weight]} (tt/apply-translator translator in-tr [] (rng/fresh-key (+ 100 seed)))]
+          (is (< (js/Math.abs (it weight)) 1e-5)
+              (str "reparam weight ~ 0 (x=" (it (tt/read-choice (:choices in-tr) :x)) ")"))))))
+  (testing "MISMATCHED law (u ~ N(0,sd=sqrt(0.5)) => x ~ N(0,2)) gives NONZERO weight"
+    (let [P1 (reparam-p1)
+          P2bad (gen [] (trace :u (dist/gaussian 0 0.7071067811865476)))  ;; var 0.5 => x~N(0,2)
+          h (fn [in _aux] {:trace (tt/write-choice cm/EMPTY :u
+                                                   (mx/divide (tt/read-choice in :x) (mx/scalar 2.0)))
+                           :aux cm/EMPTY :log-det-jacobian (mx/scalar (- LOG2))})
+          translator (tt/trace-translator {:p2 P2bad :h h})
+          in-tr (p/simulate (dyn/with-key P1 (rng/fresh-key 9)) [(mx/scalar 1.0)])]
+      ;; pick a trace with x clearly nonzero so the density mismatch shows
+      (let [in-tr (loop [s 9] (let [t (p/simulate (dyn/with-key P1 (rng/fresh-key s)) [])]
+                                (if (> (js/Math.abs (it (tt/read-choice (:choices t) :x))) 0.5) t (recur (inc s)))))
+            {:keys [weight]} (tt/apply-translator translator in-tr [] (rng/fresh-key 3))]
+        (is (> (js/Math.abs (it weight)) 1e-3) "wrong-variance reparam is not weight-0")))))
+
+;; ===========================================================================
+;; 4. Bijection round-trip (split then merge recovers the trace)
+;; ===========================================================================
+
+(deftest bijection-roundtrip
+  (testing "split (mu,u)->(mu1,mu2) then merge recovers (mu,u) and the Jacobians are exact negatives"
+    (doseq [[mu u] [[1.0 0.5] [-0.3 0.2] [2.7 -1.1]]]
+      (let [mu1 (- mu u) mu2 (+ mu u)
+            mu' (/ (+ mu1 mu2) 2.0) u' (/ (- mu2 mu1) 2.0)]
+        (is (< (js/Math.abs (- mu mu')) 1e-9) "merge recovers mu")
+        (is (< (js/Math.abs (- u u')) 1e-9) "merge recovers u")))
+    (is (< (js/Math.abs (+ LOG2 (- LOG2))) 1e-12) "log|det J_split| + log|det J_merge| = 0")))
+
+;; ===========================================================================
+;; 5. Discrete <-> continuous bridge (Eq 3.12 with a discrete coordinate)
+;; ===========================================================================
+
+(def ^:private bridge-logits
+  (mx/array [(js/Math.log 0.2) (js/Math.log 0.5) (js/Math.log 0.3)]))
+(defn- bridge-p1 [] (gen [] (let [z (trace :z (dist/categorical bridge-logits))]
+                              (trace :y (dist/gaussian z 1)))))
+(defn- bridge-p2 [] (gen [] (let [w (trace :w (dist/gaussian 1 1))]
+                              (trace :y (dist/gaussian w 1)))))
+
+(deftest discrete-continuous-bridge
+  (testing "Eq 3.12 weight with one discrete coord: discrete adds NO Jacobian; weight matches oracle"
+    (let [P1 (bridge-p1) P2 (bridge-p2)
+          q1 (gen [_in] (trace :a (dist/gaussian 0 0.3)))    ;; forward aux a ~ N(0,0.3)
+          ;; h: w = z + a ; backward is deterministic (z=round w) => no aux, q2=nil, log|det J|=0
+          h (fn [in aux]
+              (let [z (tt/read-choice in :z) a (tt/read-aux aux :a)]
+                {:trace (-> cm/EMPTY
+                            (tt/write-choice :w (mx/add z a))
+                            (tt/copy-choice in :y))
+                 :aux cm/EMPTY}))    ;; no :log-det-jacobian => 0 (volume-preserving over a->w)
+          translator (tt/trace-translator {:p2 P2 :q1 q1 :h h :volume-preserving? true})
+          y 1.0
+          in-tr (:trace (p/generate (dyn/with-key P1 (rng/fresh-key 1)) []
+                                    (cm/choicemap :z (mx/scalar 1.0) :y (mx/scalar y))))
+          {:keys [trace weight log-det-jacobian]}
+          (tt/apply-translator translator in-tr [] (rng/fresh-key 2))
+          z 1.0
+          w (it (tt/read-choice (:choices trace) :w))
+          a (- w z)
+          ;; independent oracle at the SAMPLED a:
+          log-p1 (+ (js/Math.log 0.5) (o-log-gauss y z 1))       ;; log P(z=1)+logN(y;z,1)
+          log-q1 (o-log-gauss a 0 0.3)                           ;; forward aux (denominator)
+          log-p2 (+ (o-log-gauss w 1 1) (o-log-gauss y w 1))     ;; logN(w;1,1)+logN(y;w,1)
+          oracle (- (+ log-p2 0.0) (+ log-p1 log-q1))]           ;; +q2(=0) +log|detJ|(=0)
+      (is (< (js/Math.abs (it log-det-jacobian)) 1e-12)
+          "discrete coordinate contributes NO Jacobian: log|det J| = 0")
+      (is (< (js/Math.abs (- (it weight) oracle)) 1e-4)
+          (str "bridge weight " (it weight) " matches Eq 3.12 oracle " oracle " (a=" a ")")))))
+
+;; ===========================================================================
+;; 6. Reversible-jump MCMC: split/merge recovers the exact model posterior
+;; ===========================================================================
+
+;; k=0 => one shared mean :mu; k=1 => two means :mu1,:mu2 (fixed assignment).
+;; Prior P(k)=0.5, s0=10, sigma=1, data y0=-2, y1=2. Oracle: P(k=2|y)=0.8804741734.
+(defn- sm-model []
+  (gen []
+    (let [k (trace :k (dist/bernoulli 0.5))]
+      (if (> (mx/item k) 0.5)
+        (let [mu1 (trace :mu1 (dist/gaussian 0 10))
+              mu2 (trace :mu2 (dist/gaussian 0 10))]
+          (trace :y0 (dist/gaussian mu1 1))
+          (trace :y1 (dist/gaussian mu2 1)))
+        (let [mu (trace :mu (dist/gaussian 0 10))]
+          (trace :y0 (dist/gaussian mu 1))
+          (trace :y1 (dist/gaussian mu 1)))))))
+
+(def ^:private su 1.5)   ;; split auxiliary sd
+(defn- u-proposal [] (gen [_in] (trace :u (dist/gaussian 0 su))))
+
+(defn- two? [t] (> (it (tt/read-choice (:choices t) :k)) 0.5))
+
+(defn- split-translator [model]
+  ;; k=0 -> k=1: (mu,u) -> (mu1,mu2)=(mu-u,mu+u), Jacobian +log 2; backward aux empty.
+  (tt/trace-translator
+   {:p2 model :q1 (u-proposal)
+    :h (fn [in aux]
+         (let [m (tt/read-choice in :mu) u (tt/read-aux aux :u)]
+           {:trace (-> cm/EMPTY
+                       (tt/write-choice :k (mx/scalar 1.0))
+                       (tt/write-choice :mu1 (mx/subtract m u))
+                       (tt/write-choice :mu2 (mx/add m u))
+                       (tt/copy-choice in :y0)
+                       (tt/copy-choice in :y1))
+            :aux cm/EMPTY
+            :log-det-jacobian (mx/scalar LOG2)}))
+    :applicable? (complement two?)}))
+
+(defn- merge-translator [model]
+  ;; k=1 -> k=0: (mu1,mu2) -> mu=(mu1+mu2)/2; recovered u=(mu2-mu1)/2 is the
+  ;; backward aux scored under q2; Jacobian -log 2.
+  (tt/trace-translator
+   {:p2 model :q2 (u-proposal)
+    :h (fn [in _aux]
+         (let [m1 (tt/read-choice in :mu1) m2 (tt/read-choice in :mu2)]
+           {:trace (-> cm/EMPTY
+                       (tt/write-choice :k (mx/scalar 0.0))
+                       (tt/write-choice :mu (mx/divide (mx/add m1 m2) (mx/scalar 2.0)))
+                       (tt/copy-choice in :y0)
+                       (tt/copy-choice in :y1))
+            :aux (tt/write-aux cm/EMPTY :u (mx/divide (mx/subtract m2 m1) (mx/scalar 2.0)))
+            :log-det-jacobian (mx/scalar (- LOG2))}))
+    :applicable? two?}))
+
+(defn- rw-sweep
+  "One within-model Gaussian random-walk sweep over the active mean site(s) via
+   p/update, threading the key. The standard parameter move RJMCMC interleaves."
+  [model t step key]
+  (let [sites (if (two? t) [:mu1 :mu2] [:mu])]
+    (loop [t t, ss sites, k key]
+      (if (empty? ss)
+        t
+        (let [[kp ka knext] (rng/split-n k 3)
+              addr (first ss)
+              cur (it (tt/read-choice (:choices t) addr))
+              prop (+ cur (* step (it (rng/normal kp []))))
+              {nt :trace w :weight} (p/update (dyn/with-key model ka) t
+                                              (cm/choicemap addr (mx/scalar prop)))]
+          (recur (if (u/accept-mh? (it w) ka) nt t) (rest ss) knext))))))
+
+(defn- rw-refresh
+  "Several within-model RW sweeps to decorrelate the continuous params between
+   structural moves (keeps the k-indicator's effective sample size high)."
+  [model t step n-sweeps key]
+  (loop [t t, i 0, k key]
+    (if (>= i n-sweeps)
+      t
+      (let [[k1 k2] (rng/split k)]
+        (recur (rw-sweep model t step k1) (inc i) k2)))))
+
+(defn- o-marginal-k1
+  "log p(y0,y1 | k=1): y ~ N(0, Sigma), Sigma = sigma^2 I + s0^2 11^T."
+  [y0 y1 s0 sigma]
+  (let [d (+ (* sigma sigma) (* s0 s0))     ;; diagonal
+        o (* s0 s0)                          ;; off-diagonal
+        det (- (* d d) (* o o))
+        quad (/ (+ (* d y0 y0) (* -2 o y0 y1) (* d y1 y1)) det)]
+    (* -0.5 (+ (* 2 (js/Math.log (* 2 js/Math.PI))) (js/Math.log det) quad))))
+
+(deftest reversible-jump-split-merge
+  ;; Less-separated data => P(k=2|y) ~ 0.566 => balanced split/merge transitions
+  ;; => fast k-mixing. Exact posterior from the closed-form marginal likelihoods.
+  (testing "split/merge RJMCMC recovers the exact model posterior P(k=2|y)"
+    (let [model (sm-model)
+          s0 10.0 sigma 1.0 yy0 -1.5 yy1 1.5
+          ;; independent oracle: exact P(k=2|y) from marginal likelihoods (priors equal)
+          lp1 (o-marginal-k1 yy0 yy1 s0 sigma)
+          lp2 (+ (o-log-gauss yy0 0 (js/Math.sqrt (+ (* s0 s0) (* sigma sigma))))
+                 (o-log-gauss yy1 0 (js/Math.sqrt (+ (* s0 s0) (* sigma sigma)))))
+          p-k2 (/ 1.0 (+ 1.0 (js/Math.exp (- lp1 lp2))))
+          init (:trace (p/generate (dyn/with-key model (rng/fresh-key 1)) []
+                                   (cm/choicemap :k (mx/scalar 0.0)
+                                                 :y0 (mx/scalar yy0) :y1 (mx/scalar yy1))))
+          moves [{:translator (split-translator model) :applicable? (complement two?)}
+                 {:translator (merge-translator model) :applicable? two?}]
+          n-samp 9000 burn 2000
+          frac (loop [t init i 0 k (rng/fresh-key 77) acc 0]
+                 (if (>= i (+ burn n-samp))
+                   (/ acc (double n-samp))
+                   (let [[k1 k2 k3] (rng/split-n k 3)
+                         t1 (rw-refresh model t 0.8 2 k1)
+                         {t2 :trace} (tt/reversible-jump-mh-step t1 moves k2)]
+                     (recur t2 (inc i) k3
+                            (if (and (>= i burn) (two? t2)) (inc acc) acc)))))]
+      (is (< (js/Math.abs (- p-k2 0.5656)) 0.01) (str "oracle sanity P(k=2)=" p-k2))
+      (is (< (js/Math.abs (- frac p-k2)) 0.04)
+          (str "RJMCMC P(k=2|y) fraction " frac " ~ exact " p-k2)))))
+
+;; ===========================================================================
+;; 7. Coarse-to-fine SMC
+;; ===========================================================================
+
+(defn- ctf-model [] (gen [] (let [x (trace :x (dist/gaussian 0 1))]
+                              (trace :y (dist/gaussian x 1)))))
+
+(deftest coarse-to-fine
+  (testing "identity-translator coarse-to-fine SMC log-ML == direct importance-sampling log-ML"
+    (let [model (ctf-model)
+          obs (cm/choicemap :y (mx/scalar 1.5))
+          ;; identity translator: same model, no aux, h copies everything, |det J|=1
+          ident (tt/trace-translator
+                 {:p2 model :h (fn [in _aux] {:trace in :aux cm/EMPTY}) :volume-preserving? true})
+          n 4000
+          ctf (tt/coarse-to-fine-smc {:models [model model model]
+                                      :stage-obs [obs obs obs]
+                                      :translators [ident ident]
+                                      :n-particles n :key (rng/fresh-key 5)})
+          ;; direct IS log-ML on the fine model: logmeanexp of generate weights
+          direct (let [ks (rng/split-n (rng/fresh-key 6) n)
+                       lws (mapv #(it (:weight (p/generate (dyn/with-key model %) [] obs))) ks)
+                       m (reduce max lws)]
+                   (+ m (js/Math.log (/ (reduce + (map (fn [x] (js/Math.exp (- x m))) lws)) n))))
+          ;; analytic log p(y) = log N(1.5; 0, sqrt(2))
+          analytic (o-log-gauss 1.5 0 (js/Math.sqrt 2))]
+      (is (< (js/Math.abs (- (:log-ml ctf) analytic)) 0.05)
+          (str "coarse-to-fine log-ML " (:log-ml ctf) " ~ analytic " analytic))
+      (is (< (js/Math.abs (- (:log-ml ctf) direct)) 0.06)
+          (str "coarse-to-fine log-ML " (:log-ml ctf) " ~ direct IS " direct))
+      (is (= n (count (:particles ctf))) "returns N fine-model particles")))
+  (testing "genuine 2-stage reparam bridge preserves the marginal likelihood"
+    (let [coarse (gen [] (let [x (trace :x (dist/gaussian 0 1))] (trace :y (dist/gaussian x 1))))
+          ;; fine model uses u with x=2u (same law) — coordinates change, density preserved
+          fine (gen [] (let [u (trace :u (dist/gaussian 0 0.5))]
+                         (trace :y (dist/gaussian (mx/multiply (mx/scalar 2.0) u) 1))))
+          obs (cm/choicemap :y (mx/scalar 1.5))
+          reparam (tt/trace-translator
+                   {:p2 fine
+                    :h (fn [in _aux]
+                         {:trace (-> cm/EMPTY
+                                     (tt/write-choice :u (mx/divide (tt/read-choice in :x) (mx/scalar 2.0)))
+                                     (tt/copy-choice in :y))
+                          :aux cm/EMPTY :log-det-jacobian (mx/scalar (- LOG2))})})
+          ctf (tt/coarse-to-fine-smc {:models [coarse fine] :stage-obs [obs obs]
+                                      :translators [reparam] :n-particles 4000
+                                      :key (rng/fresh-key 11)})
+          analytic (o-log-gauss 1.5 0 (js/Math.sqrt 2))]
+      (is (< (js/Math.abs (- (:log-ml ctf) analytic)) 0.06)
+          (str "reparam-bridged log-ML " (:log-ml ctf) " ~ analytic " analytic)))))
+
+;; ===========================================================================
+;; 8. GFI laws registered + hold
+;; ===========================================================================
+
+(deftest gfi-laws-registered
+  (let [names (set (map :name gfi/laws))]
+    (doseq [nm [:translator-weight-formula :translator-jacobian-ad
+                :translator-bijection-roundtrip :translator-sparsity-equiv
+                :reversible-jump-detailed-balance]]
+      (is (contains? names nm) (str nm " registered")))))
+
+(deftest gfi-laws-hold
+  (doseq [law-name [:translator-weight-formula :translator-jacobian-ad
+                    :translator-bijection-roundtrip :translator-sparsity-equiv
+                    :reversible-jump-detailed-balance]]
+    (let [{:keys [pass? error]} (gfi/check-law law-name (dyn/auto-key (ctf-model)) [])]
+      (is pass? (str law-name (when error (str " — ERROR: " error)))))))
+
+(cljs.test/run-tests)

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -327,6 +327,7 @@ fast test/genmlx/trace_immutability_property_test.cljs
 fast test/genmlx/trace_immutability_test.cljs core
 fast test/genmlx/trace_mh_elim_test.cljs core
 fast test/genmlx/trace_test.cljs core
+medium test/genmlx/trace_translator_test.cljs
 fast test/genmlx/tutorial/ch01_test.cljs
 medium test/genmlx/tutorial/ch02_test.cljs
 fast test/genmlx/tutorial/ch03_test.cljs


### PR DESCRIPTION
Implements **general trace translators** — Cusumano-Towner 2020 thesis §3.6–3.7 (bean `genmlx-oen5`), generalizing the involutive-MCMC kernel (the symmetric special case) to translators between models with different latent representations.

## What's new
- **`inference/translator.cljs`** (NEW, +358):
  - `DeterministicTraceTranslator` + `trace-translator` (Def 3.6.1).
  - `apply-translator` / `translator-weight` — Eq 3.12: `log w = (score2−score1) + (q2−q1) + log|det J|` (forward aux denominator, backward numerator, Jacobian over continuous coords only).
  - AD Jacobian `jacobian-logdet` (`mx/grad`); `log|det|` on the **host** via LU because the native `mx/det` is wrong for non-diagonal matrices (captured as `genmlx-rqp9`). Sparsity-aware `sparse-jacobian-logdet` (§3.6.2 — copied coords are identity columns, excluded).
  - `read`/`write`/`copy` introspection API for writing bijections.
  - `reversible-jump-mh(-step)` — structure-changing split/merge (§3.7.4).
  - `coarse-to-fine-smc` — model sequence bridged by translators (§3.6.4).
  - `apply-translator` strips the L3 analytical path so a conjugate target yields joint scores (the `genmlx-540f` class).
- **`gfi.cljs`**: 5 self-contained laws (`translator-weight-formula`, `translator-jacobian-ad`, `translator-sparsity-equiv`, `translator-bijection-roundtrip`, `reversible-jump-detailed-balance`).
- **`trace_translator_test.cljs`** (NEW): 9 tests / 41 assertions, independent oracles.
- **`ARCHITECTURE.md`**: new Part IV (encapsulated randomness §4.5 + trace translators §3.6–3.7) + `omega` field + file map — closing the Phase 1 **zero-divergence** exit criterion.

## Validation (independent oracles)
- reparam translator weight = 0; split/merge Jacobians = ±log2
- discrete↔continuous bridge weight = −0.1008 (discrete coord contributes no Jacobian)
- RJMCMC split/merge recovers the exact model posterior **P(k=2|y)=0.566** (closed-form marginal likelihoods)
- coarse-to-fine SMC log-ML = direct importance-sampling log-ML
- **Zero regressions**: core, L0 68/68, gfi-laws, well-formedness, score-type, encapsulated, mutation-boundary.

Three real bugs were caught & fixed during development: native `mx/det` (worked around + bean), a rank-vs-length shape bug in the sparse Jacobian, and conjugate-model analytical-path leakage into particle weights.

> Note: the automated adversarial-review workflow crashed mid-run (empty output); this PR rests on the independent math-verifier oracles, the 5 GFI laws, the 41 assertions, and the zero-regression sweep above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)