### PR TITLE
fix(engine,llm): resolve 4 Phase 0-3 trust beans (lcka/py4a/wrt6/z7m2)

### DIFF
--- a/docs/reference-v2/src/gfi.md
+++ b/docs/reference-v2/src/gfi.md
@@ -52,7 +52,9 @@ Forward-sample all random choices from their prior distributions. No observation
 
 Execute the model with some choices constrained to observed values. Unconstrained choices are sampled from the prior. Returns a trace and an importance weight.
 
-The weight is \\(\log p(\text{constraints} \mid \text{args})\\) -- specifically, the sum of log-probabilities at constrained addresses. For a fully constrained model, this equals the joint log-probability.
+The weight is the sum of log-probabilities at the constrained addresses, i.e. \\(\log p(\text{constraints} \mid \text{latents}, \text{args})\\) where the latents are the values sampled into the trace. For a fully constrained model, this equals the joint log-probability. The returned trace is `:joint` (see [score-type](trace.md)).
+
+**Conjugate special case (L3 analytical elimination).** When the model's *static* keyword addresses form a detected conjugate pair (e.g. a `gaussian` prior + `gaussian` likelihood) and the observation is constrained while its prior latent is not, `generate` marginalizes the latent analytically: the latent in the returned trace is the **deterministic analytic posterior mean** (not a prior sample), and the weight is the **analytic marginal** \\(\log p(\text{obs} \mid \text{args})\\) with the latent integrated out. This is the optimal, zero-variance importance weight, and the trace is tagged `:marginal` rather than `:joint` — detect it with `(genmlx.trace/score-type (:trace result))`. The same joint written with *dynamic* addresses (e.g. `(keyword (str "y" j))`) skips conjugacy detection and uses the default prior-sample + conditional-weight behavior above. To force the default behavior on a conjugate model — required for correct multi-particle importance sampling and trace-MH (the analytic path yields identical particles otherwise) — strip it with `genmlx.dynamic/strip-analytical-path`. All built-in inference entry points do this automatically.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|

--- a/src/genmlx/compiled.cljs
+++ b/src/genmlx/compiled.cljs
@@ -821,7 +821,14 @@
         (= dist-type :delta)
         (fn [{:keys [values score]} _site-idx _noise-array args-vec]
           (let [eval-args (mapv #(% values args-vec) compiled-args)
-                value (first eval-args)]
+                ;; A bare numeric-literal delta arg (e.g. (dist/delta 1)) compiles
+                ;; to a raw JS number (compile-expr number? branch), but the handler
+                ;; path wraps delta args with ensure-array so the choice value is an
+                ;; MLX array. Match the handler — otherwise mx/item on the choice
+                ;; fails with "Failed to recover MxArray type from napi value"
+                ;; (genmlx-lcka: compiled-vs-handler parity bug surfaced by
+                ;; branch_rewrite distribution-variety delta case).
+                value (mx/ensure-array (first eval-args))]
             {:values (assoc values addr value)
              :score score}))
 

--- a/src/genmlx/inference/importance.cljs
+++ b/src/genmlx/inference/importance.cljs
@@ -28,22 +28,35 @@
   "Importance sampling. Generate traces constrained by observations,
    return weighted samples.
 
-   opts: {:samples N :key prng-key}
+   opts: {:samples N :key prng-key :gc-every K}
    model: generative function
    args: model arguments
    observations: choice map of observed values
+   :gc-every — sweep dead native arrays every K particles (default 50); pass a
+   smaller K for heavy nested-combinator/plate models that allocate hundreds of
+   leaves per sample.
 
    Returns {:traces [Trace ...] :log-weights [MLX-scalar ...]
             :log-ml-estimate MLX-scalar}"
-  [{:keys [samples key] :or {samples 100}} model args observations]
+  [{:keys [samples key gc-every] :or {samples 100}} model args observations]
   (let [model (-> model dyn/auto-key strip-analytical)
         keys (rng/split-n (rng/ensure-key key) samples)
+        ;; Deep-materialize EACH FULL trace (all choice leaves + retval + score),
+        ;; not just weight+score: an un-materialized leaf MxArray pins its whole
+        ;; per-sample computation subgraph (hundreds of native buffers for a
+        ;; nested-combinator plate) alive, which the dead-buffer sweep cannot free
+        ;; while the retained trace still references it. u/materialize-state
+        ;; evaluates every leaf, detaching it so the per-sample intermediates
+        ;; become dead + sweepable (genmlx-py4a). mh already does this via
+        ;; collect-samples/tidy-step.
+        gc-every (or gc-every 50)
         results (into []
                       (map-indexed
                        (fn [i ki]
                          (let [r (p/generate (dyn/with-key model ki) args observations)]
-                           (mx/materialize! (:weight r) (:score (:trace r)))
-                           (when (zero? (mod (inc i) 50)) (mx/sweep-dead-arrays!))
+                           (mx/materialize! (:weight r))
+                           (u/materialize-state (:trace r))
+                           (when (zero? (mod (inc i) gc-every)) (mx/sweep-dead-arrays!))
                            r)))
                       keys)
         traces     (mapv :trace results)

--- a/src/genmlx/protocols.cljs
+++ b/src/genmlx/protocols.cljs
@@ -10,7 +10,23 @@
 
 (defprotocol IGenerate
   (generate [gf args constraints]
-    "Constrained execution. Returns {:trace Trace :weight MLX-scalar}."))
+    "Constrained execution. Returns {:trace Trace :weight MLX-scalar}.
+
+     Default (handler/compiled paths): unconstrained choices are sampled from the
+     prior; :weight is the sum of log-probabilities at the constrained addresses
+     (log p(constraints | sampled latents)); the trace's score-type is :joint.
+
+     L3 analytical special case: when the model's STATIC keyword addresses form a
+     detected conjugate pair and the observation is constrained while its prior
+     latent is not, generate marginalizes the latent analytically — the latent in
+     the returned trace is the deterministic analytic posterior mean (not a prior
+     sample) and :weight is the analytic MARGINAL log p(obs). This is the optimal
+     zero-variance importance weight; the trace is tagged :marginal (detect with
+     genmlx.trace/score-type). The same joint written with DYNAMIC addresses skips
+     conjugacy and uses the default behavior. To force prior-sample + conditional
+     (:joint) weight — required for correct multi-particle importance sampling and
+     trace-MH — strip the path with genmlx.dynamic/strip-analytical-path (every
+     built-in importance/SMC/MCMC entry point does this internally)."))
 
 (defprotocol IAssess
   (assess [gf args choices]

--- a/test/genmlx/iid_compiled_test.cljs
+++ b/test/genmlx/iid_compiled_test.cljs
@@ -125,13 +125,15 @@
       mu)))
 
 (deftest multi-site-gaussian-iid
-  (testing "multi-site: gaussian + iid-gaussian"
+  (testing "multi-site gaussian + iid-gaussian declines compiled, runs via handler"
     (let [schema (:schema multi-model)]
       (is (:static? schema) "multi-site: static")
-      (is (some? (:compiled-simulate schema)) "multi-site: has compiled-simulate"))
-    (is (thrown? js/Error
-          (p/simulate (dyn/auto-key multi-model) []))
-        "compiled simulate crashes on multi-site iid (pre-existing)")))
+      (is (nil? (:compiled-simulate schema))
+          "no compiled-simulate — iid-gaussian site declines, falls back to handler (genmlx-b210)"))
+    (let [trace (p/simulate (dyn/auto-key multi-model) [])]
+      (is (= [4] (mx/shape (cm/get-value (cm/get-submap (:choices trace) :ys))))
+          "ys shape [4]")
+      (is (js/isFinite (mx/item (:score trace))) "score finite"))))
 
 ;; ---------------------------------------------------------------------------
 ;; 8. [T]-shaped mu in compiled path
@@ -145,9 +147,13 @@
       mu)))
 
 (deftest per-elem-mu-compiled
-  (testing "[T]-shaped mu compiled (pre-existing compiled path issue)"
-    (is (thrown? js/Error
-          (p/simulate (dyn/auto-key per-elem-model) []))
-        "compiled simulate crashes on per-elem iid (pre-existing)")))
+  (testing "[T]-shaped mu declines compiled, runs via handler"
+    (let [schema (:schema per-elem-model)]
+      (is (nil? (:compiled-simulate schema))
+          "no compiled-simulate — iid-gaussian site declines, falls back to handler (genmlx-b210)"))
+    (let [trace (p/simulate (dyn/auto-key per-elem-model) [])]
+      (is (= [3] (mx/shape (cm/get-value (cm/get-submap (:choices trace) :ys))))
+          "ys shape [3]")
+      (is (js/isFinite (mx/item (:score trace))) "score finite"))))
 
 (cljs.test/run-tests)

--- a/test/genmlx/iid_test.cljs
+++ b/test/genmlx/iid_test.cljs
@@ -108,12 +108,14 @@
       (trace :ys (dist/iid-gaussian mu (mx/scalar 1.0) t))
       mu)))
 
-;; NOTE: scalar simulate triggers compiled path which has a pre-existing
-;; bug (nth on MLX array constructor). This test documents that known error.
+;; An iid-gaussian site declines :compiled-simulate (genmlx-b210), so a static
+;; model containing one falls back to the handler and simulates cleanly.
 (deftest model-scalar-simulate
-  (testing "iid in model: scalar simulate (known compiled path issue)"
-    (is (thrown? js/Error (p/simulate (dyn/auto-key iid-model) [5]))
-        "compiled path error on iid model with dynamic T (pre-existing)")))
+  (testing "iid in model: scalar simulate falls back to handler"
+    (let [trace (p/simulate (dyn/auto-key iid-model) [5])]
+      (is (= [5] (mx/shape (cm/get-value (cm/get-submap (:choices trace) :ys))))
+          "ys shape [5]")
+      (is (js/isFinite (mx/item (:score trace))) "score finite"))))
 
 (deftest model-scalar-generate
   (testing "iid in model: scalar generate with stacked obs"

--- a/test/genmlx/llm_backend_test.cljs
+++ b/test/genmlx/llm_backend_test.cljs
@@ -79,11 +79,10 @@
    ;; ---------------------------------------------------------------
    ;; 1.3 forward-prefill (cached path)
    ;;
-   ;; NB the uncached `.forward` / forward-pass path is BROKEN for the
-   ;; qwen3_5 arch (returns garbage logits — see bean genmlx-z7m2 + the gated
-   ;; 1.6 smoke below). The cached forwardWithCache path is correct and is
-   ;; what make-llm-gf / codegen / bytes / msa actually use, so 1.3-1.5 test
-   ;; that path.
+   ;; The cached forwardWithCache path is what make-llm-gf / codegen / bytes /
+   ;; msa actually use, so 1.3-1.5 test that path. The uncached `.forward` path
+   ;; for qwen3_5 — previously reported as garbage on the bf16 artifact
+   ;; (genmlx-z7m2) — now agrees with it and is asserted correct in 1.6.
    ;; ---------------------------------------------------------------
   _ (println "\n== 1.3 forward-prefill (cached) ==")
   prompt-ids (llm/encode tok "The capital of France is")
@@ -147,21 +146,26 @@
   _ (assert-true "decodes to a string" (string? gen-text))
 
    ;; ---------------------------------------------------------------
-   ;; 1.6 uncached forward-pass — KNOWN-BROKEN for qwen3_5 (bean genmlx-z7m2)
+   ;; 1.6 uncached forward-pass — qwen3_5 bf16 (genmlx-z7m2 RESOLVED 2026-06-14)
    ;;
-   ;; The native `.forward` path RUNS and returns a vocab-sized logits vector,
-   ;; but its values are GARBAGE for qwen3_5 (mishandles attn_output_gate /
-   ;; full_attention_interval). We exercise it as a smoke test (so a future
-   ;; regression to a throw/crash is caught) but DELIBERATELY do not assert
-   ;; correctness — the fix is tracked in genmlx-z7m2. Contrast with 1.4: the
-   ;; cached path predicts "Paris", this one predicts token 0 ("!").
+   ;; The earlier z7m2 report (uncached `.forward` returns garbage for qwen3_5 on
+   ;; the bf16 artifact — argmax 0 = "!" + a Metal GPU-timeout) no longer
+   ;; reproduces on the pinned mlx-node build: the uncached path now agrees with
+   ;; the cached path (1.4) and predicts "Paris". The GenMLX-owned forward (f6ov)
+   ;; is the trusted path (parity-gated vs upstream); this asserts the upstream
+   ;; uncached path on the bf16 artifact is correct too, so a future binary that
+   ;; reintroduced the garbage-logits drift would be CAUGHT here, not silent.
    ;; ---------------------------------------------------------------
-  _ (println "\n== 1.6 uncached forward-pass (KNOWN-BROKEN for qwen3_5 — see z7m2) ==")
+  _ (println "\n== 1.6 uncached forward-pass (qwen3_5 bf16 — z7m2 resolved) ==")
   u-logits (llm/forward-pass (:model m) prompt-ids)
   u-argmax (mx/item (mx/argmax u-logits))
   u-pred (llm/decode tok (js/Uint32Array.from #js [u-argmax]))
-  _ (println (str "  Uncached argmax: " u-argmax " → '" u-pred "' (cached 1.4 gave 'Paris')"))
-  _ (assert-true "uncached path executes + returns vocab-sized logits (correctness NOT asserted — z7m2)"
-                 (>= (first (mx/shape u-logits)) vs))]
+  _ (println (str "  Uncached argmax: " u-argmax " → '" u-pred "' (cached 1.4 gave '" predicted "')"))
+  _ (assert-true "uncached path returns vocab-sized logits"
+                 (>= (first (mx/shape u-logits)) vs))
+  _ (assert-true "uncached argmax == cached argmax (z7m2 resolved)"
+                 (= argmax-id u-argmax))
+  _ (assert-true "uncached predicts Paris (z7m2 resolved)"
+                 (re-find #"(?i)paris" u-pred))]
 
   (println (str "\n== Phase 1: " @pass-count " passed, " @fail-count " failed ==")))

--- a/test/genmlx/membrane_churn_test.cljs
+++ b/test/genmlx/membrane_churn_test.cljs
@@ -83,4 +83,49 @@
       (is (some? result) "importance-sampling completed without abort")
       (is (< c (long (* 0.9 limit))) "IS live-buffer count bounded under the wall"))))
 
+;; --- genmlx-py4a: nested PLATE (shared latent + N sessions x cycles tracing
+;;     sites) at MODERATE scale. Before the deep-trace materialize fix
+;;     (importance.cljs only materialized weight+score), each of the N retained
+;;     traces pinned its whole per-sample subgraph (hundreds of native buffers)
+;;     alive — the dead-buffer sweep cannot free buffers a live retained leaf
+;;     references. After the fix (u/materialize-state per particle) each retained
+;;     trace holds only bounded leaf buffers and the intermediates become
+;;     dead+sweepable. This is a bounded-completion regression guard exercising
+;;     the retain-many-leaves path; the EXTREME regime (~264 arrays/sample at
+;;     very high :samples) stays deferred to the wedge-tolerant host.
+(def plate-model
+  (dyn/auto-key
+    (gen [n-sessions n-cycles]
+      (let [mu (trace :mu (dist/gaussian 0 5))]
+        (dotimes [s n-sessions]
+          (let [seed (trace (keyword (str "s" s "_seed")) (dist/gaussian mu 1.0))]
+            (dotimes [c n-cycles]
+              (trace (keyword (str "s" s "_c" c)) (dist/gaussian seed 0.5)))))
+        :done))))
+
+(deftest py4a-plate-importance-sampling-bounded
+  (testing "IS on a nested plate deep-materializes each retained trace + stays bounded"
+    (reset! mx/alloc-retry-count 0)
+    (reset! mx/proactive-sweep-count 0)
+    (let [sessions 8 cycles 12 samples 250
+          sites-per-sample (+ 1 (* sessions (+ 1 cycles)))
+          limit (mx/get-resource-limit)
+          obs (cm/choicemap (keyword "s0_c0") (mx/scalar 0.0)
+                            (keyword "s1_c0") (mx/scalar 0.5))
+          {:keys [traces log-ml-estimate]}
+          (is/importance-sampling {:samples samples :gc-every 25 :key (rng/fresh-key 11)}
+                                  plate-model [sessions cycles] obs)
+          c (mx/get-num-resources)
+          ml (mx/item log-ml-estimate)]
+      (println (str "  PLATE IS " samples " samples x " sites-per-sample
+                    " sites/sample | live-buffers=" c "/" limit
+                    " | proactive-sweeps=" @mx/proactive-sweep-count
+                    " | reactive-retries=" @mx/alloc-retry-count " | log-ml=" ml))
+      (is (= samples (count traces)) "all N traces returned (usable weighted traces)")
+      (is (js/isFinite ml) "log-ml estimate is finite")
+      (is (js/isFinite (mx/item (cm/get-value (cm/get-submap (:choices (first traces)) :mu))))
+          "retained trace leaf is materialized + usable (deep-materialize worked)")
+      (is (< c (long (* 0.9 limit)))
+          (str "plate IS live-buffer count " c " stays under the ~" limit " wall")))))
+
 (cljs.test/run-tests)


### PR DESCRIPTION
## What & why

Resolves four Phase 0–3 "trust" beans surfaced by a full-codebase trust audit. Three were fixes; one was a stale report. One of the four turned up a **real compiled-vs-handler parity bug**.

### `lcka` — fast-tier failures on `main`
- **Real bug (parity):** the compiled M2/M4 `delta` step stored a bare numeric-literal arg as a **raw JS number** (`compile-expr`'s `number?` branch returns the literal), while the handler wraps delta args with `ensure-array`. `mx/item` on the resulting choice then failed with *"Failed to recover MxArray type from napi value"* in `distribution-variety-test`. Fixed by wrapping the delta value with `mx/ensure-array` so the compiled path matches the handler (handler is ground truth).
- **3 stale tests** (`iid_compiled` ×2, `iid_test`) still asserted pre-`b210` behavior (`some? :compiled-simulate` + `(thrown? …)`); rewritten to assert the decline + handler-fallback (shapes/finite score). `branching_property` was already fixed by `qm7m` — confirmed green.

### `py4a` — `importance-sampling` native buffer growth on plate models
`importance-sampling` retained all N traces but materialized **only** weight+score, so each retained trace's choice leaves stayed lazy and pinned their entire per-sample subgraph (hundreds of native buffers for a nested-combinator plate) — buffers the dead-array sweep can't free.
- Now deep-materializes **each full trace** per particle via `u/materialize-state` → retained traces hold only bounded leaf buffers; intermediates become dead + sweepable.
- Added optional `:gc-every` and a bounded nested-plate IS stress test (`membrane_churn_test`).
- `mh` already deep-materializes via `collect-samples`/`tidy-step` (no change). The uncatchable exit-144 abort was already fixed earlier (`with-alloc-retry` + proactive sweep).

### `wrt6` — `p/generate` analytical special case (doc-only)
The conjugate-static analytical `generate` returns the deterministic posterior mean + **marginal** weight. This is **intentional and correct** (zero-variance collapsed importance weight), **already tagged `:marginal`** via the Phase-1 score-type metadata, with a public opt-out (`strip-analytical-path`) that every built-in inference path uses. The only defect was documentation — fixed in the `protocols.cljs` `IGenerate` docstring and `gfi.md` (also reconciled contradictory weight wording). **No behavioral change.**

### `z7m2` — qwen3.5-0.8b-mlx-bf16 "garbage logits" (stale)
No longer reproduces on the pinned build: the bf16 0.8b predicts " Paris" on **both** the GenMLX-owned forward (21/21 parity) and the upstream uncached path. Tightened `llm_backend_test` 1.6 from a non-asserting smoke test into a correctness/drift guard.

## Verification (serial runs, no regressions)
`branch_rewrite` 93✓ · `iid_compiled` 27✓ · `iid_test` 21✓ · `branching_property` 11✓ · `inference` 7✓ · `auto_wiring` 42✓ · `conjugacy` 73✓ · `l3_5_gate` 10✓ · `compiled_simulate` 82✓ · `combinator_compile` 92✓ · `exact` 120✓ · `inference_smc` 7✓ · `smc_evidence` 17✓ · `membrane_churn` 9✓ · `llm_backend` 25✓

8 files changed, +132/−37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
