### PR TITLE
fix(mlx): correct general-matrix determinant; split SPD vs general det families (rqp9)

### DIFF
--- a/src/genmlx/dist.cljs
+++ b/src/genmlx/dist.cljs
@@ -1371,8 +1371,8 @@
         ;; Recompute V-inv and log-det-V from scale-matrix (not precomputed)
         ;; so gradient tape is preserved for differentiating w.r.t. V.
         V-inv (mx/inv scale-matrix)
-        log-det-V (mx/logdet scale-matrix)
-        log-det-X (mx/logdet x-2d)
+        log-det-V (mx/spd-logdet scale-matrix)
+        log-det-X (mx/spd-logdet x-2d)
         ;; log p(X) = ((df-k-1)/2)*log|X| - (1/2)*tr(V^{-1}X) - (df*k/2)*log(2)
         ;;            - (df/2)*log|V| - log_multivariate_gamma(df/2, k)
         half-df (/ df 2.0)
@@ -1415,8 +1415,8 @@
         X-inv (mx/inv x-2d)
         ;; Recompute log-det from raw matrices (not precomputed) so gradient
         ;; tape is preserved for differentiating w.r.t. Psi and X.
-        log-det-Psi (mx/logdet scale-matrix)
-        log-det-X (mx/logdet x-2d)
+        log-det-Psi (mx/spd-logdet scale-matrix)
+        log-det-X (mx/spd-logdet x-2d)
         ;; log p(X) = (df/2)*log|Psi| - (df*k/2)*log(2) - log_multivariate_gamma(df/2, k)
         ;;            - ((df+k+1)/2)*log|X| - (1/2)*tr(Psi * X^{-1})
         half-df (/ df 2.0)

--- a/src/genmlx/inference/translator.cljs
+++ b/src/genmlx/inference/translator.cljs
@@ -46,34 +46,11 @@
 ;; ---------------------------------------------------------------------------
 ;; Jacobian via automatic differentiation (mx/grad)
 ;;
-;; NOTE on the determinant: the native mx/det is unreliable for non-diagonal
-;; matrices (genmlx-det-bug: [[1,2],[3,4]] -> 25 not -2) and mx/logdet is
-;; cholesky-based (SPD only). Jacobians of trace-translator bijections are
-;; LOW-dimensional (1-4 coords), so we realize the AD Jacobian and take its
-;; log|det| on the HOST via LU with partial pivoting — exact and bug-free.
-;; (The host-geometry / GPU-linalg split.)
+;; The AD Jacobian is built row-by-row with mx/grad; its log|det| comes from
+;; mx/logabsdet (QR-based, general — correct for the non-symmetric Jacobians
+;; bijections produce, where the SPD-only mx/spd-logdet would be silently wrong;
+;; genmlx-rqp9).
 ;; ---------------------------------------------------------------------------
-
-(defn- host-log-abs-det
-  "log|det| of a small square matrix (clj nested-vector `rows`) via Gaussian
-   elimination with partial pivoting. -Infinity for a singular matrix."
-  [rows]
-  (let [n (count rows)]
-    (loop [a (mapv #(mapv double %) rows), k 0, acc 0.0]
-      (if (>= k n)
-        acc
-        (let [p (apply max-key #(js/Math.abs (get-in a [% k])) (range k n))
-              a (if (= p k) a (assoc a k (a p) p (a k)))
-              piv (get-in a [k k])]
-          (if (zero? piv)
-            ##-Inf
-            (let [a (reduce
-                     (fn [a i]
-                       (let [f (/ (get-in a [i k]) piv)]
-                         (reduce (fn [a j] (update-in a [i j] - (* f (get-in a [k j]))))
-                                 a (range k n))))
-                     a (range (inc k) n))]
-              (recur a (inc k) (+ acc (js/Math.log (js/Math.abs piv)))))))))))
 
 (defn jacobian-matrix
   "The n x n Jacobian of g : R^n -> R^n at point x ([n]-shaped MLX vector),
@@ -85,8 +62,8 @@
 
 (defn jacobian-logdet
   "log|det J_g(x)| (MLX scalar) for a bijective numeric transform
-   g : R^n -> R^n at x. The AD Jacobian (mx/grad on g) is realized and its
-   log|det| taken on the host (orientation-sign-safe).
+   g : R^n -> R^n at x. The AD Jacobian (mx/grad on g) is fed to mx/logabsdet
+   (QR, general / orientation-safe).
 
    SPARSITY (thesis §3.6.2): pass g and x restricted to the TRANSFORMED
    continuous coordinates only. Coordinates that h copies unchanged contribute
@@ -94,7 +71,7 @@
    while reducing the matrix from m x m to (m-c) x (m-c) — O((m-c)^3) instead of
    O(m^3). sparse-jacobian-logdet packages this from the full transform."
   [g x n]
-  (mx/scalar (host-log-abs-det (mx/->clj (jacobian-matrix g x n)))))
+  (mx/logabsdet (jacobian-matrix g x n)))
 
 (defn sparse-jacobian-logdet
   "Sparsity-aware (thesis §3.6.2) log|det J| (MLX scalar). `g-full` : R^m -> R^m
@@ -104,11 +81,11 @@
    indices (the copied coordinates are identity rows/cols, determinant 1).
    Equals jacobian-logdet on the full matrix but over the smaller block."
   [g-full x transformed-idxs]
-  (let [m (first (mx/shape x))           ;; vector length (not rank)
-        full-j (mx/->clj (jacobian-matrix g-full x m))
-        idxs (vec transformed-idxs)
-        sub (mapv (fn [i] (mapv (fn [j] (get-in full-j [i j])) idxs)) idxs)]
-    (mx/scalar (host-log-abs-det sub))))
+  (let [m (first (mx/shape x))                  ;; vector length (not rank)
+        full-j (jacobian-matrix g-full x m)
+        idx (mx/array (vec transformed-idxs) mx/int32)
+        sub (mx/take-idx (mx/take-idx full-j idx 0) idx 1)]  ;; rows then cols
+    (mx/logabsdet sub)))
 
 ;; ---------------------------------------------------------------------------
 ;; read / write / copy — introspection API for writing bijections h

--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -996,12 +996,87 @@
   ([a]     (.linalgNorm c a))
   ([a ord] (.linalgNorm c a ord)))
 
-(defn logdet [a]
+;; --- Determinants ---------------------------------------------------------
+;;
+;; Two families. The SPD pair (spd-logdet/spd-det) is Cholesky-based: lazy,
+;; on-device, and DIFFERENTIABLE, but valid ONLY for symmetric positive-definite
+;; matrices (covariances — MVN/Wishart). The general family
+;; (logabsdet/slogdet/det/logdet) is correct for ANY square matrix:
+;;   - logabsdet uses QR (lazy, on-device): |det A| = prod |R_ii|;
+;;   - slogdet/det/logdet add the sign via a host-side LU with partial pivoting,
+;;     which MATERIALIZES the input (not part of a lazy/differentiable graph).
+;; Cholesky silently returns garbage on a non-SPD matrix (it reads one triangle),
+;; so a determinant of a general matrix MUST go through the general family, never
+;; spd-*. (genmlx-rqp9.)
+
+(defn spd-logdet
+  "log(det A) for a SYMMETRIC POSITIVE-DEFINITE A, via Cholesky — lazy and
+   DIFFERENTIABLE (for MVN/Wishart log-prob). Silently WRONG for non-SPD A; use
+   logdet/logabsdet for general matrices."
+  [a]
   (let [L (cholesky a)]
     (multiply (scalar 2.0) (sum (log (diag L))))))
-(defn det [a]
+
+(defn spd-det
+  "det A for a SYMMETRIC POSITIVE-DEFINITE A, via Cholesky — lazy and
+   DIFFERENTIABLE. Silently WRONG for non-SPD A; use det for general matrices."
+  [a]
   (let [L (cholesky a)]
     (power (prod (diag L)) (scalar 2))))
+
+(defn logabsdet
+  "log|det A| for ANY square matrix A, via QR (lazy, on-device): |det A| =
+   prod_i |R_ii|. Correct for non-symmetric / indefinite A (unlike spd-logdet).
+   The general workhorse for change-of-variables / Jacobian log-determinants."
+  [a]
+  (sum (log (abs (diag (second (qr a)))))))
+
+(defn- host-lu-slogdet
+  "[sign, log|det|] of a square matrix (clj nested-vector `rows`) via Gaussian
+   elimination with partial pivoting. sign in {-1.0, 0.0, 1.0}; log|det| is
+   -Infinity for a singular matrix. Exact for any square matrix."
+  [rows]
+  (let [n (count rows)]
+    (loop [a (mapv #(mapv double %) rows), k 0, acc 0.0, sign 1.0]
+      (if (>= k n)
+        [sign acc]
+        (let [p (apply max-key #(js/Math.abs (get-in a [% k])) (range k n))
+              sign (if (= p k) sign (- sign))
+              a (if (= p k) a (assoc a k (a p) p (a k)))
+              piv (get-in a [k k])]
+          (if (zero? piv)
+            [0.0 ##-Inf]
+            (let [a (reduce
+                     (fn [a i]
+                       (let [f (/ (get-in a [i k]) piv)]
+                         (reduce (fn [a j] (update-in a [i j] - (* f (get-in a [k j]))))
+                                 a (range k n))))
+                     a (range (inc k) n))]
+              (recur a (inc k) (+ acc (js/Math.log (js/Math.abs piv)))
+                     (if (neg? piv) (- sign) sign)))))))))
+
+(defn slogdet
+  "[sign, log|det A|] for ANY square matrix A (host-side LU; MATERIALIZES A).
+   sign is an MLX scalar in {-1, 0, 1}; the second element is log|det A|. For
+   an SPD A inside a differentiable graph, use spd-logdet."
+  [a]
+  (let [[sgn lad] (host-lu-slogdet (realize-clj a))]
+    [(scalar sgn) (scalar lad)]))
+
+(defn det
+  "Signed det A for ANY square matrix A (host-side LU; MATERIALIZES A). For an
+   SPD A inside a differentiable graph, use spd-det."
+  [a]
+  (let [[sgn lad] (host-lu-slogdet (realize-clj a))]
+    (scalar (* sgn (js/Math.exp lad)))))
+
+(defn logdet
+  "log(det A) for ANY square matrix A with det A > 0 (host-side LU; MATERIALIZES
+   A); NaN when det A <= 0. For an SPD A inside a differentiable graph (the
+   common MVN/Wishart case), use spd-logdet; for |det| use logabsdet."
+  [a]
+  (let [[sgn lad] (host-lu-slogdet (realize-clj a))]
+    (scalar (if (pos? sgn) lad ##NaN))))
 
 ;; --- Utilities ---
 

--- a/test/genmlx/det_contract_test.cljs
+++ b/test/genmlx/det_contract_test.cljs
@@ -1,0 +1,84 @@
+;; @tier fast core
+(ns genmlx.det-contract-test
+  "genmlx-rqp9: determinant membrane contract.
+
+   Two families in mlx.cljs:
+   - spd-det / spd-logdet : Cholesky-based, lazy, DIFFERENTIABLE, valid ONLY for
+     symmetric positive-definite matrices (covariances — MVN/Wishart).
+   - logabsdet (QR) + slogdet/det/logdet (host-LU) : correct for ANY square
+     matrix, including non-symmetric / indefinite ones.
+
+   The original bug (genmlx-rqp9): a single cholesky-based `det`/`logdet` was used
+   for general matrices, silently returning garbage on non-SPD inputs
+   ([[1,2],[3,4]] -> 25 instead of -2; [[1,-1],[1,1]] -> 0 instead of 2). This
+   guard pins both families against hand-computed oracles so a regression (or a
+   stale/drifted MLX binary changing cholesky/qr behaviour) fails loudly."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.mlx :as mx]))
+
+(defn- it [a] (mx/item a))
+(defn- close? [a b] (< (js/Math.abs (- a b)) 1e-4))
+
+;; ===========================================================================
+;; SPD family (cholesky) — valid for symmetric positive-definite matrices
+;; ===========================================================================
+
+(deftest spd-determinants
+  (testing "spd-det / spd-logdet on SPD matrices == hand oracle"
+    ;; diagonal: det = product
+    (is (close? (it (mx/spd-det (mx/array [[2.0 0.0] [0.0 3.0]]))) 6.0))
+    (is (close? (it (mx/spd-logdet (mx/array [[2.0 0.0] [0.0 3.0]]))) (js/Math.log 6.0)))
+    ;; dense SPD [[4,1],[1,3]] : det = 12 - 1 = 11
+    (is (close? (it (mx/spd-det (mx/array [[4.0 1.0] [1.0 3.0]]))) 11.0))
+    (is (close? (it (mx/spd-logdet (mx/array [[4.0 1.0] [1.0 3.0]]))) (js/Math.log 11.0)))))
+
+;; ===========================================================================
+;; General family — correct for ANY square matrix (the regression cases)
+;; ===========================================================================
+
+(deftest general-determinants
+  (testing "det: the previously-WRONG non-SPD cases are now correct"
+    (is (close? (it (mx/det (mx/array [[1.0 2.0] [3.0 4.0]]))) -2.0)
+        "[[1,2],[3,4]] det = -2 (was 25)")
+    (is (close? (it (mx/det (mx/array [[1.0 -1.0] [1.0 1.0]]))) 2.0)
+        "[[1,-1],[1,1]] det = 2 (was 0)"))
+  (testing "det: diagonal, 3x3, and singular"
+    (is (close? (it (mx/det (mx/array [[2.0 0.0] [0.0 3.0]]))) 6.0))
+    (is (close? (it (mx/det (mx/array [[1.0 2.0 3.0] [0.0 1.0 4.0] [5.0 6.0 0.0]]))) 1.0))
+    (is (close? (it (mx/det (mx/array [[1.0 2.0] [2.0 4.0]]))) 0.0) "singular det = 0"))
+  (testing "logabsdet (QR): log|det| for non-SPD matrices"
+    (is (close? (it (mx/logabsdet (mx/array [[1.0 2.0] [3.0 4.0]]))) (js/Math.log 2.0)))
+    (is (close? (it (mx/logabsdet (mx/array [[1.0 -1.0] [1.0 1.0]]))) (js/Math.log 2.0)))
+    (is (close? (it (mx/logabsdet (mx/array [[1.0 2.0 3.0] [0.0 1.0 4.0] [5.0 6.0 0.0]]))) 0.0)
+        "3x3 |det|=1 => log|det|=0"))
+  (testing "slogdet: sign and log|det|"
+    (let [[s la] (mx/slogdet (mx/array [[1.0 2.0] [3.0 4.0]]))]
+      (is (= -1.0 (it s)) "negative-det sign")
+      (is (close? (it la) (js/Math.log 2.0)) "log|det|"))
+    (let [[s la] (mx/slogdet (mx/array [[1.0 -1.0] [1.0 1.0]]))]
+      (is (= 1.0 (it s)) "positive-det sign")
+      (is (close? (it la) (js/Math.log 2.0)))))
+  (testing "logdet: log(det) for det>0, NaN for det<=0"
+    (is (close? (it (mx/logdet (mx/array [[2.0 0.0] [0.0 3.0]]))) (js/Math.log 6.0)))
+    (is (js/Number.isNaN (it (mx/logdet (mx/array [[1.0 2.0] [3.0 4.0]]))))
+        "det = -2 < 0 => logdet NaN")))
+
+;; ===========================================================================
+;; Cross-family consistency
+;; ===========================================================================
+
+(deftest determinant-consistency
+  (testing "det == sign * exp(logabsdet) for general matrices"
+    (doseq [m [[[1.0 2.0] [3.0 4.0]] [[1.0 -1.0] [1.0 1.0]]
+               [[1.0 2.0 3.0] [0.0 1.0 4.0] [5.0 6.0 0.0]]]]
+      (let [a (mx/array m)
+            [s la] (mx/slogdet a)]
+        (is (close? (it (mx/det a)) (* (it s) (js/Math.exp (it la))))))))
+  (testing "on SPD matrices, the general and SPD families agree"
+    (doseq [m [[[2.0 0.0] [0.0 3.0]] [[4.0 1.0] [1.0 3.0]]]]
+      (let [a (mx/array m)]
+        (is (close? (it (mx/det a)) (it (mx/spd-det a))) "det == spd-det")
+        (is (close? (it (mx/logabsdet a)) (it (mx/spd-logdet a))) "logabsdet == spd-logdet")
+        (is (close? (it (mx/logdet a)) (it (mx/spd-logdet a))) "logdet == spd-logdet (det>0)")))))
+
+(cljs.test/run-tests)

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -90,6 +90,7 @@ fast test/genmlx/contract_verification_test.cljs
 fast test/genmlx/correctness_test.cljs
 fast test/genmlx/custom_gradient_test.cljs
 fast test/genmlx/dep_graph_test.cljs
+fast test/genmlx/det_contract_test.cljs core
 medium test/genmlx/differentiable_hard_test.cljs
 medium test/genmlx/differentiable_hard2_test.cljs
 medium test/genmlx/differentiable_resample_test.cljs


### PR DESCRIPTION
Fixes **genmlx-rqp9**: `mx/det`/`mx/logdet` returned wrong values for non-diagonal matrices.

## Root cause (the bean's "native binding" hypothesis was wrong)
`det`/`logdet` were a single **Cholesky-based** pair — lazy and on-device, but valid *only* for symmetric positive-definite matrices. Cholesky silently reads one triangle, so on a general matrix they produced garbage:
- `[[1,2],[3,4]]` → det **25** (should be −2)
- `[[1,-1],[1,1]]` → det **0** (should be 2)

It's a CLJS membrane impl using an SPD-only algorithm for a general operation — not a Rust/NAPI bug. `@mlx-node/core` exposes `cholesky` + `qr` but no native `lu`/`det`, so the fix is pure CLJS (no rebuild).

## Fix — two explicit families in `mlx.cljs`
- **`spd-logdet` / `spd-det`** — Cholesky, lazy, **differentiable**, SPD-only (covariances).
- **`logabsdet`** — QR-based, lazy, on-device, **general**: `|det A| = ∏|R_ii|`.
- **`slogdet` / `det` / `logdet`** — host-side LU with partial pivoting; **signed**, correct for any square matrix (materialize the input; not differentiable).

## Callers updated
- `dist.cljs`: Wishart / inverse-Wishart `logdet` → `spd-logdet` (SPD scale & sample matrices; differentiable gradient path preserved — `wishart_gradient_test` green).
- `translator.cljs`: retired the private host-LU workaround; `jacobian-logdet` + `sparse-jacobian-logdet` now use `mx/logabsdet`.

## Guard test
`det_contract_test.cljs` (NEW, fast-core, 27 assertions) pins both families against hand oracles — including the previously-wrong non-SPD cases, sign/NaN behavior, and cross-family consistency (`det == sign·exp(logabsdet)`; general == SPD on SPD inputs).

## Validation
det_contract 27 · trace_translator 10/44 (QR path) · dist 14/48 · wishart_gradient 8/20 · l3_5_multivariate 8/33 · **L0 68/68** · clip_contract 6/7. Zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)