### PR TITLE
Phase 0 & Phase 1 final close-out (v4mz, wojm, pdm2, 0nyj, nt0c)

### DIFF
--- a/src/genmlx/dist.cljs
+++ b/src/genmlx/dist.cljs
@@ -582,6 +582,38 @@
         perturbed (mx/add logits gumbel)]
     (mx/argmax perturbed 1)))
 
+;; Gumbel-softmax (concrete) reparameterization for categorical (genmlx-0nyj).
+;; Enables low-variance reparameterized gradients through a discrete choice via
+;; ADEV instead of REINFORCE. CONTRACT: returns a [K] STRAIGHT-THROUGH ONE-HOT
+;; vector — forward value is the exact one-hot of the Gumbel-argmax (so the trace
+;; choice stays a legitimate discrete one-hot), backward gradient is the smooth
+;; Gumbel-softmax Jacobian via stop_gradient(hard − soft) + soft. This is the
+;; ADEV/gradient path only; ordinary categorical sample/log-prob/assess/generate
+;; are unchanged (they keep integer indices + exact log-softmax). Temperature is
+;; read from (:reparam-tau params) (default 0.5); smaller = lower bias, higher
+;; variance. Assumes 1-D logits [K] (the sequential ADEV path); batched/vadev
+;; categorical reparam needs a dist-reparam-n and is a follow-up.
+(defmethod dc/dist-reparam :categorical [d key]
+  (let [{:keys [logits reparam-tau]} (:params d)
+        tau (mx/scalar (double (or reparam-tau 0.5)))
+        k (last (mx/shape logits))
+        g (rng/gumbel (rng/ensure-key key) [k])
+        perturbed (mx/add (logits->logprobs logits) g)
+        soft (mx/softmax (mx/divide perturbed tau) -1)
+        ;; straight-through: exact one-hot forward, soft Jacobian backward.
+        ;; (Ties are measure-zero under continuous Gumbel noise.)
+        hard (mx/astype (mx/equal soft (mx/amax soft)) mx/float32)]
+    (mx/add (mx/stop-gradient (mx/subtract hard soft)) soft)))
+
+;; Differentiable score of a relaxed categorical: <one-hot, log_softmax(logits)>.
+;; Equals log_softmax(logits)[argmax] in the forward pass, but is differentiable
+;; w.r.t. BOTH the straight-through value and the logits — unlike dist-log-prob
+;; :categorical, which int-casts its argument and index-gathers (corrupting a
+;; one-hot). Kept off the ordinary scoring path (genmlx-0nyj).
+(defmethod dc/dist-reparam-log-prob :categorical [d value]
+  (let [{:keys [logits]} (:params d)]
+    (mx/sum (mx/multiply value (logits->logprobs logits)))))
+
 (defn categorical-weights
   "Categorical distribution from unnormalized weights (not logits).
    Handles zero weights safely — no log(0), no NaN gradients.

--- a/src/genmlx/dist/core.cljs
+++ b/src/genmlx/dist/core.cljs
@@ -17,6 +17,13 @@
 (defmulti dist-sample*   (fn [d _key] (:type d)))
 (defmulti dist-log-prob  (fn [d _value] (:type d)))
 (defmulti dist-reparam   (fn [d _key] (:type d)))
+;; Differentiable log-prob of a REPARAMETERIZED sample. For continuous dists the
+;; reparam value is an ordinary sample, so the default delegates to dist-log-prob
+;; (unchanged behavior). Discrete relaxations (Gumbel-softmax categorical) whose
+;; reparam value is a [K] one-hot — which dist-log-prob would int-truncate and
+;; mis-gather — override this with a differentiable score, keeping the relaxation
+;; OUT of ordinary categorical scoring/assess/generate (genmlx-0nyj).
+(defmulti dist-reparam-log-prob (fn [d _value] (:type d)))
 (defmulti dist-support   (fn [d] (:type d)))
 (defmulti dist-log-prob-support
   "Log-probabilities for ALL support values at once. Returns tensor of shape
@@ -44,6 +51,10 @@
 (defmethod dist-reparam :default [d _]
   (throw (ex-info (str "Distribution " (:type d) " does not support reparameterized sampling")
                   {:type (:type d)})))
+
+;; Default: the reparam value is an ordinary sample, score it as usual. Only
+;; relaxed-discrete dists (categorical) need an override.
+(defmethod dist-reparam-log-prob :default [d v] (dist-log-prob d v))
 
 (defmethod dist-support :default [d]
   (throw (ex-info (str "Distribution " (:type d) " is not enumerable")

--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -938,10 +938,17 @@
                         score-plus (-> (p/generate model args choices-plus)
                                        :trace :score ev)
                         score-minus (-> (p/generate model args choices-minus)
-                                        :trace :score ev)
-                        fd-grad (/ (- score-plus score-minus) (* 2 h))
-                        analytical (ev (get grads addr))]
-                    (approx= analytical fd-grad 0.05)))
+                                        :trace :score ev)]
+                    ;; If a finite-difference probe leaves the site's support
+                    ;; (bounded distributions near an edge) its score is -Inf and
+                    ;; the FD gradient is undefined — skip that address rather than
+                    ;; report a spurious law violation on a domain artifact. The
+                    ;; interior comparison (the real AD-vs-FD check) is unchanged.
+                    (if (and (js/isFinite score-plus) (js/isFinite score-minus))
+                      (let [fd-grad (/ (- score-plus score-minus) (* 2 h))
+                            analytical (ev (get grads addr))]
+                        (approx= analytical fd-grad 0.05))
+                      true)))
                 addrs)))}
 
    {:name :gradient-argument-correctness

--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -921,7 +921,9 @@
    {:name :gradient-choice-correctness
     :from "[T] Eq 2.12"
     :theorem "Choice gradients: d(score)/d(tau[a]) matches finite-difference
-              approximation for all continuous addresses."
+              approximation for all continuous addresses within the distribution
+              support (a probe that leaves support has an undefined FD gradient
+              and is skipped — genmlx-v4mz)."
     :tags #{:gradient :core}
     :check (fn [{:keys [model args]}]
              (let [t (p/simulate model args)

--- a/src/genmlx/inference/adev.cljs
+++ b/src/genmlx/inference/adev.cljs
@@ -21,6 +21,21 @@
   [dist]
   (contains? (methods dc/dist-reparam) (:type dist)))
 
+(def ^:private discrete-relaxation-types
+  "Distributions whose dist-reparam is a SCALAR straight-through relaxation
+   (Gumbel-softmax) with no batched dist-reparam-n yet. The shape-batched vadev
+   path samples reparam sites via dist-sample-n, which for these returns a hard
+   (non-differentiable) index — so vadev must treat them as NON-reparam (REINFORCE)
+   or it would silently produce zero gradients. Sequential adev handles them via
+   dist-reparam; batched categorical reparam is a follow-up (genmlx-0nyj)."
+  #{:categorical})
+
+(defn- batch-reparam?
+  "Reparameterizable along the shape-batched (dist-sample-n) path. Excludes the
+   scalar-only discrete relaxations so vadev keeps them on the REINFORCE path."
+  [dist]
+  (and (has-reparam? dist) (not (discrete-relaxation-types (:type dist)))))
+
 ;; ---------------------------------------------------------------------------
 ;; ADEV handler transition (sequential)
 ;; ---------------------------------------------------------------------------
@@ -36,7 +51,12 @@
         value (if reparam?
                 (dc/dist-reparam dist k2)
                 (mx/stop-gradient (dc/dist-sample dist k2)))
-        lp (dc/dist-log-prob dist value)]
+        ;; Score the reparam value via dist-reparam-log-prob (default = dist-log-prob,
+        ;; so continuous dists are unchanged; categorical's [K] one-hot needs the
+        ;; differentiable override — dist-log-prob would int-truncate it). genmlx-0nyj.
+        lp (if reparam?
+             (dc/dist-reparam-log-prob dist value)
+             (dc/dist-log-prob dist value))]
     [value (-> state
              (assoc :key k1)
              (update :choices #(cm/set-choice % [addr] value))
@@ -124,7 +144,10 @@
   [state addr dist]
   (let [n (:batch-size state)
         [k1 k2] (rng/split (:key state))
-        reparam? (has-reparam? dist)
+        ;; batch-reparam? (not has-reparam?): a scalar-only discrete relaxation
+        ;; (categorical) has no differentiable dist-sample-n, so it stays on the
+        ;; REINFORCE path in batched mode (genmlx-0nyj).
+        reparam? (batch-reparam? dist)
         value (if reparam?
                 (dc/dist-sample-n dist k2 n)
                 (mx/stop-gradient (dc/dist-sample-n dist k2 n)))

--- a/src/genmlx/vmap.cljs
+++ b/src/genmlx/vmap.cljs
@@ -230,6 +230,10 @@
               ;; score is [N]-shaped, sum for total
               total-score (mx/sum (:score result))
               element-scores (mapv #(mx/index (:score result) %) (range n))]
+          ;; No ::nested-element-meta on the fast paths: it is only needed when the
+          ;; kernel is ITSELF a combinator, and combinators (records, no :body-fn)
+          ;; never satisfy the fast-path guard above — a combinator kernel always
+          ;; takes the slow path, where nested metadata IS captured (genmlx-nt0c).
           (with-meta
             (tr/make-trace {:gen-fn this :args args
                             :choices (:choices result) :retval (:retval result)

--- a/src/genmlx/vmap.cljs
+++ b/src/genmlx/vmap.cljs
@@ -155,14 +155,36 @@
   [f results]
   (reduce (fn [acc r] (mx/add acc (f r))) (mx/scalar 0.0) results))
 
+(defn- capture-nested-meta
+  "Per-element vector of each inner trace's OWN combinator metadata (nil entries
+   for plain-kernel elements; nil overall when no element carries any). Stored on
+   a vmap trace as ::nested-element-meta and re-attached by element-trace so that a
+   reconstructed inner trace — when the kernel is ITSELF a combinator — carries
+   its own ::element-scores. The general retained-only regenerate/update weight is
+   project-based and NOT linear in the element :score, so without the inner
+   metadata a nested (vmap-of-vmap / combinator-of-combinator) general-path
+   regenerate mis-weights by the whole inner old score (genmlx-nt0c). Selecting
+   ::nested-element-meta too makes the propagation recursive (3+ levels)."
+  [traces]
+  (let [v (mapv #(not-empty (select-keys (meta %)
+                              [::element-scores ::n ::nested-element-meta ::batched?]))
+                traces)]
+    (when (some some? v) v)))
+
 (defn- element-trace
   "Reconstruct the kernel trace for element i from stored per-element state.
-   Score falls back to scalar 0.0 when no element-scores were recorded."
-  [kernel args choices element-scores i]
-  (tr/make-trace
-   {:gen-fn kernel :args args
-    :choices choices :retval nil
-    :score (if element-scores (nth element-scores i) (mx/scalar 0.0))}))
+   Score falls back to scalar 0.0 when no element-scores were recorded. nested-meta
+   (when present) re-attaches element i's own combinator metadata so a nested
+   kernel's regenerate/update/project sees its ::element-scores (genmlx-nt0c)."
+  ([kernel args choices element-scores i]
+   (element-trace kernel args choices element-scores i nil))
+  ([kernel args choices element-scores i nested-meta]
+   (let [t (tr/make-trace
+            {:gen-fn kernel :args args
+             :choices choices :retval nil
+             :score (if element-scores (nth element-scores i) (mx/scalar 0.0))})
+         m (when nested-meta (nth nested-meta i))]
+     (if m (vary-meta t merge m) t))))
 
 (defn- kernel-update
   "Update a kernel trace. Throws when the kernel does not implement IUpdate:
@@ -225,6 +247,7 @@
             (tr/make-trace {:gen-fn this :args args
                             :choices choices :retval retvals :score score})
             {::element-scores element-scores
+             ::nested-element-meta (capture-nested-meta results)
              ::n n})))))
 
   p/IGenerate
@@ -268,6 +291,7 @@
                     (tr/make-trace {:gen-fn this :args args
                                     :choices choices :retval retvals :score score})
                     {::element-scores element-scores
+                     ::nested-element-meta (capture-nested-meta (mapv :trace results))
                      ::n n})
            :weight weight}))))
 
@@ -279,11 +303,12 @@
           scalar-c? (scalar-constraints? constraints)
           new-per-constraints (when-not scalar-c? (unstack-choices constraints n))
           old-element-scores (::element-scores (meta trace))
+          old-nested-meta (::nested-element-meta (meta trace))
           results (mapv (fn [i]
                           (let [elem-args (extract-element-args (:args trace) in-axes i)
                                 old-trace (element-trace kernel elem-args
                                                          (nth old-per-choices i)
-                                                         old-element-scores i)]
+                                                         old-element-scores i old-nested-meta)]
                             (kernel-update kernel old-trace
                                            (if scalar-c? constraints (nth new-per-constraints i)))))
                         (range n))
@@ -309,6 +334,7 @@
                 (tr/make-trace {:gen-fn this :args (:args trace)
                                 :choices choices :retval retvals :score score})
                 {::element-scores element-scores
+                 ::nested-element-meta (capture-nested-meta (mapv :trace results))
                  ::n n})
        :weight weight
        :discard discard}))
@@ -319,11 +345,12 @@
                 (resolve-axis-size (:args trace) in-axes axis-size))
           old-per-choices (unstack-choices (:choices trace) n)
           old-element-scores (::element-scores (meta trace))
+          old-nested-meta (::nested-element-meta (meta trace))
           results (mapv (fn [i]
                           (let [elem-args (extract-element-args (:args trace) in-axes i)
                                 old-trace (element-trace kernel elem-args
                                                          (nth old-per-choices i)
-                                                         old-element-scores i)]
+                                                         old-element-scores i old-nested-meta)]
                             (kernel-regenerate kernel old-trace
                                                (extract-element-selection selection i))))
                         (range n))
@@ -333,14 +360,16 @@
           ;; Regenerate weights are additive across independent elements, but each
           ;; element weight was computed against the constructed old score
           ;; (recorded element score, or 0 without metadata). Re-base against the
-          ;; true total old score. NOTE (genmlx-nt0c): this is exact when
-          ;; ::element-scores is present (the re-base term is 0 — every vmap-produced
-          ;; trace carries it, so both fast and general kernel paths are correct),
-          ;; and also for FAST-path kernels when it is absent (e.g. the nested-vmap
-          ;; reconstructed inner trace: −old_total exactly compensates). The one
-          ;; unsound case is a GENERAL retained-only kernel weight on a trace whose
-          ;; ::element-scores were externally dropped — a project-based weight is
-          ;; not linear in the element :score; callers must keep the metadata.
+          ;; true total old score: W = Σ wᵢ + Σ constructed_oldᵢ − old_total.
+          ;; NOTE (genmlx-nt0c): ::element-scores is now propagated through nested
+          ;; reconstructions (::nested-element-meta + element-trace), so every
+          ;; reconstructed kernel old-trace — including the inner trace of a
+          ;; vmap-of-vmap — carries its own metadata and the re-base term is 0 for
+          ;; BOTH fast and general kernel paths. The expression is kept verbatim as
+          ;; a 0-valued safety net: a fast-eligible kernel still degrades exactly
+          ;; (−old_total compensates) if a trace's metadata is ever externally
+          ;; stripped; only a GENERAL retained-only kernel on an externally-stripped
+          ;; trace (no longer produced anywhere) would mis-weight.
           constructed-old (if old-element-scores
                             (reduce mx/add (mx/scalar 0.0) old-element-scores)
                             (mx/scalar 0.0))
@@ -351,6 +380,7 @@
                 (tr/make-trace {:gen-fn this :args (:args trace)
                                 :choices choices :retval retvals :score score})
                 {::element-scores element-scores
+                 ::nested-element-meta (capture-nested-meta (mapv :trace results))
                  ::n n})
        :weight weight}))
 
@@ -390,13 +420,14 @@
     (let [n (or (::n (meta trace))
                 (resolve-axis-size (:args trace) (:in-axes this) (:axis-size this)))
           old-per-choices (unstack-choices (:choices trace) n)
-          old-element-scores (::element-scores (meta trace))]
+          old-element-scores (::element-scores (meta trace))
+          old-nested-meta (::nested-element-meta (meta trace))]
       (reduce
        (fn [acc i]
          (let [elem-args (extract-element-args (:args trace) (:in-axes this) i)
                elem-trace (element-trace (:kernel this) elem-args
                                          (nth old-per-choices i)
-                                         old-element-scores i)]
+                                         old-element-scores i old-nested-meta)]
            (mx/add acc (p/project (:kernel this) elem-trace
                                   (extract-element-selection selection i)))))
        (mx/scalar 0.0)

--- a/test/genmlx/adev_test.cljs
+++ b/test/genmlx/adev_test.cljs
@@ -14,6 +14,31 @@
             [genmlx.inference.adev :as adev])
   (:require-macros [genmlx.gen :refer [gen]]))
 
+;; Deterministic seeding for the statistical reparam tests (genmlx-0nyj): the
+;; reparam value entropy comes from rng/fresh-key's 0-arg js/Math.random path, so
+;; we reseed it from one mulberry32 stream (the proven project pattern) around the
+;; convergence/variance assertions to make their thresholds reproducible.
+(defn- mulberry32 [seed]
+  (let [state (atom (bit-or seed 0))]
+    (fn []
+      (let [a (swap! state #(bit-or (+ % 0x6D2B79F5) 0))
+            t (js/Math.imul (bit-xor a (unsigned-bit-shift-right a 15)) (bit-or a 1))
+            t (bit-xor (+ t (js/Math.imul (bit-xor t (unsigned-bit-shift-right t 7))
+                                          (bit-or t 61))) t)]
+        (/ (unsigned-bit-shift-right (bit-xor t (unsigned-bit-shift-right t 14)) 0)
+           4294967296)))))
+(def ^:private rng-stream (mulberry32 0xADE0))
+(def ^:private orig-fresh-key rng/fresh-key)
+(defn- det-fresh-key
+  ([]     (orig-fresh-key (js/Math.floor (* (rng-stream) 2147483647))))
+  ([seed] (orig-fresh-key seed)))
+
+;; categorical with an explicit Gumbel-softmax temperature (the reparam path reads
+;; :reparam-tau from params; default 0.5). Public arity of dist/categorical is
+;; unchanged — this just sets the param for gradient tests.
+(defn- cat-tau [logits tau]
+  (update (dist/categorical logits) :params assoc :reparam-tau tau))
+
 (deftest has-reparam-detection-test
   (testing "has-reparam? detection"
     (is (adev/has-reparam? (dist/gaussian 0 1)) "gaussian is reparameterizable")
@@ -21,7 +46,7 @@
     (is (adev/has-reparam? (dist/exponential 1)) "exponential is reparameterizable")
     (is (adev/has-reparam? (dist/laplace 0 1)) "laplace is reparameterizable")
     (is (not (adev/has-reparam? (dist/bernoulli 0.5))) "bernoulli is NOT reparameterizable")
-    (is (not (adev/has-reparam? (dist/categorical (mx/array [-1 -1])))) "categorical is NOT reparameterizable")
+    (is (adev/has-reparam? (dist/categorical (mx/array [-1 -1]))) "categorical IS reparameterizable via Gumbel-softmax (genmlx-0nyj)")
     (is (not (adev/has-reparam? (dist/beta-dist 2 2))) "beta is NOT reparameterizable")))
 
 (deftest pure-reparam-model-test
@@ -220,5 +245,85 @@
           last-loss (last loss-history)]
       (is (h/close? 5.0 final-mu 1.5) "mu converges near 5.0 with baseline")
       (is (< last-loss first-loss) "loss decreases with baseline"))))
+
+;; ---------------------------------------------------------------------------
+;; Categorical Gumbel-softmax reparameterization (genmlx-0nyj)
+;; ---------------------------------------------------------------------------
+
+(deftest categorical-reparam-contract-test
+  (testing "reparam value is a [K] straight-through one-hot; ordinary ops unchanged"
+    (let [d (cat-tau (mx/array [0.5 -0.5 1.0]) 0.3)
+          v (dc/dist-reparam d (rng/fresh-key 7))]
+      (mx/eval! v)
+      (is (= [3] (vec (mx/shape v))) "reparam value has shape [K]")
+      (is (h/close? 1.0 (mx/item (mx/sum v)) 1e-5) "one-hot sums to 1")
+      (let [vals (mx/->clj v)]
+        (is (every? #(or (h/close? 0.0 % 1e-5) (h/close? 1.0 % 1e-5)) vals)
+            "forward value is exactly one-hot (0/1 entries)")))
+    ;; NON-CORRUPTION GUARD: ordinary categorical sampling/scoring is untouched —
+    ;; the relaxation is scoped to the ADEV/dist-reparam path only.
+    (let [d (dist/categorical (mx/array [0.0 0.0 0.0]))
+          s (dc/dist-sample d (rng/fresh-key 9))]
+      (mx/eval! s)
+      (is (integer? (mx/item s)) "ordinary sample is an integer index, not a one-hot")
+      (is (h/close? (js/Math.log (/ 1.0 3.0)) (mx/item (dc/dist-log-prob d (mx/scalar 1 mx/int32))) 1e-4)
+          "ordinary log-prob is exact log-softmax, not the relaxed score"))))
+
+(deftest categorical-reparam-gradient-oracle-test
+  ;; INDEPENDENT ORACLE: 2-category categorical with logits θ=[t0,t1], objective
+  ;; f(c)=c (the category index 0/1). E[f]=p1=softmax(θ)[1]; the EXACT analytic
+  ;; gradient (derived without GenMLX) is dE/dt1=p1(1-p1), dE/dt0=-p1(1-p1).
+  ;; With θ=[0,0]: p1=0.5 → grad=[-0.25, 0.25].
+  (with-redefs [rng/fresh-key det-fresh-key]
+    (testing "reparam gradient converges to the analytic softmax gradient"
+      (let [model (gen [] (let [t0 (param :t0 0.0) t1 (param :t1 0.0)
+                                logits (mx/stack [t0 t1])
+                                c (trace :c (cat-tau logits 0.2))]
+                            (mx/sum (mx/multiply c (mx/array [0.0 1.0])))))
+            cost-fn (fn [tr] (:retval tr))
+            {:keys [grad]} (adev/adev-gradient {:n-samples 4000} model []
+                                               cost-fn [:t0 :t1] (mx/array [0.0 0.0]))
+            g0 (mx/item (mx/index grad 0))
+            g1 (mx/item (mx/index grad 1))]
+        (is (h/close? -0.25 g0 0.05) (str "dE/dt0 ~ -0.25 (got " g0 ")"))
+        (is (h/close? 0.25 g1 0.05) (str "dE/dt1 ~ +0.25 (got " g1 ")"))
+        (is (h/close? g1 (- g0) 0.02) "gradient is antisymmetric (2-category softmax)")))
+    (testing "relaxation bias shrinks as temperature decreases"
+      (let [grad-at (fn [tau]
+                      (let [model (gen [] (let [t0 (param :t0 0.0) t1 (param :t1 0.0)
+                                                logits (mx/stack [t0 t1])
+                                                c (trace :c (cat-tau logits tau))]
+                                            (mx/sum (mx/multiply c (mx/array [0.0 1.0])))))]
+                        (mx/item (mx/index (:grad (adev/adev-gradient {:n-samples 4000} model []
+                                                    (fn [tr] (:retval tr)) [:t0 :t1] (mx/array [0.0 0.0]))) 1))))
+            err-hi (js/Math.abs (- 0.25 (grad-at 0.7)))
+            err-lo (js/Math.abs (- 0.25 (grad-at 0.1)))]
+        (is (<= err-lo err-hi)
+            (str "smaller tau is at least as close to the analytic gradient (lo=" err-lo " hi=" err-hi ")"))))))
+
+(deftest categorical-reparam-single-sample-unbiased-test
+  ;; The reparam (Gumbel-softmax) single-sample gradient is a usable low-bias
+  ;; estimator: averaging a modest number of n-samples=1 draws lands near the
+  ;; analytic 0.25, and every draw is finite (gradient genuinely flows through
+  ;; the discrete site). NOTE: we deliberately do NOT assert lower variance than
+  ;; REINFORCE — for a single binary choice with the linear objective f(c)=c,
+  ;; REINFORCE's score-function estimator (score ∈ {0, 0.5}) is already
+  ;; low-variance and beats Gumbel-softmax at τ=0.2; the variance advantage of
+  ;; the relaxation is regime-dependent (smooth/high-dim objectives), not a
+  ;; universal property worth asserting on this toy (genmlx-0nyj, empirically
+  ;; verified: reparam var ≈ 0.12 > REINFORCE var ≈ 0.06 here).
+  (with-redefs [rng/fresh-key det-fresh-key]
+    (let [model (gen [] (let [t0 (param :t0 0.0) t1 (param :t1 0.0)
+                              lg (mx/stack [t0 t1])
+                              c (trace :c (cat-tau lg 0.2))]
+                          (mx/sum (mx/multiply c (mx/array [0.0 1.0])))))
+          k 300
+          gs (vec (for [_ (range k)]
+                    (mx/item (mx/index (:grad (adev/adev-gradient {:n-samples 1} model []
+                                                (fn [tr] (:retval tr)) [:t0 :t1] (mx/array [0.0 0.0]))) 1))))
+          mean (/ (reduce + gs) (count gs))]
+      (is (every? js/isFinite gs) "every single-sample reparam gradient is finite")
+      (is (h/close? 0.25 mean 0.05)
+          (str "mean of single-sample reparam gradients ~ analytic 0.25 (got " mean ")")))))
 
 (cljs.test/run-tests)

--- a/test/genmlx/gen_jl_speed_test.cljs
+++ b/test/genmlx/gen_jl_speed_test.cljs
@@ -90,6 +90,19 @@
     (gen []
       (trace :x (dist/gaussian 0 1)))))
 
+;; Model 1b: 1-latent Normal-Normal for compiled-MH (genmlx-pdm2).
+;; single-gaussian's only site :x is the one the constraint observes, so
+;; compiled-MH would (correctly) throw :no-mcmc-latents — there is no free
+;; latent to sample. This model gives compiled-MH a genuine 1-parameter target:
+;; latent :mu, with a SEPARATE observed :y, so the tensor score exposes one
+;; sampling parameter.
+(def normal-normal-1d
+  (dyn/auto-key
+    (gen []
+      (let [mu (trace :mu (dist/gaussian 0 1))]
+        (trace :y (dist/gaussian mu 1))
+        mu))))
+
 ;; Model 2: Linear Regression (5 obs + 2 latents = 7 sites)
 (def linear-regression
   (dyn/auto-key
@@ -147,6 +160,9 @@
 
 (defn- constraints-single-gaussian []
   (cm/choicemap :x (mx/scalar 0.5)))
+
+(defn- obs-normal-normal-1d []
+  (cm/choicemap :y (mx/scalar 0.5)))
 
 (defn- constraints-linear-regression []
   (-> cm/EMPTY
@@ -371,10 +387,13 @@
 
 (println "\n-- Compiled MH (200 steps) --")
 
-(run-bench! "single_gaussian" "compiled_mh" 200
+;; 1-param compiled-MH: normal-normal (latent :mu, observed :y). single-gaussian's
+;; only site :x is observed by its constraint, so compiled-MH has no free latent
+;; (it would throw :no-mcmc-latents — the correct contract; genmlx-pdm2).
+(run-bench! "normal_normal_1d" "compiled_mh" 200
   (fn [] (mcmc/compiled-mh
-           {:samples 200 :addresses [:x]}
-           single-gaussian [] (constraints-single-gaussian))))
+           {:samples 200 :addresses [:mu]}
+           normal-normal-1d [] (obs-normal-normal-1d))))
 
 (run-bench! "linear_regression" "compiled_mh" 200
   (fn [] (mcmc/compiled-mh
@@ -392,10 +411,10 @@
 
 (println "\n-- Loop-Compiled MH (200 steps) --")
 
-(run-bench! "single_gaussian" "compiled_mh_loop" 200
+(run-bench! "normal_normal_1d" "compiled_mh_loop" 200
   (fn [] (mcmc/compiled-mh
-           {:samples 200 :addresses [:x] :compile? true}
-           single-gaussian [] (constraints-single-gaussian))))
+           {:samples 200 :addresses [:mu] :compile? true}
+           normal-normal-1d [] (obs-normal-normal-1d))))
 
 (run-bench! "linear_regression" "compiled_mh_loop" 200
   (fn [] (mcmc/compiled-mh
@@ -475,6 +494,7 @@
 
 (let [;; Abbreviate labels for table readability
       abbrev {"single_gaussian" "gauss1"
+              "normal_normal_1d" "nn1"
               "linear_regression" "linreg"
               "mixed" "mixed"
               "map_combinator" "map"

--- a/test/genmlx/gfi_laws_helpers.cljs
+++ b/test/genmlx/gfi_laws_helpers.cljs
@@ -9,8 +9,52 @@
             [genmlx.protocols :as p]
             [genmlx.choicemap :as cm]
             [genmlx.gfi :as gfi]
+            [genmlx.mlx.random :as rng]
             [genmlx.test-helpers :as h])
   (:require-macros [genmlx.gen :refer [gen]]))
+
+;; ---------------------------------------------------------------------------
+;; Deterministic seeding (genmlx-v4mz)
+;; ---------------------------------------------------------------------------
+;; The GFI law suite asserts stochastic convergence/finiteness thresholds, so it
+;; must be reproducible. Its sampled VALUES come from `rng/fresh-key`, whose
+;; 0-arg form seeds itself from js/Math.random (mlx/random.cljs L23) — NOT from
+;; test.check's :seed (which only controls gen/elements model selection + shrink
+;; order). nbb/SCI cannot propagate a (set! js/Math.random) override into required
+;; namespaces, so each split test file wraps its trailing (t/run-tests) in
+;;   (with-redefs [rng/fresh-key glh/det-fresh-key] (t/run-tests))
+;; which reseeds fresh-key from one deterministic mulberry32 stream. MLX's keyed
+;; RNG + compute are bit-reproducible across processes given a seed, so the suite
+;; is then fully deterministic. Each test file runs as its OWN nbb process, so it
+;; gets its own fresh `rng-stream` state below — no cross-file coupling.
+;; Test-only: no production code or inference behavior changes.
+
+(defn- mulberry32
+  "Deterministic seeded PRNG: a 0-arg fn yielding doubles in [0,1) (bryc/code)."
+  [seed]
+  (let [state (atom (bit-or seed 0))]
+    (fn []
+      (let [a (swap! state #(bit-or (+ % 0x6D2B79F5) 0))
+            t (js/Math.imul (bit-xor a (unsigned-bit-shift-right a 15)) (bit-or a 1))
+            t (bit-xor (+ t (js/Math.imul (bit-xor t (unsigned-bit-shift-right t 7))
+                                          (bit-or t 61)))
+                       t)]
+        (/ (unsigned-bit-shift-right (bit-xor t (unsigned-bit-shift-right t 14)) 0)
+           4294967296)))))
+
+(def ^:private rng-stream (mulberry32 424242))
+
+(def ^:private orig-fresh-key
+  "The real rng/fresh-key, captured at load time so det-fresh-key never recurses."
+  rng/fresh-key)
+
+(defn det-fresh-key
+  "rng/fresh-key reseeded from the shared mulberry32 stream instead of
+   js/Math.random (which nbb cannot override inside required namespaces). The
+   explicit-seed 1-arg form passes through unchanged. with-redefs'd around
+   (t/run-tests) at the bottom of each split GFI-law test file."
+  ([]     (orig-fresh-key (js/Math.floor (* (rng-stream) 2147483647))))
+  ([seed] (orig-fresh-key seed)))
 
 ;; ---------------------------------------------------------------------------
 ;; Helpers

--- a/test/genmlx/gfi_laws_test.cljs
+++ b/test/genmlx/gfi_laws_test.cljs
@@ -32,6 +32,7 @@
             [genmlx.test-helpers :as h]
             [genmlx.combinators :as comb]
             [genmlx.inference.smc :as smc]
+            [genmlx.gfi-laws-helpers :as glh]
             [genmlx.verify :as verify])
   (:require-macros [genmlx.gen :refer [gen]]
                    [clojure.test.check.clojure-test :refer [defspec]]))
@@ -708,10 +709,17 @@
                            score-plus (-> (p/generate model args choices-plus)
                                           :trace :score ev)
                            score-minus (-> (p/generate model args choices-minus)
-                                           :trace :score ev)
-                           fd-grad (/ (- score-plus score-minus) (* 2 h))
-                           analytical (ev (get grads addr))]
-                       (close? analytical fd-grad 0.05)))
+                                           :trace :score ev)]
+                       ;; If a finite-difference probe leaves the site's support
+                       ;; (uniform/beta/exponential near a boundary) its score is
+                       ;; -Inf and the FD gradient is undefined — skip that address
+                       ;; (vacuously true) rather than fail on a domain artifact.
+                       ;; Interior probes still assert AD==FD at 0.05 (genmlx-v4mz).
+                       (if (and (h/finite? score-plus) (h/finite? score-minus))
+                         (let [fd-grad (/ (- score-plus score-minus) (* 2 h))
+                               analytical (ev (get grads addr))]
+                           (close? analytical fd-grad 0.05))
+                         true)))
                    addrs))))
 
 (defspec law:gradient-argument-correctness 50
@@ -2239,4 +2247,5 @@
           (t/is (close? fd-grad analytical 0.01)
                 (str "FD grad at x=" x-val ": " fd-grad " vs analytical " analytical)))))))
 
-(t/run-tests)
+(with-redefs [rng/fresh-key glh/det-fresh-key]
+  (t/run-tests))

--- a/test/genmlx/gfi_laws_test_p1.cljs
+++ b/test/genmlx/gfi_laws_test_p1.cljs
@@ -130,4 +130,5 @@
                       aw (ev weight)]
                   (close? pw aw 1e-5))))
 
-(t/run-tests)
+(with-redefs [rng/fresh-key glh/det-fresh-key]
+  (t/run-tests))

--- a/test/genmlx/gfi_laws_test_p10.cljs
+++ b/test/genmlx/gfi_laws_test_p10.cljs
@@ -4,6 +4,7 @@
   (:require [cljs.test :as t]
             [genmlx.mlx :as mx]
             [genmlx.gfi :as gfi]
+            [genmlx.mlx.random :as rng]
             [genmlx.gfi-laws-helpers :as glh
              :refer [gaussian-chain branching-model]])
   (:require-macros [genmlx.gen :refer [gen]]))
@@ -46,4 +47,5 @@
             (str "Too few core law passes on branching model: "
                  (:total-pass report))))))
 
-(t/run-tests)
+(with-redefs [rng/fresh-key glh/det-fresh-key]
+  (t/run-tests))

--- a/test/genmlx/gfi_laws_test_p2.cljs
+++ b/test/genmlx/gfi_laws_test_p2.cljs
@@ -158,4 +158,5 @@
                       proj (ev (p/project (:model m) t sel/none))]
                   (close? 0.0 proj 0.01))))
 
-(t/run-tests)
+(with-redefs [rng/fresh-key glh/det-fresh-key]
+  (t/run-tests))

--- a/test/genmlx/gfi_laws_test_p3.cljs
+++ b/test/genmlx/gfi_laws_test_p3.cljs
@@ -185,4 +185,5 @@
                        (close? (+ w1 w2) 0.0 1e-3)
                        choices-match))))
 
-(t/run-tests)
+(with-redefs [rng/fresh-key glh/det-fresh-key]
+  (t/run-tests))

--- a/test/genmlx/gfi_laws_test_p4.cljs
+++ b/test/genmlx/gfi_laws_test_p4.cljs
@@ -85,10 +85,17 @@
                            score-plus (-> (p/generate model args choices-plus)
                                           :trace :score ev)
                            score-minus (-> (p/generate model args choices-minus)
-                                           :trace :score ev)
-                           fd-grad (/ (- score-plus score-minus) (* 2 h))
-                           analytical (ev (get grads addr))]
-                       (close? analytical fd-grad 0.05)))
+                                           :trace :score ev)]
+                       ;; If a finite-difference probe leaves the site's support
+                       ;; (uniform/beta/exponential near a boundary) its score is
+                       ;; -Inf and the FD gradient is undefined — skip that address
+                       ;; (vacuously true) rather than fail on a domain artifact.
+                       ;; Interior probes still assert AD==FD at 0.05 (genmlx-v4mz).
+                       (if (and (h/finite? score-plus) (h/finite? score-minus))
+                         (let [fd-grad (/ (- score-plus score-minus) (* 2 h))
+                               analytical (ev (get grads addr))]
+                           (close? analytical fd-grad 0.05))
+                         true)))
                    addrs))))
 
 (defspec law:gradient-argument-correctness 50
@@ -187,4 +194,5 @@
       (t/is (close? log-ml analytical 0.1)
             (str "log-ML " log-ml " not close to analytical " analytical)))))
 
-(t/run-tests)
+(with-redefs [rng/fresh-key glh/det-fresh-key]
+  (t/run-tests))

--- a/test/genmlx/gfi_laws_test_p5.cljs
+++ b/test/genmlx/gfi_laws_test_p5.cljs
@@ -294,4 +294,5 @@
             (str "Factorization failed (constrain a+c) in "
                  (count (remove true? results-ac)) "/20 trials")))))
 
-(t/run-tests)
+(with-redefs [rng/fresh-key glh/det-fresh-key]
+  (t/run-tests))

--- a/test/genmlx/gfi_laws_test_p6.cljs
+++ b/test/genmlx/gfi_laws_test_p6.cljs
@@ -394,4 +394,5 @@
             (str "p: expected score=" analytical-score
                  ", got " (ev (:score trace)))))))
 
-(t/run-tests)
+(with-redefs [rng/fresh-key glh/det-fresh-key]
+  (t/run-tests))

--- a/test/genmlx/gfi_laws_test_p7.cljs
+++ b/test/genmlx/gfi_laws_test_p7.cljs
@@ -339,4 +339,5 @@
                                   1e-6))
                                unselected)))))
 
-(t/run-tests)
+(with-redefs [rng/fresh-key glh/det-fresh-key]
+  (t/run-tests))

--- a/test/genmlx/gfi_laws_test_p7.cljs
+++ b/test/genmlx/gfi_laws_test_p7.cljs
@@ -8,6 +8,7 @@
             [genmlx.dist :as dist]
             [genmlx.diff :as diff]
             [genmlx.dynamic :as dyn]
+            [genmlx.dispatch :as dispatch]
             [genmlx.edit :as edit]
             [genmlx.protocols :as p]
             [genmlx.choicemap :as cm]
@@ -101,6 +102,104 @@
                        (h/finite? (ev (:score t2)))
                        (= (set (cm/addresses (:choices t1)))
                           (set (cm/addresses (:choices t2))))))))
+
+;; --- Law: Proposal Override [T] Alg 16, §4.1.4 ---
+;; Algorithm 16 routes :generate through a custom proposal Q instead of model P's
+;; internal (prior) proposal, via dispatch/with-dispatch. R = P plus a custom
+;; dispatch fn that, on :generate, samples latents from Q and returns the
+;; importance weight log p(latents, obs) − log q(latents); every other op
+;; delegates to a CLEAN P. Proves: (A) the non-overridden op (simulate) is
+;; untouched; (B) Q is genuinely in the generate path — the proposed latent is
+;; Q-distributed, not prior-distributed (the non-vacuity guard); (C) both P's
+;; default-prior proposal AND R's Q proposal give importance-sampling log-ML
+;; estimates that converge to the SAME closed-form Normal-Normal marginal
+;; likelihood — the independent oracle. (genmlx-wojm)
+
+(t/deftest law:proposal-override-alg16
+  (t/testing "Alg-16 proposal override via with-dispatch"
+    (let [;; Target P: mu ~ N(0,2), y ~ N(mu,1). strip-analytical-path so generate
+          ;; samples mu from the PRIOR (a real sampling proposal) rather than the
+          ;; conjugate analytical path (which would pin mu and zero the variance).
+          P (dyn/strip-analytical-path
+              (gen [] (let [mu (trace :mu (dist/gaussian 0 2))]
+                        (trace :y (dist/gaussian mu 1))
+                        mu)))
+          ;; Custom proposal Q: deliberately overdispersed and OFF the prior
+          ;; (mean 2 ≠ prior mean 0, sd 1.5) so its weights provably differ from
+          ;; P's, while still covering the posterior (mu|y=3 ~ N(2.4, 0.89)).
+          Q (gen [_obs] (trace :mu (dist/gaussian 2 1.5)))
+          obs (cm/choicemap :y (mx/scalar 3.0))
+          ;; Independent oracle: y ~ N(0, sqrt(prior_var+obs_var)=sqrt5).
+          analytical (- (* -0.5 (js/Math.log (* 2 js/Math.PI)))
+                        (* 0.5 (js/Math.log 5.0))
+                        (* 0.5 (/ 9.0 5.0)))
+          ;; Algorithm-16 dispatch fn. On :generate, propose mu~Q, score the full
+          ;; joint under P, return IS weight log p(mu,y) − log q(mu). df closes
+          ;; over the CLEAN P (no custom-dispatch) and delegates other ops to it —
+          ;; calling p/* on `gf` (=R) would recurse forever.
+          df (fn [op _gf args key opts]
+               (case op
+                 :generate
+                 (let [[kq kp] (rng/split key)
+                       {q-choices :choices q-score :weight}
+                       (p/propose (dyn/with-key Q kq) [(:constraints opts)])
+                       full (cm/merge-cm (:constraints opts) q-choices)
+                       {p-trace :trace} (p/generate (dyn/with-key P kp) args full)
+                       w (mx/subtract (:score p-trace) q-score)]
+                   {:trace p-trace :weight w})
+                 :simulate (p/simulate (dyn/with-key P key) args)
+                 :assess   (p/assess   (dyn/with-key P key) args (:constraints opts))
+                 :propose  (p/propose  (dyn/with-key P key) args)
+                 (throw (ex-info "proposal-override: op not delegated" {:op op}))))
+          R (dispatch/with-dispatch P df)
+          k (fn [base i] (rng/fresh-key (+ base i)))
+          mu-of (fn [choices] (ev (cm/get-value (cm/get-submap choices :mu))))]
+
+      ;; (A) simulate(R) is the non-overridden op — must equal simulate(P): same
+      ;;     address set and prior-distributed mu (mean ≈ 0).
+      (let [r-mus (vec (for [i (range 1000)]
+                         (mu-of (:choices (p/simulate (dyn/with-key R (k 5000 i)) [])))))
+            p-mus (vec (for [i (range 1000)]
+                         (mu-of (:choices (p/simulate (dyn/with-key P (k 7000 i)) [])))))
+            r-addrs (set (cm/addresses (:choices (p/simulate (dyn/with-key R (k 1 0)) []))))
+            p-addrs (set (cm/addresses (:choices (p/simulate (dyn/with-key P (k 2 0)) []))))]
+        (t/is (= r-addrs p-addrs) "simulate(R) address set = simulate(P)")
+        (t/is (close? (glh/sample-mean r-mus) 0.0 0.2)
+              "simulate(R) mu ~ prior (mean 0): non-overridden op untouched")
+        (t/is (close? (glh/sample-mean r-mus) (glh/sample-mean p-mus) 0.2)
+              "simulate(R) mu-mean = simulate(P) mu-mean"))
+
+      ;; (B) NON-VACUITY: generate(R) must use Q — the proposed latent mu is
+      ;;     Q-distributed (mean ≈ 2), NOT prior-distributed (mean 0). If the
+      ;;     override silently fell through to P, mu would have mean 0.
+      (let [r-gen-mus (vec (for [i (range 1000)]
+                             (mu-of (:choices (:trace (p/generate (dyn/with-key R (k 8000 i)) [] obs))))))
+            p-gen-mus (vec (for [i (range 1000)]
+                             (mu-of (:choices (:trace (p/generate (dyn/with-key P (k 9000 i)) [] obs))))))]
+        (t/is (close? (glh/sample-mean r-gen-mus) 2.0 0.2)
+              "generate(R) proposes mu ~ Q (mean 2): Q is genuinely in the path")
+        (t/is (close? (glh/sample-mean p-gen-mus) 0.0 0.2)
+              "generate(P) proposes mu ~ prior (mean 0)")
+        (t/is (> (js/Math.abs (- (glh/sample-mean r-gen-mus) (glh/sample-mean p-gen-mus))) 1.0)
+              "R's proposal differs from P's default proposal (non-vacuous)"))
+
+      ;; (C) HEADLINE: both proposals give IS log-ML estimates converging to the
+      ;;     SAME closed-form marginal likelihood — the independent oracle. (A
+      ;;     manual loop keeps R's custom-dispatch path intact; importance-sampling
+      ;;     would re-wrap/strip it.)
+      (let [n 4000
+            w-P (vec (for [i (range n)]
+                       (ev (:weight (p/generate (dyn/with-key P (k 100000 i)) [] obs)))))
+            w-R (vec (for [i (range n)]
+                       (ev (:weight (p/generate (dyn/with-key R (k 200000 i)) [] obs)))))
+            est-P (- (glh/logsumexp w-P) (js/Math.log n))
+            est-R (- (glh/logsumexp w-R) (js/Math.log n))]
+        (t/is (close? est-P analytical 0.2)
+              (str "P default-proposal IS log-ML " est-P " vs analytical " analytical))
+        (t/is (close? est-R analytical 0.2)
+              (str "R Q-proposal IS log-ML " est-R " vs analytical " analytical))
+        (t/is (close? est-P est-R 0.25)
+              "both proposals agree on the marginal likelihood")))))
 
 ;; --- Law #16: Mixture Kernel Stationarity [T] Prop 3.4.1 ---
 ;; Mix of stationary kernels is stationary. Random-mix and deterministic-cycle

--- a/test/genmlx/gfi_laws_test_p8.cljs
+++ b/test/genmlx/gfi_laws_test_p8.cljs
@@ -351,4 +351,5 @@
       (t/is (close? var-x 0.2 0.08)
             (str "Posterior var=" var-x " expected=0.2")))))
 
-(t/run-tests)
+(with-redefs [rng/fresh-key glh/det-fresh-key]
+  (t/run-tests))

--- a/test/genmlx/gfi_laws_test_p9.cljs
+++ b/test/genmlx/gfi_laws_test_p9.cljs
@@ -200,4 +200,5 @@
           (t/is (close? fd-grad analytical 0.01)
                 (str "FD grad at x=" x-val ": " fd-grad " vs analytical " analytical)))))))
 
-(t/run-tests)
+(with-redefs [rng/fresh-key glh/det-fresh-key]
+  (t/run-tests))

--- a/test/genmlx/mcmc_elim_filter_test.cljs
+++ b/test/genmlx/mcmc_elim_filter_test.cljs
@@ -16,12 +16,13 @@
    These tests pin which path each model class takes, so a dispatch change
    that silently flips a model between joint and Rao-Blackwellized MCMC
    (or zeroes out a param vector) fails here first."
-  (:require [cljs.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is testing]]
             [genmlx.mlx :as mx]
             [genmlx.dist :as dist]
             [genmlx.dynamic :as dyn]
             [genmlx.protocols :as p]
             [genmlx.choicemap :as cm]
+            [genmlx.inference.mcmc :as mcmc]
             [genmlx.inference.util :as u])
   (:require-macros [genmlx.gen :refer [gen]]))
 
@@ -79,6 +80,33 @@
         "empty latent-index throws a clear :no-mcmc-latents ex-info")
     (is (= [2] (vec (mx/shape (u/extract-params-by-index trace {:a 0 :b 1}))))
         "non-empty latent-index still extracts normally (no regression)")))
+
+(deftest pdm2-observed-only-latent-throws-but-free-latent-samples
+  ;; genmlx-pdm2: the gen_jl_speed_test "single_gaussian" compiled-MH benchmark
+  ;; observed its ONLY latent (model :x, constraint {:x 0.5}), leaving zero free
+  ;; latents — so compiled-MH (correctly) threw :no-mcmc-latents. The bean's
+  ;; premise (linreg/many are "fully eliminated") was inverted: those are
+  ;; non-static loop models that sample fine; single_gaussian was the real crash,
+  ;; an observed-sole-latent collision. The fix replaces it with a 1-latent
+  ;; normal-normal (latent :mu, SEPARATE observed :y). This pins both halves.
+  (testing "sole latent is observed -> :no-mcmc-latents (the documented contract)"
+    (let [m (dyn/auto-key (gen [] (trace :x (dist/gaussian 0 1))))
+          obs (cm/choicemap :x (mx/scalar 0.5))
+          {:keys [trace]} (p/generate m [] obs)]
+      (is (thrown-with-msg? js/Error #"no free latent addresses to sample"
+            (u/prepare-mcmc-score m [] obs [:x] trace))
+          "selecting the sole observed latent exposes zero sampling params")))
+  (testing "free latent (normal-normal :mu, observed :y) -> samples, no throw"
+    (let [m (dyn/auto-key (gen [] (let [mu (trace :mu (dist/gaussian 0 1))]
+                                    (trace :y (dist/gaussian mu 1))
+                                    mu)))
+          obs (cm/choicemap :y (mx/scalar 0.5))
+          {:keys [trace]} (p/generate m [] obs)
+          r (u/prepare-mcmc-score m [] obs [:mu] trace)
+          samples (mcmc/compiled-mh {:samples 10 :addresses [:mu]} m [] obs)]
+      (is (= 1 (:n-params r)) "the :mu latent is a free sampling parameter")
+      (is (= 10 (count samples)) "compiled-MH returns the requested samples")
+      (is (= 1 (count (first samples))) "each sample is the 1-D :mu latent"))))
 
 (cljs.test/run-tests)
 

--- a/test/genmlx/vmap_test.cljs
+++ b/test/genmlx/vmap_test.cljs
@@ -486,4 +486,41 @@
       (mx/eval! (:weight vtrace))
       (is (js/isFinite (mx/item (:weight vtrace))) "vgenerate weight is finite"))))
 
+(deftest general-path-regenerate-weight-equals-delta-project
+  ;; genmlx-nt0c: a kernel that forces the GENERAL retained-only regenerate path —
+  ;; a 3-site chain a→b→c, selecting {:a :b} so a selected site (:a) feeds another
+  ;; selected site (:b) (not fast-eligible) and :c is a dependent RETAINED site.
+  ;; The general retained-only weight is project-based (W = Σ_retained Δlp), NOT
+  ;; linear in the element :score, so a reconstructed inner trace MUST carry its
+  ;; own ::element-scores. ORACLE (thesis, non-circular): the regenerate weight
+  ;; must equal project(new, retained) − project(old, retained), computed via
+  ;; vmap's project (an element-wise sum of retained log-probs — a different code
+  ;; path than regenerate's re-base).
+  (let [kern (dyn/auto-key (gen [m] (let [a (trace :a (dist/gaussian m 1))
+                                          b (trace :b (dist/gaussian a 1))
+                                          c (trace :c (dist/gaussian b 1))]
+                                      c)))
+        sel-ab (sel/select :a :b)
+        retained (sel/select :c)
+        delta-project (fn [gf old-tr new-tr]
+                        (mx/subtract (p/project gf new-tr retained)
+                                     (p/project gf old-tr retained)))]
+    (testing "single-level vmap, general retained-only path"
+      (let [v (vmap/vmap-gf kern)
+            tr (p/simulate v [(mx/array [0.0 1.0 2.0])])
+            {new-tr :trace w :weight} (p/regenerate v tr sel-ab)]
+        (is (js/isFinite (mx/item w)) "weight finite")
+        (is (h/close? (mx/item (delta-project v tr new-tr)) (mx/item w) 1e-3)
+            "single-level weight = Δproject(retained)")))
+    (testing "NESTED vmap-of-vmap, general retained-only path (the nt0c bug)"
+      ;; Without nested ::element-scores propagation this mis-weighted by the whole
+      ;; inner old score (empirically 2.93 vs oracle -23.86).
+      (let [inner (vmap/vmap-gf kern)
+            outer (vmap/vmap-gf inner)
+            tr (p/simulate outer [(mx/array [[0.0 1.0 2.0] [3.0 4.0 5.0]])])
+            {new-tr :trace w :weight} (p/regenerate outer tr sel-ab)]
+        (is (js/isFinite (mx/item w)) "nested weight finite")
+        (is (h/close? (mx/item (delta-project outer tr new-tr)) (mx/item w) 1e-3)
+            "nested vmap-of-vmap weight = Δproject(retained)")))))
+
 (cljs.test/run-tests)

--- a/test/genmlx/vmap_test.cljs
+++ b/test/genmlx/vmap_test.cljs
@@ -505,6 +505,11 @@
         delta-project (fn [gf old-tr new-tr]
                         (mx/subtract (p/project gf new-tr retained)
                                      (p/project gf old-tr retained)))]
+    ;; ANTI-VACUITY: the whole point is the GENERAL retained-only path (project-
+    ;; based weight). If this selection were fast-eligible, w_i would be linear in
+    ;; the element score and the test would pass even with the bug present. Pin it.
+    (is (not (#'dyn/regen-fast-eligible? kern sel-ab))
+        "test kernel+selection must force the general (non-fast) regenerate path")
     (testing "single-level vmap, general retained-only path"
       (let [v (vmap/vmap-gf kern)
             tr (p/simulate v [(mx/array [0.0 1.0 2.0])])


### PR DESCRIPTION
## Phase 0 & Phase 1 final close-out

Closes the last deferred ROADMAP Phase-0/1 items. The Phase-0 (`genmlx-p3uy`) and
Phase-1 (`genmlx-2s3n`) milestones were already complete; this PR clears the
trailing deferrals. Each fix is fail→fix→pass with an **independent, non-circular
oracle** (the ke9i rule).

### What landed

- **`genmlx-v4mz`** — boundary-guard `law:gradient-choice-correctness` (the real
  flake: a finite-difference probe leaving a bounded site's support → `-Inf` →
  spurious failure) in both test copies **and** the source-of-truth `gfi.cljs`
  `:check`; interior AD-vs-FD comparison unchanged at 0.05 (no tolerance widening).
  Deterministic value-seeding across all 11 gfi_laws files via a shared
  `glh/det-fresh-key` (mulberry32) `with-redefs`'d around `(t/run-tests)`.

- **`genmlx-wojm`** — `law:proposal-override-alg16` (Cusumano-Towner Alg 16) in
  `gfi_laws_test_p7` via `dispatch/with-dispatch` (the `df` closes over a clean P to
  avoid recursion). Three oracles: `simulate(R)=simulate(P)`; `generate(R)` proposes
  `mu~Q` (mean≈2 ≠ prior mean 0 — non-vacuity); both proposals' IS log-ML converge
  to the closed-form Normal-Normal marginal `log N(3;0,√5) = -2.6236`. No src change.

- **`genmlx-pdm2`** — the bean premise was **inverted** (verified out-of-tree):
  `linear_regression`/`many_addresses` are non-static loop models that sample fine;
  the real crash was `single_gaussian` compiled-MH **observing its only latent `:x`**
  (empty tensor latent index → `:no-mcmc-latents`). Replaced that benchmark with a
  1-latent normal-normal; regression test in `mcmc_elim_filter_test` pins both halves
  (observed-sole-latent → throws; free latent → samples).

- **`genmlx-0nyj`** — Gumbel-softmax `dist-reparam :categorical` (straight-through
  one-hot) + a new `dist-reparam-log-prob` multimethod that keeps the relaxation
  **out of** ordinary categorical sampling/scoring; ADEV uses it, vADEV excludes it
  (`discrete-relaxation-types`) so batched mode stays on REINFORCE rather than
  silently zeroing gradients. Gradient converges to the analytic `±p1(1−p1)`.
  *Empirical correction to the design spec:* Gumbel-softmax is **not** universally
  lower-variance than REINFORCE (false for a binary linear objective), so the test
  asserts gradient **correctness**, not a false variance claim.

- **`genmlx-nt0c`** — escalated from "latent footgun" to a **confirmed reachable
  bug**: a nested vmap-of-vmap with a general-path kernel mis-weighted `2.93` vs
  oracle `-23.86` (the reconstructed inner trace lacked its own `::element-scores`,
  and the general retained-only weight is project-based, not linear in the score).
  Fix: propagate nested metadata (`capture-nested-meta` + `::nested-element-meta` +
  `element-trace` re-attach) at every producer/consumer; the re-base is kept as a
  now-0 safety net. Oracle test: weight = `project(new,retained) − project(old,retained)`
  (the thesis identity, a different code path than the re-base — non-circular), with
  an anti-vacuity assertion that the kernel forces the general path.

- **polish** — applied the genuine adversarial-review points (anti-vacuity assert,
  fast-path comment, gradient-law scope docstring). The review's two "critical" wojm
  findings were **false** (it misread Clojure's variadic `(- A B C)`=A−B−C and called
  a closed-form constant circular; oracle verified `= -2.6236` exactly) — no change.

### Verification — all gates green

level0 68 · schema 246 · compiled_simulate 82 · partial_compile 92 ·
combinator_compile 92 · l4 41 · gen_clj 356 · genjax 73 · all 11 gfi_laws +
monolith (82/196) · exact 120 · adev 42 · vectorized 72 · core data + membrane
guards. The only non-green test anywhere is **pre-existing and unrelated**
(`splice-of-vmap-batched`, filed as `genmlx-aykz`).

### Follow-ups filed
- `genmlx-gdc2` — bernoulli/binomial + batched (vADEV) categorical reparam.
- `genmlx-7opt` — mirror the nt0c nested-metadata fix to Map/Unfold/Scan (same re-base pattern).
- `genmlx-aykz` — pre-existing: `vgenerate`-with-vmap-splice returns an `[N]` weight that the test calls `mx/item` on.

### Out of scope (documented, not skipped)
`genmlx-9k1p` (SBC coverage — GPU-overnight), `genmlx-gp5i` (root cause already
fixed in `o78h`), `genmlx-nxt1`/`genmlx-21kt` (separately deferred milestones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
