### PR TITLE
fix: foundation hardening sweep — 13 engine bug fixes from post-Phase-0/1 audit (genmlx-bjcq)

### DIFF
--- a/src/genmlx/affine.cljs
+++ b/src/genmlx/affine.cljs
@@ -294,6 +294,18 @@
         result (when natural-arg
                  (analyze-affine natural-arg target-sym env))]
     (cond
+      ;; A bare-symbol natural parameter that is NOT a direct trace alias of the
+      ;; prior is a rebinding whose defining expression the schema has erased
+      ;; (only the symbol survives, e.g. (let [mu (trace :mu ...) mu (mx/add mu 5)]
+      ;; ...)); its affine form is unknowable, so decline rather than assume
+      ;; coeff 1 / offset 0 via the name-based target match (genmlx-1thx). Only
+      ;; applies when the walker recorded :arg-aliases provenance; hand-built
+      ;; schemas without it keep the legacy behavior.
+      (and (symbol? natural-arg)
+           (contains? obs-site :arg-aliases)
+           (not= prior-addr (get (:arg-aliases obs-site) natural-arg)))
+      {:type :nonlinear}
+
       (or (nil? result)
           (not (:affine? result))
           (not (:has-target? result)))  ;; nonlinear, unknown, or no prior dependency

--- a/src/genmlx/agents/biased_planners.cljs
+++ b/src/genmlx/agents/biased_planners.cljs
@@ -184,17 +184,29 @@
                                (h/softmax-action alpha (mx/array (clj->js (eu-row s)) mx/float32))))]
     {:mdp mdp
      :policy policy
-     :act (fn [s] (int (mx/item (:retval (p/simulate (dyn/auto-key policy) [s])))))
+     ;; 2-arity like agent/make-mdp-agent: (act s) draws fresh entropy, (act s key)
+     ;; is deterministic in key. simulate-mdp's keyed :host path calls (act s k-act),
+     ;; so a 1-arity :act threw an ArityException under :key (genmlx-m3nn).
+     :act (fn
+            ([s] (int (mx/item (:retval (p/simulate (dyn/auto-key policy) [s])))))
+            ([s key] (int (mx/item (:retval (p/simulate (if key (dyn/with-key policy key) (dyn/auto-key policy)) [s]))))))
      :expected-utility (fn [s a] (eu s a H 0))
      :eu eu
      :params {:alpha alpha :gamma gamma :horizon H
               :discount discount :bias bias :reward-myopic-bound reward-myopic-bound}}))
 
-(def simulate-biased-mdp
-  "Roll a biased MDP agent out from `start` for ≤ horizon steps (= agent/simulate-mdp,
-   which re-plans via :act each step — the d=0 re-planning that drives Naive
-   time-inconsistency)."
-  agent/simulate-mdp)
+(defn simulate-biased-mdp
+  "Roll a biased MDP agent out from `start` for ≤ horizon steps (= agent/simulate-mdp's
+   :host path, which re-plans via :act each step — the d=0 re-planning that drives
+   Naive time-inconsistency). :rollout-mode :fused is unsupported: biased agents
+   carry no tensor :Q, so rollout/rollout-mdp would deref nil (genmlx-m3nn) — use
+   the default :host rollout."
+  [ag start horizon & [opts]]
+  (when (= (:rollout-mode opts) :fused)
+    (throw (ex-info (str "simulate-biased-mdp does not support :rollout-mode :fused — "
+                         "biased agents have no tensor :Q; use the default :host rollout")
+                    {:agent-keys (keys ag)})))
+  (agent/simulate-mdp ag start horizon opts))
 
 (defn- argmax-of [xs] (first (apply max-key second (map-indexed vector xs))))
 

--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -2313,10 +2313,21 @@
                                         :retval (:retval new-inner-trace)
                                         :score new-score})
                         [new-inner-trace])
-               :weight (mx/subtract new-score (:score trace))
+               ;; Same component: the inner update weight is the combinator
+               ;; weight (the unchanged index score cancels). Using the raw
+               ;; score delta over-counts any fresh sites the inner update
+               ;; sampled on a nested structural change (genmlx-zek9).
+               :weight (:weight result)
                :discard (:discard result)})))
-        ;; Different component: generate new component from scratch
-        (let [new-component (nth (:components this) new-idx)
+        ;; Different component: generate new component from scratch.
+        ;; Thesis weight: the generate weight counts only constrained inner
+        ;; sites (fresh unconstrained sites cancel against the internal
+        ;; proposal); add the new index score and charge the removed old
+        ;; component via the recorded old total. Using (:score new-inner-trace)
+        ;; here would double-count the new component's fresh latents
+        ;; (genmlx-zek9). The new component is keyed so its unconstrained
+        ;; latents can be sampled (else p/generate throws 'No PRNG key').
+        (let [new-component (ensure-kernel-key (nth (:components this) new-idx))
               new-idx-score (dc/dist-log-prob idx-dist (mx/scalar new-idx mx/int32))
               gen-result (p/generate new-component args inner-constraints)
               new-inner-trace (:trace gen-result)
@@ -2329,7 +2340,8 @@
                                     :retval (:retval new-inner-trace)
                                     :score new-score})
                     [new-inner-trace])
-           :weight (mx/subtract new-score (:score trace))
+           :weight (mx/subtract (mx/add (:weight gen-result) new-idx-score)
+                                (:score trace))
            :discard old-choices}))))
 
   p/IRegenerate
@@ -2346,28 +2358,51 @@
           old-idx-score (dc/dist-log-prob idx-dist (mx/scalar old-idx mx/int32))
           idx-selected? (sel/selected? selection :component-idx)]
       (if idx-selected?
-        ;; Resample component index and simulate new component. EVERYTHING
-        ;; under the Mix is freshly drawn from the prior, so the regenerate
-        ;; MH weight is exactly 0: the score delta cancels against the
-        ;; forward/backward prior-proposal ratio (system convention
-        ;; W = dS - proposal_ratio, and proposal_ratio = dS here). The old
-        ;; scoreDelta return un-cancelled the whole subtree score at parent
-        ;; splices and skewed top-level MH acceptance (genmlx-v740).
+        ;; Resample the component index. Only :component-idx is selected, so
+        ;; the inner component sites are UNSELECTED and must be retained
+        ;; whenever the structure is unchanged (genmlx-zek9).
         (let [new-idx-trace (dc/dist-simulate idx-dist)
               new-idx (int (mx/item (cm/get-value (:choices new-idx-trace))))
-              new-idx-score (:score new-idx-trace)
-              new-component (ensure-kernel-key (nth (:components this) new-idx))
-              new-comp-trace (p/simulate new-component args)
-              new-score (mx/add (:score new-comp-trace) new-idx-score)]
-          {:trace (tag-from-traces
-                    (tr/make-trace {:gen-fn this :args args
-                                    :choices (cm/set-choice (:choices new-comp-trace)
-                                                            [:component-idx]
-                                                            (mx/scalar new-idx mx/int32))
-                                    :retval (:retval new-comp-trace)
-                                    :score new-score})
-                    [new-comp-trace])
-           :weight ZERO})
+              new-idx-score (:score new-idx-trace)]
+          (if (= new-idx old-idx)
+            ;; Same component resampled: retain the unselected inner choices.
+            ;; Nothing under the component moves, so the retained-only weight
+            ;; is 0 (and the selected index resample cancels its own delta).
+            (let [component (nth (:components this) old-idx)
+                  inner-old-choices (without-component-idx old-choices)
+                  inner-old-score (mx/subtract (:score trace) old-idx-score)
+                  inner-old-trace (tr/make-trace {:gen-fn component :args args
+                                                  :choices inner-old-choices
+                                                  :retval (:retval trace)
+                                                  :score inner-old-score})
+                  new-score (mx/add inner-old-score new-idx-score)]
+              {:trace (tag-from-traces
+                        (tr/make-trace {:gen-fn this :args args
+                                        :choices (cm/set-choice inner-old-choices
+                                                                [:component-idx]
+                                                                (mx/scalar new-idx mx/int32))
+                                        :retval (:retval trace)
+                                        :score new-score})
+                        [inner-old-trace])
+               :weight ZERO})
+            ;; Different component: EVERYTHING under the Mix is freshly drawn
+            ;; from the prior, so the regenerate MH weight is exactly 0: the
+            ;; score delta cancels against the forward/backward prior-proposal
+            ;; ratio (W = dS - proposal_ratio, proposal_ratio = dS here). The
+            ;; old scoreDelta return un-cancelled the whole subtree score at
+            ;; parent splices and skewed top-level MH acceptance (genmlx-v740).
+            (let [new-component (ensure-kernel-key (nth (:components this) new-idx))
+                  new-comp-trace (p/simulate new-component args)
+                  new-score (mx/add (:score new-comp-trace) new-idx-score)]
+              {:trace (tag-from-traces
+                        (tr/make-trace {:gen-fn this :args args
+                                        :choices (cm/set-choice (:choices new-comp-trace)
+                                                                [:component-idx]
+                                                                (mx/scalar new-idx mx/int32))
+                                        :retval (:retval new-comp-trace)
+                                        :score new-score})
+                        [new-comp-trace])
+               :weight ZERO})))
         ;; Same component: regenerate within the component
         (let [component (nth (:components this) old-idx)
               inner-old-score (mx/subtract (:score trace) old-idx-score)

--- a/src/genmlx/compiled_ops.cljs
+++ b/src/genmlx/compiled_ops.cljs
@@ -138,7 +138,7 @@
   "Build a compiled generate for models with rewritable branches (L1-M4).
    Returns (fn [key args-vec constraints] -> {:values :score :weight :retval}) or nil."
   [schema source]
-  (when-let [{:keys [site-specs retval-fn seed-conds]}
+  (when-let [{:keys [site-specs retval-fn seed-conds addrs]}
              (compiled/prepare-branch-sites schema source)]
     (let [step-fns (mapv build-generate-site-step site-specs)]
       (when (every? some? step-fns)
@@ -152,7 +152,10 @@
                  {:values (seed-conds args-vec)
                   :score (mx/scalar 0.0) :weight (mx/scalar 0.0) :key key}
                  step-fns)]
-            {:values (:values result)
+            ;; Strip the reserved branch-cond bookkeeping keys so the trace
+            ;; choicemap holds only real addresses (genmlx-gc4w); the simulate
+            ;; path already does this via unpack-result.
+            {:values (select-keys (:values result) addrs)
              :score (:score result)
              :weight (:weight result)
              ;; retval-fn proven truthy by prepare-branch-sites
@@ -257,7 +260,7 @@
    Returns (fn [key args-vec constraints old-choices]
              -> {:values :score :discard :retval}) or nil."
   [schema source]
-  (when-let [{:keys [site-specs retval-fn seed-conds]}
+  (when-let [{:keys [site-specs retval-fn seed-conds addrs]}
              (compiled/prepare-branch-sites schema source)]
     (let [step-fns (mapv build-update-site-step site-specs)]
       (when (every? some? step-fns)
@@ -270,7 +273,8 @@
                  {:values (seed-conds args-vec)
                   :score (mx/scalar 0.0) :discard {} :key key}
                  step-fns)]
-            {:values (:values result)
+            ;; Strip reserved branch-cond keys from the trace choicemap (genmlx-gc4w)
+            {:values (select-keys (:values result) addrs)
              :score (:score result)
              :discard (:discard result)
              :retval (retval-fn (:values result) mlx-args)}))))))
@@ -643,7 +647,7 @@
              (not (:dynamic-addresses? schema)))
     (when-let [raw-sites (compiled/extract-rewritable-sites source)]
       (when (seq raw-sites)
-        (when-let [{:keys [site-specs retval-fn seed-conds]}
+        (when-let [{:keys [site-specs retval-fn seed-conds addrs]}
                    (compiled/compile-branch-rewritten-site-specs schema source raw-sites)]
           (let [step-fns (mapv build-regenerate-site-step site-specs)]
             (when (every? some? step-fns)
@@ -656,7 +660,8 @@
                        {:values (seed-conds args-vec)
                         :score (mx/scalar 0.0) :weight (mx/scalar 0.0) :key key}
                        step-fns)]
-                  {:values (:values result)
+                  ;; Strip reserved branch-cond keys from the trace choicemap (genmlx-gc4w)
+                  {:values (select-keys (:values result) addrs)
                    :score (:score result)
                    :weight (:weight result)
                    :retval (retval-fn (:values result) mlx-args)})))))))))

--- a/src/genmlx/conjugacy.cljs
+++ b/src/genmlx/conjugacy.cljs
@@ -138,8 +138,19 @@
         {:type :log-link}
         {:type :nonlinear})
 
-      ;; Direct: the natural parameter arg IS the prior symbol
-      (symbol-resolves-to-addr? natural-arg prior-addr)
+      ;; Direct: the natural parameter arg is a symbol bound DIRECTLY to
+      ;; (trace prior-addr ...). When the schema walker recorded :arg-aliases
+      ;; provenance, use it: it distinguishes a direct binding from an affine
+      ;; rebinding that reuses the same symbol name, e.g.
+      ;;   (let [mu (trace :mu ...) mu (mx/add mu 5)] (trace :y (gaussian mu 1)))
+      ;; which must fall through to affine analysis, not be scored as if the
+      ;; offset were 0 (genmlx-1thx); it also recognizes a direct alias under a
+      ;; different name (m = (trace :mu ...)). Hand-built schemas without the
+      ;; :arg-aliases key fall back to the legacy name match.
+      (if (contains? obs-site :arg-aliases)
+        (and (symbol? natural-arg)
+             (= prior-addr (get (:arg-aliases obs-site) natural-arg)))
+        (symbol-resolves-to-addr? natural-arg prior-addr))
       {:type :direct}
 
       ;; Try affine analysis on the natural parameter expression
@@ -234,6 +245,27 @@
     (if (empty? multi)
       pairs
       (vec (remove #(contains? multi (:obs-addr %)) pairs)))))
+
+(defn drop-mixed-family-priors
+  "Remove all pairs whose PRIOR is conjugate to obs of MORE THAN ONE family.
+
+   A single prior conjugate to two different obs families (e.g. a Gamma prior
+   with both Poisson and Exponential children) has no correct single-family
+   scalar elimination: the joint marginal couples the families through the
+   shared latent, so it is NOT the product of the per-family marginals, and
+   applying one family's update-step to every obs in the group scores the
+   minority family with the wrong likelihood (genmlx-1thx). Decline such
+   priors entirely so the handler path scores them exactly. (Joint
+   multi-family elimination would be a future feature, not a bug fix.)"
+  [pairs]
+  (let [mixed (into #{}
+                    (keep (fn [[prior-addr ps]]
+                            (when (> (count (distinct (map :family ps))) 1)
+                              prior-addr)))
+                    (group-by :prior-addr pairs))]
+    (if (empty? mixed)
+      pairs
+      (vec (remove #(contains? mixed (:prior-addr %)) pairs)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Schema augmentation

--- a/src/genmlx/dist.cljs
+++ b/src/genmlx/dist.cljs
@@ -899,11 +899,13 @@
   "Geometric distribution: number of failures before first success, p in (0,1)."
   [p]
   (sample [key]
-    ;; Inverse CDF: floor(log(u) / log(1-p))
+    ;; Inverse CDF: floor(log(1-u) / log(1-p)). Use (1-u), not u: rng/uniform
+    ;; returns [0,1) which INCLUDES 0, and log(0) = -Inf -> +Inf, a sample
+    ;; outside the support; 1-u in (0,1] keeps the log finite (genmlx-lgun).
           (let [u (rng/uniform key [])
-                log-u (mx/log u)
+                log-1mu (mx/log (mx/subtract ONE u))
                 log-1mp (mx/log (mx/subtract ONE p))]
-            (mx/floor (mx/divide log-u log-1mp))))
+            (mx/floor (mx/divide log-1mu log-1mp))))
   (log-prob [v]
     ;; log p(k) = k * log(1-p) + log(p)
     ;; xlogy guard: at p=1 (legal — success on the first trial, k=0 w.p. 1)
@@ -923,9 +925,10 @@
   (let [{:keys [p]} (:params d)
         key (rng/ensure-key key)
         u (rng/uniform key [n])
-        log-u (mx/log u)
+        ;; (1-u), not u: avoid log(0)=-Inf -> +Inf at the u=0 boundary (genmlx-lgun)
+        log-1mu (mx/log (mx/subtract ONE u))
         log-1mp (mx/log (mx/subtract ONE p))]
-    (mx/floor (mx/divide log-u log-1mp))))
+    (mx/floor (mx/divide log-1mu log-1mp))))
 
 (let [raw geometric]
   (defn geometric
@@ -1205,12 +1208,19 @@
           (let [sh (mx/shape mu)]
             (mx/add mu (mx/multiply sigma (rng/normal key sh)))))
   (log-prob [v]
-            (let [z (mx/divide (mx/subtract v mu) sigma)]
-              (mx/sum
-               (mx/negative
-                (mx/add LOG-2PI-HALF
-                        (mx/log sigma)
-                        (mx/multiply HALF (mx/square z)))))))
+            (let [k (count (mx/shape mu))   ; event rank (mu carries the event shape)
+                  z (mx/divide (mx/subtract v mu) sigma)
+                  lp (mx/negative
+                      (mx/add LOG-2PI-HALF
+                              (mx/log sigma)
+                              (mx/multiply HALF (mx/square z))))]
+              ;; Sum only over the trailing event axes so a leading particle axis
+              ;; survives in batched mode: [...mu]->scalar, [N,...mu]->[N]. Summing
+              ;; over ALL axes collapsed the particle axis to a scalar and
+              ;; corrupted per-particle weights (genmlx-lgun); cf. gaussian-vec.
+              (if (pos? k)
+                (mx/sum lp (vec (range (- k) 0)))
+                lp)))
   (reparam [key]
            (let [sh (mx/shape mu)]
              (mx/add mu (mx/multiply sigma (rng/normal key sh))))))

--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -204,6 +204,11 @@
       (:has-branches? schema) false
       (:dynamic-addresses? schema) false
       (:has-loops? schema) false
+      ;; Opaque-escape bodies have hidden trace sites the walker never recorded,
+      ;; so fast-eligibility cannot be proven (a hidden structure change or
+      ;; interdependent hidden site would mis-weight or throw). Force the general
+      ;; retained-only path (genmlx-9yuw).
+      (:opaque-gen-escape? schema) false
       :else
       ;; Only the parent's DIRECT trace sites are checked here. Spliced
       ;; sub-gfs recurse through p/regenerate and gate themselves; a parent
@@ -732,7 +737,16 @@
           ;; scores consistently. Stable (no-reopen) moves keep the fast path.
           (when (and (:auto-regenerate-transition schema)
                      (= :marginal (tr/score-type (:trace opts)))
-                     (not (regen-reopens-analytical? schema (:selection opts))))
+                     (not (regen-reopens-analytical? schema (:selection opts)))
+                     ;; The analytical fast per-site weight
+                     ;; (new-score − old-score − proposal-ratio) is exact ONLY
+                     ;; for fast-eligible selections; for interdependent residual
+                     ;; selections it mis-weights, and the compiled dispatcher's
+                     ;; fast-eligible guard sits AFTER this one in the stack — so
+                     ;; gate here too, declining to the handler general
+                     ;; retained-only path otherwise (genmlx-9yuw).
+                     (:selection opts)
+                     (regen-fast-eligible? (:gf opts) (:selection opts)))
             {:run run-fn :score-type :marginal :label :analytical})
 
           :update

--- a/src/genmlx/inference/adev.cljs
+++ b/src/genmlx/inference/adev.cljs
@@ -171,14 +171,17 @@
 
 (defn vadev-gradient
   "Compute ADEV gradient via vectorized execution (single model body call).
-   opts: {:n-samples N} — batch size (default 100).
+   opts: {:n-samples N :baseline b} — batch size (default 100), and an
+   optional variance-reduction baseline forwarded to vadev-surrogate (the
+   default vectorized path otherwise silently ignores :baseline-decay —
+   genmlx-9rwf). A control-variate baseline does not bias the gradient.
    Returns {:loss MLX-scalar, :grad MLX-array}."
-  [{:keys [n-samples] :or {n-samples 100}} gf args cost-fn param-names params-array]
+  [{:keys [n-samples baseline] :or {n-samples 100}} gf args cost-fn param-names params-array]
   (let [loss-fn (fn [p]
                   (let [store {:params (learn/array->params p param-names)}
                         gf' (vary-meta gf assoc :genmlx.dynamic/param-store store)
                         key (rng/fresh-key)]
-                    (vadev-surrogate gf' args cost-fn n-samples key)))
+                    (vadev-surrogate gf' args cost-fn n-samples key baseline)))
         vg (mx/value-and-grad loss-fn)
         [loss grad] (vg params-array)]
     {:loss loss :grad grad}))
@@ -232,7 +235,7 @@
         {:params params :loss-history (persistent! losses)}
         (let [{:keys [loss grad]}
               (if use-vectorized?
-                (vadev-gradient {:n-samples n-samples}
+                (vadev-gradient {:n-samples n-samples :baseline baseline}
                                 gf args cost-fn param-names params)
                 (adev-gradient {:n-samples n-samples :baseline baseline}
                                gf args cost-fn param-names params))

--- a/src/genmlx/inference/auto_analytical.cljs
+++ b/src/genmlx/inference/auto_analytical.cljs
@@ -668,7 +668,9 @@
    so two priors claiming one obs would silently mis-marginalize, genmlx-b470).
    Returns a merged map of {addr handler-fn} for all conjugate sites."
   [conjugate-pairs]
-  (let [grouped (conj/group-by-prior (conj/drop-multi-parent-pairs conjugate-pairs))]
+  (let [grouped (conj/group-by-prior
+                 (conj/drop-mixed-family-priors
+                  (conj/drop-multi-parent-pairs conjugate-pairs)))]
     (reduce
      (fn [handlers [prior-addr pairs]]
        (let [family (:family (first pairs))
@@ -717,7 +719,9 @@
    Multi-parent obs pairs are dropped first (see build-auto-handlers).
    Returns a merged map of {addr handler-fn}."
   [conjugate-pairs]
-  (let [grouped (conj/group-by-prior (conj/drop-multi-parent-pairs conjugate-pairs))]
+  (let [grouped (conj/group-by-prior
+                 (conj/drop-mixed-family-priors
+                  (conj/drop-multi-parent-pairs conjugate-pairs)))]
     (reduce
      (fn [handlers [prior-addr pairs]]
        (let [family (:family (first pairs))
@@ -795,7 +799,9 @@
    are skipped — callers must decline the analytical-update path for models that
    contain them. Returns a merged map of {addr handler-fn}."
   [conjugate-pairs]
-  (let [grouped (conj/group-by-prior (conj/drop-multi-parent-pairs conjugate-pairs))]
+  (let [grouped (conj/group-by-prior
+                 (conj/drop-mixed-family-priors
+                  (conj/drop-multi-parent-pairs conjugate-pairs)))]
     (reduce
      (fn [handlers [prior-addr pairs]]
        (let [family (:family (first pairs))

--- a/src/genmlx/inference/fisher.cljs
+++ b/src/genmlx/inference/fisher.cljs
@@ -193,7 +193,16 @@
 
    Returns {:log-evidence scalar, :log-ml scalar, :log-det-fisher scalar}."
   [{:keys [fisher log-ml]} D]
-  (let [{:keys [L added-damping]} (robust-cholesky fisher D default-cholesky-schedule)
+  (let [chol (robust-cholesky fisher D default-cholesky-schedule)
+        ;; robust-cholesky returns nil when EVERY damping attempt fails (it uses
+        ;; `some`); destructuring nil left L=nil and crashed opaquely in
+        ;; (mx/diag nil). Fail with a clear diagnostic instead (genmlx-alxa).
+        _ (when-not chol
+            (throw (ex-info (str "laplace-log-evidence: Fisher information is not "
+                                 "positive-definite even after maximal damping "
+                                 "(near-singular or NaN Fisher) — cannot compute log|F|")
+                            {:D D})))
+        {:keys [L added-damping]} chol
         log-det (log-det-via-cholesky L)
         _ (mx/materialize! log-det)
         log-ml-val (mx/item log-ml)

--- a/src/genmlx/inference/mcmc.cljs
+++ b/src/genmlx/inference/mcmc.cljs
@@ -2431,11 +2431,16 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- compute-u-turn?
-  "Check NUTS U-turn criterion."
-  [q-minus q-plus p-minus p-plus]
+  "Check NUTS U-turn criterion. The criterion uses the VELOCITY v = M^{-1} p, not
+   raw momentum, so it is correct under a non-identity mass matrix (:metric /
+   :adapt-metric); for the identity metric M^{-1}p = p and this is unchanged
+   (genmlx-o78h)."
+  [q-minus q-plus p-minus p-plus metric]
   (let [diff (mx/subtract q-plus q-minus)
-        check-fwd (mx/sum (mx/multiply diff p-plus))
-        check-bwd (mx/sum (mx/multiply diff p-minus))]
+        v-plus (inv-mass-multiply p-plus metric)
+        v-minus (inv-mass-multiply p-minus metric)
+        check-fwd (mx/sum (mx/multiply diff v-plus))
+        check-bwd (mx/sum (mx/multiply diff v-minus))]
     ;; Break lazy graph — dot products needed as JS numbers for U-turn check
     (mx/materialize! check-fwd check-bwd)
     (and (>= (mx/item check-fwd) 0)
@@ -2480,7 +2485,7 @@
               q-plus (if (pos? v) (:q-plus tree2) (:q-plus tree1))
               p-plus (if (pos? v) (:p-plus tree2) (:p-plus tree1))
               s' (and (:s' tree2)
-                      (compute-u-turn? q-minus q-plus p-minus p-plus))]
+                      (compute-u-turn? q-minus q-plus p-minus p-plus (:metric ctx)))]
           {:q-minus q-minus :p-minus p-minus
            :q-plus q-plus :p-plus p-plus
            :q' q' :n' total-n :s' s'
@@ -2572,7 +2577,7 @@
                                    qp' (if (pos? v) (:q-plus tree) q-plus)
                                    pp' (if (pos? v) (:p-plus tree) p-plus)
                                    cont? (and (:s' tree)
-                                              (compute-u-turn? qm' qp' pm' pp'))]
+                                              (compute-u-turn? qm' qp' pm' pp' (:metric local-ctx)))]
                                (recur (inc j) qm' pm' qp' pp' q''
                                       (+ depth-n (:n' tree)) cont?
                                       (+ total-alpha (:alpha tree))
@@ -2633,7 +2638,7 @@
                                   qp' (if (pos? v) (:q-plus tree) q-plus)
                                   pp' (if (pos? v) (:p-plus tree) p-plus)
                                   cont? (and (:s' tree)
-                                             (compute-u-turn? qm' qp' pm' pp'))]
+                                             (compute-u-turn? qm' qp' pm' pp' (:metric ctx)))]
                               (recur (inc j) qm' pm' qp' pp' q''
                                      (+ depth-n (:n' tree)) cont?
                                      dk-next tk-next))))]

--- a/src/genmlx/inference/smc.cljs
+++ b/src/genmlx/inference/smc.cljs
@@ -127,11 +127,16 @@
               (loop [i 0, cumsum 0.0, j 0, acc (transient [])]
                 (if (>= j n-resid)
                   (persistent! acc)
-                  (let [threshold (+ u (/ j n-resid))
-                        cumsum' (+ cumsum (nth resid-probs i))]
-                    (if (>= cumsum' threshold)
-                      (recur i cumsum (inc j) (conj! acc i))
-                      (recur (inc i) cumsum' j acc)))))]
+                  (if (>= i (count resid-probs))
+                    ;; Floating-point exhaustion: residual probs sum to <1.0;
+                    ;; fill remaining slots with the last particle (mirrors
+                    ;; u/systematic-resample — genmlx-vqh9).
+                    (persistent! (reduce conj! acc (repeat (- n-resid j) (dec (count resid-probs)))))
+                    (let [threshold (+ u (/ j n-resid))
+                          cumsum' (+ cumsum (nth resid-probs i))]
+                      (if (>= cumsum' threshold)
+                        (recur i cumsum (inc j) (conj! acc i))
+                        (recur (inc i) cumsum' j acc))))))]
         (into det-indices resid-indices)))))
 
 (defn- stratified-resample
@@ -148,11 +153,16 @@
     (loop [i 0, cumsum 0.0, j 0, indices (transient [])]
       (if (>= j n)
         (persistent! indices)
-        (let [threshold (nth uniforms j)
-              cumsum' (+ cumsum (nth probs i))]
-          (if (>= cumsum' threshold)
-            (recur i cumsum (inc j) (conj! indices i))
-            (recur (inc i) cumsum' j indices)))))))
+        (if (>= i (count probs))
+          ;; Floating-point exhaustion: probs sum to <1.0 due to rounding; fill
+          ;; remaining strata with the last particle (mirrors
+          ;; u/systematic-resample — genmlx-vqh9). Avoids an out-of-bounds nth.
+          (persistent! (reduce conj! indices (repeat (- n j) (dec (count probs)))))
+          (let [threshold (nth uniforms j)
+                cumsum' (+ cumsum (nth probs i))]
+            (if (>= cumsum' threshold)
+              (recur i cumsum (inc j) (conj! indices i))
+              (recur (inc i) cumsum' j indices))))))))
 
 (defn- dispatch-resample
   "Dispatch to the appropriate resampling method.

--- a/src/genmlx/inference/smcp3.cljs
+++ b/src/genmlx/inference/smcp3.cljs
@@ -15,6 +15,14 @@
             [genmlx.inference.smc :as smc]
             [genmlx.inference.util :as u]))
 
+(defn- rekey
+  "Give gf a deterministic per-particle PRNG key pk for reproducibility, or
+   auto-key when pk is nil (no seed supplied). Threading these keys is what makes
+   SMCP3 reproducible under a fixed :key — previously the proposals/models were
+   only ever auto-keyed, drawing fresh global entropy (genmlx-ivs0)."
+  [gf pk]
+  (when gf (if pk (dyn/with-key gf pk) (dyn/auto-key gf))))
+
 
 ;; ---------------------------------------------------------------------------
 ;; SMCP3 init step
@@ -31,27 +39,30 @@
 
    Returns {:traces :log-weights :log-ml-increment}"
   [model args observations proposal-gf particles key]
-  (let [model (-> model dyn/auto-key smc/strip-analytical)
-        proposal-gf (when proposal-gf (dyn/auto-key proposal-gf))
+  (let [model (smc/strip-analytical model)
+        pkeys (rng/split-n-or-nils key particles)
         results (mapv
-                  (fn [_]
-                    (if proposal-gf
-                      ;; Use proposal to generate initial choices
-                      (let [{proposal-choices :choices proposal-score :weight}
-                            (p/propose proposal-gf [])
-                            ;; Merge proposal choices with observations
-                            merged (cm/merge-cm proposal-choices observations)
-                            ;; Generate model trace with merged constraints
-                            {:keys [trace weight]} (p/generate model args merged)
-                            ;; Importance weight = model-weight - proposal-score
-                            iw (mx/subtract weight proposal-score)]
-                        (mx/materialize! iw (:score trace))
-                        {:trace trace :weight iw})
-                      ;; No proposal: standard importance sampling
-                      (let [r (p/generate model args observations)]
-                        (mx/materialize! (:weight r) (:score (:trace r)))
-                        r)))
-                  (range particles))
+                  (fn [pk]
+                    (let [[kp kg] (rng/split-n-or-nils pk 2)
+                          model (rekey model kg)
+                          proposal-gf (rekey proposal-gf kp)]
+                      (if proposal-gf
+                        ;; Use proposal to generate initial choices
+                        (let [{proposal-choices :choices proposal-score :weight}
+                              (p/propose proposal-gf [])
+                              ;; Merge proposal choices with observations
+                              merged (cm/merge-cm proposal-choices observations)
+                              ;; Generate model trace with merged constraints
+                              {:keys [trace weight]} (p/generate model args merged)
+                              ;; Importance weight = model-weight - proposal-score
+                              iw (mx/subtract weight proposal-score)]
+                          (mx/materialize! iw (:score trace))
+                          {:trace trace :weight iw})
+                        ;; No proposal: standard importance sampling
+                        (let [r (p/generate model args observations)]
+                          (mx/materialize! (:weight r) (:score (:trace r)))
+                          r))))
+                  pkeys)
         traces (mapv :trace results)
         log-weights (mapv :weight results)
         w-arr (u/materialize-weights log-weights)
@@ -100,41 +111,47 @@
                                 (vec (repeat particles (mx/scalar 0.0)))])
                              [traces log-weights])
         obs-empty? (empty? (cm/addresses observations))
+        ;; Per-particle keys derived from the step-key so the per-particle
+        ;; proposal/update sampling is reproducible under a fixed seed
+        ;; (genmlx-ivs0); rekey falls back to auto-key when no seed is given.
+        pkeys (rng/split-n-or-nils step-key particles)
         ;; Apply forward kernel to each particle via edit
         results (mapv
-                  (fn [trace]
-                    (if forward-kernel
-                      ;; Use proposal edit
-                      (if backward-kernel
-                        ;; Apply the observations first — the proposal edit
-                        ;; only applies the forward kernel's choices, so
-                        ;; without this step the observations never reach the
-                        ;; trace. Doing it before the edit lets the forward
-                        ;; kernel condition on them (locally-optimal
-                        ;; proposals). Weights compose additively.
-                        (let [obs-result (when-not obs-empty?
-                                           (p/update (:gen-fn trace) trace observations))
-                              trace1 (if obs-result (:trace obs-result) trace)
-                              edit-req (edit/proposal-edit forward-kernel backward-kernel)
-                              {:keys [trace weight]} (edit/edit (:gen-fn trace1) trace1 edit-req)
-                              weight (if obs-result
-                                       (mx/add (:weight obs-result) weight)
-                                       weight)]
+                  (fn [trace pk]
+                    (let [[k-obs k-fwd k-upd] (rng/split-n-or-nils pk 3)]
+                      (if forward-kernel
+                        ;; Use proposal edit
+                        (if backward-kernel
+                          ;; Apply the observations first — the proposal edit
+                          ;; only applies the forward kernel's choices, so
+                          ;; without this step the observations never reach the
+                          ;; trace. Doing it before the edit lets the forward
+                          ;; kernel condition on them (locally-optimal
+                          ;; proposals). Weights compose additively.
+                          (let [obs-result (when-not obs-empty?
+                                             (p/update (rekey (:gen-fn trace) k-obs) trace observations))
+                                trace1 (if obs-result (:trace obs-result) trace)
+                                ;; only the forward kernel samples; backward only scores
+                                edit-req (edit/proposal-edit (rekey forward-kernel k-fwd) backward-kernel)
+                                {:keys [trace weight]} (edit/edit (rekey (:gen-fn trace1) k-upd) trace1 edit-req)
+                                weight (if obs-result
+                                         (mx/add (:weight obs-result) weight)
+                                         weight)]
+                            (mx/materialize! weight)
+                            {:trace trace :weight weight})
+                          ;; Without backward kernel, fall back to constraint update.
+                          ;; This changes weight semantics: no backward/forward proposal
+                          ;; correction is applied — weight is pure update weight only.
+                          (let [{:keys [trace weight]}
+                                (edit/edit (rekey (:gen-fn trace) k-upd) trace
+                                           (edit/constraint-edit observations))]
+                            (mx/materialize! weight)
+                            {:trace trace :weight weight}))
+                        ;; Standard update
+                        (let [{:keys [trace weight]} (p/update (rekey (:gen-fn trace) k-upd) trace observations)]
                           (mx/materialize! weight)
-                          {:trace trace :weight weight})
-                        ;; Without backward kernel, fall back to constraint update.
-                        ;; This changes weight semantics: no backward/forward proposal
-                        ;; correction is applied — weight is pure update weight only.
-                        (let [{:keys [trace weight]}
-                              (edit/edit (:gen-fn trace) trace
-                                         (edit/constraint-edit observations))]
-                          (mx/materialize! weight)
-                          {:trace trace :weight weight}))
-                      ;; Standard update
-                      (let [{:keys [trace weight]} (p/update (:gen-fn trace) trace observations)]
-                        (mx/materialize! weight)
-                        {:trace trace :weight weight})))
-                  traces')
+                          {:trace trace :weight weight}))))
+                  traces' pkeys)
         new-traces (mapv :trace results)
         update-weights (mapv :weight results)
         new-weights (mapv mx/add weights' update-weights)

--- a/src/genmlx/inference/translator.cljs
+++ b/src/genmlx/inference/translator.cljs
@@ -249,7 +249,12 @@
             {:keys [trace weight]} (apply-translator translator current-trace
                                                      (or args2 (:args current-trace)) k-app)
             n-prop (count (applicable-moves moves trace))
-            corr (if (pos? n-prop) (- (js/Math.log n-cur) (js/Math.log n-prop)) 0.0)
+            ;; If the proposed state has no applicable moves the reverse move is
+            ;; unselectable (reverse prob 0), so the Hastings ratio is 0 and the
+            ;; move MUST be rejected; corr = log(n-cur) - log(0) = +Inf in the
+            ;; denominator, i.e. -Inf correction (genmlx-jtou). corr=0 here could
+            ;; wrongly accept and break detailed balance.
+            corr (if (pos? n-prop) (- (js/Math.log n-cur) (js/Math.log n-prop)) ##-Inf)
             log-w (+ (mx/realize weight) corr)
             accept? (u/accept-mh? log-w k-acc)]
         {:trace (if accept? trace current-trace) :accepted? accept? :move i}))))
@@ -333,14 +338,22 @@
          :log-ml (+ log-ml (logmeanexp-js (mapv :lw parts)))}
         (let [;; normalise + (optionally) resample before bridging to the next model
               lws (mapv :lw parts)
-              lme (logmeanexp-js lws)
               [k-res rk1] (rng/split rk)
-              parts' (if resample?
-                       ;; systematic-resample takes MLX log-weight scalars; our
-                       ;; lws are realized JS numbers, so box them.
-                       (let [idxs (u/systematic-resample (mapv mx/scalar lws) n k-res)]
-                         (mapv (fn [j] {:trace (:trace (nth parts j)) :lw 0.0}) idxs))
-                       parts)
+              ;; The SMC log-Z increment (logmeanexp over the current weights) is
+              ;; only valid when paired with a weight RESET — i.e. when a resample
+              ;; actually happens. Without resampling, weights accumulate and a
+              ;; SINGLE terminal logmeanexp over the fully-accumulated weights is
+              ;; the unbiased single-path IS estimate; adding a per-stage
+              ;; increment too would double-count (genmlx-jtou).
+              [parts' log-ml']
+              (if resample?
+                ;; systematic-resample takes MLX log-weight scalars; our lws are
+                ;; realized JS numbers, so box them. Reset weights to 0 and bank
+                ;; the normaliser increment.
+                (let [idxs (u/systematic-resample (mapv mx/scalar lws) n k-res)]
+                  [(mapv (fn [j] {:trace (:trace (nth parts j)) :lw 0.0}) idxs)
+                   (+ log-ml (logmeanexp-js lws))])
+                [parts log-ml])
               ;; bridge every particle to the next model via the translator
               tt (nth translators stage)
               keysT (rng/split-n rk1 (inc n))
@@ -351,4 +364,4 @@
                                                       (nth keysT j))]
                                 {:trace t2 :lw (+ lw (mx/realize w))}))
                             (range n))]
-          (recur (inc stage) bridged (+ log-ml lme) (nth keysT n)))))))
+          (recur (inc stage) bridged log-ml' (nth keysT n)))))))

--- a/src/genmlx/inference/vi.cljs
+++ b/src/genmlx/inference/vi.cljs
@@ -311,21 +311,28 @@
           log-k (mx/scalar (js/Math.log k))
           ;; IWELBO estimate: L̂ = logsumexp(log_w) - log(K)
           l-hat (mx/subtract (mx/logsumexp log-w) log-k)
-          ;; Leave-one-out geometric means:
-          ;; loo_mean_k = (sum(log_w) - log_w_k) / (K-1)
-          loo-mean (mx/divide (mx/subtract (mx/sum log-w) log-w)
-                              (mx/scalar (dec k)))
-          ;; Build [K,K] matrix: row k has all log_w values,
-          ;; with diagonal (k,k) replaced by loo_mean_k
-          off-diag (mx/broadcast-to (mx/reshape log-w [1 k]) [k k])
-          loo-bcast (mx/broadcast-to (mx/reshape loo-mean [k 1]) [k k])
-          loo-matrix (mx/where (mx/eye k) loo-bcast off-diag)
-          ;; Baselines: L̂_{-k} = logsumexp(loo_matrix[k,:]) - log(K)
-          baselines (mx/subtract (mx/logsumexp loo-matrix [1]) log-k)
-          ;; REINFORCE signal with leave-one-out baseline
-          signal (mx/stop-gradient (mx/subtract l-hat baselines))
-          reinforce-term (mx/mean (mx/multiply signal log-q))]
-      ;; Surrogate loss: gradient equals VIMCO estimator
+          ;; REINFORCE score-function term with leave-one-out control
+          ;; variates. It must be SUMMED over the K samples so its scale
+          ;; matches l-hat's direct term, whose autodiff gradient is the full
+          ;; sum Σ_k w̃_k ∇log_w_k; averaging would make this term K× too small
+          ;; and mis-scale the two halves of the gradient (genmlx-9rwf).
+          ;; VIMCO needs K>1 — for K=1 the leave-one-out mean divides by zero,
+          ;; so the score term is 0 (single-sample IWELBO).
+          reinforce-term
+          (if (> k 1)
+            (let [;; loo_mean_k = (sum(log_w) - log_w_k) / (K-1)
+                  loo-mean (mx/divide (mx/subtract (mx/sum log-w) log-w)
+                                      (mx/scalar (dec k)))
+                  ;; [K,K] matrix: row k = all log_w, diagonal replaced by loo_mean_k
+                  off-diag (mx/broadcast-to (mx/reshape log-w [1 k]) [k k])
+                  loo-bcast (mx/broadcast-to (mx/reshape loo-mean [k 1]) [k k])
+                  loo-matrix (mx/where (mx/eye k) loo-bcast off-diag)
+                  ;; baselines: L̂_{-k} = logsumexp(loo_matrix[k,:]) - log(K)
+                  baselines (mx/subtract (mx/logsumexp loo-matrix [1]) log-k)
+                  signal (mx/stop-gradient (mx/subtract l-hat baselines))]
+              (mx/sum (mx/multiply signal log-q)))
+            (mx/scalar 0.0))]
+      ;; Surrogate loss: gradient equals the VIMCO estimator
       (mx/add l-hat reinforce-term))))
 
 (defn- per-sample-objective

--- a/src/genmlx/llm/grammar.cljs
+++ b/src/genmlx/llm/grammar.cljs
@@ -125,9 +125,15 @@
                        (= q :opt)   [:alt node [:empty]]
                        (vector? q)  (let [[_ lo hi] q
                                           required (repeat lo node)
-                                          optional (repeat (- hi lo) [:alt node [:empty]])]
-                                      (reduce (fn [a b] [:cat a b])
-                                              (concat required optional)))))
+                                          optional (repeat (- hi lo) [:alt node [:empty]])
+                                          parts (concat required optional)]
+                                      (if (seq parts)
+                                        (reduce (fn [a b] [:cat a b]) parts)
+                                        ;; a{0} / a{0,0}: zero copies — matches the
+                                        ;; empty string for this atom. Without this
+                                        ;; (reduce ... ()) returned nil and crashed
+                                        ;; NFA construction (genmlx-abw8).
+                                        [:empty]))))
        :cat        (fn [& items]
                      (if (= 1 (count items))
                        (first items)

--- a/src/genmlx/program.cljs
+++ b/src/genmlx/program.cljs
@@ -307,12 +307,16 @@
 (defn- vsub [a b] (mapv - a b))
 
 (defn- mat-lu-solve
-  "Solve Ax = b via Gaussian elimination with partial pivoting. A is p*p, b is p-vector."
+  "Solve Ax = b via Gaussian elimination with partial pivoting. A is p*p, b is
+   p-vector. Returns nil when A is SINGULAR (a near-zero pivot remains): the old
+   early-exit left that zero on the diagonal and back-substitution divided by it,
+   producing Inf/NaN that silently poisoned downstream estimates (genmlx-alxa).
+   Callers must handle nil."
   [A b]
   (let [p (count b)
-        aug (vec (for [i (range p)]
-                   (conj (vec (nth A i)) (nth b i))))
-        aug (loop [k 0, aug aug]
+        aug0 (vec (for [i (range p)]
+                    (conj (vec (nth A i)) (nth b i))))
+        aug (loop [k 0, aug aug0]
               (if (>= k p) aug
                   (let [pivot-row (apply max-key
                                          (fn [i] (js/Math.abs (get-in aug [i k])))
@@ -323,7 +327,7 @@
                                       (assoc pivot-row tmp))))
                         pivot-val (get-in aug [k k])]
                     (if (< (js/Math.abs pivot-val) 1e-15)
-                      aug
+                      ::singular
                       (recur (inc k)
                              (reduce (fn [aug i]
                                        (let [factor (/ (get-in aug [i k]) pivot-val)]
@@ -335,12 +339,13 @@
                                                  (range k (inc p)))))
                                      aug
                                      (range (inc k) p)))))))]
-    (loop [k (dec p), x (vec (repeat p 0.0))]
-      (if (< k 0) x
-          (let [sum (reduce + (map (fn [j] (* (get-in aug [k j]) (nth x j)))
-                                   (range (inc k) p)))
-                x-k (/ (- (get-in aug [k p]) sum) (get-in aug [k k]))]
-            (recur (dec k) (assoc x k x-k)))))))
+    (when-not (= aug ::singular)
+      (loop [k (dec p), x (vec (repeat p 0.0))]
+        (if (< k 0) x
+            (let [sum (reduce + (map (fn [j] (* (get-in aug [k j]) (nth x j)))
+                                     (range (inc k) p)))
+                  x-k (/ (- (get-in aug [k p]) sum) (get-in aug [k k]))]
+              (recur (dec k) (assoc x k x-k))))))))
 
 (defn- mat-log-det
   "Log absolute determinant of a p*p matrix via Gaussian elimination."
@@ -416,15 +421,20 @@
                    (* s s)
                    (if (<= n p)
                      1.0
-                     (let [beta-hat (mat-lu-solve gram Xty)
-                           Xbeta-y (reduce + (map * beta-hat Xty))
-                           rss (- (get yty target) Xbeta-y)]
-                       (/ (max rss 0.001) n))))
+                     (if-let [beta-hat (mat-lu-solve gram Xty)]
+                       (let [Xbeta-y (reduce + (map * beta-hat Xty))
+                             rss (- (get yty target) Xbeta-y)]
+                         (/ (max rss 0.001) n))
+                       ;; Singular Gram (constant / collinear predictor) — no OLS
+                       ;; estimate; fall back like the n<=p case (genmlx-alxa).
+                       1.0)))
         M (vec (for [i (range p)]
                  (vec (for [j (range p)]
                         (+ (get-in gram [i j])
                            (if (= i j) (/ sigma-sq (nth s0 i)) 0))))))
-        Minv-Xtr (mat-lu-solve M Xtr)
+        ;; M is gram + positive diagonal (sigma/s0 > 0) so it is PD and
+        ;; non-singular; guard defensively against nil (genmlx-alxa).
+        Minv-Xtr (or (mat-lu-solve M Xtr) (vec (repeat p 0.0)))
         quad-corr (reduce + (map * Xtr Minv-Xtr))
         A (vec (for [i (range p)]
                  (vec (for [j (range p)]

--- a/src/genmlx/rewrite.cljs
+++ b/src/genmlx/rewrite.cljs
@@ -176,11 +176,14 @@
         ;; Group remaining conjugate pairs by prior (excluding claimed addrs).
         ;; Multi-parent obs (one obs claimed by several priors) have no correct
         ;; scalar elimination — drop those pairs entirely (genmlx-b470).
-        remaining-pairs (conj-detect/drop-multi-parent-pairs
-                         (vec (remove (fn [p]
-                                        (or (contains? claimed (:prior-addr p))
-                                            (contains? claimed (:obs-addr p))))
-                                      conjugate-pairs)))
+        ;; Decline priors conjugate to >1 obs family (no correct single-family
+        ;; scalar elimination — genmlx-1thx) in addition to multi-parent obs.
+        remaining-pairs (conj-detect/drop-mixed-family-priors
+                         (conj-detect/drop-multi-parent-pairs
+                          (vec (remove (fn [p]
+                                         (or (contains? claimed (:prior-addr p))
+                                             (contains? claimed (:obs-addr p))))
+                                       conjugate-pairs))))
         grouped (group-by :prior-addr remaining-pairs)
 
         ;; One pass over grouped priors: compute non-conjugate children once and

--- a/src/genmlx/schema.cljs
+++ b/src/genmlx/schema.cljs
@@ -242,6 +242,21 @@
   [acc env forms]
   (reduce (fn [acc form] (walk-form acc env form)) acc forms))
 
+(defn- bare-trace-alias-addr
+  "If `val-form` is a bare trace call to a static (keyword) address —
+   (trace :addr <dist> ...) — return that address keyword, else nil. Recorded
+   under env's ::arg-aliases so conjugacy classification can tell a DIRECT
+   binding (mu = (trace :mu ...)) from an affine REBINDING that reuses the
+   symbol name (mu = (mx/add mu 5)) — the latter must not classify :direct
+   (genmlx-1thx). Also lets a direct alias with a non-matching name (m =
+   (trace :mu ...)) be recognized as direct."
+  [val-form]
+  (when (and (seq? val-form) (seq val-form)
+             (symbol? (first val-form))
+             (= "trace" (name (first val-form)))
+             (keyword? (second val-form)))
+    (second val-form)))
+
 (defn- handle-trace [acc env args]
   (let [addr-form (first args)
         dist-form (second args)
@@ -259,6 +274,9 @@
                                    :dist-type dist-type
                                    :dist-args (or dist-args [])
                                    :deps deps
+                                   ;; direct trace-alias provenance for dist-arg
+                                   ;; symbols (genmlx-1thx)
+                                   :arg-aliases (or (::arg-aliases env) {})
                                    :static? static?})
         (cond-> (not static?) (assoc :dynamic-addresses? true)))))
 
@@ -305,16 +323,31 @@
                                sym-deps (into (compute-deps env val-form)
                                               (trace-addrs-in val-form))]
                            (if (symbol? sym)
-                             [acc' (if (seq sym-deps)
-                                     (assoc env sym sym-deps)
-                                     env)]
+                             ;; Maintain direct trace-alias provenance: record
+                             ;; sym -> :addr when bound directly to (trace :addr
+                             ;; ...), and clear it on any rebinding so an affine
+                             ;; reuse of the name is not mistaken for a direct
+                             ;; natural parameter (genmlx-1thx).
+                             (let [env1 (if (seq sym-deps) (assoc env sym sym-deps) env)
+                                   alias-addr (bare-trace-alias-addr val-form)
+                                   env2 (cond
+                                          alias-addr (assoc-in env1 [::arg-aliases sym] alias-addr)
+                                          (get-in env1 [::arg-aliases sym]) (update env1 ::arg-aliases dissoc sym)
+                                          :else env1)]
+                               [acc' env2])
                              ;; Destructuring binding — conservatively give
                              ;; every bound symbol the full deps of the value
-                             ;; form (over-approximation keeps dep edges).
-                             [acc' (if (seq sym-deps)
-                                     (reduce (fn [e s] (assoc e s sym-deps))
-                                             env (find-symbols sym))
-                                     env)])))
+                             ;; form (over-approximation keeps dep edges), and
+                             ;; clear any aliases for the bound symbols.
+                             (let [env1 (if (seq sym-deps)
+                                          (reduce (fn [e s] (assoc e s sym-deps))
+                                                  env (find-symbols sym))
+                                          env)
+                                   env2 (if (::arg-aliases env1)
+                                          (update env1 ::arg-aliases
+                                                  #(apply dissoc % (find-symbols sym)))
+                                          env1)]
+                               [acc' env2]))))
                        [acc env]
                        (or pairs []))]
       (walk-forms acc' env' body))))

--- a/src/genmlx/schemas.cljs
+++ b/src/genmlx/schemas.cljs
@@ -186,14 +186,21 @@
    [:dist-type keyword?]
    [:dist-args vector?]
    [:deps set?]
+   ;; direct trace-alias provenance for dist-arg symbols (schema.cljs, genmlx-1thx)
+   [:arg-aliases {:optional true} map?]
    [:static? boolean?]])
 
 (def SpliceSite
-  "One splice site extracted from a gen body."
+  "One splice site extracted from a gen body (matches schema.cljs/handle-splice:
+   :addr :addr-form :gf-form :splice-args :deps :static? — there is no :gf-sym
+   key anywhere; the real key is :gf-form, genmlx-flmw)."
   [:map
    [:addr some?]
-   [:gf-sym some?]
-   [:deps set?]])
+   [:addr-form some?]
+   [:gf-form some?]
+   [:splice-args vector?]
+   [:deps set?]
+   [:static? boolean?]])
 
 (def ModelSchema
   "[T] section 2.2.2 denotational semantics. Output of schema/extract-schema,

--- a/src/genmlx/vmap.cljs
+++ b/src/genmlx/vmap.cljs
@@ -330,11 +330,17 @@
           choices (stack-choices (mapv (comp :choices :trace) results))
           retvals (stack-retvals (mapv (comp :retval :trace) results))
           score (mx-sum-by (comp :score :trace) results)
-          ;; Regenerate weights are additive across independent elements, but
-          ;; each element weight was computed against the constructed old score
-          ;; (recorded element score, or 0 without metadata). Re-base against
-          ;; the true total old score so both cases stay exact:
-          ;; W = Σ w_i + Σ constructed_old_i - old_total.
+          ;; Regenerate weights are additive across independent elements, but each
+          ;; element weight was computed against the constructed old score
+          ;; (recorded element score, or 0 without metadata). Re-base against the
+          ;; true total old score. NOTE (genmlx-nt0c): this is exact when
+          ;; ::element-scores is present (the re-base term is 0 — every vmap-produced
+          ;; trace carries it, so both fast and general kernel paths are correct),
+          ;; and also for FAST-path kernels when it is absent (e.g. the nested-vmap
+          ;; reconstructed inner trace: −old_total exactly compensates). The one
+          ;; unsound case is a GENERAL retained-only kernel weight on a trace whose
+          ;; ::element-scores were externally dropped — a project-based weight is
+          ;; not linear in the element :score; callers must keep the metadata.
           constructed-old (if old-element-scores
                             (reduce mx/add (mx/scalar 0.0) old-element-scores)
                             (mx/scalar 0.0))

--- a/test/genmlx/hardening_sweep_2026_06_14_test.cljs
+++ b/test/genmlx/hardening_sweep_2026_06_14_test.cljs
@@ -1,0 +1,287 @@
+;; @tier fast
+(ns genmlx.hardening-sweep-2026-06-14-test
+  "Independent-oracle regression tests for the 2026-06-14 foundation hardening
+   sweep (epic genmlx-bjcq). Each block pins a bug found by the static bug-hunt
+   to a closed-form / handler-parity oracle so the fix can never silently
+   regress. One section per child bean, labelled with its id.
+
+   No models are loaded; all LLM-layer findings are tracked elsewhere."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.dist :as dist]
+            [genmlx.dist.core :as dc]
+            [genmlx.dynamic :as dyn]
+            [genmlx.combinators :as comb]
+            [genmlx.inference.smcp3 :as smcp3]
+            [genmlx.inference.vi :as vi]
+            [genmlx.llm.grammar :as grammar]
+            [genmlx.agents.biased-planners :as bp]
+            [genmlx.test-helpers :as h])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(defn- v-at [trace addr]
+  (mx/item (cm/get-value (cm/get-submap (:choices trace) addr))))
+
+;; ===========================================================================
+;; genmlx-abw8 (C26) — {0}/{0,0} repeat quantifier no longer crashes; matches ε
+;; ===========================================================================
+
+(deftest grammar-zero-repeat-quantifier
+  (testing "a{0}b compiles and is equivalent to b (the atom matches empty)"
+    (let [dfa (grammar/compile-regex "a{0}b")]
+      (is (grammar/dfa-accepts? dfa "b") "a{0}b accepts \"b\"")
+      (is (not (grammar/dfa-accepts? dfa "ab")) "a{0}b rejects \"ab\"")))
+  (testing "a{0,0}c compiles and is equivalent to c"
+    (let [dfa (grammar/compile-regex "a{0,0}c")]
+      (is (grammar/dfa-accepts? dfa "c") "a{0,0}c accepts \"c\"")
+      (is (not (grammar/dfa-accepts? dfa "aac")) "a{0,0}c rejects \"aac\"")))
+  (testing "non-zero repeats still work (no regression)"
+    (let [dfa (grammar/compile-regex "a{2}")]
+      (is (grammar/dfa-accepts? dfa "aa"))
+      (is (not (grammar/dfa-accepts? dfa "a")))
+      (is (not (grammar/dfa-accepts? dfa "aaa"))))))
+
+;; ===========================================================================
+;; genmlx-lgun (C1) — broadcasted-normal batched log-prob keeps the particle axis
+;; ===========================================================================
+
+(deftest broadcasted-normal-batched-logprob
+  (testing "[N,D] batch -> [N] per-row log-prob (oracle: per-element gaussian-lp)"
+    (let [mu    [1.0 2.0 3.0]
+          sigma [0.5 0.7 1.0]
+          d     (dist/broadcasted-normal (mx/array mu) (mx/array sigma))
+          rows  [[1.0 2.0 3.0] [0.0 0.0 0.0]]
+          v     (mx/array rows)
+          lp    (dc/dist-log-prob d v)]
+      (is (= [2] (mx/shape lp)) "log-prob preserves the leading particle axis -> [N]")
+      (doseq [[i row] (map-indexed vector rows)]
+        (let [oracle (reduce + (map (fn [x m s] (h/gaussian-lp x m s)) row mu sigma))]
+          (is (h/close? oracle (mx/item (mx/index lp i)) 1e-4)
+              (str "row " i " log-prob = sum of per-element gaussian log-probs"))))))
+  (testing "scalar (unbatched) mode still collapses to a scalar"
+    (let [d  (dist/broadcasted-normal (mx/array [1.0 2.0 3.0]) (mx/array [0.5 0.7 1.0]))
+          lp (dc/dist-log-prob d (mx/array [1.0 2.0 3.0]))]
+      (is (= [] (mx/shape lp)) "unbatched [D] value -> scalar log-prob"))))
+
+;; ===========================================================================
+;; genmlx-lgun (C18) — geometric inverse-CDF cannot produce +Inf at the u=0 edge
+;; ===========================================================================
+
+(deftest geometric-u0-boundary
+  (testing "u=0 yields a finite k=0, not +Inf (inverse-CDF uses 1-u)"
+    (with-redefs [rng/uniform (fn [_key _shape] (mx/scalar 0.0))]
+      (let [g (dyn/auto-key (gen [] (trace :g (dist/geometric 0.3))))
+            t (p/simulate g [])
+            v (v-at t :g)]
+        (is (js/isFinite v) "geometric sample at u=0 is finite")
+        (is (= 0.0 v) "geometric sample at u=0 is k=0")))))
+
+;; ===========================================================================
+;; genmlx-zek9 — Mix combinator update/regenerate weight + key
+;; ===========================================================================
+
+;; Components carry an UNCONSTRAINED latent :m and an obs :x. :x is INDEPENDENT
+;; of :m (deliberately non-conjugate) so the components score with the joint
+;; generate semantics (weight = constrained sites only), not the L3 analytical
+;; marginal-weight path that a normal-normal pair would trigger.
+(def ^:private mix-a (dyn/auto-key (gen [] (let [m (trace :m (dist/gaussian 0.0 1.0))]
+                                             (trace :x (dist/gaussian 0.0 0.5))
+                                             m))))
+(def ^:private mix-b (dyn/auto-key (gen [] (let [m (trace :m (dist/gaussian 5.0 1.0))]
+                                             (trace :x (dist/gaussian 0.0 0.5))
+                                             m))))
+(def ^:private mix2 (comb/mix-combinator [mix-a mix-b]
+                                         (mx/array [(js/Math.log 0.5) (js/Math.log 0.5)])))
+
+(deftest mix-component-flip-update-weight
+  (testing "component-flip update weight excludes the fresh latent (oracle: score-delta - weight = log p(fresh m'))"
+    (let [c0  (-> cm/EMPTY
+                  (cm/set-choice [:component-idx] (mx/scalar 0 mx/int32))
+                  (cm/set-choice [:x] (mx/scalar 0.3)))
+          {t0 :trace} (p/generate mix2 [] c0)
+          ;; flip to component 1; keep x constrained, resample its latent m
+          c1  (-> cm/EMPTY
+                  (cm/set-choice [:component-idx] (mx/scalar 1 mx/int32))
+                  (cm/set-choice [:x] (mx/scalar 0.3)))
+          {t1 :trace w :weight} (p/update mix2 t0 c1)   ; must NOT throw (latent keyed)
+          m'  (v-at t1 :m)
+          score-delta (- (mx/item (:score t1)) (mx/item (:score t0)))
+          ;; fresh latent m' was drawn from component 1's prior N(5,1)
+          oracle (h/gaussian-lp m' 5.0 1.0)]
+      (is (h/close? oracle (- score-delta (mx/item w)) 1e-4)
+          "score(t')-score(t)-weight == log p(fresh latent under new component prior)")
+      ;; The pre-fix bug (weight = full new score) made this difference exactly 0.
+      (is (> (Math/abs (- score-delta (mx/item w))) 1e-3)
+          "weight is not the buggy full-score delta (which would give 0)"))))
+
+(deftest mix-index-regen-retains-inner
+  (testing "regenerate of :component-idx with one component retains the unselected inner choices, W=0"
+    (let [mix1 (comb/mix-combinator [mix-a] (mx/array [0.0]))
+          c0   (-> cm/EMPTY
+                   (cm/set-choice [:component-idx] (mx/scalar 0 mx/int32))
+                   (cm/set-choice [:x] (mx/scalar 0.3)))
+          {t0 :trace} (p/generate mix1 [] c0)
+          m0   (v-at t0 :m)
+          x0   (v-at t0 :x)
+          {t1 :trace w :weight} (p/regenerate mix1 t0 (sel/select :component-idx))]
+      (is (= 0.0 (mx/item w)) "index-only regenerate weight is 0")
+      (is (= m0 (v-at t1 :m))
+          "unselected inner latent :m is retained bit-for-bit (not resampled)")
+      (is (= x0 (v-at t1 :x)) "unselected inner obs :x is retained bit-for-bit"))))
+
+;; ===========================================================================
+;; genmlx-gc4w (C5) — branch-rewritten compiled ops must not leak the reserved
+;; branch-cond key into the trace choicemap
+;; ===========================================================================
+
+(def ^:private branch-model
+  (gen [flag]
+    (if flag
+      (trace :x (dist/gaussian 0.0 1.0))
+      (trace :x (dist/gaussian 0.0 2.0)))))
+
+(defn- has-branch-cond-leak? [trace]
+  ;; cm/addresses returns paths (vectors); a leaked reserved key would appear as
+  ;; a path element with the "genmlx.compiled" namespace.
+  (some (fn [path]
+          (some #(and (keyword? %) (= "genmlx.compiled" (namespace %))) path))
+        (cm/addresses (:choices trace))))
+
+(deftest branch-rewrite-no-cond-key-leak
+  (testing "compiled branch-rewritten generate/update do not leak branch-cond keys"
+    (let [gf  (dyn/with-key branch-model (rng/fresh-key 7))
+          c   (cm/set-choice cm/EMPTY [:x] (mx/scalar 0.5))
+          {t0 :trace} (p/generate gf [true] c)
+          {t1 :trace} (p/update gf t0 (cm/set-choice cm/EMPTY [:x] (mx/scalar 0.9)))]
+      (is (not (has-branch-cond-leak? t0)) "generate trace choicemap has no genmlx.compiled/* leaf")
+      (is (not (has-branch-cond-leak? t1)) "update trace choicemap has no genmlx.compiled/* leaf")
+      (is (= #{[:x]} (set (cm/addresses (:choices t0)))) "generate choices are exactly {:x}")
+      (is (= #{[:x]} (set (cm/addresses (:choices t1)))) "update choices are exactly {:x}"))))
+
+;; ===========================================================================
+;; genmlx-1thx — conjugate analytical detection
+;; ===========================================================================
+
+;; A Gamma prior conjugate to BOTH a Poisson and an Exponential child: a single
+;; family cannot eliminate it correctly, so the analytical path must decline and
+;; the weight must equal the handler path (strip-analytical).
+(def ^:private mixed-family-model
+  (dyn/auto-key
+    (gen []
+      (let [rate (trace :rate (dist/gamma-dist 2.0 1.0))]
+        (trace :c (dist/poisson rate))
+        (trace :xx (dist/exponential rate))
+        rate))))
+
+(deftest conjugate-mixed-family-declines
+  (testing "gamma prior with poisson+exponential children: analytical weight == handler weight"
+    (let [obs (-> cm/EMPTY
+                  (cm/set-choice [:c] (mx/scalar 3 mx/int32))
+                  (cm/set-choice [:xx] (mx/scalar 0.8)))
+          k   (rng/fresh-key 11)
+          wa  (mx/item (:weight (p/generate (dyn/with-key mixed-family-model k) [] obs)))
+          wh  (mx/item (:weight (p/generate (dyn/with-key (dyn/strip-analytical-path mixed-family-model) k) [] obs)))]
+      (is (h/close? wh wa 1e-3)
+          "mixed-family prior is declined to the handler (no wrong single-family marginal)"))))
+
+;; A let-rebound (affine-shadowed) natural parameter: y ~ N(mu+5, 1). The schema
+;; erases the +5, so :direct must NOT fire; the path declines to the handler.
+(def ^:private affine-shadow-model
+  (dyn/auto-key
+    (gen []
+      (let [mu (trace :mu (dist/gaussian 0.0 10.0))
+            mu (mx/add mu (mx/scalar 5.0))]
+        (trace :y (dist/gaussian mu 1.0))
+        mu))))
+
+(deftest conjugate-affine-shadow-not-direct
+  (testing "let-rebound affine natural param: analytical weight == handler weight (offset not dropped)"
+    (let [obs (cm/set-choice cm/EMPTY [:y] (mx/scalar 2.0))
+          k   (rng/fresh-key 13)
+          wa  (mx/item (:weight (p/generate (dyn/with-key affine-shadow-model k) [] obs)))
+          wh  (mx/item (:weight (p/generate (dyn/with-key (dyn/strip-analytical-path affine-shadow-model) k) [] obs)))]
+      (is (h/close? wh wa 1e-3)
+          "shadowed natural param not scored as a direct (offset-0) conjugate"))))
+
+(deftest conjugate-direct-still-detected
+  (testing "a genuine direct conjugate (mu used directly) is still eliminated (no false negative)"
+    (let [m (dyn/auto-key (gen [] (let [mu (trace :mu (dist/gaussian 0.0 10.0))]
+                                    (trace :y (dist/gaussian mu 1.0))
+                                    mu)))
+          pairs (:conjugate-pairs (:schema m))]
+      (is (= 1 (count pairs)) "direct normal-normal pair detected")
+      (is (= :direct (:type (:dependency-type (first pairs)))) "classified :direct"))))
+
+;; ===========================================================================
+;; genmlx-9rwf (C22) — VIMCO objective is finite at K=1 (no /0 NaN)
+;; ===========================================================================
+
+(deftest vimco-k1-finite
+  (testing "vimco-objective with a single sample is finite (reinforce term guarded)"
+    (let [obj (vi/vimco-objective (fn [z] (mx/negative (mx/sum (mx/square z))))
+                                  (fn [z] (mx/negative (mx/sum (mx/square z)))))
+          samples (mx/reshape (mx/array [0.3 -0.2]) [1 2])  ; K=1, d=2
+          loss (obj samples)]
+      (is (js/isFinite (mx/item loss)) "K=1 VIMCO loss is finite (not NaN)"))))
+
+;; ===========================================================================
+;; genmlx-ivs0 — SMCP3 is reproducible under a fixed :key
+;; ===========================================================================
+
+(def ^:private smcp3-model
+  (dyn/auto-key (gen [] (let [z (trace :z (dist/gaussian 0.0 1.0))]
+                          (trace :y (dist/gaussian z 1.0))
+                          z))))
+
+(deftest smcp3-reproducible-under-key
+  (testing "two SMCP3 runs with the same explicit :key produce identical particles"
+    (let [obs-seq [(cm/choicemap :y (mx/scalar 2.0))]
+          run (fn [] (smcp3/smcp3 {:particles 8 :key (rng/fresh-key 99)}
+                                  smcp3-model [] obs-seq))
+          r1 (run)
+          r2 (run)
+          zs (fn [r] (mapv #(v-at % :z) (:traces r)))]
+      (is (= (zs r1) (zs r2)) "particle :z values are identical across keyed runs"))))
+
+;; ===========================================================================
+;; genmlx-m3nn — biased MDP agent: keyed rollout works + :fused is rejected
+;; ===========================================================================
+
+(deftest biased-mdp-keyed-rollout
+  (testing "simulate-biased-mdp with :key runs (no arity crash) and is reproducible"
+    (let [mdp   (bp/procrastination-mdp {})
+          agent (bp/make-biased-mdp-agent {:mdp mdp :alpha 2.0 :gamma 1.0 :n-iters 14}
+                                          {:bias :naive})
+          k     (rng/fresh-key 5)
+          r1    (bp/simulate-biased-mdp agent 0 10 {:key k})
+          r2    (bp/simulate-biased-mdp agent 0 10 {:key k})]
+      (is (vector? (:actions r1)) "keyed biased rollout returns actions (no ArityException)")
+      (is (= (:actions r1) (:actions r2)) "same key -> same trajectory")))
+  (testing ":rollout-mode :fused is rejected for biased agents (no nil-Q deref)"
+    (let [mdp   (bp/procrastination-mdp {})
+          agent (bp/make-biased-mdp-agent {:mdp mdp :alpha ##Inf :gamma 1.0 :n-iters 14}
+                                          {:bias :naive})]
+      (is (thrown? js/Error (bp/simulate-biased-mdp agent 0 5 {:rollout-mode :fused}))
+          "fused rollout on a biased agent throws a clear error"))))
+
+;; ===========================================================================
+;; genmlx-flmw — SpliceSite schema shape matches schema.cljs/handle-splice
+;; ===========================================================================
+
+(deftest splice-site-schema-shape
+  (testing "a real splice site uses :gf-form (not the non-existent :gf-sym)"
+    (let [child (gen [] (trace :z (dist/gaussian 0.0 1.0)))
+          host  (gen [] (let [a (splice :sub child)] a))
+          sch   (:schema host)
+          ss    (first (:splice-sites sch))]
+      (is (some? ss) "host model has a splice site")
+      (is (contains? ss :gf-form) "splice site has :gf-form")
+      (is (not (contains? ss :gf-sym)) "splice site has no :gf-sym key")
+      (is (every? #(contains? ss %) [:addr :addr-form :gf-form :splice-args :deps :static?])
+          "splice site carries the full handle-splice key set"))))
+
+(cljs.test/run-tests)


### PR DESCRIPTION
## Foundation hardening sweep (post-Phase-0/1)

After Phases 0 and 1 closed, I ran an exhaustive **static** bug-hunt across the engine (18 codebase slices, read-only — no GPU, Metal-wedge-safe) with **2-lens adversarial verification** on every finding. This PR lands the **13 confirmed correctness fixes** plus a dedicated independent-oracle regression suite. Tracked under epic `genmlx-bjcq` (one child bean per fix).

Each fix is small and surgical, in a non-overlapping file set, and carries its bean id in the code comment. Verified **serially** (no parallel GPU); ~35 existing suites re-run with **zero regressions**, and the new suite is **13 tests / 35 assertions green**.

### Fixes by subsystem

| Bean | Subsystem | Fix |
|---|---|---|
| `zek9` | Combinators (Mix) | component-flip update weight uses the generate weight (was full new score → double-counted fresh latents); same-component update forwards child weight; new component keyed before generate; index-regen retains unselected inner choices |
| `1thx` | Conjugate detection | decline mixed-family priors (gamma+poisson+exponential scored one family's marginal); `:direct` is alias-aware via new schema `:arg-aliases` provenance, so a let-rebound `mu := mu+5` is no longer scored as offset-0 |
| `flmw` | Schema | `SpliceSite` Malli schema matches `handle-splice` (`:gf-form`, not a non-existent `:gf-sym`) |
| `gc4w` | Compiled (M4) | branch-rewritten generate/update/regenerate strip the reserved `:genmlx.compiled/branch-cond-*` key from the trace choicemap |
| `9yuw` | Regen dispatch | fast/general gating for opaque-escape bodies + the analytical regenerate dispatcher |
| `vqh9` | SMC | stratified + residual resample get the float-exhaustion guard `systematic-resample` already had |
| `jtou` | Translators | `coarse-to-fine-smc` couples the log-ML increment to the weight reset (no double-count when `resample?=false`); RJMCMC correction → `-Inf` when no reverse move exists |
| `o78h` | NUTS | U-turn criterion uses the velocity `M⁻¹p` under a non-identity mass matrix |
| `ivs0` | SMCP3 | per-particle PRNG key threading → reproducible under a fixed `:key` |
| `9rwf` | VI / ADEV | VIMCO score-function term summed (not meaned — was K× under-scaled), K=1 NaN guard; ADEV vectorized path forwards the variance-reduction baseline |
| `lgun` | Distributions | `broadcasted-normal` batched log-prob keeps the particle axis (`[N,…]→[N]`); `geometric` inverse-CDF uses `1-u` to avoid `+Inf` at the `u=0` edge |
| `alxa` | Linear algebra | `laplace-log-evidence` nil-cholesky guard; `mat-lu-solve` returns nil on singular input (was `Inf/NaN`) with caller fallbacks |
| `m3nn` | Agents | biased-MDP agent keyed rollout (2-arity `:act`); `:rollout-mode :fused` rejected (no tensor `:Q`) |
| `abw8` | Grammar DFA | zero-count repeat quantifier `{0}`/`{0,0}` returns an empty match (was a nil-AST crash) |

### Notes
- **`nt0c` (vmap regenerate re-base)** — investigated and **documented**, not changed: the existing re-base is exact for every reachable case (all vmap-produced traces, plus fast-path/nested without metadata); the only unsound case needs *externally-dropped* `::element-scores` on a general-path kernel. Downgraded to a draft/low follow-up (comprehensive fix = nested metadata propagation).
- **LLM layer (Phase 2, WIP)** — only the pure grammar `{0}` crash is fixed here. Two further findings are delegated to their Phase-2 homes: grammar-regen weight gating → `genmlx-fayo`, MSA prefix-match parser → `genmlx-n4ds` (template mode is retiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
