### PR TITLE
feat(agents): Phase 3 item 5 — first external environment over the Bun network membrane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,10 @@ direct import of dynamic.cljs).
    - The `defdist` registry bookkeeping atom in `dist/core.cljs` (never read
      by computation paths)
    - KV cache mutation in `llm/backend.cljs` (always in try/finally)
-
+   - The live `Bun.serve` listener (an OS resource, not pure state) in the network
+     face of the Bun world membrane (`world/net.cljs`): created by `serve!`, scoped
+     and torn down by `with-server`'s `p/finally` (the blessed path) — analogous to
+     the KV-cache try/finally. A bare `serve!` hands the lifecycle to the caller.
 2. **Data-driven, open for extension.** Distributions are a single `Distribution`
    record with open multimethods. New distributions via `defdist`. New execution
    strategies via `dispatch/with-handler` or `dispatch/with-dispatch`. Grammar

--- a/examples/external_env.cljs
+++ b/examples/external_env.cljs
@@ -1,0 +1,296 @@
+(ns external-env
+  "FLAGSHIP — the FIRST EXTERNAL ENVIRONMENT (ROADMAP Phase 3, item 5). The agent/
+   environment boundary reified as REAL network I/O over the Bun world membrane
+   (genmlx.world.net), with the agent staying a pure generative function above it.
+
+   In GFI terms the boundary is two directed crossings:
+     • ACTUATOR — an outbound sampled action committed to the world (an HTTP POST).
+     • SENSOR   — an inbound observation read back (the response), the datum a model
+       conditions on.
+
+   WHAT THIS CLAIMS: the agent/env boundary is a real serialize → IO → deserialize
+   round-trip over Bun network; the SERVER owns the world's true state and the
+   randomness the agent must model; the agent reaches the world ONLY through the
+   transport seam (it never imports or calls the server handler directly, never
+   shares the world's entropy, never assesses the service's density).
+   WHAT THIS DOES NOT CLAIM: network robustness, remote hosts, auth, fault
+   tolerance, or that the peer is untrusted. This is the membrane PATTERN at the
+   seam (the AUTONOMOUS face of genmlx-gsoi), not a hardened network stack.
+
+   Three self-checking sections, each spinning up a localhost environment SERVER and
+   reaching it ONLY through the membrane (the agent never touches Bun):
+
+   1. MEMBRANE FAITHFULNESS (MDP). The SAME make-mdp-agent runs an episode across
+      the wire; at the deterministic regime (alpha = ##Inf, noise = 0) the
+      across-wire trajectory is BIT-IDENTICAL to the in-process simulate-mdp run —
+      proof the membrane is faithful and thin (the agent code is unchanged whether
+      the environment is in-process or external). The corridor world is tie-free, so
+      the argmax policy has a unique action at every state; the server only performs
+      the deterministic transition (the client computes all actions), so there is no
+      Q to drift across the wire.
+
+   2. SENSOR / ACTUATOR + INFERENCE (POMDP). A restaurant-gridworld whose latent
+      world is hidden behind the membrane; the agent POSTs actions (actuators),
+      receives observations (sensors), and FILTERS its belief on them (the inbound
+      constraint). The whole trajectory + belief sequence match in-process
+      simulate-pomdp exactly, and the belief snaps to the true world after the
+      signpost observation arrives across the wire.
+
+   3. AN API IS AN ENVIRONMENT — MODEL IT, DON'T GF IT. A localhost 'noisy oracle'
+      service owns a hidden latent AND a noise source whose scale the agent does NOT
+      know exactly. The agent holds a PURE, APPROXIMATE observation model
+      p(reading | theta) as a generative function, queries the service (actuators),
+      and conditions that model on the returns (sensors) — importance sampling
+      recovers the latent UNDER THE CLIENT'S MODEL. The service is never a generative
+      function (the client never uses the server's true noise params, never assesses
+      its density); we model what it RETURNS. The estimate is cross-checked against
+      the exact conjugate posterior of the client's model (an independent oracle) and
+      the true latent.
+
+   Localhost only — no external network egress, no credentials. Clean teardown via
+   genmlx.world.net/with-server (no leaked listeners). Zero engine change.
+
+   Run:  bun run --bun nbb examples/external_env.cljs"
+  (:require [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.choicemap :as cm]
+            [genmlx.dist :as dist]
+            [genmlx.agents.agent :as agent]
+            [genmlx.agents.worlds :as worlds]
+            [genmlx.agents.pomdp :as pomdp]
+            [genmlx.agents.pomdp-env :as penv]
+            [genmlx.agents.remote :as remote]
+            [genmlx.world.net :as net]
+            [genmlx.inference.importance :as is]
+            [promesa.core :as pr])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+;; ---------------------------------------------------------------------------
+;; tiny self-check harness (same shape as the other flagship examples)
+;; ---------------------------------------------------------------------------
+
+(def ^:private fails (atom 0))
+
+(defn- check-true [label ok]
+  (println (str (if ok "  ✓ " "  ✗ FAIL ") label))
+  (when-not ok (swap! fails inc)) ok)
+
+(defn- check-close [label expected actual tol]
+  (let [ok (<= (abs (- expected actual)) tol)]
+    (println (str (if ok "  ✓ " "  ✗ FAIL ") label
+                  " — expected " (.toFixed expected 4) ", got " (.toFixed actual 4)))
+    (when-not ok (swap! fails inc)) ok))
+
+(defn- belief-max-err [bs1 bs2 worlds]
+  (apply max 0.0 (for [[a b] (map vector bs1 bs2), w worlds]
+                   (Math/abs (- (double (get a w 0.0)) (double (get b w 0.0)))))))
+
+;; an uncaught promesa rejection EXITS 0 (verified) — which would let the self-check
+;; pass vacuously. Make any unhandled rejection a loud, nonzero failure.
+(js/process.on "unhandledRejection"
+               (fn [e] (println (str "\n✗ FAIL: unhandled rejection: "
+                                     (or (and e (.-message e)) e)))
+                 (js/process.exit 1)))
+
+;; ===========================================================================
+;; Section 1 — MDP across the wire: membrane faithfulness
+;; ===========================================================================
+
+(defn- section-1-mdp []
+  (println "\n========== 1. MDP across the wire — membrane faithfulness ==========")
+  (let [n       7
+        mdp     (worlds/line-mdp {:n n})            ; 1×7 corridor, goal at idx 6, tie-free
+        ag      (agent/make-mdp-agent {:mdp mdp :alpha ##Inf :gamma 1.0 :n-iters 24})
+        start   (:start-idx mdp)
+        H       12
+        in-proc (agent/simulate-mdp ag start H)]
+    (check-true "agent is in the deterministic regime (alpha = ##Inf)"
+                (= ##Inf (:alpha (:params ag))))
+    (net/with-server (remote/mdp-env-handler mdp {:start start})
+      (fn [url]
+        (pr/let [rem (remote/remote-mdp-rollout ag (remote/gym-transport url) H)]
+          (println (str "  in-process states: " (:states in-proc)))
+          (println (str "  across-wire states: " (:states rem)))
+          (check-true "across-wire states == in-process states (exact parity)"
+                      (= (:states in-proc) (:states rem)))
+          (check-true "across-wire actions == in-process actions (exact parity)"
+                      (= (:actions in-proc) (:actions rem)))
+          (check-true (str "agent reached the goal (idx " (dec n) ") across the wire")
+                      (= (dec n) (last (:states rem))))
+          (check-true "each step was a real network round-trip (>=1 transition)"
+                      (pos? (count (:actions rem))))
+          :ok)))))
+
+;; ===========================================================================
+;; Section 2 — POMDP across the wire: sensor / actuator + belief filtering
+;; ===========================================================================
+
+(def ^:private pgrid
+  [[:A    :empty :B]
+   [:wall :empty :wall]
+   [:wall :empty :wall]
+   [:wall :empty :wall]
+   [:wall :empty :wall]])
+(def ^:private signpost 7)
+
+(defn- section-2-pomdp []
+  (println "\n========== 2. POMDP across the wire — sensor/actuator + belief ==========")
+  (let [tw      :A
+        env     (penv/restaurant-gridworld {:grid pgrid :goals [:A :B] :signpost signpost
+                                            :true-world tw :start [1 4]})
+        pa      (pomdp/make-pomdp-agent (assoc env :alpha ##Inf :gamma 1.0 :n-iters 40))
+        start   (:start-idx env)
+        worlds  (:worlds pa)
+        H       12
+        in-proc (pomdp/simulate-pomdp pa env start H)]
+    (net/with-server (remote/pomdp-env-handler pa env {:start start})
+      (fn [url]
+        (pr/let [rem (remote/remote-pomdp-rollout pa (remote/gym-transport url) H)]
+          (println (str "  in-process states: " (:states in-proc)))
+          (println (str "  across-wire states: " (:states rem)))
+          (println (str "  across-wire observations (sensor): " (:observations rem)))
+          (println (str "  final belief: " (last (:beliefs rem))))
+          (check-true "across-wire states == in-process states (exact parity)"
+                      (= (:states in-proc) (:states rem)))
+          (check-true "across-wire actions == in-process actions (exact parity)"
+                      (= (:actions in-proc) (:actions rem)))
+          (check-true "across-wire observations == in-process observations (sensor parity)"
+                      (= (:observations in-proc) (:observations rem)))
+          (check-true "belief sequence == in-process (max err < 1e-5)"
+                      (< (belief-max-err (:beliefs in-proc) (:beliefs rem) worlds) 1e-5))
+          (check-true (str "sensor at the signpost was received across the wire (true world " (name tw) ")")
+                      (boolean (some #{tw} (:observations rem))))
+          (check-true "the across-wire belief actually updated (final != prior)"
+                      (not= (last (:beliefs rem)) (:prior pa)))
+          (check-close (str "belief snapped to the true world P(" (name tw) ")=1")
+                       1.0 (double (get (last (:beliefs rem)) tw 0.0)) 1e-6)
+          :ok)))))
+
+;; ===========================================================================
+;; Section 3 — an API IS an environment: model it, don't GF it
+;; ===========================================================================
+;;
+;; The agent's PURE, APPROXIMATE model of the external oracle: theta ~ prior, and
+;; each reading the service returns is assumed N(theta, obs-sd). The server's TRUE
+;; noise scale (server-obs-sd) DIFFERS — the agent does not know the channel exactly.
+;; We never assess the SERVICE's density; we only condition THIS model on the values
+;; it returns (identical discipline to a real sensor: the sensor is not a GF, but
+;; p(reading | state) is).
+
+(def ^:private prior-mu      0.0)
+(def ^:private prior-sd      3.0)
+(def ^:private obs-sd        1.0)    ; the CLIENT's assumed noise scale (a modelling assumption)
+(def ^:private server-obs-sd 0.7)    ; the oracle's TRUE noise scale (agent never uses this)
+(def ^:private K             6)      ; number of queries (actuators)
+(def ^:private theta*        1.5)    ; the latent the oracle holds (agent never sees it)
+
+(def ^:private oracle-model
+  (gen []
+    (let [theta (trace :theta (dist/gaussian prior-mu prior-sd))]
+      (dotimes [i K]
+        (trace (keyword (str "r" i)) (dist/gaussian theta obs-sd)))
+      theta)))
+
+(defn- collect-readings
+  "Issue K sequential queries (actuators) and gather the K readings (sensors), each
+   a real POST across the neutral net/request crossing (no fake reward/done)."
+  [url k]
+  (pr/loop [i 0, acc []]
+    (if (>= i k)
+      acc
+      (pr/let [resp (net/request url "/query" {:i i})]
+        (pr/recur (inc i) (conj acc (:reading resp)))))))
+
+(defn- section-3-api []
+  (println "\n========== 3. an API is an environment — model it, don't GF it ==========")
+  (let [oracle-key (atom (rng/fresh-key 7))      ; world-owned noise (agent does NOT own it)
+        handler    (fn [route _payload]
+                     (case route
+                       "/query" (let [[k1 k2] (rng/split @oracle-key)]
+                                  (reset! oracle-key k2)
+                                  {:reading (mx/item (dist/sample (dist/gaussian theta* server-obs-sd) k1))})
+                       {:error (str "unknown route " route)}))]
+    (net/with-server handler
+      (fn [url]
+        (pr/let [readings (collect-readings url K)]
+          (let [;; --- exact conjugate posterior of the CLIENT'S model (independent oracle) ---
+                sum-r    (reduce + readings)
+                prec0    (/ 1.0 (* prior-sd prior-sd))
+                precN    (+ prec0 (/ K (* obs-sd obs-sd)))
+                post-var (/ 1.0 precN)
+                post-sd  (Math/sqrt post-var)
+                post-mu  (* post-var (+ (* prec0 prior-mu) (/ sum-r (* obs-sd obs-sd))))
+                ;; --- importance sampling over the PURE model, conditioned on the
+                ;;     sensor readings (the service is never a GF) ---
+                constraints (cm/from-map (into {} (map-indexed
+                                                    (fn [i r] [(keyword (str "r" i)) (mx/scalar r)])
+                                                    readings)))
+                {:keys [traces log-weights]} (is/importance-sampling
+                                               {:samples 4000 :key (rng/fresh-key 42)}
+                                               oracle-model [] constraints)
+                lw     (mapv mx/item log-weights)
+                m      (apply max lw)
+                ws     (mapv #(Math/exp (- % m)) lw)
+                z      (reduce + ws)
+                thetas (mapv #(mx/item (:retval %)) traces)
+                is-mu  (/ (reduce + (map * ws thetas)) z)]
+            (println (str "  readings (sensors across the wire): " (mapv #(.toFixed % 3) readings)))
+            (println (str "  exact conjugate posterior (client model): mean " (.toFixed post-mu 4)
+                          "  sd " (.toFixed post-sd 4)))
+            (println (str "  importance-sampling posterior mean: " (.toFixed is-mu 4)
+                          "  (true theta* = " theta* ")"))
+            (check-true (str "all " K " readings crossed the network as real queries")
+                        (= K (count readings)))
+            (check-true "every reading is a finite number (a real sensor value)"
+                        (every? #(and (number? %) (js/isFinite %)) readings))
+            (check-true "the server OWNS the noise: readings vary (the client holds no entropy over them)"
+                        (> (count (distinct readings)) 1))
+            (check-true "the client never used the server's true noise scale (model is only an approximation)"
+                        (not= obs-sd server-obs-sd))
+            (check-true "the conjugate posterior identifies the latent (|mean - theta*| < 3 sd)"
+                        (< (abs (- post-mu theta*)) (* 3.0 post-sd)))
+            (check-close "importance-sampling posterior matches the exact conjugate posterior"
+                         post-mu is-mu 0.2)
+            :ok))))))
+
+;; ===========================================================================
+;; driver
+;; ===========================================================================
+
+(defn run
+  "Run all three sections in sequence (each spins up + tears down its own server).
+   Returns a promise resolving to :ok / exiting nonzero on any failed check. A
+   watchdog converts a wedged network round-trip into a loud exit(124) rather than
+   letting it hang to the slow-tier cap."
+  []
+  (let [wd (js/setTimeout
+             (fn [] (println "\n✗ FAIL: watchdog timeout — external-env wedged") (js/process.exit 124))
+             90000)]
+    (-> (pr/let [_ (section-1-mdp)
+                 _ (section-2-pomdp)
+                 _ (section-3-api)]
+          (js/clearTimeout wd)
+          (println (str "\n" (if (zero? @fails) "ALL CHECKS PASSED ✓"
+                                 (str @fails " CHECK(S) FAILED ✗"))))
+          (when (pos? @fails) (js/process.exit 1))
+          :ok)
+        (pr/catch (fn [e]
+                    (js/clearTimeout wd)
+                    (println (str "\n✗ FAIL: external-env flagship errored: " (.-message e)
+                                  "\n" (.-stack e)))
+                    (js/process.exit 1))))))
+
+(defn run-or-skip
+  "Run the self-checking flagship, or skip cleanly if the Bun network membrane is
+   unavailable (e.g. not running under Bun). Returns a promise (the test wrapper
+   awaits it as its top-level promise)."
+  []
+  (if-not (net/available?)
+    (do (println "\nSKIP: Bun network membrane unavailable (run under `bun run --bun nbb`). (clean skip, exit 0)")
+        (pr/resolved :skipped))
+    (run)))
+
+(def ^:private main?
+  (boolean (some #(re-find #"external_env\.cljs" (str %)) (array-seq js/process.argv))))
+
+(when main? (run-or-skip))

--- a/src/genmlx/agents/CONTRACTS.md
+++ b/src/genmlx/agents/CONTRACTS.md
@@ -80,3 +80,14 @@ arity. Consumers must dispatch on the agent family, not assume a universal shape
 A future uniform agent protocol could normalize `:act` (e.g. a single
 `(act agent state-or-belief & [key])`), but that is an API *change* (owner decision),
 not part of this freeze. This document fixes the surface **as built**.
+
+## NOT frozen — `genmlx.agents.remote` is PROVISIONAL
+
+`genmlx.agents.remote` (the glue for the FIRST EXTERNAL ENVIRONMENT, ROADMAP Phase 3
+item 5 — Gym transport, env-server handlers, and remote rollouts over the
+`genmlx.world.net` membrane) is **explicitly OUTSIDE this frozen surface**. Its
+signatures may change; it is **not pinned by a contracts test** (only by the
+behavioural/parity self-checks in `examples/external_env.cljs` +
+`test/genmlx/external_env_test.cljs`). Do not treat anything in `genmlx.agents.remote`
+as a stable v1.0 contract. (The membrane it sits on, `genmlx.world.net`, lives in the
+`genmlx.world.*` membrane tree, mirroring `genmlx.mlx` — not the agents surface.)

--- a/src/genmlx/agents/remote.cljs
+++ b/src/genmlx/agents/remote.cljs
@@ -1,0 +1,204 @@
+(ns genmlx.agents.remote
+  "PROVISIONAL — NOT part of the frozen v1.0 agents surface (CONTRACTS.md fences it
+   out explicitly; its signatures may change and are NOT pinned by a contracts test).
+
+   The agents-side glue for the FIRST EXTERNAL ENVIRONMENT (ROADMAP Phase 3 item 5):
+   pure flow ABOVE the genmlx.world.net membrane that reifies the agent/environment
+   boundary as real network I/O. (It lives in genmlx.agents — not genmlx.world —
+   because it depends on the agents layer, e.g. agent/sample-next; the membrane must
+   not depend on agents, so the layering points the right way: agents -> world.net.)
+
+   Three parts, all pure above the membrane:
+
+   1. THE RL SEAM — `gym-transport` composes the neutral net/request crossing into a
+      Gym-style episodic transport {:step :reset :close}. The RL contract (action /
+      observation / reward / done / step / reset) belongs HERE in the agents layer,
+      NOT in the neutral membrane (genmlx.world.net stays domain-free).
+
+   2. SERVE an agents environment behind the membrane — `mdp-env-handler` /
+      `pomdp-env-handler` turn an MDP/POMDP bundle into the single
+      (fn [route payload] -> response-map) genmlx.world.net/serve! hosts. The
+      world's TRUE state lives behind the membrane (a server-side atom — the
+      external world's own state, deliberately outside pure flow) and the world OWNS
+      its transition randomness (a private key the agent never sees); the agent only
+      learns the next state/observation by receiving it across the wire.
+
+   3. DRIVE an agent against a REMOTE environment — `remote-mdp-rollout` /
+      `remote-pomdp-rollout` run the SAME act / transition / observe / filter loop as
+      agent/simulate-mdp and pomdp/simulate-pomdp, but the transition + observation
+      cross the wire. act stays pure on the client; the POSTed action is the
+      ACTUATOR, the returned observation is the SENSOR. The loops are ASYNC ONLY at
+      the wire crossing (pr/let over a transport call); the per-step decision math
+      (policy, belief filter) is pure and synchronous between awaits — no GPU eval
+      inside the await loop. They return promesa promises of the SAME trajectory
+      shapes as their in-process twins.
+
+   FAITHFULNESS: at the deterministic regime (alpha = ##Inf, noise = 0) the remote
+   trajectory is BIT-IDENTICAL to the in-process simulate-mdp / simulate-pomdp run —
+   the same parity regime as the fused rollouts (genmlx.agents.rollout,
+   pomdp/fused-simulate-pomdp). That equality is the proof the membrane is faithful
+   and thin: the agent code is unchanged whether the env is in-process or external.
+   Off that regime (finite alpha / noise > 0) only the DISTRIBUTION matches, never
+   the per-step sequence — RNG keys do not cross the wire.
+
+   Zero engine change; reuses agent/sample-next, the existing belief filter,
+   build-mdp tensors, and the GFI policy."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.agents.agent :as agent]
+            [genmlx.world.net :as net]
+            [promesa.core :as pr]))
+
+;; ===========================================================================
+;; 1. The RL seam — Gym episodic transport over the neutral crossing
+;; ===========================================================================
+
+(defn gym-transport
+  "Compose net/request into the Gym-style episodic transport the rollouts use:
+   {:step (fn [action] -> Promise<obs-map>) :reset (fn [] -> Promise<obs-map>)
+    :close (fn [] -> nil)} where obs-map = {:obs :reward :done :info}. :step POSTs
+   {:action action} to /step, :reset POSTs {} to /reset. The RL contract lives here,
+   in the agents layer — the membrane (genmlx.world.net) stays neutral."
+  [url]
+  {:step  (fn [action] (net/request url "/step" {:action action}))
+   :reset (fn [] (net/request url "/reset"))
+   :close (fn [] nil)})
+
+;; ===========================================================================
+;; 2. Serve an agents environment behind the membrane (server side)
+;; ===========================================================================
+;;
+;; The world's transition randomness (when noise > 0) lives HERE, server-side, in a
+;; world-owned key the agent never sees — genuine externality. At noise = 0 the
+;; T-row is one-hot so the transition is deterministic and key-independent, which is
+;; what makes across-wire == in-process parity exact.
+
+(defn- world-step
+  "Apply the world transition behind the membrane. Deterministic at noise 0; if a
+   world-owned `kref` holds a key, advance it and sample (stochastic world)."
+  [T kref s a]
+  (if-let [k @kref]
+    (let [[k1 k2] (rng/split k)]
+      (reset! kref k2)
+      (agent/sample-next T s a k1))
+    (agent/sample-next T s a)))
+
+(defn mdp-env-handler
+  "Build the single genmlx.world.net/serve! handler (fn [route payload] -> map) that
+   hosts an MDP behind the membrane. `mdp` is a build-mdp bundle
+   ({:T :R :terminals :start-idx ...}). Options:
+     :start — start state index (default the mdp's :start-idx)
+     :key   — a world-owned RNG key for a STOCHASTIC world (omit ⇒ deterministic).
+   /reset and /step yield {:obs s' :reward r :done term? :info {}} — the next state
+   is the (fully observed) sensor; the reward is R[s,a]."
+  [{:keys [T R terminals start-idx]} & [{:keys [start key]}]]
+  (let [s0   (or start start-idx)
+        st   (atom s0)
+        kref (atom key)]
+    (fn [route payload]
+      (case route
+        "/reset" (do (reset! st s0)
+                     {:obs s0 :reward 0.0 :done (contains? terminals s0) :info {}})
+        "/step"  (let [s  @st
+                       a  (:action payload)
+                       s' (world-step T kref s a)
+                       r  (double (mx/item (mx/idx (mx/idx R s) a)))]
+                   (reset! st s')
+                   {:obs s' :reward r :done (contains? terminals s') :info {}})
+        {:error (str "unknown route " route)}))))
+
+(defn pomdp-env-handler
+  "Build the serve! handler hosting a POMDP (restaurant-gridworld bundle) behind the
+   membrane. The world holds the TRUE physical location AND the hidden latent world;
+   /step transitions the location via the true world's T and returns
+   {:obs {:loc s' :sense o} ...} — the location is fully observed; `:sense` is the
+   partial observation o = (observe true-world loc') that reveals the latent (a
+   keyword is sent as its name; remote-pomdp-rollout decodes it). `pomdp-agent` is a
+   make-pomdp-agent result; `env` carries :true-world and :start-idx. Options :start,
+   :key as in mdp-env-handler."
+  [pomdp-agent env & [{:keys [start key]}]]
+  (let [true-world (:true-world env)
+        true-mdp   (:mdp ((:world-agents pomdp-agent) true-world))
+        T          (:T true-mdp)
+        terminals  (:terminals true-mdp)
+        observe    (:observe pomdp-agent)
+        ;; keyword observations -> name strings on the wire (JSON has no keywords)
+        enc        (fn [o] (cond (nil? o) nil (keyword? o) (name o) :else o))
+        s0         (or start (:start-idx env))
+        st         (atom s0)
+        kref       (atom key)]
+    (fn [route payload]
+      (case route
+        "/reset" (do (reset! st s0)
+                     {:obs    {:loc s0 :sense (enc (observe true-world s0))}
+                      :reward 0.0 :done (contains? terminals s0) :info {}})
+        "/step"  (let [s  @st
+                       a  (:action payload)
+                       s' (world-step T kref s a)
+                       o  (observe true-world s')]
+                   (reset! st s')
+                   {:obs    {:loc s' :sense (enc o)}
+                    :reward 0.0 :done (contains? terminals s') :info {}})
+        {:error (str "unknown route " route)}))))
+
+;; ===========================================================================
+;; 3. Drive an agent against a REMOTE environment (client side)
+;; ===========================================================================
+
+(defn remote-mdp-rollout
+  "Drive `agent` (a make-mdp-agent result) against a REMOTE MDP over `transport`
+   (a gym-transport) for at most `horizon` steps, stopping at a terminal. Mirrors
+   agent/simulate-mdp, but the transition crosses the wire: act (pure, client) →
+   POST action (actuator) → receive {:obs s' :reward :done} (sensor) → repeat.
+   Returns a PROMISE of {:states [s0 s1 ...] :actions [a0 ...] :rewards [r0 ...]} —
+   the simulate-mdp shape plus per-step rewards. `:key` threads per-step policy
+   sub-keys exactly as simulate-mdp does (split 3-ways, the transition half
+   discarded since the world owns it); at alpha=##Inf it is irrelevant and the
+   trajectory matches simulate-mdp bit-for-bit at noise 0."
+  [{:keys [act]} transport horizon & [{:keys [key]}]]
+  (pr/let [o0 ((:reset transport))]
+    (let [start (:obs o0)]
+      (pr/loop [s start, step 0, k key, done? (:done o0)
+                states [start], actions [], rewards []]
+        (if (or (>= step horizon) done?)
+          {:states states :actions actions :rewards rewards}
+          (let [[k-act _k-world k'] (if k (rng/split-n k 3) [nil nil nil])
+                a (if k-act (act s k-act) (act s))]
+            (pr/let [o ((:step transport) a)]
+              (pr/recur (:obs o) (inc step) k' (:done o)
+                        (conj states (:obs o)) (conj actions a) (conj rewards (:reward o))))))))))
+
+(defn- decode-sense
+  "Reconstruct a keyword observation from its wire form (a name string) by matching
+   against the agent's known `worlds`. nil and non-string values pass through."
+  [worlds s]
+  (cond
+    (nil? s)    nil
+    (string? s) (some #(when (= (name %) s) %) worlds)
+    :else       s))
+
+(defn remote-pomdp-rollout
+  "Drive a POMDP `agent` (make-pomdp-agent result) against a REMOTE POMDP over
+   `transport` (a gym-transport). Mirrors pomdp/simulate-pomdp, but the transition +
+   observation cross the wire: act from belief (pure) → POST action (actuator) →
+   receive {:loc s' :sense o} (sensor) → FILTER the belief on o (the inbound
+   constraint) → repeat. Returns a PROMISE of
+   {:states :actions :observations :beliefs} (the simulate-pomdp shape). At
+   alpha=##Inf / noise=0 the states, actions, observations and beliefs match
+   simulate-pomdp exactly."
+  [{:keys [act update-belief prior worlds]} transport horizon & [_opts]]
+  (pr/let [o0 ((:reset transport))]
+    (let [start (:loc (:obs o0))]
+      (pr/loop [s start, b prior, step 0, done? (:done o0)
+                states [start], actions [], obss [], beliefs [prior]]
+        (if (or (>= step horizon) done?)
+          {:states states :actions actions :observations obss :beliefs beliefs}
+          (let [a (act b s)]
+            (pr/let [o ((:step transport) a)]
+              (let [obsmap (:obs o)
+                    s'     (:loc obsmap)
+                    sense  (decode-sense worlds (:sense obsmap))
+                    b'     (update-belief b s' sense)]
+                (pr/recur s' b' (inc step) (:done o)
+                          (conj states s') (conj actions a)
+                          (conj obss sense) (conj beliefs b'))))))))))

--- a/src/genmlx/agents/remote.cljs
+++ b/src/genmlx/agents/remote.cljs
@@ -47,6 +47,7 @@
             [genmlx.mlx.random :as rng]
             [genmlx.agents.agent :as agent]
             [genmlx.world.net :as net]
+            [cljs.reader :as reader]
             [promesa.core :as pr]))
 
 ;; ===========================================================================
@@ -58,7 +59,12 @@
    {:step (fn [action] -> Promise<obs-map>) :reset (fn [] -> Promise<obs-map>)
     :close (fn [] -> nil)} where obs-map = {:obs :reward :done :info}. :step POSTs
    {:action action} to /step, :reset POSTs {} to /reset. The RL contract lives here,
-   in the agents layer — the membrane (genmlx.world.net) stays neutral."
+   in the agents layer — the membrane (genmlx.world.net) stays neutral.
+
+   `:close` is intentionally INERT: this transport holds only the url, not the live
+   listener, so it cannot stop the server. The server lifecycle is owned by
+   genmlx.world.net/with-server (its p/finally tears the listener down) — never by
+   the client transport."
   [url]
   {:step  (fn [action] (net/request url "/step" {:action action}))
    :reset (fn [] (net/request url "/reset"))
@@ -99,12 +105,14 @@
       (case route
         "/reset" (do (reset! st s0)
                      {:obs s0 :reward 0.0 :done (contains? terminals s0) :info {}})
-        "/step"  (let [s  @st
-                       a  (:action payload)
-                       s' (world-step T kref s a)
-                       r  (double (mx/item (mx/idx (mx/idx R s) a)))]
-                   (reset! st s')
-                   {:obs s' :reward r :done (contains? terminals s') :info {}})
+        "/step"  (let [a (:action payload)]
+                   (if-not (number? a)
+                     {:error "step requires an integer :action"}
+                     (let [s  @st
+                           s' (world-step T kref s a)
+                           r  (double (mx/item (mx/idx (mx/idx R s) a)))]
+                       (reset! st s')
+                       {:obs s' :reward r :done (contains? terminals s') :info {}})))
         {:error (str "unknown route " route)}))))
 
 (defn pomdp-env-handler
@@ -122,8 +130,10 @@
         T          (:T true-mdp)
         terminals  (:terminals true-mdp)
         observe    (:observe pomdp-agent)
-        ;; keyword observations -> name strings on the wire (JSON has no keywords)
-        enc        (fn [o] (cond (nil? o) nil (keyword? o) (name o) :else o))
+        ;; EDN-encode the observation for the wire (JSON has no keywords/vectors):
+        ;; pr-str round-trips ANY observe range (a keyword, nil, or a [restaurant
+        ;; open?] vector) — remote-pomdp-rollout decodes with reader/read-string.
+        enc        (fn [o] (pr-str o))
         s0         (or start (:start-idx env))
         st         (atom s0)
         kref       (atom key)]
@@ -132,13 +142,15 @@
         "/reset" (do (reset! st s0)
                      {:obs    {:loc s0 :sense (enc (observe true-world s0))}
                       :reward 0.0 :done (contains? terminals s0) :info {}})
-        "/step"  (let [s  @st
-                       a  (:action payload)
-                       s' (world-step T kref s a)
-                       o  (observe true-world s')]
-                   (reset! st s')
-                   {:obs    {:loc s' :sense (enc o)}
-                    :reward 0.0 :done (contains? terminals s') :info {}})
+        "/step"  (let [a (:action payload)]
+                   (if-not (number? a)
+                     {:error "step requires an integer :action"}
+                     (let [s  @st
+                           s' (world-step T kref s a)
+                           o  (observe true-world s')]
+                       (reset! st s')
+                       {:obs    {:loc s' :sense (enc o)}
+                        :reward 0.0 :done (contains? terminals s') :info {}})))
         {:error (str "unknown route " route)}))))
 
 ;; ===========================================================================
@@ -168,14 +180,12 @@
               (pr/recur (:obs o) (inc step) k' (:done o)
                         (conj states (:obs o)) (conj actions a) (conj rewards (:reward o))))))))))
 
-(defn- decode-sense
-  "Reconstruct a keyword observation from its wire form (a name string) by matching
-   against the agent's known `worlds`. nil and non-string values pass through."
-  [worlds s]
-  (cond
-    (nil? s)    nil
-    (string? s) (some #(when (= (name %) s) %) worlds)
-    :else       s))
+(defn- decode-obs
+  "Reverse `enc`: read the EDN wire form of an observation back to its value
+   (keyword, nil, vector, …). The peer always sends a pr-str string; a non-string
+   (defensive) passes through unchanged."
+  [s]
+  (if (string? s) (reader/read-string s) s))
 
 (defn remote-pomdp-rollout
   "Drive a POMDP `agent` (make-pomdp-agent result) against a REMOTE POMDP over
@@ -185,8 +195,9 @@
    constraint) → repeat. Returns a PROMISE of
    {:states :actions :observations :beliefs} (the simulate-pomdp shape). At
    alpha=##Inf / noise=0 the states, actions, observations and beliefs match
-   simulate-pomdp exactly."
-  [{:keys [act update-belief prior worlds]} transport horizon & [_opts]]
+   simulate-pomdp exactly. (At finite alpha act uses auto-key, same as
+   simulate-pomdp, so neither is per-step reproducible — hence no :key option.)"
+  [{:keys [act update-belief prior]} transport horizon]
   (pr/let [o0 ((:reset transport))]
     (let [start (:loc (:obs o0))]
       (pr/loop [s start, b prior, step 0, done? (:done o0)
@@ -197,7 +208,7 @@
             (pr/let [o ((:step transport) a)]
               (let [obsmap (:obs o)
                     s'     (:loc obsmap)
-                    sense  (decode-sense worlds (:sense obsmap))
+                    sense  (decode-obs (:sense obsmap))
                     b'     (update-belief b s' sense)]
                 (pr/recur s' b' (inc step) (:done o)
                           (conj states s') (conj actions a)

--- a/src/genmlx/world/net.cljs
+++ b/src/genmlx/world/net.cljs
@@ -1,0 +1,150 @@
+(ns genmlx.world.net
+  "The NETWORK/IO face of the Bun WORLD membrane (bean genmlx-gsoi) — a thin,
+   honest boundary over Bun's network APIs, the SECOND effect membrane alongside
+   `genmlx.mlx` (the COMPUTE membrane).
+
+   Same architectural MOVE as mlx.cljs, different substrate GRADE:
+
+     mlx-node : compute effect : eval! -> Metal     SYNC dispatch to a TRANSPARENT
+                                                    substrate (exact; no model needed)
+     Bun net  : world effect   : request/serve      ASYNC crossing to an AUTONOMOUS
+                                                    OTHER (uncertain returns, can fail,
+                                                    must be MODELLED — never GF'd)
+
+   The PATTERN is shared (a thin membrane isolating one effect class, pure flow
+   above); the substrate grade is NOT (mlx-node is your own values realized exactly;
+   the network reaches a genuine other). The docstring states the mirror AND the
+   difference on purpose — claiming net.cljs is 'just like eval!' would be a
+   dishonest membrane claim.
+
+   FACE 1 OF N, HTTP/JSON only. This is one face of the Bun membrane; the others are
+   distinct (persistence = genmlx.memory via bun:sqlite; process/worker = the control
+   scheduler via Worker/Bun.spawn). WebSocket / Bun.spawn-stdio / bun:ffi are FUTURE
+   transports of THIS face, deliberately out of scope here. The reusable discipline
+   the world faces share (so faces 2-3 don't reinvent it):
+     1. ONE effect class, named and sectioned;
+     2. live resources fenced as an explicit RESOURCE BOUNDARY with a blessed
+        with-* scope carrying the try/finally cleanup (with-server here);
+     3. pure synchronous flow BETWEEN crossings; async only AT the crossing.
+
+   TWO effect shapes live here, honestly distinguished (this is NOT a single
+   chokepoint like eval!):
+
+   A. THE DATA CROSSING (the membrane proper) — `request`: one outbound POST + the
+      parsed response, the thin mirror of eval!'s single dispatch. In GFI terms the
+      OUTBOUND payload is an ACTUATOR (a sampled action committed to the world) and
+      the INBOUND response is a SENSOR (the datum a model conditions on).
+
+   B. THE SERVER LIFECYCLE — the RESOURCE BOUNDARY (`serve!`/`with-server`): a
+      `Bun.serve` listener is a live, stateful, externally-observable OS resource —
+      unlike eval!'s stateless dispatch. It is the one mutable boundary of this face
+      (mirroring mlx.cljs's fenced 'Memory Management — the mutable boundary'). Use
+      `with-server` (it guarantees teardown); `serve!` is the low-level escape hatch
+      (parallel to raw eval! under tidy-run). serve! exists chiefly so tests/examples
+      can stand up a localhost PEER — the agent-side FACE is the client (`request`);
+      the server is scaffolding for the other side of the boundary.
+
+   GOTCHA (load-bearing, empirically confirmed): a `Bun.serve` `fetch` handler MUST
+   return a plain `Response` or a NATIVE `Promise` (`.then` chain). A promesa
+   (`p/let`/`p/then`) promise is NOT `instanceof js/Promise`, so Bun does NOT await
+   it — it falls through to a default HTTP 200 'Welcome to Bun' page (worse than a
+   hang: the client then JSON-parses HTML and fails downstream). `serve!` therefore
+   reads the request body via a native `.then` chain. Client-side promesa is fine.
+
+   sync/async split: the network face is the ASYNC half of the Bun membrane —
+   `request` returns a promise and the rollout loop is a promesa loop; the per-step
+   decision math between crossings stays pure and synchronous (CLAUDE.md's
+   'sync math, async events')."
+  (:require [promesa.core :as p]))
+
+(def ^:private Bun (.-Bun js/globalThis))
+
+(defn available?
+  "True when the Bun runtime network APIs backing this face are present (running
+   under `bun`). Pure flow above can branch on this to skip cleanly off-Bun."
+  []
+  (boolean (and Bun (fn? (.-serve Bun)) (fn? (.-fetch js/globalThis)))))
+
+;; ===========================================================================
+;; A. THE DATA CROSSING — `request` (the agent's outbound face; the membrane)
+;; ===========================================================================
+
+(defn request
+  "The agent's single neutral crossing OUT to an external service: POST `payload`
+   (JSON) to `url`+`route`, parse the JSON response, return a promesa promise of the
+   keywordized map. This is the sole DATA side effect of the network face — the thin
+   mirror of mlx.cljs's eval! (one crossing), except ASYNC and to an autonomous
+   OTHER. `route` is a path like \"/step\" or \"/query\"; the service shape (route
+   names, payload keys) is a convention of the PEER, not baked into the membrane —
+   higher layers (e.g. genmlx.agents.remote) compose `request` into their own seams.
+
+   (Scope: POST/JSON only — the FIRST external-env transport. A heterogeneous
+   third-party API, GET, or non-JSON body would compose a different crossing; that
+   is a future increment, not this face's claim.)"
+  ([url route] (request url route {}))
+  ([url route payload]
+   (-> (js/fetch (str url route)
+                 #js {:method  "POST"
+                      :headers #js {"content-type" "application/json"}
+                      :body    (js/JSON.stringify (clj->js payload))})
+       (p/then (fn [resp] (.json resp)))
+       (p/then (fn [j] (js->clj j :keywordize-keys true))))))
+
+;; ===========================================================================
+;; B. SERVER LIFECYCLE — the RESOURCE BOUNDARY (scaffolding for the peer side)
+;; ===========================================================================
+;;
+;; The ONE mutable boundary of this face: a live Bun.serve listener (a process-level
+;; OS resource). It is created, used within a scope, and torn down — never escaping
+;; pure flow. `with-server` is the blessed scope (try/finally teardown); `serve!` is
+;; the escape hatch. A leaked listener never lets the process exit, so teardown is a
+;; first-class requirement (a leak would wedge the slow-tier test cap like a hang).
+
+(defn serve!
+  "Stand up a localhost `Bun.serve` HTTP peer that routes EVERY POST to a single
+   `handler` — a PURE function (fn [route payload-map] -> response-map) that touches
+   no Bun and does no I/O. Returns {:url :port :server :stop}; `:stop` is a 0-arg fn
+   that force-closes the live listener. `:port` 0 (default) ⇒ OS-assigned (read it
+   back from `:port`, which makes concurrent/test servers collision-free). Binds
+   127.0.0.1 by default.
+
+   The handler reads the JSON body via a NATIVE `.then` chain (see the ns gotcha) and
+   converts any handler exception into a 500 rather than crashing the listener.
+   Prefer `with-server`, which guarantees teardown; reach for bare `serve!` only when
+   you must manage the lifecycle yourself."
+  ([handler] (serve! handler {}))
+  ([handler {:keys [port host] :or {port 0 host "127.0.0.1"}}]
+   (let [respond  (fn [m] (js/Response.json (clj->js m)))
+         dispatch (fn [route body]
+                    (try
+                      (respond (handler route (js->clj body :keywordize-keys true)))
+                      (catch :default e
+                        (js/Response. (str "env error: " (.-message e))
+                                      #js {:status 500}))))
+         server   (.serve Bun
+                    #js {:port     port
+                         :hostname host
+                         :fetch    (fn [req]
+                                     (let [route (.-pathname (js/URL. (.-url req)))]
+                                       ;; native .then (NOT promesa) — see ns gotcha.
+                                       ;; the rejection arm covers an empty/absent body.
+                                       (.then (.json req)
+                                              (fn [b] (dispatch route b))
+                                              (fn [_] (dispatch route #js {})))))})
+         actual   (.-port server)]
+     {:url    (str "http://" host ":" actual)
+      :port   actual
+      :server server
+      :stop   (fn [] (.stop server true))})))
+
+(defn with-server
+  "[blessed scope] Stand up `handler`, call `(f url)` — which MUST return a promise —
+   and GUARANTEE the listener is stopped afterwards, on success OR failure (the
+   p/finally runs even when f's promise rejects). Returns the promise of `(f url)`'s
+   result. This is the only place a server lifecycle should exist in tests/examples:
+   no leaked listener (a leaked Bun.serve never exits)."
+  ([handler f] (with-server handler {} f))
+  ([handler opts f]
+   (let [{:keys [url stop]} (serve! handler opts)]
+     (-> (p/let [r (f url)] r)
+         (p/finally (fn [& _] (stop)))))))

--- a/test/genmlx/external_env_test.cljs
+++ b/test/genmlx/external_env_test.cljs
@@ -1,0 +1,25 @@
+;; @tier slow
+;; FIRST EXTERNAL ENVIRONMENT (ROADMAP Phase 3, item 5) — suite wrapper.
+;;
+;; The runnable example examples/external_env.cljs reifies the agent/environment
+;; boundary as real network I/O over the Bun world membrane (genmlx.world.net):
+;; actuator = an outbound action POSTed to a localhost environment server, sensor =
+;; the observation read back. It self-checks three sections — (1) MDP across the wire
+;; is BIT-IDENTICAL to in-process simulate-mdp at the deterministic regime (membrane
+;; faithfulness); (2) a POMDP whose latent is hidden behind the membrane, where the
+;; belief filters on sensor observations and matches simulate-pomdp exactly; (3) an
+;; external 'noisy oracle' API modelled (never GF'd) with importance sampling
+;; recovering the latent — exiting non-zero on any failed check, or SKIPPING cleanly
+;; if the Bun network membrane is unavailable (not under `bun`).
+;;
+;; @tier slow is load-bearing: the slow tier runs SERIAL, so this stands up Bun.serve
+;; listeners + does Metal value-iteration without parallel-GPU contention. The
+;; self-check is async, so this wrapper calls run-or-skip explicitly and returns its
+;; promise (nbb awaits the top-level promise; with-server guarantees server teardown).
+;;
+;; Run: bun run --bun nbb test/genmlx/external_env_test.cljs
+
+(ns genmlx.external-env-test
+  (:require [external-env :as flag]))
+
+(flag/run-or-skip)

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -129,6 +129,7 @@ fast test/genmlx/error_message_test.cljs
 bench test/genmlx/eval_cost_model_2.cljs
 bench test/genmlx/eval_cost_model.cljs
 medium test/genmlx/exact_test.cljs
+slow test/genmlx/external_env_test.cljs
 medium test/genmlx/fisher_test.cljs
 medium test/genmlx/fit_test.cljs
 medium test/genmlx/fused_inference_test.cljs


### PR DESCRIPTION
## Phase 3 item 5 — first external environment

Completes **ROADMAP Phase 3 (`genmlx.agents`)**: items 1–4 were already done; this is item 5, the last gate. The agent/environment boundary is reified as **real network I/O** over the Bun world membrane, with the agent staying a pure generative function above it.

`sensor = inbound observation (a constraint)` · `actuator = outbound action`. **Zero engine change.**

### What's here
- **`genmlx.world.net`** — the network/IO face of the Bun *world* membrane (the second effect membrane alongside `genmlx.mlx`). Kept **neutral**: `request` (the data crossing) + `serve!`/`with-server` (the fenced server-lifecycle resource boundary). No domain vocabulary in the membrane.
- **`genmlx.agents.remote`** (**PROVISIONAL** — fenced out of the frozen surface in `CONTRACTS.md`): the Gym `{:step :reset :close}` adapter, MDP/POMDP env-server handlers (the world owns its state + entropy behind the membrane), and `remote-mdp-rollout` / `remote-pomdp-rollout` returning the `simulate-mdp` / `simulate-pomdp` shapes.
- **`examples/external_env.cljs`** — flagship, **18/18 self-checks**:
  1. **MDP across the wire is BIT-IDENTICAL** to in-process `simulate-mdp` at `alpha=∞, noise=0` (membrane faithfulness — the agent code is unchanged whether the env is in-process or external).
  2. **POMDP** full trajectory + belief-sequence parity vs `simulate-pomdp`; the belief snaps to the true world via the across-wire sensor.
  3. **An API IS an environment — model it, don't GF it**: the server's *true* noise scale differs from the client's *assumed* model; importance sampling recovers the latent (cross-checked vs the exact conjugate posterior); the service is never a GF.
- **`test/genmlx/external_env_test.cljs`** (`@tier slow`, serial — load-bearing for `Bun.serve` + Metal); `tiers.txt` regenerated.
- **`CLAUDE.md`** lists the live `Bun.serve` listener as a fenced mutable boundary; **`CONTRACTS.md`** fences `agents.remote` as provisional.

### Process / rigor
- A **4-lens adversarial design critique** ran *before* coding (membrane-purity / parity / testability / honesty). It moved the Gym/RL seam **out** of the neutral membrane and corrected a load-bearing gotcha: a promesa promise returned from a `Bun.serve` handler yields a **silent HTTP-200**, not a hang (server handlers use a native `.then` chain).
- A **final read-only review** confirmed the parity loops, async teardown, and conjugate/IS math correct; the second commit hardens the observation round-trip (general `pr-str`/`read-string` instead of silent keyword-narrowing) and adds `{:error …}` guards for malformed `/step` payloads.

### Verification
- Flagship: **18/18**, exit 0, deterministic (seeded).
- Agents suites green: contracts 32/32, api 27/27, agentmodels_pomdp 23/23, fused_pomdp 10/10.
- fast-core **40/41** — the one failure (`strip_compiled_test` marginal-trace update) is **pre-existing and unrelated** (it requires none of these namespaces; tracked separately).

### Scope notes
- This delivers only the gsoi **network/IO** face; persistence (`genmlx.memory`) and process/worker faces remain separate and unbuilt (Phase 4/5).
- WebSocket / `Bun.spawn`-stdio / `bun:ffi` are future transports of this same face, intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
