### PR TITLE
chore: upgrade nbb 1.4.206→1.4.208, switch malli fork→official metosin/malli

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/robert-johansson/test.check.git
 [submodule "malli"]
 	path = malli
-	url = https://github.com/robert-johansson/malli.git
+	url = https://github.com/metosin/malli.git
 [submodule "mlx-node"]
 	path = mlx-node
 	url = https://github.com/robert-johansson/mlx-node.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,11 @@ bun run --bun nbb test/genmlx/vectorized_benchmark.cljs
 No build step, no compilation. nbb interprets ClojureScript directly.
 
 **Requirements:** macOS with Apple Silicon, Bun (or Node.js 18+), `npm install`
-for `@mlx-node/core` and `@mlx-node/lm`. Malli (included as git submodule,
-temporary until upstream nbb/malli releases align).
+for `@mlx-node/core` and `@mlx-node/lm`, and nbb `1.4.208` (pinned via the `nbb`
+script in `package.json`). Malli is a git submodule tracking **official upstream
+`metosin/malli`** on the nbb classpath — the earlier robert-johansson/malli fork
+existed only for nbb 1.4.206 compatibility, which 1.4.208 made unnecessary (its
+SCI exposes `IPrintWithWriter`).
 
 ## Project structure
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ Gen implementations exist for Julia and JAX — but nothing for MLX. MLX's unifi
   - `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh` (then restart your shell, or `source "$HOME/.cargo/env"`)
 - **[Node.js](https://nodejs.org/) ≥ 18** — provides `npm` (for installing nbb and yarn). `brew install node` on macOS, or [nodejs.org](https://nodejs.org/).
 - **[Bun](https://bun.sh/)** — `curl -fsSL https://bun.sh/install | bash`. The `bun run --bun nbb …` commands throughout this README use it (recommended — 3-4x faster than Node.js for iterative inference). The installer only updates `~/.bashrc`/`~/.zshrc`; **fish** users must add it to `PATH` themselves: `fish_add_path ~/.bun/bin`. To run on Node.js instead, replace `bun run --bun nbb` with `nbb` and `bun install` with `npm install`.
-- **[nbb](https://github.com/babashka/nbb) — pin to `1.4.206`** — `npm install -g nbb@1.4.206`. ⚠️ Do **not** use the latest `1.4.207`: it ships an SCI regression that fails to resolve record types across namespaces (`Unable to resolve symbol: cm/Node`), which breaks the handler loop and therefore all inference. `1.4.206` is the last known-good release.
+- **[nbb](https://github.com/babashka/nbb) — `1.4.208`** — `npm install -g nbb@1.4.208`. The repo also pins it via the `nbb` script in `package.json`, so `bun run --bun nbb …` resolves to `1.4.208` regardless of any globally installed nbb. ⚠️ Avoid `1.4.207` specifically: it shipped a short-lived SCI regression that failed to resolve record types across namespaces (`Unable to resolve symbol: cm/Node`), breaking the handler loop and therefore all inference. `1.4.208` fixes that and additionally exposes the `IPrintWithWriter` protocol, which is what lets GenMLX run stock upstream `malli` (no fork needed).
 - **[Yarn](https://yarnpkg.com/)** — needed only to build the `mlx-node` submodule. You don't need a specific version: mlx-node vendors the exact release it wants (`.yarn/releases/yarn-4.13.0.cjs`) and any `yarn` launcher on `PATH` auto-delegates to it via the `yarnPath` setting in `.yarnrc.yml`. Install one with `npm install -g yarn` or `brew install yarn`. (If you prefer Corepack, note it is **no longer bundled** with current Node.js — `npm install -g corepack && corepack enable` — but it's unnecessary here.)
 - **`git`** with submodule support — GenMLX vendors its dependencies as nested submodules (see below).
 
 ## Quick Start
 
 ```bash
-# Clone with ALL submodules (forks of mlx-node, mlx, malli, instaparse, test.check).
+# Clone with ALL submodules (mlx-node, mlx, instaparse, test.check forks + upstream malli).
 # --recurse-submodules is required: it also pulls the MLX C++ fork nested one
 # level deeper inside mlx-node (crates/mlx-sys/mlx).
 git clone --recurse-submodules https://github.com/robert-johansson/genmlx
@@ -66,8 +66,10 @@ bun install
 bun run --bun nbb test/genmlx/inference_test.cljs
 ```
 
-> **Note — the forks.** GenMLX vendors five git submodules, all forks maintained
-> alongside this repo:
+> **Note — the submodules.** GenMLX vendors five git submodules. Four are forks
+> maintained alongside this repo; the fifth, `malli`, now tracks **upstream
+> `metosin/malli`** directly (the earlier fork existed only for nbb 1.4.206
+> compatibility, which `1.4.208` makes unnecessary):
 >
 > - [`mlx-node`](https://github.com/robert-johansson/mlx-node) — adds a custom
 >   `genmlx.rs` Rust module with 138 module-level NAPI exports tuned for
@@ -76,13 +78,15 @@ bun run --bun nbb test/genmlx/inference_test.cljs
 >   *nested* submodule ([`mlx`](https://github.com/robert-johansson/mlx) at
 >   `crates/mlx-sys/mlx`), which `--recurse-submodules` pulls automatically and
 >   `yarn build` compiles statically (the `build:native` part of the script).
-> - [`malli`](https://github.com/robert-johansson/malli),
->   [`instaparse`](https://github.com/robert-johansson/instaparse), and
->   [`test.check`](https://github.com/robert-johansson/test.check) — patched for
->   nbb/Babashka compatibility. Their source sits directly on the nbb classpath
->   (see `nbb.edn`), so no build step is needed. malli backs schema validation
->   (`genmlx.schemas`), instaparse the LLM grammar layer (`genmlx.llm.grammar`),
->   and test.check the property-based tests.
+> - [`instaparse`](https://github.com/robert-johansson/instaparse) and
+>   [`test.check`](https://github.com/robert-johansson/test.check) — forks patched
+>   for nbb/Babashka compatibility.
+> - [`malli`](https://github.com/metosin/malli) — the **official upstream** library,
+>   pinned to a specific commit; no fork is needed under nbb `1.4.208`.
+>
+>   All three sit directly on the nbb classpath (see `nbb.edn`), so no build step is
+>   needed. malli backs schema validation (`genmlx.schemas`), instaparse the LLM
+>   grammar layer (`genmlx.llm.grammar`), and test.check the property-based tests.
 
 Run the included examples:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "nbb": "bunx nbb@1.4.206",
+    "nbb": "bunx nbb@1.4.208",
     "test:fast": "bash test/run.sh core",
     "test:fast-all": "bash test/run.sh fast",
     "test:medium": "bash test/run.sh medium",

--- a/src/genmlx/inference/vi.cljs
+++ b/src/genmlx/inference/vi.cljs
@@ -475,7 +475,7 @@
                 (callback {:iter i :loss loss-val}))
               (when (zero? (mod i 50)) (mx/sweep-dead-arrays!) (mx/clear-cache!))
               (recur (inc i) params' opt-state'
-                     (conj! losses loss-val)))))))))
+                     (conj! losses loss-val) next-key))))))))
 
 (defn vimco
   "VIMCO: Variational Inference with Multi-sample Objectives.

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -173,6 +173,7 @@ fast test/genmlx/handler_property_test.cljs
 fast test/genmlx/handler_purity_test.cljs core
 fast test/genmlx/handler_test.cljs core
 fast test/genmlx/handler_transitions_test.cljs core
+fast test/genmlx/hardening_sweep_2026_06_14_test.cljs
 medium test/genmlx/hmc_mass_resample_test.cljs
 medium test/genmlx/hmm_forward_test.cljs
 fast test/genmlx/iid_compiled_test.cljs


### PR DESCRIPTION
## What

Upgrades nbb **1.4.206 → 1.4.208** and switches the `malli` submodule from the `robert-johansson/malli` fork to **official `metosin/malli`** at upstream HEAD (`a74e3b45` = 0.20.1-24).

nbb 1.4.208 fixes the 1.4.207 `cm/Node` SCI regression **and** exposes the `IPrintWithWriter` protocol, so the fork — which existed *only* for nbb-1.4.206 compat — is no longer needed.

## Changes

- **`package.json`** — nbb pin `1.4.206` → `1.4.208`. Both `bun run --bun nbb` and `test/run.sh` resolve to it via the package.json script (the script wins over any global homebrew nbb).
- **`.gitmodules` + `malli` gitlink** — url `robert-johansson/malli` → `metosin/malli`, pinned at `a74e3b45`.
- **`src/genmlx/inference/vi.cljs`** — **latent bug fix.** 1.4.208's analyzer validates `recur` arity at load time; `compiled-programmable-vi`'s loop has 5 bindings (`i params opt-state losses rk`) but the recur passed only 4, silently dropping the threaded RNG key across optimizer iterations. Now matches the sibling `programmable-vi` loop.
- **`test/tiers.txt`** — regenerated (registers `hardening_sweep_2026_06_14_test`, a pre-existing drift from 8e3aa8a).
- **`README.md`, `CLAUDE.md`** — document the new nbb version and official malli.

## Verification

All under 1.4.208 + official malli:
- `malli_load_test` 13/13 (stock upstream, no patches); `handler_test` passes (`cm/Node` resolves)
- fast tier 146/151; cert gates **level0 68 / l4 41 / gen_clj_compat 356 / genjax_compat 73**; medium tier exit-0
- **Every** remaining test failure reproduces *identically* under 1.4.206 → all pre-existing; **zero new failures** from the upgrade (method: isolated each failure by re-running under the old nbb version)

## Notes

Two pre-existing RED-on-main failures were found incidentally and tracked separately (not addressed here): `strip_compiled_test` L3 marginal-update weight off by 0.0625, and `branch_rewrite_test` napi `MxArray` recovery error. The `fused_mcmc_test` `[metal::malloc] Resource limit (499000) exceeded` is pre-existing buffer-count pressure (reproduces under both nbb versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)