### PR TITLE
Phase 3 agents: chapter ports + agents×llm flagship + API contracts + fused POMDP

### DIFF
--- a/examples/agentmodels/ch01_intro.cljs
+++ b/examples/agentmodels/ch01_intro.cljs
@@ -1,0 +1,166 @@
+(ns agentmodels.ch01-intro
+  "agentmodels.org Chapter 1 — \"Introduction / Probabilistic programming\" ported
+   to GenMLX. The textbook opens by teaching that a probabilistic program is just
+   ordinary code in which `flip`/`sample` draw random choices, and `Infer` turns
+   the program into a distribution over its return value. This file ports the two
+   canonical ch1 vignettes to the GenMLX GFI:
+
+   1. The COIN-FLIP TASTER — `dist/flip` is the GenMLX `flip()`. We `p/simulate`
+      the one-site model three times and map 0/1 -> T/H only at the print boundary
+      (values stay MLX arrays inside the model, per the GenMLX discipline).
+
+   2. GEOMETRIC TWO WAYS — the recursive `geometric` of ch1
+      (`flip() ? 1 + geometric() : 0`, count the consecutive successes before the
+      first failure) shown as (a) a hand-rolled RECURSIVE gen function made exact
+      by enumeration, and (b) the idiomatic built-in `dist/geometric`. Both give
+      the same PMF P(n=k) = 0.5^(k+1) and E[n] = 1, demonstrating that an explicit
+      model and a primitive agree.
+
+      WebPPL bounds the recursion with `maxExecutions`; for EXACT enumeration we
+      bound it with an explicit `max-depth` argument instead (the all-continue
+      tail lumps into n = max-depth, mass 0.5^max-depth). With max-depth = 12 the
+      tail is ~2e-4, so P(n=0..3) match the closed form to float32.
+
+   Reuse, zero engine change: genmlx.dist (flip / geometric), genmlx.inference.exact
+   (exact-joint enumeration), the GFI (p/simulate, p/assess). Self-checking: run
+
+     bun run --bun nbb examples/agentmodels/ch01_intro.cljs
+
+   prints each marginal and asserts it against the analytic reference number;
+   exits non-zero if any check fails."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.choicemap :as cm]
+            [genmlx.dynamic :as dyn]
+            [genmlx.inference.exact :as exact]
+            [genmlx.protocols :as p]
+            [genmlx.gen :refer [gen]]))
+
+;; ---------------------------------------------------------------------------
+;; tiny self-check harness (examples are runnable + self-asserting; no test fw)
+;; ---------------------------------------------------------------------------
+
+(def ^:private fails (atom 0))
+
+(defn- ->num [v] (if (mx/array? v) (mx/item v) v))
+
+(defn- check-close [label expected actual tol]
+  (let [a  (->num actual)
+        ok (<= (abs (- expected a)) tol)]
+    (println (str (if ok "  ✓ " "  ✗ FAIL ") label
+                  " — expected " expected ", got " (.toFixed a 6)))
+    (when-not ok (swap! fails inc))
+    ok))
+
+(defn- check-true [label ok]
+  (println (str (if ok "  ✓ " "  ✗ FAIL ") label))
+  (when-not ok (swap! fails inc))
+  ok)
+
+;; ---------------------------------------------------------------------------
+;; 1. Coin-flip taster — dist/flip is the GenMLX flip()
+;; ---------------------------------------------------------------------------
+
+(def coin
+  "A one-site probabilistic program: a single fair coin. Its return value IS the
+   drawn choice, so `Infer`-ing it (here: forward p/simulate) is a distribution
+   over {0,1}."
+  (gen [] (trace :c (dist/flip 0.5))))
+
+(defn flip->HT
+  "Map the 0/1 draw to T/H at the PRINT boundary only (values stay MLX inside)."
+  [v]
+  (if (= 1 (int (->num v))) "H" "T"))
+
+(defn coin-taster
+  "Three forward draws from `coin`, each as T/H. Returns the vector of faces."
+  []
+  (mapv (fn [_]
+          (-> (p/simulate (dyn/auto-key coin) []) :retval flip->HT))
+        (range 3)))
+
+;; ---------------------------------------------------------------------------
+;; 2a. Geometric, way one: a recursive gen function made exact by enumeration
+;; ---------------------------------------------------------------------------
+;;
+;; agentmodels ch1: geometric = function(){ return flip() ? 1 + geometric() : 0 }
+;; — at each step continue with prob 0.5, and n counts the consecutive continues
+;; before the first stop. WebPPL caps the unbounded recursion with maxExecutions;
+;; for exact tensor enumeration we cap it with an explicit `max-depth`. Encoded
+;; without host control flow (which enumeration cannot branch on): n is the sum
+;; of the cumulative product of the continue-flips, i.e. the length of the leading
+;; run of 1s. This is a fixed-depth unroll, so every flip is a distinct enumeration
+;; axis and `reached`/`n` broadcast across the full joint support.
+
+(defn geometric-recursive
+  "Depth-bounded recursive geometric as a gen function. n = number of consecutive
+   `continue`s (fair flips landing 1) before the first stop; capped at max-depth."
+  [max-depth]
+  (gen []
+    (loop [i 0, reached (mx/scalar 1.0), n (mx/scalar 0.0)]
+      (if (>= i max-depth)
+        n
+        (let [c        (trace (keyword (str "c" i)) (dist/flip 0.5))
+              ;; reached stays 1.0 only while every earlier flip continued
+              continue (mx/multiply reached (.astype c mx/float32))]
+          (recur (inc i) continue (mx/add n continue)))))))
+
+(defn geometric-pmf-recursive
+  "Exactly enumerate the recursive geometric and read off P(n=0..3) and E[n] by
+   probability-weighting the (tensor-shaped) return value over the full joint."
+  [max-depth]
+  (let [{:keys [probs retval]} (exact/exact-joint (geometric-recursive max-depth) [] nil)
+        rv (.astype retval mx/float32)
+        pk (fn [k]
+             (mx/item (mx/sum (mx/multiply probs
+                                (.astype (mx/equal rv (mx/scalar (* 1.0 k))) mx/float32)))))]
+    {:pmf  (mapv pk (range 4))
+     :mean (mx/item (mx/sum (mx/multiply probs rv)))}))
+
+;; ---------------------------------------------------------------------------
+;; 2b. Geometric, way two: the idiomatic built-in dist/geometric
+;; ---------------------------------------------------------------------------
+
+(def geometric-builtin
+  "The same distribution as a single primitive trace site."
+  (gen [] (trace :n (dist/geometric 0.5))))
+
+(defn geometric-pmf-builtin
+  "Exact P(n=0..3) read directly from the primitive's log-prob via p/assess —
+   no enumeration/normalization, so these are the exact 0.5^(k+1)."
+  []
+  (mapv (fn [k]
+          (let [{:keys [weight]} (p/assess (dyn/auto-key geometric-builtin) []
+                                           (cm/choicemap :n (mx/scalar k)))]
+            (js/Math.exp (->num weight))))
+        (range 4)))
+
+;; ---------------------------------------------------------------------------
+;; run + self-check
+;; ---------------------------------------------------------------------------
+
+(defn -main []
+  (println "\n=== agentmodels.org Ch 1 — Introduction (GenMLX port) ===")
+
+  (println "\n-- 1. coin-flip taster: three forward draws of dist/flip --")
+  (let [faces (coin-taster)]
+    (println (str "  faces: " faces))
+    (check-true "each face is H or T" (every? #{"H" "T"} faces)))
+
+  (println "\n-- 2a. geometric (recursive gen, exact enumeration; depth 12) --")
+  (let [{:keys [pmf mean]} (geometric-pmf-recursive 12)]
+    (doseq [k (range 4)]
+      (check-close (str "P(n=" k ") = 0.5^" (inc k)) (js/Math.pow 0.5 (inc k)) (nth pmf k) 1e-5))
+    (check-close "E[n] = 1" 1.0 mean 5e-3))
+
+  (println "\n-- 2b. geometric (idiomatic dist/geometric, exact via p/assess) --")
+  (let [pmf (geometric-pmf-builtin)]
+    (doseq [k (range 4)]
+      (check-close (str "P(n=" k ")") (js/Math.pow 0.5 (inc k)) (nth pmf k) 1e-5)))
+
+  (println (str "\n" (if (zero? @fails)
+                       "ALL CHECKS PASSED ✓"
+                       (str @fails " CHECK(S) FAILED ✗"))))
+  (when (pos? @fails) (js/process.exit 1)))
+
+(-main)

--- a/examples/agentmodels/ch02_webppl.cljs
+++ b/examples/agentmodels/ch02_webppl.cljs
@@ -1,0 +1,250 @@
+(ns agentmodels.ch02-webppl
+  "agentmodels.org Chapter 2 — \"WebPPL: a probabilistic programming language\"
+   ported to GenMLX. Ch2 is the language primer: elementary random primitives
+   (ERPs), conditioning, and `Infer`. This file ports its canonical vignettes to
+   the GenMLX GFI, using exact tensor enumeration where the textbook uses
+   `Infer({method:'enumerate'})`.
+
+   Vignettes:
+   1. ERP DRAWS — forward p/simulate of discrete (bernoulli, categorical) and
+      continuous (gaussian, uniform) primitives; values map to readable output
+      only at the print boundary.
+   2. MULTIVARIATE GAUSSIAN — dist/multivariate-normal (the GenMLX
+      `multivariateGaussian`), a 2-D draw with the given mean/covariance.
+   3. BINOMIAL FROM THREE FLIPS — `binomial = flip()+flip()+flip()`, with the
+      distribution over the SUM obtained two ways and shown to agree: by
+      enumerating the three-flip model and probability-weighting its return
+      value, and by the primitive dist/binomial. PMF = [1 3 3 1]/8.
+   4. twoHeads / moreThanTwoHeads — CONDITIONING via the bernoulli-indicator
+      trick + exact-posterior. P(first flip = H | total heads >= 2) = 0.75;
+      evidence P(total heads >= 2) = 0.5; posterior over the total given >=2 is
+      {2: 0.75, 3: 0.25}.
+   5. STRUCTURED RETURNS + a forward positionDist — a model returning a joint
+      structure, and a small discrete random-walk position distribution
+      enumerated exactly.
+
+   Reuse, zero engine change: genmlx.dist (bernoulli/categorical/gaussian/uniform/
+   multivariate-normal/binomial), genmlx.inference.exact (exact-joint /
+   exact-posterior), the GFI (p/simulate, p/assess). Self-checking: run
+
+     bun run --bun nbb examples/agentmodels/ch02_webppl.cljs
+
+   prints each result and asserts deterministic (enumerated) quantities against
+   the analytic reference numbers; exits non-zero if any check fails. Random
+   forward draws are asserted structurally (shape / support), never by value."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.choicemap :as cm]
+            [genmlx.dynamic :as dyn]
+            [genmlx.inference.exact :as exact]
+            [genmlx.protocols :as p]
+            [genmlx.gen :refer [gen]]))
+
+;; ---------------------------------------------------------------------------
+;; tiny self-check harness
+;; ---------------------------------------------------------------------------
+
+(def ^:private fails (atom 0))
+
+(defn- ->num [v] (if (mx/array? v) (mx/item v) v))
+
+(defn- check-close [label expected actual tol]
+  (let [a  (->num actual)
+        ok (<= (abs (- expected a)) tol)]
+    (println (str (if ok "  ✓ " "  ✗ FAIL ") label
+                  " — expected " expected ", got " (.toFixed a 6)))
+    (when-not ok (swap! fails inc))
+    ok))
+
+(defn- check-true [label ok]
+  (println (str (if ok "  ✓ " "  ✗ FAIL ") label))
+  (when-not ok (swap! fails inc))
+  ok)
+
+;; ---------------------------------------------------------------------------
+;; 1. ERP draws — forward sampling of discrete + continuous primitives
+;; ---------------------------------------------------------------------------
+
+(def erp-model
+  "A handful of ERPs in one program, returned as a structured map. Forward
+   p/simulate draws all of them jointly."
+  (gen []
+    (let [b (trace :bern (dist/bernoulli 0.5))
+          c (trace :cat  (dist/categorical (mx/array [0.0 0.0 0.0]))) ; uniform over 3
+          g (trace :norm (dist/gaussian 0.0 1.0))
+          u (trace :unif (dist/uniform 0.0 1.0))]
+      {:bern b :cat c :norm g :unif u})))
+
+(defn erp-draw
+  "One forward draw of the ERP bundle, as plain numbers (print boundary)."
+  []
+  (let [r (p/simulate (dyn/auto-key erp-model) [])
+        rv (:retval r)]
+    {:bern (int (->num (:bern rv)))
+     :cat  (int (->num (:cat rv)))
+     :norm (->num (:norm rv))
+     :unif (->num (:unif rv))}))
+
+;; ---------------------------------------------------------------------------
+;; 2. multivariateGaussian — a 2-D draw
+;; ---------------------------------------------------------------------------
+
+(def mvn-model
+  (gen []
+    (trace :pos (dist/multivariate-normal (mx/array [0.0 0.0])
+                                          (mx/array [[1.0 0.0] [0.0 1.0]])))))
+
+(defn mvn-draw []
+  (mx/->clj (:retval (p/simulate (dyn/auto-key mvn-model) []))))
+
+;; ---------------------------------------------------------------------------
+;; 3. binomial from three flips — distribution over the SUM, two ways
+;; ---------------------------------------------------------------------------
+
+(def three-flips-sum
+  "binomial = flip() + flip() + flip(); the program RETURNS the sum, so the
+   distribution over the return value is Binomial(3, 0.5)."
+  (gen []
+    (let [a (trace :a (dist/flip 0.5))
+          b (trace :b (dist/flip 0.5))
+          c (trace :c (dist/flip 0.5))]
+      (mx/add (mx/add (.astype a mx/float32) (.astype b mx/float32))
+              (.astype c mx/float32)))))
+
+(defn binomial-pmf-from-flips
+  "Enumerate the three-flip program and read P(sum = 0..3) by probability-
+   weighting the (tensor-shaped) return value across the full joint."
+  []
+  (let [{:keys [probs retval]} (exact/exact-joint three-flips-sum [] nil)
+        rv (.astype retval mx/float32)]
+    (mapv (fn [k]
+            (mx/item (mx/sum (mx/multiply probs
+                               (.astype (mx/equal rv (mx/scalar (* 1.0 k))) mx/float32)))))
+          (range 4))))
+
+(def binomial-builtin (gen [] (trace :k (dist/binomial 3 0.5))))
+
+(defn binomial-pmf-builtin
+  "P(k = 0..3) read from the primitive via exact-posterior marginals."
+  []
+  (let [r (exact/exact-posterior binomial-builtin [] nil)]
+    (mapv (fn [k] (get-in r [:marginals :k k])) (range 4))))
+
+;; ---------------------------------------------------------------------------
+;; 4. twoHeads / moreThanTwoHeads — conditioning via the bernoulli-indicator
+;; ---------------------------------------------------------------------------
+;;
+;; agentmodels conditions with `condition(totalHeads >= 2)`. In GenMLX the exact
+;; analogue is the bernoulli-indicator trick (see inference/exact.cljs): trace a
+;; deterministic bernoulli whose probability is the 1/0 event mask, then observe
+;; it = 1. Observing bernoulli(mask)=1 contributes log(mask): 0 where the event
+;; holds, -inf where it does not, which is precisely a hard `condition`.
+
+(def first-flip-given-ge2
+  "Three fair flips; condition (via :ge2) on total heads >= 2; RETURN the first
+   flip so its marginal is P(first = H | total >= 2)."
+  (gen []
+    (let [a     (trace :a (dist/flip 0.5))
+          b     (trace :b (dist/flip 0.5))
+          c     (trace :c (dist/flip 0.5))
+          total (mx/add (mx/add (.astype a mx/float32) (.astype b mx/float32))
+                        (.astype c mx/float32))
+          mask  (mx/where (mx/greater-equal total (mx/scalar 2.0))
+                          (mx/scalar 1.0) (mx/scalar 0.0))]
+      (trace :ge2 (dist/bernoulli mask))
+      a)))
+
+(def total-given-ge2
+  "Binomial(3,0.5) conditioned on k >= 2; its :k marginal is P(total | total>=2)."
+  (gen []
+    (let [k    (trace :k (dist/binomial 3 0.5))
+          mask (mx/where (mx/greater-equal k (mx/scalar 2))
+                         (mx/scalar 1.0) (mx/scalar 0.0))]
+      (trace :ge2 (dist/bernoulli mask))
+      k)))
+
+(defn two-heads-results []
+  (let [r-first (exact/exact-posterior first-flip-given-ge2 []
+                                       (cm/choicemap :ge2 (mx/scalar 1)))
+        r-total (exact/exact-posterior total-given-ge2 []
+                                       (cm/choicemap :ge2 (mx/scalar 1)))]
+    {:p-first-heads (get-in r-first [:marginals :a 1])
+     :evidence      (js/Math.exp (:log-ml r-first)) ; P(total heads >= 2)
+     :p-total-2     (get-in r-total [:marginals :k 2])
+     :p-total-3     (get-in r-total [:marginals :k 3])
+     :p-total-0     (get-in r-total [:marginals :k 0])}))
+
+;; ---------------------------------------------------------------------------
+;; 5. structured returns + forward positionDist (discrete random walk)
+;; ---------------------------------------------------------------------------
+
+(def position-walk
+  "A 2-step ±1 random walk from 0: each step is a fair flip mapped to ±1, and the
+   return value is the final position in {-2, 0, +2}. Enumerated exactly, this is
+   agentmodels' forward positionDist in miniature."
+  (gen []
+    (let [s1 (trace :s1 (dist/flip 0.5))
+          s2 (trace :s2 (dist/flip 0.5))
+          step (fn [f] (mx/subtract (mx/multiply (.astype f mx/float32) (mx/scalar 2.0))
+                                    (mx/scalar 1.0)))] ; 1->+1, 0->-1
+      (mx/add (step s1) (step s2)))))
+
+(defn position-dist
+  "P(final position = v) for v in {-2, 0, +2}."
+  []
+  (let [{:keys [probs retval]} (exact/exact-joint position-walk [] nil)
+        rv (.astype retval mx/float32)
+        pv (fn [v] (mx/item (mx/sum (mx/multiply probs
+                              (.astype (mx/equal rv (mx/scalar (* 1.0 v))) mx/float32)))))]
+    {-2 (pv -2) 0 (pv 0) 2 (pv 2)}))
+
+;; ---------------------------------------------------------------------------
+;; run + self-check
+;; ---------------------------------------------------------------------------
+
+(defn -main []
+  (println "\n=== agentmodels.org Ch 2 — WebPPL primer (GenMLX port) ===")
+
+  (println "\n-- 1. ERP forward draws (bernoulli / categorical / gaussian / uniform) --")
+  (let [d (erp-draw)]
+    (println (str "  draw: " d))
+    (check-true "bern in {0,1}"  (contains? #{0 1} (:bern d)))
+    (check-true "cat in {0,1,2}" (contains? #{0 1 2} (:cat d)))
+    (check-true "unif in [0,1)"  (<= 0.0 (:unif d) 1.0)))
+
+  (println "\n-- 2. multivariateGaussian: one 2-D draw --")
+  (let [v (mvn-draw)]
+    (println (str "  pos: [" (.toFixed (nth v 0) 3) ", " (.toFixed (nth v 1) 3) "]"))
+    (check-true "draw has 2 components" (= 2 (count v))))
+
+  (println "\n-- 3. binomial from 3 flips: P(sum=k), two ways --")
+  (let [from-flips (binomial-pmf-from-flips)
+        builtin    (binomial-pmf-builtin)
+        ref        [0.125 0.375 0.375 0.125]]
+    (doseq [k (range 4)]
+      (check-close (str "from-flips P(sum=" k ")") (nth ref k) (nth from-flips k) 1e-5)
+      (check-close (str "dist/binomial P(k=" k ")") (nth ref k) (nth builtin k) 1e-5)))
+
+  (println "\n-- 4. twoHeads / moreThanTwoHeads: conditioning --")
+  (let [{:keys [p-first-heads evidence p-total-2 p-total-3 p-total-0]} (two-heads-results)]
+    (check-close "P(first = H | total >= 2)" 0.75 p-first-heads 1e-5)
+    (check-close "evidence P(total >= 2)"    0.5  evidence      1e-5)
+    (check-close "P(total = 2 | total >= 2)" 0.75 p-total-2     1e-5)
+    (check-close "P(total = 3 | total >= 2)" 0.25 p-total-3     1e-5)
+    (check-close "P(total = 0 | total >= 2)" 0.0  p-total-0     1e-5))
+
+  (println "\n-- 5. forward positionDist: 2-step ±1 walk, P(final position) --")
+  (let [pd (position-dist)]
+    (println (str "  P(-2)=" (.toFixed (pd -2) 3)
+                  "  P(0)=" (.toFixed (pd 0) 3)
+                  "  P(+2)=" (.toFixed (pd 2) 3)))
+    (check-close "P(position = -2)" 0.25 (pd -2) 1e-5)
+    (check-close "P(position =  0)" 0.5  (pd 0)  1e-5)
+    (check-close "P(position = +2)" 0.25 (pd 2)  1e-5))
+
+  (println (str "\n" (if (zero? @fails)
+                       "ALL CHECKS PASSED ✓"
+                       (str @fails " CHECK(S) FAILED ✗"))))
+  (when (pos? @fails) (js/process.exit 1)))
+
+(-main)

--- a/examples/agentmodels/ch08_library_guide.cljs
+++ b/examples/agentmodels/ch08_library_guide.cljs
@@ -1,0 +1,241 @@
+(ns agentmodels.ch08-library-guide
+  "agentmodels.org Chapter 8 — \"WebPPL agents library\" ported to GenMLX as a
+   guided tour of the genmlx.agents foundation. Ch8 in the textbook is a quick-
+   start over the reusable env/agent surface; this file is the same tour over the
+   GenMLX library spine (src/genmlx/agents/*), showing that the constructors
+   compose and that you can drop in your OWN policy without leaving the GFI.
+
+   The tour:
+   1. make-line-mdp        — worlds/line-mdp: a 1-D corridor MDP.
+   2. make-mdp-agent       — agent/make-mdp-agent, OPTIMAL (alpha = ##Inf, hard
+                             argmax) and SOFT-RATIONAL (finite alpha, Boltzmann).
+   3. make-gridworld-mdp   — worlds/hike-mdp: the 5×5 hiking gridworld; an agent
+                             plans a route to the high peak.
+   4. hyperbolic discounting— biased_planners/make-biased-mdp-agent: a present-
+                             biased (Naive hyperbolic) planner, the genuine
+                             time-inconsistent agent, alongside the optimal one.
+   5. make-line-pomdp      — pomdp_env/restaurant-gridworld on a corridor +
+                             pomdp/make-pomdp-agent: belief filtering over a hidden
+                             goal (manifest action trajectory ⟂ latent world); the
+                             belief snaps to truth at the signpost (QMDP).
+   6. custom agents        — a RANDOM agent (uniform-draw policy) and an
+                             EPSILON-GREEDY agent (a mix of a uniform explore branch
+                             and exact/categorical-argmax exploitation) — both are
+                             ordinary policy generative functions.
+
+   Reuse, zero engine change: genmlx.agents.{worlds,agent,gridworld,biased-planners,
+   pomdp,pomdp-env,helpers}, genmlx.inference.exact (categorical-argmax), the GFI.
+   Self-checking: run
+
+     bun run --bun nbb examples/agentmodels/ch08_library_guide.cljs
+
+   prints each demo's output and asserts the headline behaviors; exits non-zero on
+   any failure. Deterministic behaviors (optimal first action, POMDP belief snap,
+   epsilon=0 greedy) are asserted by value; stochastic ones structurally."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.dynamic :as dyn]
+            [genmlx.inference.exact :as exact]
+            [genmlx.protocols :as p]
+            [genmlx.gen :refer [gen]]
+            [genmlx.agents.worlds :as worlds]
+            [genmlx.agents.agent :as agent]
+            [genmlx.agents.biased-planners :as bp]
+            [genmlx.agents.pomdp :as pomdp]
+            [genmlx.agents.pomdp-env :as env]
+            [genmlx.agents.helpers :as h]))
+
+;; ---------------------------------------------------------------------------
+;; tiny self-check harness
+;; ---------------------------------------------------------------------------
+
+(def ^:private fails (atom 0))
+
+(defn- ->num [v] (if (mx/array? v) (mx/item v) v))
+
+(defn- check-true [label ok]
+  (println (str (if ok "  ✓ " "  ✗ FAIL ") label))
+  (when-not ok (swap! fails inc))
+  ok)
+
+(defn- check-equal [label expected actual]
+  (let [ok (= expected actual)]
+    (println (str (if ok "  ✓ " "  ✗ FAIL ") label " — expected " expected ", got " actual))
+    (when-not ok (swap! fails inc))
+    ok))
+
+(defn- check-close [label expected actual tol]
+  (let [ok (<= (abs (- expected actual)) tol)]
+    (println (str (if ok "  ✓ " "  ✗ FAIL ") label " — expected " expected ", got " actual))
+    (when-not ok (swap! fails inc))
+    ok))
+
+;; gridworld action indices (from genmlx.agents.gridworld): [:left :right :up :down]
+(def RIGHT 1)
+
+;; ---------------------------------------------------------------------------
+;; 1 + 2. line MDP + make-mdp-agent (optimal and soft-rational)
+;; ---------------------------------------------------------------------------
+
+(defn demo-line-mdp []
+  (println "\n-- 1+2. make-line-mdp + make-mdp-agent (optimal vs soft) --")
+  (let [mdp        (worlds/line-mdp {:n 7 :reward 1.0 :time-cost -0.1})
+        start      (:start-idx mdp)
+        optimal    (agent/make-mdp-agent {:mdp mdp :alpha ##Inf :gamma 1.0 :n-iters 24})
+        soft       (agent/make-mdp-agent {:mdp mdp :alpha 3.0   :gamma 1.0 :n-iters 24})
+        a-opt      ((:act optimal) start)
+        roll       (agent/simulate-mdp optimal start 12)]
+    (println (str "  start=" start "  optimal first action=" a-opt
+                  " (1=right)  optimal path states=" (:states roll)))
+    (check-equal "optimal agent steps RIGHT toward the goal first" RIGHT a-opt)
+    (check-equal "optimal rollout ends at the goal cell (idx 6)" 6 (last (:states roll)))
+    ;; soft-rational agent is a valid policy; its EU favors the goal direction
+    (let [eu-row (mapv (fn [a] (->num ((:expected-utility soft) start a))) (range 4))]
+      (println (str "  soft EU(start, ·) = " (mapv #(.toFixed % 3) eu-row)))
+      (check-true "soft agent: EU(right) >= EU(left)" (>= (nth eu-row 1) (nth eu-row 0))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. gridworld MDP — the hiking world; plan a route to the high (East) peak
+;; ---------------------------------------------------------------------------
+
+(defn demo-gridworld-mdp []
+  (println "\n-- 3. make-gridworld-mdp (hiking 5×5) + planned route --")
+  (let [mdp     (worlds/hike-mdp {:noise 0.0})
+        start   (:start-idx mdp)
+        ag      (agent/make-mdp-agent {:mdp mdp :alpha ##Inf :gamma 1.0 :n-iters 24})
+        roll    (agent/simulate-mdp ag start 16)
+        end     (last (:states roll))
+        east-idx 14] ; the prize peak (utility 10)
+    (println (str "  start=" start "  path=" (:states roll) "  ends at idx " end))
+    (check-equal "optimal hiker reaches the East peak (idx 14)" east-idx end)))
+
+;; ---------------------------------------------------------------------------
+;; 4. hyperbolic discounting — a present-biased (Naive) planner
+;; ---------------------------------------------------------------------------
+
+(defn demo-hyperbolic []
+  (println "\n-- 4. make-biased-mdp-agent (Naive hyperbolic) vs optimal --")
+  (let [mdp      (worlds/line-mdp {:n 7 :reward 1.0 :time-cost -0.1})
+        start    (:start-idx mdp)
+        optimal  (agent/make-mdp-agent {:mdp mdp :alpha ##Inf :gamma 1.0 :n-iters 24})
+        ;; k=0 reproduces the optimal plan; k>0 is genuinely present-biased
+        naive-k0 (bp/make-biased-mdp-agent {:mdp mdp :alpha ##Inf :gamma 1.0 :n-iters 24}
+                                           {:discount 0.0 :bias :naive})
+        naive-k1 (bp/make-biased-mdp-agent {:mdp mdp :alpha ##Inf :gamma 1.0 :n-iters 24}
+                                           {:discount 1.0 :bias :naive})
+        a-opt    ((:act optimal) start)
+        a-k0     ((:act naive-k0) start)
+        a-k1     ((:act naive-k1) start)]
+    (println (str "  optimal first action=" a-opt
+                  "  naive(k=0)=" a-k0 "  naive(k=1)=" a-k1))
+    (check-equal "biased agent with k=0 matches the optimal first action" a-opt a-k0)
+    (check-true "naive hyperbolic agent yields a valid action (0..3)"
+                (contains? #{0 1 2 3} a-k1))
+    (check-true "make-biased-mdp-agent exposes a :policy GF + :expected-utility"
+                (and (some? (:policy naive-k1)) (fn? (:expected-utility naive-k1))))))
+
+;; ---------------------------------------------------------------------------
+;; 5. line POMDP — belief filtering over a hidden goal (manifest ⟂ latent)
+;; ---------------------------------------------------------------------------
+;;
+;; A corridor whose only route to the two goals (A left, B right) passes the
+;; signpost (P), which reveals the latent world. The MANIFEST is the action
+;; trajectory; the LATENT is which goal is real. QMDP plans on the belief; the
+;; belief snaps to truth once the signpost is observed.
+
+(def pomdp-grid
+  [[:A    :empty :B]
+   [:wall :empty :wall]
+   [:wall :empty :wall]
+   [:wall :empty :wall]
+   [:wall :empty :wall]])
+(def pomdp-signpost 7)
+
+(defn demo-line-pomdp []
+  (println "\n-- 5. make-line-pomdp + make-pomdp-agent (belief filtering) --")
+  (doseq [[tw goal-idx] [[:A 0] [:B 2]]]
+    (let [e    (env/restaurant-gridworld {:grid pomdp-grid :goals [:A :B]
+                                          :signpost pomdp-signpost
+                                          :true-world tw :start [1 4]})
+          pa   (pomdp/make-pomdp-agent (assoc e :alpha ##Inf :gamma 1.0 :n-iters 40))
+          roll (pomdp/simulate-pomdp pa e (:start-idx e) 12)
+          {:keys [states beliefs]} roll]
+      (println (str "  true world " (name tw) " | path " states
+                    " | P(" (name tw) ")=" (mapv #(.toFixed (get % tw) 2) beliefs)))
+      (check-close (str (name tw) ": latent prior is flat at the start") 0.5
+                   (get (first beliefs) tw) 1e-9)
+      (check-close (str (name tw) ": belief snaps to truth at the signpost") 1.0
+                   (get (nth beliefs 2) tw) 1e-9)
+      (check-equal (str (name tw) ": QMDP agent reaches the true goal") goal-idx
+                   (last states)))))
+
+;; ---------------------------------------------------------------------------
+;; 6. custom agents — drop-in policies that are ordinary generative functions
+;; ---------------------------------------------------------------------------
+
+(defn random-policy
+  "A custom RANDOM agent: act uniformly at random over `n-actions`, via the
+   value-carrying uniform-draw helper."
+  [n-actions]
+  (gen [_s] (trace :action (:dist (h/uniform-draw (vec (range n-actions)))))))
+
+(defn epsilon-greedy-policy
+  "A custom EPSILON-GREEDY agent: with prob epsilon explore uniformly, else exploit
+   the greedy argmax of the Q-row via exact/categorical-argmax. `q-rows` is the
+   host-side [S][A] value table (mx/->clj of an agent's :Q)."
+  [q-rows n-actions epsilon]
+  (gen [s]
+    (let [explore (trace :explore (dist/flip epsilon))]
+      (trace :action
+             (if (pos? (int (mx/item explore)))
+               (:dist (h/uniform-draw (vec (range n-actions))))
+               (exact/categorical-argmax (mx/array (nth q-rows s) mx/float32)))))))
+
+(defn- policy-act [policy s]
+  (int (mx/item (:retval (p/simulate (dyn/auto-key policy) [s])))))
+
+(defn demo-custom-agents []
+  (println "\n-- 6. custom agents: random + epsilon-greedy --")
+  (let [mdp     (worlds/line-mdp {:n 7 :reward 1.0 :time-cost -0.1})
+        start   (:start-idx mdp)
+        n-act   4
+        optimal (agent/make-mdp-agent {:mdp mdp :alpha ##Inf :gamma 1.0 :n-iters 24})
+        q-rows  (vec (map vec (mx/->clj (:Q optimal))))
+        greedy-a (let [row (nth q-rows start)]
+                   (first (apply max-key second (map-indexed vector row))))
+        ;; random agent: 40 draws, all in range
+        rnd      (random-policy n-act)
+        rnd-acts (mapv (fn [_] (policy-act rnd start)) (range 40))
+        ;; epsilon-greedy with epsilon=0 is pure greedy (deterministic)
+        eg0      (epsilon-greedy-policy q-rows n-act 0.0)
+        eg0-acts (mapv (fn [_] (policy-act eg0 start)) (range 10))
+        ;; epsilon-greedy with epsilon=1 is pure exploration
+        eg1      (epsilon-greedy-policy q-rows n-act 1.0)
+        eg1-acts (set (mapv (fn [_] (policy-act eg1 start)) (range 60)))]
+    (println (str "  random agent actions (sample): " (take 8 rnd-acts)))
+    (check-true "random agent: every action is a legal index 0..3"
+                (every? #(contains? #{0 1 2 3} %) rnd-acts))
+    (println (str "  greedy argmax action at start = " greedy-a))
+    (check-true "epsilon-greedy(0.0) always takes the greedy argmax action"
+                (every? #(= greedy-a %) eg0-acts))
+    (println (str "  epsilon-greedy(1.0) explored actions = " (sort eg1-acts)))
+    (check-true "epsilon-greedy(1.0) explores more than one action"
+                (> (count eg1-acts) 1))))
+
+;; ---------------------------------------------------------------------------
+;; run + self-check
+;; ---------------------------------------------------------------------------
+
+(defn -main []
+  (println "\n=== agentmodels.org Ch 8 — genmlx.agents library quick-start ===")
+  (demo-line-mdp)
+  (demo-gridworld-mdp)
+  (demo-hyperbolic)
+  (demo-line-pomdp)
+  (demo-custom-agents)
+  (println (str "\n" (if (zero? @fails)
+                       "ALL CHECKS PASSED ✓"
+                       (str @fails " CHECK(S) FAILED ✗"))))
+  (when (pos? @fails) (js/process.exit 1)))
+
+(-main)

--- a/examples/agents_llm_inverse.cljs
+++ b/examples/agents_llm_inverse.cljs
@@ -1,0 +1,210 @@
+(ns agents-llm-inverse
+  "FLAGSHIP — agents × llm (ROADMAP Phase 3, item 4, Direction 2: LLM reasons OVER
+   an agent model). The companion to agents_llm_policy.cljs (Direction 1, LLM as the
+   policy). Here the nesting is the other way around: an AGENT GENERATIVE FUNCTION
+   provides the likelihood and an LLM GENERATIVE FUNCTION provides a reasoning score,
+   and the two are combined in a single Bayesian inference over the agent's hidden goal.
+
+   The task is inverse planning: we watch an agent take one action from the start cell
+   and infer which of several candidate destinations it is pursuing. Two evidence
+   sources, both generative functions, both scored through the GFI:
+     • AGENT MODEL likelihood — for each candidate goal g, build the MDP-optimal
+       softmax agent for g and read P(observed action | start, g) from its policy.
+       This is classic inverse planning (planning-as-inference).
+     • LLM REASONER score — for each goal g, ask the LLM 'the agent at (r,c) moved
+       <action>; is it heading to (gr,gc)? Answer yes/no:' and read P_LLM(yes | g)
+       from the LLM GF's per-token log-probs (p/assess on ' yes' vs ' no').
+   The joint posterior P(g | action) ∝ P(action | g) · P_LLM(yes | g) fuses the
+   agent model and the LLM reasoner — 'an LLM reasoning over an agent model.'
+
+   SAFETY/DESIGN: the inference is host-enumerated over a small fixed goal set with
+   ONE sequential LLM assess per goal — there is NO inference engine running over the
+   LLM GF, so the LLM KV cache is never shared across particles (the failure mode the
+   scoping flagged). Each LLM assess is independent, exactly like Direction 1.
+
+   HONESTY: the AGENT-model half is exact and asserted — observing g*'s own optimal
+   action makes g* the agent-model MAP (the candidate goals are chosen to induce
+   distinct optimal first actions, so the action is identifying). The LLM-reasoner
+   half is a 0.6B base model: its P_LLM(yes|g) is printed and checked only for being
+   a valid probability — NEVER asserted to reason correctly. Skip-clean if the model
+   is absent.
+
+   Reuse, zero engine change: genmlx.agents.gridworld/build-mdp + agent/make-mdp-agent
+   (the agent GF + soft policy), genmlx.llm.core/make-llm-gf (the reasoner GF), the GFI.
+   Run:  bun run --bun nbb examples/agents_llm_inverse.cljs"
+  (:require [genmlx.mlx :as mx]
+            [genmlx.choicemap :as cm]
+            [genmlx.protocols :as p]
+            [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.agent :as agent]
+            [genmlx.llm.backend :as llm]
+            [genmlx.llm.core :as llm-core]
+            [promesa.core :as pr]
+            ["fs" :as fs]))
+
+;; ---------------------------------------------------------------------------
+;; tiny self-check harness
+;; ---------------------------------------------------------------------------
+
+(def ^:private fails (atom 0))
+(defn- ->num [v] (if (mx/array? v) (mx/item v) v))
+
+(defn- check-close [label expected actual tol]
+  (let [a (->num actual) ok (<= (abs (- expected a)) tol)]
+    (println (str (if ok "  ✓ " "  ✗ FAIL ") label " — expected " expected ", got " (.toFixed a 6)))
+    (when-not ok (swap! fails inc)) ok))
+
+(defn- check-true [label ok]
+  (println (str (if ok "  ✓ " "  ✗ FAIL ") label))
+  (when-not ok (swap! fails inc)) ok)
+
+;; ---------------------------------------------------------------------------
+;; math helpers
+;; ---------------------------------------------------------------------------
+
+(defn- softmax [xs]
+  (let [m (apply max xs) es (mapv #(js/Math.exp (- % m)) xs) z (reduce + es)]
+    (mapv #(/ % z) es)))
+
+(defn- normalize [xs] (let [z (reduce + xs)] (mapv #(/ % z) xs)))
+(defn- argmax-idx [xs] (first (apply max-key second (map-indexed vector xs))))
+
+;; ---------------------------------------------------------------------------
+;; the agent model: per-goal gridworld MDP + soft policy (inverse planning)
+;; ---------------------------------------------------------------------------
+
+(def N 3)            ; 3×3 grid
+(def ALPHA 3.0)      ; softmax rationality of the modelled agent
+(def action-names [:left :right :up :down])
+
+(defn- grid-with-goal [[gr gc]]
+  (vec (for [r (range N)] (vec (for [c (range N)] (if (and (= r gr) (= c gc)) :goal :empty))))))
+
+(defn- goal-mdp [goal-rc]
+  (gw/build-mdp {:grid (grid-with-goal goal-rc)
+                 :utilities {:goal 1.0 :timeCost -0.05}
+                 :start [0 0] :gamma 1.0 :noise 0.0}))
+
+(defn- goal-agent [goal-rc]
+  (agent/make-mdp-agent {:mdp (goal-mdp goal-rc) :alpha ALPHA :gamma 1.0 :n-iters 24}))
+
+(defn- q-row [ag s] (nth (vec (map vec (mx/->clj (:Q ag)))) s))
+
+(defn- action-probs
+  "Soft policy P(action | s, goal) = softmax(ALPHA · Q_goal[s])."
+  [ag s]
+  (softmax (mapv #(* ALPHA %) (q-row ag s))))
+
+(defn- s->rc [mdp s] (let [w (:W mdp)] [(quot s w) (rem s w)]))
+
+;; ---------------------------------------------------------------------------
+;; the LLM reasoner: P_LLM(yes | observation, goal) through the GFI
+;; ---------------------------------------------------------------------------
+
+(defn- token-logprob
+  "log p(word tokens | prompt) via the LLM GF's GFI assess op. `word-ids` is the
+   pre-encoded token-id vector (encode is async, awaited by the caller)."
+  [llm-gf prompt-ids word-ids]
+  (let [n (count word-ids)
+        constraints (reduce (fn [cm i] (cm/set-value cm (keyword (str "t" i))
+                                                     (mx/scalar (nth word-ids i) mx/int32)))
+                            cm/EMPTY (range n))]
+    (->num (:weight (p/assess llm-gf [prompt-ids n] constraints)))))
+
+(defn- reasoner-prompt [mdp s a goal-rc]
+  (let [[sr sc] (s->rc mdp s) [gr gc] goal-rc]
+    (str "An agent on a 3x3 grid (rows 0-2 top to bottom, cols 0-2 left to right) is at "
+         "row " sr ", column " sc ". It just moved " (name (nth action-names a)) ". "
+         "Is the agent heading toward the destination at row " gr ", column " gc "? "
+         "Answer yes or no:")))
+
+;; ---------------------------------------------------------------------------
+;; run + self-check (async: model load + tokenizer encode are promises)
+;; ---------------------------------------------------------------------------
+
+(def model-path (str (.-HOME js/process.env) "/.cache/models/qwen3-0.6b-mlx-bf16"))
+
+(defn run [m]
+  (pr/let [tok    (:tokenizer m)
+           llm-gf (llm-core/make-llm-gf m)
+           yes-ids (pr/let [v (llm/encode tok " yes")] (vec v))
+           no-ids  (pr/let [v (llm/encode tok " no")] (vec v))]
+    ;; choose candidate goals that induce DISTINCT optimal first actions (so the
+    ;; observed action identifies the goal); g* is the first.
+    (let [ref-mdp     (goal-mdp [2 2])
+          start       (:start-idx ref-mdp)
+          candidates  (for [r (range N) c (range N) :when (not= [r c] [0 0])] [r c])
+          first-act   (fn [g] (argmax-idx (q-row (goal-agent g) start)))
+          goals       (->> candidates (group-by first-act) vals (mapv first) (take 3) vec)
+          agents      (mapv goal-agent goals)
+          g*          (first goals)
+          a*          (first-act g*)                ; observed action = g*'s optimal first move
+          ;; AGENT MODEL: P(a* | start, g) for each candidate goal
+          lik         (mapv (fn [ag] (nth (action-probs ag start) a*)) agents)
+          agent-post  (normalize lik)]
+      (println "\n=== agents × llm flagship — an LLM reasoning OVER an agent model ===")
+      (println (str "  candidate goals (row,col): " goals
+                    "   each induces optimal first action "
+                    (mapv #(name (nth action-names (first-act %))) goals)))
+      (println (str "  OBSERVED: agent at " (s->rc ref-mdp start) " moved "
+                    (name (nth action-names a*)) " (the true goal g* = " g* ")"))
+
+      ;; --- agent-model inverse planning (exact, asserted) ---
+      (println "\n-- agent-model likelihood P(action | goal) and posterior --")
+      (println (str "  P(a*|g):      " (mapv #(.toFixed % 3) lik)))
+      (println (str "  agent post.:  " (mapv #(.toFixed % 3) agent-post)
+                    "   MAP = goal " (nth goals (argmax-idx agent-post))))
+      (check-true "agent-model likelihoods all finite" (every? js/isFinite lik))
+      (check-close "agent-model posterior sums to 1" 1.0 (reduce + agent-post) 1e-6)
+      (check-true "agent-model MAP is the true goal g* (the observed action identifies it)"
+                  (= 0 (argmax-idx agent-post)))
+
+      ;; --- LLM reasoner over the agent model (printed; validity asserted) ---
+      (pr/let [prompt-ids (pr/all (mapv (fn [g] (pr/let [v (llm/encode tok (reasoner-prompt ref-mdp start a* g))] (vec v)))
+                                        goals))]
+        (let [p-yes (mapv (fn [pid]
+                            (let [ly (token-logprob llm-gf pid yes-ids)
+                                  ln (token-logprob llm-gf pid no-ids)
+                                  mx* (max ly ln)]
+                              (/ (js/Math.exp (- ly mx*))
+                                 (+ (js/Math.exp (- ly mx*)) (js/Math.exp (- ln mx*))))))
+                          prompt-ids)
+              llm-post  (normalize p-yes)
+              combined  (normalize (mapv * lik p-yes))]
+          (println "\n-- LLM reasoner P_LLM(yes | observation, goal) (0.6B model; validity-only) --")
+          (println (str "  P_LLM(yes|g): " (mapv #(.toFixed % 3) p-yes)))
+          (println (str "  LLM post.:    " (mapv #(.toFixed % 3) llm-post)))
+          (check-true "LLM P_LLM(yes|g) are all valid probabilities in [0,1]"
+                      (every? #(<= 0.0 % 1.0) p-yes))
+          (check-true "LLM P_LLM(yes|g) are finite" (every? js/isFinite p-yes))
+          (check-close "LLM-only posterior sums to 1" 1.0 (reduce + llm-post) 1e-6)
+
+          ;; --- the joint: agent model × LLM reasoner ---
+          (println "\n-- joint posterior P(goal | action) ∝ P(action|goal) · P_LLM(yes|goal) --")
+          (println (str "  combined:     " (mapv #(.toFixed % 3) combined)
+                        "   MAP = goal " (nth goals (argmax-idx combined))))
+          (check-close "combined posterior sums to 1" 1.0 (reduce + combined) 1e-6)
+          (check-true "combined posterior is finite and non-negative"
+                      (every? #(and (js/isFinite %) (>= % 0.0)) combined))
+
+          (println (str "\n" (if (zero? @fails) "ALL CHECKS PASSED ✓"
+                                 (str @fails " CHECK(S) FAILED ✗"))))
+          (when (pos? @fails) (js/process.exit 1)))))))
+
+(defn run-or-skip
+  "Load the model and run the self-checking inverse-planning flagship, or skip
+   cleanly if the model is absent. Returns a promise (the test wrapper awaits it)."
+  []
+  (if-not (.existsSync fs model-path)
+    (do (println (str "\nSKIP: model not found at " model-path
+                      " — agents×llm inverse flagship needs qwen3-0.6b-mlx-bf16. (clean skip, exit 0)"))
+        (pr/resolved :skipped))
+    (-> (pr/let [m (llm/load-model model-path)] (run m))
+        (pr/catch (fn [e]
+                    (println (str "\n✗ FAIL: agents×llm inverse flagship errored: " (.-message e)))
+                    (js/process.exit 1))))))
+
+(def ^:private main?
+  (boolean (some #(re-find #"agents_llm_inverse\.cljs" (str %)) (array-seq js/process.argv))))
+
+(when main? (run-or-skip))

--- a/examples/agents_llm_policy.cljs
+++ b/examples/agents_llm_policy.cljs
@@ -1,0 +1,288 @@
+(ns agents-llm-policy
+  "FLAGSHIP — agents × llm (ROADMAP Phase 3, item 4, Direction 1: LLM-as-policy).
+
+   The genmlx.agents thesis is that an agent is a generative function and its
+   POLICY is a pluggable GF. This example shows that the pluggable policy can be
+   an LLM: the per-action policy logits ARE the LLM generative function's own
+   per-action log-probabilities, obtained through the GFI (`p/assess` on the LLM
+   GF), and the action is then drawn by an ordinary categorical policy GF. The
+   LLM GF (genmlx.llm.core/make-llm-gf) sits in policy position, composed with the
+   genmlx.agents MDP machinery purely through the GFI — no engine change, no custom
+   dispatch.
+
+   Concretely, on a tiny 3×3 gridworld:
+     1. Describe the current state in natural language ('You are at row R, col C.
+        The goal is at row 2, col 2. ... Best move:').
+     2. For each action word in {' left',' right',' up',' down'} (aligned to
+        gridworld action indices), score it with `p/assess` on the LLM GF →
+        log p(action word | state prompt). These four numbers are the policy logits.
+     3. The policy is `(gen [logits] (trace :action (dist/categorical logits)))`,
+        a generative function whose action distribution is the LLM's. p/simulate
+        samples an action, p/assess scores one, p/generate constrains one — all
+        through the standard handler.
+     4. Roll the LLM-policy agent out with the MDP's transition (:ns-fn).
+
+   HONESTY: a 0.6B base model is NOT a competent gridworld planner. This example
+   proves the COMPOSITION (an LLM GF as a policy, scored through the GFI), not that
+   the LLM plans well. It asserts only structural GFI correctness (valid action
+   site; the policy's p/assess equals logsoftmax of the LLM logits; p/generate over
+   the four actions has probabilities summing to 1; reproducibility). The LLM's
+   action distribution is printed for inspection, never asserted to be optimal.
+
+   Reuse, zero engine change: genmlx.llm.core/make-llm-gf (verified by
+   llm_core_test, 36/36, qwen3-0.6b), genmlx.agents.gridworld/build-mdp, the GFI
+   (p/simulate, p/assess, p/generate). Self-checking + skip-clean if the model is
+   absent. Run:
+
+     bun run --bun nbb examples/agents_llm_policy.cljs"
+  (:require [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.choicemap :as cm]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.mlx.random :as rng]
+            [genmlx.gen :refer [gen]]
+            [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.agent :as agent]
+            [genmlx.llm.backend :as llm]
+            [genmlx.llm.core :as llm-core]
+            [promesa.core :as pr]
+            ["fs" :as fs]))
+
+;; ---------------------------------------------------------------------------
+;; tiny self-check harness
+;; ---------------------------------------------------------------------------
+
+(def ^:private fails (atom 0))
+
+(defn- ->num [v] (if (mx/array? v) (mx/item v) v))
+
+(defn- check-close [label expected actual tol]
+  (let [a (->num actual)
+        ok (<= (abs (- expected a)) tol)]
+    (println (str (if ok "  ✓ " "  ✗ FAIL ") label " — expected " expected ", got " (.toFixed a 6)))
+    (when-not ok (swap! fails inc))
+    ok))
+
+(defn- check-true [label ok]
+  (println (str (if ok "  ✓ " "  ✗ FAIL ") label))
+  (when-not ok (swap! fails inc))
+  ok)
+
+;; ---------------------------------------------------------------------------
+;; environment: a tiny 3×3 gridworld; goal at bottom-right
+;; ---------------------------------------------------------------------------
+
+(def grid
+  [[:empty :empty :empty]
+   [:empty :empty :empty]
+   [:empty :empty :goal]])
+
+(def mdp (gw/build-mdp {:grid grid
+                        :utilities {:goal 1.0 :timeCost -0.05}
+                        :start [0 0] :gamma 1.0 :noise 0.0}))
+
+(def W (:W mdp))
+;; action words ALIGNED to genmlx.agents.gridworld action-kw [:left :right :up :down]
+(def action-words [" left" " right" " up" " down"])
+(def goal-idx (some (fn [[idx kw]] (when (= kw :goal) idx)) (:terminals mdp)))
+
+(defn s->rc [s] [(quot s W) (rem s W)])
+
+(defn describe-state
+  "A compact natural-language prompt asking the LLM for the best gridworld move."
+  [s]
+  (let [[r c]   (s->rc s)
+        [gr gc] (s->rc goal-idx)]
+    (str "You are an agent on a 3x3 grid. Rows are numbered 0 (top) to 2 (bottom) "
+         "and columns 0 (left) to 2 (right). You are at row " r ", column " c ". "
+         "The goal is at row " gr ", column " gc ". "
+         "Choose the single best move to reach the goal. Options: left, right, up, down. "
+         "Best move:")))
+
+;; ---------------------------------------------------------------------------
+;; the LLM in policy position: per-action log-probs THROUGH the GFI (p/assess)
+;; ---------------------------------------------------------------------------
+
+(defn action-logprob
+  "log p(action tokens | state prompt) via the LLM GF's GFI assess op. `act-ids`
+   is the pre-encoded token-id vector of the action word (encode is async, so it
+   is awaited by the caller and threaded in here as plain ids)."
+  [llm-gf prompt-ids act-ids]
+  (let [n           (count act-ids)
+        constraints (reduce (fn [cm i]
+                              (cm/set-value cm (keyword (str "t" i))
+                                            (mx/scalar (nth act-ids i) mx/int32)))
+                            cm/EMPTY (range n))]
+    (->num (:weight (p/assess llm-gf [prompt-ids n] constraints)))))
+
+(defn llm-action-logits
+  "The four policy logits at a state: each is the LLM GF's assess log-prob of the
+   corresponding action word given the (pre-encoded) state prompt. Pure/sync —
+   `prompt-ids` and `act-id-lists` are already-encoded token-id vectors."
+  [llm-gf prompt-ids act-id-lists]
+  {:logits (mapv #(action-logprob llm-gf prompt-ids %) act-id-lists)
+   :ntoks  (mapv count act-id-lists)})
+
+;; the policy: an ordinary categorical GF whose logits are the LLM's per-action scores
+(def action-policy
+  (gen [logits] (trace :action (dist/categorical logits))))
+
+(defn- logsoftmax-at
+  "Host-side log_softmax(logits)[a] for cross-checking the GFI scores."
+  [logits a]
+  (let [m   (apply max logits)
+        lse (+ m (js/Math.log (reduce + (map #(js/Math.exp (- % m)) logits))))]
+    (- (nth logits a) lse)))
+
+(defn- softmax [logits]
+  (let [m  (apply max logits)
+        es (mapv #(js/Math.exp (- % m)) logits)
+        z  (reduce + es)]
+    (mapv #(/ % z) es)))
+
+;; ---------------------------------------------------------------------------
+;; rollout: state → LLM-policy action → MDP transition
+;; ---------------------------------------------------------------------------
+
+(defn encode-prompt
+  "Async: encode the state-prompt for state `s` into a token-id vector."
+  [tok s]
+  (pr/let [ids (llm/encode tok (describe-state s))] (vec ids)))
+
+(defn rollout
+  "Async: roll the LLM-policy agent from `start` for ≤ k steps. Illustrative (fresh
+   entropy per step). `act-id-lists` is the pre-encoded action vocabulary. Resolves
+   to a vector of {:state :action :probs}."
+  [llm-gf tok act-id-lists start k]
+  (let [terms (set (keys (:terminals mdp)))
+        ns-fn (:ns-fn mdp)]
+    (letfn [(step [s i acc]
+              (if (or (>= i k) (contains? terms s))
+                (pr/resolved acc)
+                (pr/let [pid    (encode-prompt tok s)
+                         res    (llm-action-logits llm-gf pid act-id-lists)
+                         logmx  (mx/array (:logits res) mx/float32)
+                         a      (int (->num (:retval (p/simulate (dyn/auto-key action-policy) [logmx]))))
+                         s'     (ns-fn s a)]
+                  (step s' (inc i) (conj acc {:state s :action a :probs (softmax (:logits res))})))))]
+      (step start 0 []))))
+
+;; ---------------------------------------------------------------------------
+;; run + self-check (async: model load + tokenizer encode are promises)
+;; ---------------------------------------------------------------------------
+
+(def model-path (str (.-HOME js/process.env) "/.cache/models/qwen3-0.6b-mlx-bf16"))
+
+(defn run [m]
+  (pr/let [tok          (:tokenizer m)
+           llm-gf       (llm-core/make-llm-gf m)
+           act-id-lists (pr/all (mapv (fn [w] (pr/let [ids (llm/encode tok w)] (vec ids))) action-words))
+           start        (:start-idx mdp)
+           start-pid    (encode-prompt tok start)
+           ;; three distinct cells for the state-dependence check (idx 0,4,7)
+           demo-states  [0 4 7]
+           demo-pids    (pr/all (mapv #(encode-prompt tok %) demo-states))]
+    (let [optimal (agent/make-mdp-agent {:mdp mdp :alpha ##Inf :gamma 1.0 :n-iters 24})
+          {:keys [logits ntoks]} (llm-action-logits llm-gf start-pid act-id-lists)
+          probs (softmax logits)
+          logmx (mx/array logits mx/float32)]
+      (println "\n=== agents × llm flagship — LLM as an agent policy (GFI nesting) ===")
+      (println (str "  grid 3x3, goal at idx " goal-idx " (row 2,col 2); actions "
+                    (mapv (comp keyword #(subs % 1)) action-words)))
+
+      (println "\n-- LLM policy logits at the start state (via p/assess on the LLM GF) --")
+      (println (str "  prompt: " (pr-str (describe-state start))))
+      (println (str "  action words: " action-words "  (token counts " ntoks ")"))
+      (println (str "  LLM log p(action|state): " (mapv #(.toFixed % 3) logits)))
+      (println (str "  policy π(action|state)  : " (mapv #(.toFixed % 3) probs)
+                    "   optimal action = " ((:act optimal) start)))
+      (check-true "all four LLM action log-probs are finite" (every? js/isFinite logits))
+      (check-close "policy distribution sums to 1" 1.0 (reduce + probs) 1e-5)
+
+      ;; --- GFI proof 1: the policy IS a generative function ---
+      (println "\n-- GFI proof: the LLM policy is a generative function --")
+      (let [sim   (p/simulate (dyn/auto-key action-policy) [logmx])
+            a-sim (int (->num (:retval sim)))]
+        (check-true "p/simulate yields a valid :action site in {0..3}"
+                    (and (contains? #{0 1 2 3} a-sim)
+                         (cm/has-value? (cm/get-submap (:choices sim) :action)))))
+
+      ;; --- GFI proof 2: p/assess weight == logsoftmax(LLM logits)[a] ---
+      (doseq [a (range 4)]
+        (let [w (->num (:weight (p/assess (dyn/auto-key action-policy) [logmx]
+                                          (cm/choicemap :action (mx/scalar a mx/int32)))))]
+          (check-close (str "p/assess(:action=" a ") == logsoftmax(LLM logits)[" a "]")
+                       (logsoftmax-at logits a) w 1e-3)))
+
+      ;; --- GFI proof 3: p/generate forcing each action; Σ exp(weight) == 1 ---
+      (let [ws (mapv (fn [a]
+                       (->num (:weight (p/generate (dyn/auto-key action-policy) [logmx]
+                                                   (cm/choicemap :action (mx/scalar a mx/int32))))))
+                     (range 4))]
+        (check-true "p/generate weights all finite" (every? js/isFinite ws))
+        (check-close "Σ exp(p/generate weight over the 4 actions) == 1"
+                     1.0 (reduce + (map js/Math.exp ws)) 1e-3))
+
+      ;; --- GFI proof 4: reproducibility (same key → same action) ---
+      (let [a1 (int (->num (:retval (p/simulate (dyn/with-key action-policy (rng/fresh-key 7)) [logmx]))))
+            a2 (int (->num (:retval (p/simulate (dyn/with-key action-policy (rng/fresh-key 7)) [logmx]))))
+            a3 (int (->num (:retval (p/simulate (dyn/with-key action-policy (rng/fresh-key 8)) [logmx]))))]
+        (check-true "same key → same sampled action" (= a1 a2))
+        (check-true "reproducible draws are valid actions" (every? #{0 1 2 3} [a1 a2 a3])))
+
+      ;; --- GFI proof 5: the policy logit IS the LLM GF assess of that action word ---
+      (let [llm-direct (action-logprob llm-gf start-pid (nth act-id-lists 1))]
+        (check-close "policy logit[:right] == LLM GF p/assess of ' right'"
+                     (nth logits 1) llm-direct 1e-4))
+
+      ;; --- state-dependence: the LLM policy genuinely conditions on the state ---
+      (println "\n-- the LLM policy conditions on state (distribution varies per cell) --")
+      (let [dists (mapv (fn [s pid]
+                          (let [d (softmax (:logits (llm-action-logits llm-gf pid act-id-lists)))]
+                            (let [[r c] (s->rc s)]
+                              (println (str "  cell (row " r ",col " c "): π=" (mapv #(.toFixed % 2) d))))
+                            d))
+                        demo-states demo-pids)]
+        (check-true "the LLM policy distribution differs across at least two cells"
+                    (some (fn [[a b]] (> (reduce + (map (comp abs -) a b)) 1e-3))
+                          (for [i (range (count dists)) j (range (count dists)) :when (< i j)]
+                            [(nth dists i) (nth dists j)]))))
+
+      ;; --- a short LLM-policy rollout (illustrative; planning quality NOT asserted) ---
+      (println "\n-- LLM-policy rollout (3 steps; illustrative, not asserted) --")
+      (pr/let [traj (rollout llm-gf tok act-id-lists start 3)]
+        (doseq [{:keys [state action probs]} traj]
+          (let [[r c] (s->rc state)]
+            (println (str "  at (row " r ",col " c ") → action "
+                          (name (nth [:left :right :up :down] action))
+                          "  π=" (mapv #(.toFixed % 2) probs)))))
+        (check-true "rollout produced at least one step with a valid action"
+                    (and (seq traj) (every? #(contains? #{0 1 2 3} (:action %)) traj)))
+
+        (println (str "\n" (if (zero? @fails)
+                             "ALL CHECKS PASSED ✓"
+                             (str @fails " CHECK(S) FAILED ✗"))))
+        (when (pos? @fails) (js/process.exit 1))))))
+
+(defn run-or-skip
+  "Load the model and run the self-checking flagship, or skip cleanly if the model
+   is absent. Returns a promise. Used both by direct invocation and the test wrapper
+   (which awaits it as its top-level promise)."
+  []
+  (if-not (.existsSync fs model-path)
+    (do (println (str "\nSKIP: model not found at " model-path
+                      " — agents×llm flagship needs qwen3-0.6b-mlx-bf16. (clean skip, exit 0)"))
+        (pr/resolved :skipped))
+    (-> (pr/let [m (llm/load-model model-path)] (run m))
+        (pr/catch (fn [e]
+                    (println (str "\n✗ FAIL: agents×llm flagship errored: " (.-message e)))
+                    (js/process.exit 1))))))
+
+;; Auto-run only when this file is the entry point (so `(:require ...)` from the
+;; test wrapper does not double-run; the wrapper calls run-or-skip explicitly and
+;; awaits it — top-level requires would not await this async self-check).
+(def ^:private main?
+  (boolean (some #(re-find #"agents_llm_policy\.cljs" (str %)) (array-seq js/process.argv))))
+
+(when main? (run-or-skip))

--- a/src/genmlx/agents/CONTRACTS.md
+++ b/src/genmlx/agents/CONTRACTS.md
@@ -1,0 +1,82 @@
+# genmlx.agents — API contracts (v1.0 surface)
+
+The stable public surface of the `genmlx.agents` vertical, pinned by **tests as
+contracts**. Every claim below is enforced by a test; if the surface drifts, the
+test fails. This document is descriptive of what the code guarantees today — it is
+not a license to change these signatures silently.
+
+**Enforcing tests**
+- `test/genmlx/agents_api_test.cljs` — reachability of the 8 promoted namespaces;
+  an agent *is* a generative function (GFI ops); tensor-VI `Q` == recursive-EU;
+  the `genmlx-xpbm` regressions; inverse-planning posteriors (host == batched).
+- `test/genmlx/agents_contracts_test.cljs` — the per-constructor return-map shapes,
+  the family-specific `:act` signatures, and the POMDP/bandit agent contracts.
+- `test/genmlx/belief_tensor_test.cljs` (36/36) — the belief filter math: host ==
+  tensor equivalence, nil-observation identity, impossible-observation defensiveness.
+
+## The minimal agent contract
+
+The **only** keys guaranteed on *every* agent returned by an `agents` constructor:
+
+| key       | type           | meaning                                   |
+|-----------|----------------|-------------------------------------------|
+| `:act`    | fn             | the action entry point (signature is family-specific — see below) |
+| `:params` | map            | the agent's parameters (for inspection/logging) |
+
+Everything else is **family-specific**. In particular there is **no** uniform
+`:policy`, `:Q`, or `:expected-utility` across all agents, and **no** single `:act`
+arity. Consumers must dispatch on the agent family, not assume a universal shape.
+
+## Constructors
+
+### `agent/make-mdp-agent {:keys [mdp alpha gamma n-iters]}` — fully-observed MDP
+- **Returns** `{:mdp :Q [S,A] :V [S] :policy <GF> :act :expected-utility :params}`.
+- `:policy` is a generative function `(gen [s] (trace :action ...))` — full GFI
+  (`p/simulate`/`p/assess`/`p/generate`/`p/update`).
+- `:act` — **state-based**: `(act s)` draws fresh entropy, `(act s key)` is
+  deterministic in `key`; both return an action int.
+- `:Q`/`:V` come from tensor value iteration; `:expected-utility` is the faithful
+  recursive path. The two agree to float32 (the flagship invariant).
+
+### `biased-planners/make-biased-mdp-agent {:keys [mdp alpha gamma n-iters]} {:keys [discount bias reward-myopic-bound]}` — biased (hyperbolic) MDP
+- **Returns** `{:mdp :policy <GF> :act :expected-utility :eu :params}` — **the same
+  shape as make-mdp-agent MINUS `:Q`/`:V`.** The biased agent is recursion-only (the
+  delay-indexed value has no single tensor table), so `:Q`/`:V` are **absent**.
+- `:act` — **state-based**, identical arities to make-mdp-agent. Re-plans from delay 0
+  each call (the Naive plan↔do divergence).
+- At `discount 0` it recovers the unbiased agent (asserted).
+
+### `pomdp/make-pomdp-agent {:keys [grid goals alpha noise gamma n-iters start prior observe world-utils]}` — partially-observed (QMDP)
+- **Returns** `{:worlds :world-agents :prior :observe :belief-Q :update-belief
+  :update-belief-tensor :act :expected-utility :params}`.
+- **Belief** is a plain `{world -> prob}` map (always; both host and tensor filters
+  return a map).
+- `:act` — **belief-based**: `(act belief s)` → action int (softmax over the QMDP
+  belief-Q).
+- `:belief-Q` — `(belief s)` → `[A]` MLX row. `:expected-utility` — `(belief s a)` → float.
+- `:update-belief` — `(belief loc obs)` → belief'. **Observation contract**: `obs = nil`
+  is the identity (absence is non-informative); an impossible observation leaves the
+  belief unchanged (defensive, no NaN). `:update-belief-tensor` runs the same algebra
+  as pure `[W]` MLX ops and returns the same map (opt-in via `simulate-pomdp`
+  `:belief-mode :tensor`).
+
+### `pomdp/make-bandit-agent {:keys [strategy alpha]}` — multi-armed bandit
+- **Returns** `{:act :update-belief :arm-values :params}` — **no `:policy`** (Thompson
+  posterior-sampling / softmax-of-means, not a GF over a fixed action set).
+- **Belief** is `{:arms [[alpha beta] ...]}` (per-arm Beta).
+- `:act` — **belief-based**: `(act belief key)` → arm int. `:arm-values` — `(belief)` →
+  vector of posterior means. `:update-belief` — `(belief arm reward)` → conjugate
+  Beta increment (success → α+1, failure → β+1; other arms unchanged).
+
+## Summary of the family-specific differences (the honest contract)
+
+| family  | `:act` signature   | `:policy` (GF) | `:Q`/`:V` | belief surface                  |
+|---------|--------------------|----------------|-----------|---------------------------------|
+| MDP     | `(s)` / `(s key)`  | yes            | yes       | —                               |
+| biased  | `(s)` / `(s key)`  | yes            | **no**    | —                               |
+| POMDP   | `(belief s)`       | — (hoisted)    | per-world | `{world->prob}`, `:update-belief` |
+| bandit  | `(belief key)`     | **no**         | —         | `{:arms [[a b]...]}`, `:update-belief` |
+
+A future uniform agent protocol could normalize `:act` (e.g. a single
+`(act agent state-or-belief & [key])`), but that is an API *change* (owner decision),
+not part of this freeze. This document fixes the surface **as built**.

--- a/src/genmlx/agents/belief.cljs
+++ b/src/genmlx/agents/belief.cljs
@@ -79,6 +79,45 @@
     b
     (filter-step b (obs-likelihood-vec observe worlds loc o))))
 
+;; -- tensor observation model (bean genmlx-qbb0; enables the fused rollout) -----
+;;
+;; obs-likelihood-vec above builds L host-side: it calls (observe w loc) per world,
+;; so loc (the next state s') must be a HOST int — which is exactly what stops a
+;; POMDP rollout from staying in-graph (bean genmlx-r35c). The fix is to precompute
+;; the observation geometry ONCE into a tensor and make the per-step likelihood a
+;; pure in-graph gather, so s' can thread through as a one-hot.
+
+(defn obs-id-tensor
+  "Precompute the [S,W] observation-id tensor: entry [s,w] is a small float id of
+   (observe w s), with DISTINCT observations (Clojure `=`, nil included) getting
+   distinct ids. Built host-side ONCE from the host `observe` geometry; the in-graph
+   likelihood (obs-likelihood-tensor) is then a pure comparison of these ids, so it
+   matches the host `=` for ANY observe model (signpost reveal / restaurant open-set
+   / nil) without a host int per step. `worlds` is the fixed world ordering."
+  [observe worlds S]
+  (let [worlds  (vec worlds)
+        ids     (atom {})
+        next-id (atom 0.0)
+        id-of   (fn [o] (if-let [i (get @ids o)] i
+                          (let [i @next-id] (swap! ids assoc o i) (swap! next-id inc) i)))
+        rows    (vec (for [s (range S)] (vec (for [w worlds] (id-of (observe w s))))))]
+    (mx/array (clj->js rows) mx/float32)))
+
+(defn obs-likelihood-tensor
+  "In-graph per-world likelihood L:[W] from the precomputed [S,W] obs-id tensor, a
+   one-hot next state `s-onehot`:[S], and a one-hot `true-w-onehot`:[W]. Threads s'
+   as a TENSOR (no host int): obs-row[w] = the obs id world w yields at s', true-obs
+   = obs-row at the true world, L[w] = [obs-row[w] == true-obs]. The tensor form of
+   obs-likelihood-vec; when the true observation is nil (uninformative cell) every
+   world matches so L is all-ones, and filter-step(b, ones) = b (the host nil
+   identity, reproduced without a fast-path)."
+  [obs-tensor s-onehot true-w-onehot]
+  (let [S        (first (mx/shape obs-tensor))
+        obs-row  (mx/sum (mx/multiply (mx/reshape s-onehot [S 1]) obs-tensor) [0])  ; [W]
+        true-obs (mx/sum (mx/multiply obs-row true-w-onehot))                       ; []
+        L        (.astype (mx/equal obs-row true-obs) mx/float32)]                  ; [W]
+    L))
+
 ;; -- belief <-> vector seam (host map/vector callers <-> [W] MLX) --------------
 
 (defn belief->vec

--- a/src/genmlx/agents/pomdp.cljs
+++ b/src/genmlx/agents/pomdp.cljs
@@ -145,6 +145,56 @@
                  (conj states s') (conj actions a)
                  (conj obss o) (conj beliefs b')))))))
 
+(defn fused-simulate-pomdp
+  "Fully-fused (in-graph) POMDP rollout for the OPTIMAL deterministic regime
+   (alpha = ##Inf, noise = 0). Threads the physical state as a one-hot [S] tensor
+   and the belief as a [W] tensor through: tensor belief-Q -> argmax action ->
+   tensor transition (argmax of T[s,a]) -> the tensor observation likelihood
+   (belief/obs-likelihood-tensor, no host int for s') -> belief/filter-step. The
+   rollout LOOP builds one lazy MLX graph with NO per-step mx/item (bean
+   genmlx-r35c); state/belief are extracted only once at the boundary.
+
+   Returns {:states [...] :beliefs [b0 b1 ...]} matching simulate-pomdp at
+   alpha = ##Inf / noise = 0: the fused run is taken to the full horizon and
+   TRUNCATED at the first terminal to align with the host early-stop. For a
+   stochastic policy or transition, use the host simulate-pomdp."
+  [{:keys [world-agents worlds prior observe]} env start horizon]
+  (let [worlds   (vec worlds)
+        W        (count worlds)
+        tw       (:true-world env)
+        true-mdp (:mdp (world-agents tw))
+        T        (:T true-mdp)                                       ; [S,A,S']
+        S        (:S true-mdp)
+        A        (:A true-mdp)
+        terms    (set (keys (:terminals true-mdp)))
+        Qstack   (mx/stack (mapv #(:Q (world-agents %)) worlds))     ; [W,S,A]
+        Obs      (belief/obs-id-tensor observe worlds S)             ; [S,W]
+        oh       (fn [i n] (.astype (mx/equal (mx/arange n) (mx/scalar (double i))) mx/float32))
+        oh-am    (fn [v n] (.astype (mx/equal (mx/arange n) (mx/argmax v)) mx/float32))
+        tw-oh    (oh (.indexOf worlds tw) W)
+        b0       (belief/belief->vec worlds prior)                   ; [W]
+        s0-oh    (oh start S)
+        ;; accumulate (s-onehot, belief) tensors over the FULL horizon — no mx/item
+        trace    (loop [s-oh s0-oh, b b0, k 0, acc [[s0-oh b0]]]
+                   (if (>= k horizon)
+                     acc
+                     (let [mixedQ (mx/sum (mx/multiply (mx/reshape b [W 1 1]) Qstack) [0])    ; [S,A]
+                           q      (mx/sum (mx/multiply (mx/reshape s-oh [S 1]) mixedQ) [0])   ; [A]
+                           a-oh   (oh-am q A)                                                 ; [A]
+                           sa     (mx/multiply (mx/reshape s-oh [S 1]) (mx/reshape a-oh [1 A])) ; [S,A]
+                           Tsa    (mx/sum (mx/multiply (mx/reshape sa [S A 1]) T) [0 1])       ; [S']
+                           s'-oh  (oh-am Tsa S)                                               ; [S'] (one-hot at noise 0)
+                           L      (belief/obs-likelihood-tensor Obs s'-oh tw-oh)              ; [W]
+                           b'     (belief/filter-step b L)]                                   ; [W]
+                       (recur s'-oh b' (inc k) (conj acc [s'-oh b'])))))
+        ;; extract once at the boundary (mx/item only here, never in the loop)
+        states   (mapv (fn [[s-oh _]] (int (mx/item (mx/argmax s-oh)))) trace)
+        beliefs  (mapv (fn [[_ b]] (belief/vec->belief worlds b)) trace)
+        term-idx (or (first (keep-indexed (fn [i s] (when (terms s) i)) states))
+                     (dec (count states)))
+        n        (inc term-idx)]
+    {:states (vec (take n states)) :beliefs (vec (take n beliefs))}))
+
 ;; ---------------------------------------------------------------------------
 ;; Multi-armed bandit POMDP (agentmodels Ch 3c/3d)
 ;; ---------------------------------------------------------------------------

--- a/test/genmlx/agentmodels_ch01_intro_test.cljs
+++ b/test/genmlx/agentmodels_ch01_intro_test.cljs
@@ -1,0 +1,15 @@
+;; @tier slow
+;; agentmodels.org Ch 1 (Introduction) port — suite wrapper.
+;;
+;; The runnable example examples/agentmodels/ch01_intro.cljs self-checks on load:
+;; it prints each marginal and asserts it against the analytic reference number
+;; (coin taster; geometric two ways, P(n=k)=0.5^(k+1), E[n]=1), exiting non-zero
+;; on any failed check. Requiring it here makes a Ch-1 regression a hard test
+;; failure under test/run.sh (exit code is the runner's reliable signal).
+;;
+;; Run: bun run --bun nbb test/genmlx/agentmodels_ch01_intro_test.cljs
+
+(ns genmlx.agentmodels-ch01-intro-test
+  (:require [agentmodels.ch01-intro]))
+
+(println "\n[agentmodels-ch01-intro-test] Ch 1 example self-check completed (PASS).")

--- a/test/genmlx/agentmodels_ch02_webppl_test.cljs
+++ b/test/genmlx/agentmodels_ch02_webppl_test.cljs
@@ -1,0 +1,16 @@
+;; @tier slow
+;; agentmodels.org Ch 2 (WebPPL primer) port — suite wrapper.
+;;
+;; The runnable example examples/agentmodels/ch02_webppl.cljs self-checks on load:
+;; ERP draws, multivariateGaussian, binomial-from-3-flips (two ways agree), the
+;; twoHeads/moreThanTwoHeads conditioning (P(first=H|total>=2)=0.75, evidence 0.5,
+;; posterior {2:0.75, 3:0.25}), and a forward positionDist — each asserted against
+;; the analytic reference number, exiting non-zero on any failed check. Requiring
+;; it here makes a Ch-2 regression a hard test failure under test/run.sh.
+;;
+;; Run: bun run --bun nbb test/genmlx/agentmodels_ch02_webppl_test.cljs
+
+(ns genmlx.agentmodels-ch02-webppl-test
+  (:require [agentmodels.ch02-webppl]))
+
+(println "\n[agentmodels-ch02-webppl-test] Ch 2 example self-check completed (PASS).")

--- a/test/genmlx/agentmodels_ch08_library_test.cljs
+++ b/test/genmlx/agentmodels_ch08_library_test.cljs
@@ -1,0 +1,17 @@
+;; @tier slow
+;; agentmodels.org Ch 8 (WebPPL agents library quick-start) port — suite wrapper.
+;;
+;; The runnable example examples/agentmodels/ch08_library_guide.cljs self-checks on
+;; load: a guided tour of the genmlx.agents foundation — make-line-mdp +
+;; make-mdp-agent (optimal/soft), the hiking gridworld, a Naive hyperbolic biased
+;; planner, a line POMDP with belief filtering (belief snaps to truth at the
+;; signpost; QMDP reaches the true goal), and custom RANDOM + EPSILON-GREEDY policy
+;; GFs — asserting each headline behavior and exiting non-zero on any failure.
+;; Requiring it here makes a Ch-8 regression a hard test failure under test/run.sh.
+;;
+;; Run: bun run --bun nbb test/genmlx/agentmodels_ch08_library_test.cljs
+
+(ns genmlx.agentmodels-ch08-library-test
+  (:require [agentmodels.ch08-library-guide]))
+
+(println "\n[agentmodels-ch08-library-test] Ch 8 example self-check completed (PASS).")

--- a/test/genmlx/agents_contracts_test.cljs
+++ b/test/genmlx/agents_contracts_test.cljs
@@ -1,0 +1,161 @@
+;; @tier medium
+;; genmlx.agents API CONTRACTS — "tests as contracts" for the v1.0 freeze
+;; (ROADMAP Phase 3 item 3, the genmlx-youg promotion criterion; bean genmlx-p4jo).
+;;
+;; agents_api_test.cljs proves reachability + agent-as-GF + VI<->recursive-EU. This
+;; suite pins the things that would silently DRIFT across an API freeze and that the
+;; scoping (wf_177d7bb0-65f) flagged: the per-constructor return-map shapes, the
+;; family-specific :act signatures, and the POMDP/bandit agent contracts. Belief
+;; host<->tensor + nil/impossible-obs MATH equivalence is already covered by
+;; belief_tensor_test.cljs (36/36) — not duplicated here.
+;;
+;; THE HONEST CONTRACT (encoded below, documented in src/genmlx/agents/CONTRACTS.md):
+;;   * The ONLY keys guaranteed on every agent are {:act, :params}.
+;;   * :act has FAMILY-SPECIFIC signatures — state-based (s)/(s key) for MDP/biased,
+;;     belief-based (belief s) for POMDP, (belief key) for bandit. There is no single
+;;     uniform :act arity.
+;;   * :Q/:V are MDP-only (biased agents are recursion-only, no tensor value table);
+;;     :policy/:expected-utility exist for the planning families but NOT for the bandit;
+;;     :belief-Q/:update-belief are the partially-observed families' surface.
+;;
+;; Run: bun run --bun nbb test/genmlx/agents_contracts_test.cljs
+
+(ns genmlx.agents-contracts-test
+  (:require [genmlx.agents.gridworld :as gw]
+            [genmlx.agents.agent :as agent]
+            [genmlx.agents.biased-planners :as bp]
+            [genmlx.agents.pomdp :as pomdp]
+            [genmlx.agents.pomdp-env :as penv]
+            [genmlx.mlx :as mx]
+            [genmlx.protocols :as p]
+            [genmlx.dynamic :as dyn]
+            [genmlx.mlx.random :as rng]
+            [genmlx.choicemap :as cm]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+(defn assert-close [msg expected actual tol]
+  (if (<= (Math/abs (- expected actual)) tol)
+    (do (vswap! passed inc) (println " PASS" msg "  =" actual))
+    (do (vswap! failed inc) (println " FAIL" msg "  expected:" expected "  got:" actual))))
+(defn- act-int? [a] (and (integer? a) (<= 0 a)))
+
+;; ---------------------------------------------------------------------------
+;; build one agent per family
+;; ---------------------------------------------------------------------------
+
+(def mdp (gw/build-mdp {:grid [[:empty :empty] [:empty :goal]]
+                        :utilities {:goal 1.0 :timeCost -0.1} :start [0 0] :gamma 1.0 :noise 0.0}))
+(def start (:start-idx mdp))
+(def A (:A mdp))
+
+(def mdp-ag    (agent/make-mdp-agent {:mdp mdp :alpha 3.0 :gamma 1.0 :n-iters 12}))
+(def biased-ag (bp/make-biased-mdp-agent {:mdp mdp :alpha 3.0 :gamma 1.0 :n-iters 12}
+                                         {:discount 0.0 :bias :sophisticated}))
+
+(def pgrid [[:A    :empty :B]
+            [:wall :empty :wall]
+            [:wall :empty :wall]
+            [:wall :empty :wall]
+            [:wall :empty :wall]])
+(def penv-e   (penv/restaurant-gridworld {:grid pgrid :goals [:A :B] :signpost 7
+                                          :true-world :A :start [1 4]}))
+(def pomdp-ag (pomdp/make-pomdp-agent (assoc penv-e :alpha 2.0 :gamma 1.0 :n-iters 40)))
+(def pstart   (:start-idx penv-e))
+
+(def bandit-ag     (pomdp/make-bandit-agent {:strategy :thompson :alpha 4.0}))
+(def bandit-belief {:arms [[1 1] [1 1]]})
+
+;; ---------------------------------------------------------------------------
+;; 1. the common minimal contract — EVERY agent has {:act fn, :params map}
+;; ---------------------------------------------------------------------------
+(println "\n== 1. common minimal contract: {:act, :params} on every agent ==")
+(doseq [[nm a] [["mdp" mdp-ag] ["biased" biased-ag] ["pomdp" pomdp-ag] ["bandit" bandit-ag]]]
+  (assert-true (str nm ": :act is callable")  (fn? (:act a)))
+  (assert-true (str nm ": :params is a map")  (map? (:params a))))
+
+;; ---------------------------------------------------------------------------
+;; 2. per-family return-map keys (the documented, asserted differences)
+;; ---------------------------------------------------------------------------
+(println "\n== 2. per-family return-map keys ==")
+;; MDP: tensor value table + GF policy + recursive EU
+(assert-true "mdp: has :Q :V :policy :expected-utility"
+             (and (some? (:Q mdp-ag)) (some? (:V mdp-ag))
+                  (some? (:policy mdp-ag)) (fn? (:expected-utility mdp-ag))))
+;; biased: GF policy + EU, but NO tensor :Q/:V (recursion-only) — the key drift
+(assert-true "biased: has :policy :expected-utility but NO :Q/:V (recursion-only)"
+             (and (some? (:policy biased-ag)) (fn? (:expected-utility biased-ag))
+                  (nil? (:Q biased-ag)) (nil? (:V biased-ag))))
+;; POMDP: belief-space surface
+(assert-true "pomdp: has :belief-Q :update-belief :expected-utility :worlds"
+             (and (fn? (:belief-Q pomdp-ag)) (fn? (:update-belief pomdp-ag))
+                  (fn? (:expected-utility pomdp-ag)) (some? (:worlds pomdp-ag))))
+;; bandit: arm-values + conjugate update, and NO GF :policy (Thompson/softmax-of-means)
+(assert-true "bandit: has :arm-values :update-belief but NO :policy"
+             (and (fn? (:arm-values bandit-ag)) (fn? (:update-belief bandit-ag))
+                  (nil? (:policy bandit-ag))))
+
+;; ---------------------------------------------------------------------------
+;; 3. :act signatures are FAMILY-SPECIFIC (state-based vs belief-based)
+;; ---------------------------------------------------------------------------
+(println "\n== 3. :act signatures (family-specific) ==")
+;; MDP/biased :act — state-based: (s) and (s key); the keyed form is deterministic
+(doseq [[nm a] [["mdp" mdp-ag] ["biased" biased-ag]]]
+  (assert-true (str nm ": (:act s) -> action int") (act-int? ((:act a) start)))
+  (let [k (rng/fresh-key 11)]
+    (assert-true (str nm ": (:act s key) is deterministic in key")
+                 (= ((:act a) start k) ((:act a) start k)))))
+;; POMDP :act — belief-based: (belief s) -> action int
+(assert-true "pomdp: (:act belief s) -> action int"
+             (act-int? ((:act pomdp-ag) (:prior pomdp-ag) pstart)))
+;; bandit :act — belief-based: (belief key) -> arm int
+(assert-true "bandit: (:act belief key) -> arm int in {0,1}"
+             (contains? #{0 1} ((:act bandit-ag) bandit-belief (rng/fresh-key 3))))
+
+;; ---------------------------------------------------------------------------
+;; 4. MDP/biased agents ARE generative functions (policy GF) via the GFI
+;; ---------------------------------------------------------------------------
+(println "\n== 4. planning agents are GFs (policy through the GFI) ==")
+(doseq [[nm a] [["mdp" mdp-ag] ["biased" biased-ag]]]
+  (let [tr (p/simulate (dyn/auto-key (:policy a)) [start])]
+    (assert-true (str nm ": p/simulate yields an :action choice + a score")
+                 (and (some? (cm/get-choice (:choices tr) [:action])) (some? (:score tr)))))
+  (let [w (mx/item (:weight (p/assess (dyn/auto-key (:policy a)) [start] (cm/choicemap :action 0))))]
+    (assert-true (str nm ": p/assess yields a finite log-weight") (js/isFinite w))))
+
+;; ---------------------------------------------------------------------------
+;; 5. POMDP belief contract — belief is {world->prob}; filtering keeps it normalized
+;; ---------------------------------------------------------------------------
+(println "\n== 5. POMDP belief contract ==")
+(let [ub    (:update-belief pomdp-ag)
+      prior (:prior pomdp-ag)]
+  (assert-true "belief is a {world->prob} map" (and (map? prior) (every? keyword? (keys prior))))
+  (assert-close "prior sums to 1" 1.0 (reduce + (vals prior)) 1e-9)
+  ;; nil-obs is the identity (absence is non-informative — the unified contract)
+  (assert-true "nil observation leaves the belief unchanged (agent level)"
+               (= prior (ub prior 10 nil)))
+  ;; an informative observation snaps + stays normalized
+  (let [b' (ub prior 7 :A)]
+    (assert-close "reveal :A at the signpost -> P(:A)=1" 1.0 (:A b') 1e-9)
+    (assert-close "filtered belief stays normalized" 1.0 (reduce + (vals b')) 1e-9))
+  ;; belief-Q is an [A] MLX row over actions
+  (let [q (:belief-Q pomdp-ag)]
+    (assert-true "belief-Q returns an [A] action row" (= [A] (mx/shape (q prior pstart))))))
+
+;; ---------------------------------------------------------------------------
+;; 6. bandit contract — arm-values + conjugate Beta update
+;; ---------------------------------------------------------------------------
+(println "\n== 6. bandit contract ==")
+(let [vals (:arm-values bandit-ag)
+      ub   (:update-belief bandit-ag)]
+  (assert-true "arm-values returns one mean per arm" (= 2 (count (vals bandit-belief))))
+  (assert-close "Beta(1,1) arm mean = 0.5" 0.5 (first (vals bandit-belief)) 1e-9)
+  (let [b' (ub bandit-belief 0 1)]            ; success on arm 0
+    (assert-true "conjugate update: arm 0 success -> alpha+1" (= [2 1] (get-in b' [:arms 0])))
+    (assert-true "conjugate update: other arms unchanged"     (= [1 1] (get-in b' [:arms 1])))))
+
+(println (str "\n" @passed " passed, " @failed " failed"))
+(when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/agents_fused_pomdp_test.cljs
+++ b/test/genmlx/agents_fused_pomdp_test.cljs
@@ -1,0 +1,88 @@
+;; @tier medium
+;; Fused POMDP rollout + the tensor observation model (beans genmlx-7kaf / qbb0 / r35c).
+;; Section 1 pins the in-graph observation likelihood against the host obs-likelihood-vec
+;; (the qbb0 tensor-observe primitive). Section 2 pins a fully-fused single-trajectory
+;; rollout against the host simulate-pomdp at alpha=Inf/noise=0 (the r35c requirement:
+;; s' threads as a tensor, no per-step mx/item).
+;;
+;; Run: bun run --bun nbb test/genmlx/agents_fused_pomdp_test.cljs
+
+(ns genmlx.agents-fused-pomdp-test
+  (:require [genmlx.agents.belief :as belief]
+            [genmlx.agents.pomdp :as pomdp]
+            [genmlx.agents.pomdp-env :as penv]
+            [genmlx.mlx :as mx]))
+
+(def passed (volatile! 0))
+(def failed (volatile! 0))
+(defn assert-true [msg c]
+  (if c (do (vswap! passed inc) (println " PASS" msg))
+        (do (vswap! failed inc) (println " FAIL" msg))))
+
+(defn- onehot [i n]
+  (.astype (mx/equal (mx/arange n) (mx/scalar (double i))) mx/float32))
+(defn- idx-of [v x] (first (keep-indexed (fn [i e] (when (= e x) i)) v)))
+
+;; corridor fixture (same as agentmodels_pomdp_test): goals A/B at the top, signpost
+;; at idx 7, the only route from the start passes it.
+(def pgrid [[:A    :empty :B]
+            [:wall :empty :wall]
+            [:wall :empty :wall]
+            [:wall :empty :wall]
+            [:wall :empty :wall]])
+(def signpost 7)
+(def env (penv/restaurant-gridworld {:grid pgrid :goals [:A :B] :signpost signpost
+                                     :true-world :A :start [1 4]}))
+(def observe (:observe env))
+(def worlds  (vec (:worlds env)))
+(def S       (* (count (first pgrid)) (count pgrid)))   ; 3×5 = 15
+
+;; ---------------------------------------------------------------------------
+;; Section 1 — tensor observation likelihood == host obs-likelihood-vec
+;; ---------------------------------------------------------------------------
+(println "\n== 1. tensor obs-likelihood == host obs-likelihood-vec (all s', all true worlds) ==")
+(def Obs (belief/obs-id-tensor observe worlds S))
+(assert-true "obs-id-tensor has shape [S,W]" (= [S (count worlds)] (mx/shape Obs)))
+
+(let [mism (atom 0)]
+  (doseq [tw worlds]
+    (let [tw-oh (onehot (idx-of worlds tw) (count worlds))]
+      (doseq [s (range S)]
+        (let [o      (observe tw s)
+              host-L (vec (mx/->clj (belief/obs-likelihood-vec observe worlds s o)))
+              tens-L (vec (mx/->clj (belief/obs-likelihood-tensor Obs (onehot s S) tw-oh)))]
+          (when (not= host-L tens-L) (swap! mism inc))))))
+  (assert-true (str "tensor L matches host L at every (s', true-world) — " (* (count worlds) S) " cases")
+               (zero? @mism)))
+
+;; spot-check the signpost semantics directly
+(let [tw-oh (onehot (idx-of worlds :A) (count worlds))]
+  (assert-true "at the signpost, true=:A -> L = onehot(:A) = [1 0]"
+               (= [1.0 0.0] (vec (mx/->clj (belief/obs-likelihood-tensor Obs (onehot signpost S) tw-oh)))))
+  (assert-true "off the signpost (nil obs) -> L = ones (uninformative)"
+               (= [1.0 1.0] (vec (mx/->clj (belief/obs-likelihood-tensor Obs (onehot 13 S) tw-oh))))))
+
+;; ---------------------------------------------------------------------------
+;; Section 2 — fused-simulate-pomdp == host simulate-pomdp (alpha=Inf, noise=0)
+;; ---------------------------------------------------------------------------
+(println "\n== 2. fused-simulate-pomdp == host simulate-pomdp (alpha=Inf, noise=0) ==")
+(doseq [tw [:A :B]]
+  (let [e     (penv/restaurant-gridworld {:grid pgrid :goals [:A :B] :signpost signpost
+                                          :true-world tw :start [1 4]})
+        pa    (pomdp/make-pomdp-agent (assoc e :alpha ##Inf :gamma 1.0 :n-iters 40))
+        host  (pomdp/simulate-pomdp pa e (:start-idx e) 12)
+        fused (pomdp/fused-simulate-pomdp pa e (:start-idx e) 12)]
+    (println (str "  true=" (name tw) "  host states " (:states host)
+                  "  fused states " (:states fused)))
+    (assert-true (str "true=" (name tw) ": fused states == host states")
+                 (= (:states host) (:states fused)))
+    (assert-true (str "true=" (name tw) ": #beliefs aligns with #states")
+                 (= (count (:states fused)) (count (:beliefs fused)) (count (:beliefs host))))
+    (let [maxerr (apply max 0.0 (for [[hb fb] (map vector (:beliefs host) (:beliefs fused))
+                                      w worlds]
+                                  (Math/abs (- (double (get hb w 0.0)) (double (get fb w 0.0))))))]
+      (assert-true (str "true=" (name tw) ": fused beliefs == host beliefs (max err " (.toFixed maxerr 8) ")")
+                   (< maxerr 1e-5)))))
+
+(println (str "\n" @passed " passed, " @failed " failed"))
+(when (pos? @failed) (js/process.exit 1))

--- a/test/genmlx/agents_llm_inverse_test.cljs
+++ b/test/genmlx/agents_llm_inverse_test.cljs
@@ -1,0 +1,20 @@
+;; @tier slow
+;; agents × llm flagship (ROADMAP Phase 3, item 4, Direction 2: LLM reasons OVER an
+;; agent model) — suite wrapper.
+;;
+;; The runnable example examples/agents_llm_inverse.cljs does inverse planning over an
+;; agent's hidden goal by FUSING two generative functions: the agent GF's action
+;; likelihood P(action|goal) and the LLM GF's reasoner score P_LLM(yes|goal), in one
+;; host-enumerated Bayesian inference (no inference engine over the LLM → no KV-cache
+;; hazard). It asserts the EXACT agent-model half (observing g*'s optimal action makes
+;; g* the agent-model MAP) and the validity of the LLM reasoner half (probabilities in
+;; [0,1], posteriors normalized), exiting non-zero on failure — or SKIPS cleanly if the
+;; qwen3-0.6b model is absent. The self-check is async, so this wrapper calls
+;; run-or-skip explicitly and returns its promise (nbb awaits the top-level promise).
+;;
+;; Run: bun run --bun nbb test/genmlx/agents_llm_inverse_test.cljs
+
+(ns genmlx.agents-llm-inverse-test
+  (:require [agents-llm-inverse :as flag]))
+
+(flag/run-or-skip)

--- a/test/genmlx/agents_llm_policy_test.cljs
+++ b/test/genmlx/agents_llm_policy_test.cljs
@@ -1,0 +1,20 @@
+;; @tier slow
+;; agents × llm flagship (ROADMAP Phase 3, item 4, Direction 1: LLM-as-policy) — suite wrapper.
+;;
+;; The runnable example examples/agents_llm_policy.cljs builds an agent whose POLICY
+;; is an LLM generative function: the per-action policy logits ARE the LLM GF's
+;; per-action p/assess log-probs, and the action is drawn by a categorical policy GF.
+;; It self-checks the GFI composition (valid :action site; p/assess == logsoftmax of
+;; the LLM logits; p/generate over the 4 actions has probs summing to 1; reproducibility;
+;; state-dependence) and exits non-zero on any failure — or SKIPS cleanly if the
+;; qwen3-0.6b model is absent. The example's self-check is async (model load +
+;; tokenizer encode are promises), so this wrapper calls run-or-skip explicitly and
+;; returns its promise (nbb awaits the top-level promise); a plain require would not
+;; await it.
+;;
+;; Run: bun run --bun nbb test/genmlx/agents_llm_policy_test.cljs
+
+(ns genmlx.agents-llm-policy-test
+  (:require [agents-llm-policy :as flag]))
+
+(flag/run-or-skip)

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -13,6 +13,9 @@ slow test/genmlx/agentmodels_5d_joint_test.cljs
 slow test/genmlx/agentmodels_5e_joint_test.cljs
 slow test/genmlx/agentmodels_biased_inverse_test.cljs
 slow test/genmlx/agentmodels_biased_planners_test.cljs
+slow test/genmlx/agentmodels_ch01_intro_test.cljs
+slow test/genmlx/agentmodels_ch02_webppl_test.cljs
+slow test/genmlx/agentmodels_ch08_library_test.cljs
 slow test/genmlx/agentmodels_diff_learn_test.cljs
 slow test/genmlx/agentmodels_helpers_test.cljs
 slow test/genmlx/agentmodels_hike_irl_test.cljs
@@ -25,6 +28,9 @@ slow test/genmlx/agentmodels_psrl_test.cljs
 slow test/genmlx/agentmodels_slice_test.cljs
 slow test/genmlx/agentmodels_worlds_test.cljs
 fast test/genmlx/agents_api_test.cljs
+medium test/genmlx/agents_contracts_test.cljs
+slow test/genmlx/agents_llm_inverse_test.cljs
+slow test/genmlx/agents_llm_policy_test.cljs
 medium test/genmlx/amortized_test.cljs
 slow test/genmlx/analytical_posterior_referee_test.cljs
 fast test/genmlx/assess_propose_test.cljs
@@ -217,12 +223,23 @@ medium test/genmlx/linear_gaussian_elim_test.cljs
 slow test/genmlx/llm_backend_test.cljs
 slow test/genmlx/llm_bytes_test.cljs
 bench test/genmlx/llm_cache_benchmark.cljs
+slow test/genmlx/llm_cljs_forward_qwen35_test.cljs
+slow test/genmlx/llm_cljs_forward_test.cljs
 slow test/genmlx/llm_codegen_test.cljs
+slow test/genmlx/llm_composition_test.cljs
 slow test/genmlx/llm_core_test.cljs
+slow test/genmlx/llm_forward_golden_test.cljs
+slow test/genmlx/llm_forward_parity_test.cljs
 slow test/genmlx/llm_gemma4_test.cljs
 slow test/genmlx/llm_grammar_test.cljs
+fast test/genmlx/llm_msa_scoring_test.cljs
 slow test/genmlx/llm_msa_test.cljs
 fast test/genmlx/llm_pure_helpers_test.cljs
+slow test/genmlx/llm_qwen35_forward_parity_test.cljs
+fast test/genmlx/llm_schema_grammar_test.cljs
+slow test/genmlx/llm_structured_test.cljs
+fast test/genmlx/llm_token_mcmc_test.cljs
+slow test/genmlx/llm_weights_test.cljs
 fast test/genmlx/location_scale_property_test.cljs
 medium test/genmlx/loop_compilation_test.cljs
 medium test/genmlx/loop_compiled_hmc_test.cljs
@@ -244,6 +261,7 @@ fast test/genmlx/membrane_honesty_test.cljs
 fast test/genmlx/memory_test.cljs
 bench test/genmlx/metal_gc_stress.cljs
 fast test/genmlx/method_selection_test.cljs
+fast test/genmlx/mlx_fused_ops_test.cljs
 medium test/genmlx/multistep_kalman_ekf_test.cljs
 fast test/genmlx/mutation_boundary_test.cljs core
 fast test/genmlx/native_guard_test.cljs core

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -29,6 +29,7 @@ slow test/genmlx/agentmodels_slice_test.cljs
 slow test/genmlx/agentmodels_worlds_test.cljs
 fast test/genmlx/agents_api_test.cljs
 medium test/genmlx/agents_contracts_test.cljs
+medium test/genmlx/agents_fused_pomdp_test.cljs
 slow test/genmlx/agents_llm_inverse_test.cljs
 slow test/genmlx/agents_llm_policy_test.cljs
 medium test/genmlx/amortized_test.cljs


### PR DESCRIPTION
## Summary

An autonomous run on the **`genmlx.agents`** vertical advancing **ROADMAP Phase 3** — four verified deliverables, additive only (no engine or existing-public-API changes).

### 1. Phase 3 item 1 — agentmodels.org chapter ports (completes milestone `vui9`)
Runnable, self-checking GenMLX-native examples, asserting against **independently math-verified** reference numbers:
- `examples/agentmodels/ch01_intro.cljs` — Ch 1: coin taster + geometric two ways (recursive-enumerated vs `dist/geometric`), `P(n=k)=0.5^(k+1)`, `E[n]=1`.
- `examples/agentmodels/ch02_webppl.cljs` — Ch 2: ERPs, `multivariateGaussian`, binomial-from-3-flips (two ways agree), twoHeads/moreThanTwoHeads conditioning, `positionDist`.
- `examples/agentmodels/ch08_library_guide.cljs` — Ch 8: line/gridworld MDP + `make-mdp-agent` optimal/soft + hyperbolic biased planner + line POMDP belief filtering + custom random/ε-greedy policy GFs.
- `@tier slow` wrappers `agentmodels_ch0{1,2,8}_*_test.cljs`. **49/49 checks.**

### 2. Phase 3 item 4 — agents × llm flagship (both nesting directions)
- `examples/agents_llm_policy.cljs` — an agent whose **policy is an LLM GF** (policy logits = the LLM GF's per-action `p/assess` log-probs). **14 GFI checks** (`p/assess`==logsoftmax, `p/generate` exp-sums-to-1, reproducibility, state-dependence).
- `examples/agents_llm_inverse.cljs` — an **LLM reasoning over an agent model**: inverse planning fusing the agent GF's `P(action|goal)` with the LLM GF's reasoner score in one host-enumerated posterior. **8 checks** (agent half exact, LLM half validity-only).
- Honest: assert the GFI **composition**, not 0.6B planning quality. Skip-clean if the model is absent; `@tier slow` wrappers (`main?` guard + awaited async `run-or-skip`).

### 3. Phase 3 item 3 — `genmlx.agents` API contracts (tests as contracts)
- `test/genmlx/agents_contracts_test.cljs` (**32/32**) — pins per-constructor return-map shapes, family-specific `:act` signatures, POMDP/bandit contracts.
- `src/genmlx/agents/CONTRACTS.md` — the v1.0 stable surface. Honest contract: only `{:act, :params}` are universal; `:Q/:V` are MDP-only; bandit has no `:policy`. **No public API changed.**

### 4. `r35c`/`7kaf` — fused POMDP rollout + tensor observation model
- `belief/obs-id-tensor` + `belief/obs-likelihood-tensor` — the host-bound `obs-likelihood-vec` made in-graph: a host-precomputed `[S,W]` observation-id tensor + a pure-tensor likelihood that threads `s'` as a one-hot (no host int), reproducing the host observe `=` for **any** env. Verified **30/30** vs host.
- `pomdp/fused-simulate-pomdp` — threads `(s-onehot [S], belief [W])` through tensor belief-Q → argmax → tensor transition → tensor observe → `belief/filter-step` with **no per-step `mx/item`**. Matches host `simulate-pomdp` **exactly** at `alpha=Inf/noise=0` (states identical, belief err 0.0). Stochastic regimes stay on the host path by design.
- `test/genmlx/agents_fused_pomdp_test.cljs` (`@tier medium`, **10/10**).

## Verification
- All new suites green. No regressions: `agents_api_test` 27/27, `belief_tensor_test` 36/36, `agentmodels_pomdp_test` 23/23.
- `test/run.sh check` OK (391 files classified).
- Phase 3 item 2 was found already-shipped (xpbm) and **not** reworked.

## Notes
- Commits: `20b0a7a` (items 1/3/4), `3eeb120` (fused POMDP / tensor observe).
- The agents×llm examples need a local `qwen3-0.6b-mlx-bf16` (skip-clean otherwise); feasibility pre-verified via `llm_core_test` 36/36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
