### PR TITLE
fix(translator): assert-joint! precondition + meaningful :volume-preserving? (oen5 review follow-up)

### DIFF
--- a/src/genmlx/inference/translator.cljs
+++ b/src/genmlx/inference/translator.cljs
@@ -160,9 +160,12 @@
      :jacobian-fn       optional (fn [in-choices aux-choices] -> log|det J|)
                         used when h omits :log-det-jacobian (e.g. via
                         jacobian-logdet).
-     :volume-preserving? when true, default log|det J| = 0 silently (discrete /
-                        copy-only moves). Otherwise a missing Jacobian also
-                        defaults to 0 but is the caller's responsibility."
+     :volume-preserving? assert that this move has unit Jacobian (log|det J| = 0)
+                        — discrete or copy-only moves. Required when neither h
+                        nor :jacobian-fn supplies a Jacobian: a continuous
+                        transform with NO declared Jacobian and this flag unset
+                        is an error (a missing Jacobian must be explicit, never
+                        a silent 0)."
   [{:keys [p2 q1 q2 h jacobian-fn volume-preserving?]}]
   (assert (some? p2) "trace-translator: :p2 (target model) is required")
   (assert (fn? h) "trace-translator: :h (bijection) must be a fn")
@@ -170,22 +173,36 @@
 
 (defn- log-det-of
   "Resolve log|det J| for one application: h's value, else the translator's
-   :jacobian-fn, else 0."
+   :jacobian-fn, else 0 IFF the translator is declared :volume-preserving?.
+   A non-volume-preserving move with no declared Jacobian throws — a missing
+   change-of-variables term must be explicit, never a silent 0 (CLAUDE.md:
+   no no-op that lies about what it does)."
   [tt h-result in-choices aux-choices]
   (cond
     (contains? h-result :log-det-jacobian)
     (let [j (:log-det-jacobian h-result)] (if (mx/array? j) j (mx/scalar j)))
     (:jacobian-fn tt)
     (let [j ((:jacobian-fn tt) in-choices aux-choices)] (if (mx/array? j) j (mx/scalar j)))
-    :else ZERO))
+    (:volume-preserving? tt) ZERO
+    :else (throw (ex-info (str "trace-translator: no Jacobian for a non-"
+                               "volume-preserving move. Return :log-det-jacobian "
+                               "from h, set :jacobian-fn (e.g. via jacobian-logdet), "
+                               "or pass :volume-preserving? true for discrete/copy-only moves.")
+                          {:genmlx/error :translator-missing-jacobian}))))
 
 (defn apply-translator
   "Apply trace translator `tt` to input trace `in-trace`, producing a trace of
    the target model p2 with new args `args2`. Returns
      {:trace out-trace :weight log-w :aux rho2 :log-det-jacobian ldj}
    where log-w is the Eq 3.12 importance weight (log domain). `key` supplies
-   entropy for the forward auxiliary proposal."
+   entropy for the forward auxiliary proposal.
+
+   PRECONDITION: `in-trace` must be JOINT-scored — the Eq 3.12 weight
+   differences score1 against score2, so a :marginal trace (latents pinned at
+   the posterior mean) would silently corrupt it. Asserted (genmlx-540f class);
+   all internal call sites already strip the analytical path."
   [tt in-trace args2 key]
+  (tr/assert-joint! in-trace :apply-translator)
   (let [{:keys [p2 q1 q2 h]} tt
         in-choices (:choices in-trace)
         [k1 k2] (rng/split (rng/ensure-key key))
@@ -304,7 +321,9 @@
      :key          prng-key
      :resample?    resample between stages (default true)
 
-   Returns {:particles [trace ...] :log-weights [scalar ...] :log-ml number}.
+   Returns {:particles [trace ...] :log-weights [number ...] :log-ml number}.
+   (:log-weights and :log-ml are realized JS numbers, not MLX scalars — the SMC
+   loop materializes per-particle weights for host-side resampling/logmeanexp.)
    log-ml is the accumulated unbiased marginal-likelihood estimate for the fine
    model: at stage 0 the importance weights are P_0.generate weights; each
    translator application multiplies in its Eq 3.12 weight; resampling adds the

--- a/test/genmlx/trace_translator_test.cljs
+++ b/test/genmlx/trace_translator_test.cljs
@@ -7,9 +7,10 @@
    model posterior), coarse-to-fine SMC, and the discrete<->continuous bridge.
 
    INDEPENDENT ORACLE discipline: every numeric expectation is a closed form
-   derived by hand here (o-log-gauss, o-cat, the change-of-variables identities,
-   the split/merge log-Jacobians +/- log 2, and the Normal-Normal marginal
-   likelihoods giving P(k=2|y)=0.8804741734), never via the code under test."
+   derived by hand here (o-log-gauss, the change-of-variables identities, the
+   split/merge log-Jacobians +/- log 2, and the Normal-Normal marginal
+   likelihoods giving P(k=2|y)=0.5656 for the RJMCMC data y=[-1.5,1.5]), never
+   via the code under test."
   (:require [cljs.test :refer [deftest is testing]]
             [genmlx.inference.translator :as tt]
             [genmlx.inference.mcmc :as mcmc]
@@ -250,8 +251,10 @@
     (* -0.5 (+ (* 2 (js/Math.log (* 2 js/Math.PI))) (js/Math.log det) quad))))
 
 (deftest reversible-jump-split-merge
-  ;; Less-separated data => P(k=2|y) ~ 0.566 => balanced split/merge transitions
-  ;; => fast k-mixing. Exact posterior from the closed-form marginal likelihoods.
+  ;; Less-separated data y=[-1.5,1.5] (s0=10, sigma=1) => P(k=2|y) ~ 0.5656 =>
+  ;; balanced split/merge transitions => fast k-mixing. (Well-separated data like
+  ;; [-2,2] gives P(k=2)=0.8805 but mixes slowly — merge is rarely accepted.)
+  ;; Exact posterior computed inline from the closed-form marginal likelihoods.
   (testing "split/merge RJMCMC recovers the exact model posterior P(k=2|y)"
     (let [model (sm-model)
           s0 10.0 sigma 1.0 yy0 -1.5 yy1 1.5
@@ -328,6 +331,40 @@
           analytic (o-log-gauss 1.5 0 (js/Math.sqrt 2))]
       (is (< (js/Math.abs (- (:log-ml ctf) analytic)) 0.06)
           (str "reparam-bridged log-ML " (:log-ml ctf) " ~ analytic " analytic)))))
+
+;; ===========================================================================
+;; 7b. Preconditions (adversarial-review hardening)
+;; ===========================================================================
+
+(deftest translator-preconditions
+  (let [P1 (reparam-p1) P2 (reparam-p2)
+        h-jac (fn [in _aux] {:trace (cm/set-value cm/EMPTY :u
+                                                  (mx/divide (tt/read-choice in :x) (mx/scalar 2.0)))
+                             :aux cm/EMPTY :log-det-jacobian (mx/scalar (- LOG2))})]
+    (testing "apply-translator rejects a non-joint (:marginal) input trace"
+      (let [translator (tt/trace-translator {:p2 P2 :h h-jac})
+            jt (p/simulate (dyn/with-key P1 (rng/fresh-key 1)) [])
+            marginal-t (tr/with-score-type jt :marginal)]
+        (is (thrown? js/Error
+                     (tt/apply-translator translator marginal-t [] (rng/fresh-key 2)))
+            "a :marginal input would silently corrupt the Eq 3.12 weight")))
+    (testing "continuous move with NO declared Jacobian and not volume-preserving throws"
+      (let [h-nojac (fn [in _aux] {:trace (cm/set-value cm/EMPTY :u
+                                                        (mx/divide (tt/read-choice in :x) (mx/scalar 2.0)))
+                                   :aux cm/EMPTY})   ;; transforms but declares no Jacobian
+            translator (tt/trace-translator {:p2 P2 :h h-nojac})  ;; no :volume-preserving?, no :jacobian-fn
+            jt (p/simulate (dyn/with-key P1 (rng/fresh-key 3)) [])]
+        (is (thrown? js/Error
+                     (tt/apply-translator translator jt [] (rng/fresh-key 4)))
+            "a missing change-of-variables term must be explicit, never a silent 0")))
+    (testing "volume-preserving? true allows a missing Jacobian (log|det J| = 0)"
+      (let [P2id (gen [] (trace :u (dist/gaussian 0 1)))
+            h-copy (fn [in _aux] {:trace (cm/set-value cm/EMPTY :u (tt/read-choice in :x))
+                                  :aux cm/EMPTY})
+            translator (tt/trace-translator {:p2 P2id :h h-copy :volume-preserving? true})
+            jt (p/simulate (dyn/with-key P1 (rng/fresh-key 5)) [])
+            {:keys [log-det-jacobian]} (tt/apply-translator translator jt [] (rng/fresh-key 6))]
+        (is (= 0.0 (it log-det-jacobian)) "volume-preserving => log|det J| = 0")))))
 
 ;; ===========================================================================
 ;; 8. GFI laws registered + hold


### PR DESCRIPTION
Post-merge follow-up from the **genmlx-oen5 adversarial review** (8 confirmed; the Eq 3.12 sign convention, RJMCMC detailed balance, and all tests/laws were *verified correct* — these are hardening + honesty fixes, not correctness bugs in current usage).

## Changes
- **`apply-translator` asserts joint-scored input** (`tr/assert-joint!`), mirroring `mcmc/mh-step`. The Eq 3.12 weight differences `score1` against `score2`, so a `:marginal` input (latents pinned at the posterior mean) would silently corrupt it (the genmlx-540f class). All internal call sites already strip the analytical path; this guards direct callers.
- **`:volume-preserving?` is now meaningful** instead of dead code with a docstring that lied about controlling behavior (CLAUDE.md: *no no-op that lies about what it does*). A continuous move with **no declared Jacobian** (neither `h`'s `:log-det-jacobian` nor `:jacobian-fn`) and the flag unset now **throws** — a missing change-of-variables term must be explicit, never a silent 0. All existing translators provide a Jacobian or set the flag, so behavior is unchanged.
- **Docs:** ns docstring `P(k=2|y)` `0.88 → 0.5656` (stale after the RJMCMC data change to `y=[-1.5,1.5]`); inline data-dependency label; `coarse-to-fine-smc` `:log-weights` documented as realized JS numbers.
- **+3 precondition tests** (`translator-preconditions`): marginal-input rejection, missing-Jacobian throw, `:volume-preserving?` allows a unit Jacobian.

## Validation
`trace_translator_test` **10/10 (44 assertions)** green, including the 5 GFI laws via `gfi-laws-hold`. Validated serially (single GPU process).

🤖 Generated with [Claude Code](https://claude.com/claude-code)