### PR TITLE
Phase 4: genmlx.memory persistence face + two-tier install guard (genmlx-7qbr, genmlx-91b3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ bun install
 # the freshly-built native MLX addon, so it confirms both the build and your nbb
 # version are good. Should print "0 failures, 0 errors".
 bun run --bun nbb test/genmlx/inference_test.cljs
+
+# Confirm a COMPATIBLE native core loaded (not a stale prebuilt). Prints
+# {:ok? true ... :version "x.y.z"}; on a stale/incompatible binary the Tier-A
+# install guard throws a clear rebuild instruction instead of a cryptic NAPI
+# error deep in an op. (LLM checkpoints are additionally capability-checked at
+# load-model — Tier-B in genmlx.llm.backend.)
+bun run --bun nbb -e '(require (quote [genmlx.mlx :as mx])) (prn (mx/native-core-report))'
 ```
 
 > **Note — the submodules.** GenMLX vendors five git submodules. Four are forks

--- a/src/genmlx/llm/backend.cljs
+++ b/src/genmlx/llm/backend.cljs
@@ -36,6 +36,67 @@
 (defn cljs-forward-model? [model] (instance? CljsForwardModel model))
 
 ;; ---------------------------------------------------------------------------
+;; Install guard — Tier-B LLM-forward capability probe (genmlx-91b3)
+;;
+;; Tier-A (genmlx.mlx) asserts the native CORE is alive at require time. Tier-B
+;; asserts, at load-model, that the forward surface the LLM-as-GF actually drives
+;; is present — and it differs by path because f6ov flipped the default:
+;;   - OWNED path (default for supported families): the GenMLX-owned forward
+;;     (genmlx.llm.forward) supplies the fns this backend actually drives —
+;;     load-model, next-token-logits (the uncached scoring path), prefill, step.
+;;   - UPSTREAM path ({:cljs-forward? false} / unsupported family): the loaded
+;;     mlx-node model INSTANCE supplies native .forward + .forwardWithCache.
+;; The upstream check is the one that catches the genmlx-7siy stale-prebuilt
+;; fallback (@mlx-node/core@0.0.6 lacks Qwen3.5 .forward), turning a cryptic
+;; "Could not find instance method: forward" into a clear rebuild instruction.
+;; Both assert CAPABILITY, not version.
+;; ---------------------------------------------------------------------------
+
+(defn assert-owned-forward!
+  "Tier-B (owned path): the GenMLX-owned forward must expose the fns this backend
+   actually drives on the CljsForwardModel path — load-model (constructs the
+   model), next-token-logits (the uncached scoring path forward-pass drives),
+   prefill, and step (the cached path). Throws a clear ex-info naming the missing
+   fn if genmlx.llm.forward is broken; returns nil when complete. (Deliberately
+   does NOT check fwd/forward — it is not invoked on the owned LLM-as-GF path.)"
+  []
+  (let [present {:load-model        (fn? fwd/load-model)
+                 :next-token-logits (fn? fwd/next-token-logits)
+                 :prefill           (fn? fwd/prefill)
+                 :step              (fn? fwd/step)}
+        missing (->> present (remove (comp true? val)) (mapv key))]
+    (when (seq missing)
+      (throw (ex-info
+               (str "genmlx.llm.backend: the GenMLX-owned forward is missing "
+                    (pr-str missing) " — genmlx.llm.forward is broken or partially built. "
+                    "Rebuild the native layer and reinstall:\n"
+                    "  (cd mlx-node && yarn build:native) && bun install")
+               {:genmlx/error :owned-forward-incomplete :missing missing})))
+    nil))
+
+(defn assert-upstream-forward!
+  "Tier-B (upstream path): the loaded mlx-node model instance must expose
+   .forward + .forwardWithCache. Throws a clear ex-info (naming the missing
+   capability + rebuild steps) when the binary is stale/incompatible — the guard
+   that converts the genmlx-7siy cryptic NAPI failure into an actionable error.
+   Returns nil when capable."
+  [model]
+  (let [present {:forward          (fn? (.-forward model))
+                 :forwardWithCache (fn? (.-forwardWithCache model))}
+        missing (->> present (remove (comp true? val)) (mapv key))]
+    (when (seq missing)
+      (throw (ex-info
+               (str "genmlx.llm.backend: the loaded mlx-node model is missing "
+                    (pr-str missing) " — the native binary is stale/incompatible "
+                    "(the napi loader likely fell back to an older prebuilt). Rebuild it:\n"
+                    "  git submodule update --init --recursive\n"
+                    "  (cd mlx-node && yarn build:native) && bun install\n"
+                    "Or, for a supported family, force the GenMLX-owned forward with "
+                    "{:cljs-forward? true}.")
+               {:genmlx/error :upstream-forward-incompatible :missing missing})))
+    nil))
+
+;; ---------------------------------------------------------------------------
 ;; Model loading
 ;; ---------------------------------------------------------------------------
 
@@ -71,10 +132,16 @@
                        (boolean (:cljs-forward? opts))
                        (fwd/supported? model-path))]
        (if use-cljs?
-         {:model (->CljsForwardModel (fwd/load-model model-path) (atom nil))
-          :tokenizer tokenizer
-          :type (keyword model-type)}
+         (do
+           ;; Tier-B (owned path): assert the owned forward surface before use.
+           (assert-owned-forward!)
+           {:model (->CljsForwardModel (fwd/load-model model-path) (atom nil))
+            :tokenizer tokenizer
+            :type (keyword model-type)})
          (p/let [model (.loadModel mlx-lm model-path)]
+           ;; Tier-B (upstream path): assert the loaded instance exposes the
+           ;; native forward methods — catches the genmlx-7siy stale prebuilt.
+           (assert-upstream-forward! model)
            {:model model
             :tokenizer tokenizer
             :type (keyword model-type)}))))))

--- a/src/genmlx/memory.cljs
+++ b/src/genmlx/memory.cljs
@@ -1,0 +1,555 @@
+(ns genmlx.memory
+  "The PERSISTENCE face of the Bun WORLD membrane (bean genmlx-gsoi, sibling of
+   `genmlx.world.net`) — a thin, honest boundary that owns ONE side effect:
+   durable read/write to a process-external store via SYNCHRONOUS `bun:sqlite`
+   (WAL, prepared statements). Pure flow above; the store is the only mutable,
+   externally-observable resource and it is fenced behind a blessed `with-store`
+   scope (try/finally close), exactly like `with-server` fences a Bun.serve
+   listener.
+
+   WHY THIS — AND ONLY THIS — EARNS A NAMESPACE
+   -------------------------------------------------------------------------
+   Across-EPISODE persistence (within one process run) is FREE: don't reset the
+   fold — the carried accumulator (belief / params / library / experience) is a
+   threaded value, the same pattern as a Trace or a PRNG key one timescale up.
+   Across-SESSION persistence (process death + restart) is the ONE thing that is
+   NOT free: it is an irreducible side effect (a write to a durable store). That
+   single effect is all `genmlx.memory` owns, by the same logic that gave the
+   control layer its scheduler. De Houwer discipline: this names the MECHANISM
+   (memory = retention), not the RELATION (learning = experience->behaviour,
+   which the whole composition exhibits and is correctly NOT a module). Memory is
+   dumb retention, pure-above, owning durable read/write only — no learning
+   algorithm, no abstraction/library-growth, no planning lives here.
+
+   SYNC, NOT ASYNC (the difference from net.cljs)
+   -------------------------------------------------------------------------
+   `bun:sqlite` is synchronous, so persistence is the SYNC half of the Bun
+   membrane: a checkpoint at an episode/session boundary is an ordinary
+   synchronous call, consistent with GenMLX's sync core (CLAUDE.md: 'sync math,
+   async events'). There is ZERO promesa in this namespace. The network face is
+   the async half (a request reaches an autonomous other); persistence writes
+   your own values to your own disk, exactly, like eval! — so it stays sync.
+
+   TWO KINDS OF CROSS-SESSION KEY (the addressing discipline)
+   -------------------------------------------------------------------------
+   Mirroring the GFI choicemap-address discipline (content = leaf-value
+   identity; named = the address slot):
+
+     1. CONTENT-ADDRESS  (`content-hash`, `put-content!`): sha256 of the
+        CANONICAL serialization, for IMMUTABLE artifacts (Traces, particle
+        snapshots, experience entries). Reproducible across process death with
+        no registry. CRITICAL: the canonicalization recursively SORTS map keys
+        before hashing — JSON.stringify / CLJS map iteration are insertion-order
+        dependent, so without this two structurally-equal choicemaps would hash
+        differently and a session-50 recall of a session-3 value would silently
+        fail.
+     2. NAMED-KEY  (\"ns/name\" string): for MUTABLE THREADED SLOTS (the
+        parameter store, the current ConceptMemory, the carried accumulator).
+        Overwritten each fold (upsert), so it needs a stable program name, not a
+        content hash.
+
+   GOTCHAS (empirically confirmed this session)
+   -------------------------------------------------------------------------
+   - WAL only engages on an ON-DISK database: `PRAGMA journal_mode=WAL` returns
+     \"wal\" for a file path but \"memory\" for an in-memory (\":memory:\") db.
+   - bun:sqlite BLOB columns return a typed-array-like; serialized payloads are
+     stored in a TEXT column (the serializer already emits a JSON / EDN string).
+   - records print with a reader tag `read-string` cannot parse, so EDN payloads
+     (ConceptMemory, experience entries) are flattened to plain maps first
+     (`deep-plain`); they restore as plain data, not as the original record type.
+
+   Composes `genmlx.serialize` (the value<->data codecs) and reconstructs a
+   `VectorizedTrace` for particle sets. Requires nothing from control/agents and
+   is never itself a generative function."
+  (:require [genmlx.serialize :as ser]
+            [genmlx.trace :as tr]
+            [genmlx.vectorized :as vec]
+            [clojure.string :as str]
+            [cljs.reader :as reader]))
+
+(def ^:private sqlite
+  (try (js/require "bun:sqlite") (catch :default _ nil)))
+
+(def ^:private Database (some-> sqlite .-Database))
+
+(def ^:private node-crypto
+  (try (js/require "node:crypto") (catch :default _ nil)))
+
+(def schema-version-v
+  "The current durable schema version this build writes. `migrate!` is an honest
+   no-op at v1; the seam exists so a future version can transform v1 stores."
+  1)
+
+(defn available?
+  "True when the bun:sqlite + node:crypto backends this face needs are present
+   (running under `bun`). Pure flow above can branch on this to skip cleanly
+   off-Bun, mirroring `genmlx.world.net/available?`."
+  []
+  (boolean (and Database node-crypto)))
+
+;; ===========================================================================
+;; Canonical serialization + content hashing (THE load-bearing law)
+;; ===========================================================================
+;;
+;; A content address must be a pure function of the LOGICAL value, independent
+;; of how the map happened to be built. JSON.stringify and CLJS map iteration
+;; are both insertion-order dependent, so we serialize through `canonical-str`,
+;; which recursively sorts map keys (and sorts set elements). Two
+;; structurally-equal values therefore produce byte-identical strings and
+;; identical hashes — the property cross-session recall relies on.
+
+(defn- kname
+  "Stable string for a map key (keyword -> its name without the colon; any
+   other key -> its string form)."
+  [k]
+  (if (keyword? k) (subs (str k) 1) (str k)))
+
+(defn canonical-str
+  "Order-independent canonical string for a CLJS data value: map keys sorted
+   lexicographically, vectors/seqs kept in order, set elements sorted by their
+   own canonical form, scalars escaped via JSON.stringify. Works on both parsed
+   JSON (string keys) and EDN data (keyword keys). The basis of content
+   addressing."
+  [x]
+  (cond
+    (map? x)
+    (str "{"
+         (->> x
+              (sort-by (comp kname key))
+              (map (fn [[k v]] (str (js/JSON.stringify (kname k)) ":" (canonical-str v))))
+              (str/join ","))
+         "}")
+
+    (set? x)
+    ;; '#set' prefix keeps a set DISJOINT from a vector of the same elements —
+    ;; both would otherwise render "[...]" and a set would falsely content-hash
+    ;; equal to a vector (they are not =).
+    (str "#set[" (str/join "," (sort (map canonical-str x))) "]")
+
+    (or (vector? x) (seq? x))
+    (str "[" (str/join "," (map canonical-str x)) "]")
+
+    ;; '#kw' prefix keeps a keyword VALUE disjoint from the same-named string
+    ;; value. NOTE: map KEYS deliberately collapse keyword<->string (see the
+    ;; map branch above, via kname) so a JSON artifact ({"a":..}) and the EDN it
+    ;; encodes ({:a ..}) address identically — JSON object keys are always
+    ;; strings, so that cross-codec equivalence is required. VALUES carry no such
+    ;; equivalence (serialize encodes a keyword value as a tagged map, never a
+    ;; bare string), so distinguishing them here only removes a false collision.
+    (keyword? x) (str "#kw" (js/JSON.stringify (kname x)))
+    (string? x)  (js/JSON.stringify x)
+    ;; JSON.stringify collapses EVERY non-finite to "null", aliasing NaN/±Inf
+    ;; with each other and with nil; emit distinct tokens so a score of -Inf
+    ;; (an impossible-event log-prob) never content-hashes equal to nil.
+    (number? x)  (if (js/isFinite x)
+                   (js/JSON.stringify x)
+                   (cond (js/Number.isNaN x) "#nan"
+                         (pos? x)            "#+inf"
+                         :else               "#-inf"))
+    (boolean? x) (str x)
+    (nil? x)     "null"
+    :else        (js/JSON.stringify (clj->js x))))
+
+(defn- sha256-hex
+  [s]
+  (-> (.createHash node-crypto "sha256")
+      (.update s "utf8")
+      (.digest "hex")))
+
+(defn content-hash
+  "Content address of a value: `\"sha256:<hex>\"` over its canonical
+   serialization. Insertion-order independent and cross-process reproducible —
+   the same logical value always yields the same key, with no registry."
+  [value]
+  (str "sha256:" (sha256-hex (canonical-str value))))
+
+(defn content-hash-json
+  "Content address of a JSON payload STRING (e.g. the output of
+   `genmlx.serialize/save-choices`). Parses, canonicalizes, hashes — so
+   whitespace and key order in the source JSON do not affect the key."
+  [json-str]
+  (content-hash (js->clj (js/JSON.parse json-str))))
+
+;; ===========================================================================
+;; Store lifecycle — the RESOURCE BOUNDARY (mirrors net.cljs's with-server)
+;; ===========================================================================
+
+(def ^:private create-objects-sql
+  ;; payload is TEXT: the serializer emits a JSON / EDN string (BLOB would come
+  ;; back as a typed-array-like). score_type records the trace score encoding
+  ;; (:joint / :marginal / :collapsed) so restore can refuse a :collapsed trace.
+  "CREATE TABLE IF NOT EXISTS objects (
+     key        TEXT PRIMARY KEY,
+     kind       TEXT NOT NULL,
+     payload    TEXT NOT NULL,
+     score_type TEXT,
+     created_at INTEGER NOT NULL
+   )")
+
+(def ^:private create-meta-sql
+  "CREATE TABLE IF NOT EXISTS meta (k TEXT PRIMARY KEY, v TEXT)")
+
+(def ^:private create-kind-index-sql
+  "CREATE INDEX IF NOT EXISTS idx_objects_kind_created ON objects (kind, created_at)")
+
+(defn- now-ms [] (js/Date.now))
+
+(defn- meta-get [db k]
+  (some-> (.get (.query db "SELECT v FROM meta WHERE k = ?") k) .-v))
+
+(defn- meta-put! [db k v]
+  (.run (.prepare db "INSERT INTO meta (k, v) VALUES (?, ?)
+                      ON CONFLICT(k) DO UPDATE SET v = excluded.v")
+        k (str v)))
+
+(defn open-store
+  "Open (creating if absent) a durable store at `path` and return a store map
+   `{:db <Database> :path path}`. Sets WAL journaling (effective on-disk only),
+   creates the `objects` + `meta` tables and the kind index, and stamps the
+   schema version into `meta` on first creation.
+
+   `path` may be a filesystem path (durable, across-process) or \":memory:\"
+   (ephemeral, for tests that don't need persistence). Opts: `:read-only?`."
+  ([path] (open-store path {}))
+  ([path {:keys [read-only?]}]
+   (when-not (available?)
+     (throw (ex-info "genmlx.memory unavailable: bun:sqlite / node:crypto not present (run under bun)"
+                     {:genmlx/error :memory-unavailable})))
+   (let [db (if read-only?
+              (Database. path #js {:readonly true})
+              (Database. path))]
+     (when-not read-only?
+       (.run db "PRAGMA journal_mode = WAL")
+       (.run db create-objects-sql)
+       (.run db create-meta-sql)
+       (.run db create-kind-index-sql)
+       (when (nil? (meta-get db "schema_version"))
+         (meta-put! db "schema_version" schema-version-v)))
+     {:db db :path path})))
+
+(defn close-store!
+  "Close the underlying database, releasing the OS resource (and flushing the
+   WAL). Idempotent: closing an already-closed store is a silent no-op in
+   bun:sqlite (verified), so `with-store`'s finally may safely close a store the
+   body already closed."
+  [{:keys [db]}]
+  (.close db))
+
+(defn with-store
+  "[blessed scope] Open the store at `path`, call `(f store)`, and GUARANTEE the
+   database is closed afterwards — on success OR throw (try/finally). Returns
+   the value of `(f store)`. This is the only place a store lifecycle should
+   live; a leaked handle keeps a WAL file open. SYNCHRONOUS (no promesa): the
+   sqlite backend is synchronous, so unlike `with-server` this does not return a
+   promise."
+  ([path f] (with-store path {} f))
+  ([path opts f]
+   (let [store (open-store path opts)]
+     (try (f store)
+          (finally (close-store! store))))))
+
+(defn journal-mode
+  "The store's active SQLite journal mode (\"wal\" on-disk, \"memory\" for an
+   in-memory db). Exposed so callers/tests can confirm WAL engaged."
+  [{:keys [db]}]
+  (some-> (.get (.query db "PRAGMA journal_mode")) .-journal_mode))
+
+(defn schema-version
+  "The durable schema version recorded in the store's `meta` table."
+  [{:keys [db]}]
+  (some-> (meta-get db "schema_version") js/parseInt))
+
+(defn migrate!
+  "Versioning seam. At schema v1 this is an HONEST no-op: there is no prior
+   durable format to transform. Returns `{:from v :to v :migrated false}`. A
+   future schema bump implements the real transform here rather than silently
+   reading an incompatible store."
+  [store]
+  (let [v (schema-version store)]
+    {:from v :to schema-version-v :migrated false}))
+
+;; ===========================================================================
+;; Low-level key/value recall surface (sqlite-indexed)
+;; ===========================================================================
+
+(defn put!
+  "Upsert one object. `payload` is a TEXT string (JSON or EDN). `score-type` is
+   optional metadata (nil for non-trace kinds). Overwrites any existing row at
+   `key` — the named-key (mutable threaded slot) discipline."
+  ([store key kind payload] (put! store key kind payload nil (now-ms)))
+  ([store key kind payload score-type] (put! store key kind payload score-type (now-ms)))
+  ([{:keys [db]} key kind payload score-type created-at]
+   (.run (.prepare db "INSERT INTO objects (key, kind, payload, score_type, created_at)
+                       VALUES (?, ?, ?, ?, ?)
+                       ON CONFLICT(key) DO UPDATE SET
+                         kind = excluded.kind,
+                         payload = excluded.payload,
+                         score_type = excluded.score_type,
+                         created_at = excluded.created_at")
+         key kind payload (when score-type (name score-type)) created-at)
+   key))
+
+(defn fetch
+  "Fetch the raw row at `key` as `{:key :kind :payload :score-type :created-at}`,
+   or nil if absent. (Named `fetch`, not `get`, to avoid shadowing core/get.)"
+  [{:keys [db]} key]
+  (let [row (.get (.query db "SELECT key, kind, payload, score_type, created_at
+                              FROM objects WHERE key = ?") key)]
+    (when (and row (not (undefined? row)))
+      {:key        (.-key row)
+       :kind       (.-kind row)
+       :payload    (.-payload row)
+       :score-type (some-> (.-score_type row) keyword)
+       :created-at (.-created_at row)})))
+
+(defn has?
+  "True when an object exists at `key`."
+  [{:keys [db]} key]
+  (boolean (.get (.query db "SELECT 1 FROM objects WHERE key = ? LIMIT 1") key)))
+
+(defn forget!
+  "Delete the object at `key`. Returns true if a row was present and removed."
+  [store key]
+  (let [present (has? store key)]
+    (.run (.prepare (:db store) "DELETE FROM objects WHERE key = ?") key)
+    present))
+
+(defn list-keys
+  "All keys in the store, or all keys of one `kind`. Ascending by key."
+  ([{:keys [db]}]
+   (->> (.all (.query db "SELECT key FROM objects ORDER BY key ASC"))
+        (mapv #(.-key %))))
+  ([{:keys [db]} kind]
+   (->> (.all (.query db "SELECT key FROM objects WHERE kind = ? ORDER BY key ASC")
+              (name kind))
+        (mapv #(.-key %)))))
+
+(defn recent
+  "The `n` most recently written keys of `kind`, newest first (by created_at)."
+  [{:keys [db]} kind n]
+  (->> (.all (.query db "SELECT key FROM objects WHERE kind = ?
+                         ORDER BY created_at DESC, key DESC LIMIT ?")
+             (name kind) n)
+       (mapv #(.-key %))))
+
+(defn count-objects
+  "Total object count, or count of one `kind`."
+  ([{:keys [db]}]
+   (.-c (.get (.query db "SELECT count(*) c FROM objects"))))
+  ([{:keys [db]} kind]
+   (.-c (.get (.query db "SELECT count(*) c FROM objects WHERE kind = ?") (name kind)))))
+
+;; ===========================================================================
+;; Typed save / restore (composes genmlx.serialize)
+;; ===========================================================================
+
+(defn- require-row [store key]
+  (or (fetch store key)
+      (throw (ex-info (str "genmlx.memory: no object at key " (pr-str key))
+                      {:genmlx/error :key-absent :key key}))))
+
+;; --- choices (named-key; re-generation reproduces the score) ---------------
+
+(defn save-choices!
+  "Persist a trace's choices (kind \"choices\") under `key`. Throws on a
+   :collapsed trace (enumerate/exact): its choicemap is EMPTY, so re-generating
+   from the stored choices cannot reproduce the collapsed score — persisting it
+   would be a silent-empty-choices trap (consistent with `save-trace!`).
+   Returns `key`."
+  [store key trace & {:keys [created-at]}]
+  (when (= :collapsed (tr/score-type trace))
+    (throw (ex-info "genmlx.memory: cannot persist choices of a :collapsed trace (empty choicemap)"
+                    {:genmlx/error :collapsed-trace :key key})))
+  (put! store key "choices" (ser/save-choices trace) nil (or created-at (now-ms))))
+
+(defn restore-choices
+  "Load the ChoiceMap stored at `key`."
+  [store key]
+  (ser/load-choices (:payload (require-row store key))))
+
+;; --- full trace (caller supplies the gen-fn; :collapsed refused) -----------
+
+(defn save-trace!
+  "Persist a full trace (kind \"trace\", with its score-type) under `key`.
+   Throws on a :collapsed trace: enumerate/exact traces have an EMPTY choicemap
+   and no recoverable choices, so persisting one would store a misleading
+   artifact (restore re-generates from choices). Returns `key`."
+  [store key trace & {:keys [created-at]}]
+  (let [st (tr/score-type trace)]
+    (when (= :collapsed st)
+      (throw (ex-info "genmlx.memory: cannot persist a :collapsed trace (empty choicemap, nothing to re-generate)"
+                      {:genmlx/error :collapsed-trace :key key})))
+    (put! store key "trace" (ser/save-trace trace) st (or created-at (now-ms)))))
+
+(defn restore-trace
+  "Reconstruct a full trace at `key` by re-generating from the saved choices and
+   args with the caller-supplied `gen-fn` (gen-fns are never serialized). Refuses
+   a :collapsed row."
+  [store key gen-fn]
+  (let [{:keys [payload score-type]} (require-row store key)]
+    (when (= :collapsed score-type)
+      (throw (ex-info "genmlx.memory: stored trace is :collapsed and cannot be restored"
+                      {:genmlx/error :collapsed-trace :key key})))
+    (ser/load-trace gen-fn payload)))
+
+;; --- particle set (VectorizedTrace; no serialize path exists upstream) ------
+
+(defn save-particles!
+  "Persist a VectorizedTrace particle set (kind \"particles\") under `key`:
+   the [N]-leaf choices plus the [N] score, weight, n-particles and args. The
+   gen-fn is NOT serialized (supplied on restore). Returns `key`."
+  [store key vtrace & {:keys [created-at]}]
+  (let [data {:format      "genmlx-particles-v1"
+              :n-particles (:n-particles vtrace)
+              :choices     (ser/choices->data (:choices vtrace))
+              :score       (ser/value->data (:score vtrace))
+              :weight      (ser/value->data (:weight vtrace))
+              :args        (mapv ser/value->data (:args vtrace))}]
+    (put! store key "particles"
+          (js/JSON.stringify (clj->js data))
+          nil (or created-at (now-ms)))))
+
+(defn restore-particles
+  "Reconstruct a VectorizedTrace at `key` with the caller-supplied `gen-fn`.
+   retval is not persisted (best-effort nil)."
+  [store key gen-fn]
+  (let [data    (js->clj (js/JSON.parse (:payload (require-row store key)))
+                         :keywordize-keys true)
+        choices (ser/data->choices (:choices data))
+        score   (ser/data->value (:score data))
+        weight  (ser/data->value (:weight data))
+        args    (mapv ser/data->value (:args data))]
+    (vec/->VectorizedTrace gen-fn args choices score weight (:n-particles data) nil)))
+
+;; --- parameter store (named-key; overwrite semantics) ----------------------
+
+(defn save-param-store!
+  "Persist a learning parameter store `{:params {name -> MLX-array} :version n}`
+   (kind \"param-store\") under `key`. Upserts — re-saving under the same key
+   OVERWRITES, the mutable-threaded-slot discipline. Returns `key`."
+  [store key param-store & {:keys [created-at]}]
+  (put! store key "param-store"
+        (js/JSON.stringify (clj->js (ser/value->data param-store)))
+        nil (or created-at (now-ms))))
+
+(defn restore-param-store
+  "Load the parameter store stored at `key` (MLX arrays restored)."
+  [store key]
+  (ser/data->value
+    (js->clj (js/JSON.parse (:payload (require-row store key))) :keywordize-keys true)))
+
+;; --- pure-EDN values (ConceptMemory, experience log, skill library) --------
+
+(defn- deep-plain
+  "Recursively convert records to plain maps so a value is EDN-printable AND
+   reader-readable (records print with a tag `read-string` cannot parse).
+   Preserves maps/vectors/sets/keywords/scalars."
+  [v]
+  (cond
+    (record? v)     (deep-plain (into {} v))
+    (map? v)        (into {} (map (fn [[k val]] [k (deep-plain val)])) v)
+    (set? v)        (into #{} (map deep-plain) v)
+    (vector? v)     (mapv deep-plain v)
+    (seq? v)        (mapv deep-plain v)
+    :else           v))
+
+(defn save-edn!
+  "Persist an arbitrary pure-data value (no MLX arrays) as EDN under `key` with
+   the given `kind` — for the experience log, a skill library, or any folded
+   accumulator that is plain data. Records are flattened to maps first. Returns
+   `key`."
+  [store key kind value & {:keys [created-at]}]
+  (put! store key (name kind) (pr-str (deep-plain value)) nil (or created-at (now-ms))))
+
+(defn restore-edn
+  "Load an EDN value stored by `save-edn!`. Records restore as PLAIN MAPS."
+  [store key]
+  (reader/read-string (:payload (require-row store key))))
+
+(defn save-concept-memory!
+  "Persist a sensorimotor `ConceptMemory` (kind \"concept-memory\") under `key`.
+   It is pure data (no MLX arrays), so it round-trips as EDN; its `Implication`
+   records and the index sets are flattened to plain maps/sets. Returns `key`."
+  [store key concept-memory & {:keys [created-at]}]
+  (apply save-edn! store key "concept-memory" concept-memory
+         (when created-at [:created-at created-at])))
+
+(defn restore-concept-memory
+  "Load a ConceptMemory's field data at `key`. Returns the three index maps as
+   PLAIN data (`{:by-key .. :by-precondition .. :by-consequent ..}`); the caller
+   re-wraps with `sensorimotor/map->ConceptMemory` if it needs the record type."
+  [store key]
+  (restore-edn store key))
+
+;; ===========================================================================
+;; Content addressing (immutable artifacts; no registry)
+;; ===========================================================================
+
+(defn put-content!
+  "Store an immutable JSON `payload` under its CONTENT address and return that
+   key (`\"sha256:<hex>\"`). Storing the same logical payload twice — even built
+   with different map key order — yields the same key and is idempotent. Use for
+   Traces, particle snapshots, experience entries that should be addressed by
+   value, not by name."
+  [store kind payload & {:keys [score-type created-at]}]
+  (let [key (content-hash-json payload)]
+    (put! store key (name kind) payload score-type (or created-at (now-ms)))
+    key))
+
+(defn save-trace-content!
+  "Persist a trace by CONTENT address (kind \"trace\"); returns the content key.
+   Like `save-trace!` but the key is the canonical content hash, so an identical
+   trace persisted again resolves to the same key. Refuses :collapsed traces."
+  [store trace & {:keys [created-at]}]
+  (let [st (tr/score-type trace)]
+    (when (= :collapsed st)
+      (throw (ex-info "genmlx.memory: cannot content-address a :collapsed trace"
+                      {:genmlx/error :collapsed-trace})))
+    (put-content! store "trace" (ser/save-trace trace)
+                  :score-type st :created-at (or created-at (now-ms)))))
+
+;; ===========================================================================
+;; Session lifecycle — synchronous checkpoint of the carried accumulator
+;; ===========================================================================
+;;
+;; A session is a durable store stamped with a session id; a snapshot is an
+;; ATOMIC (single db.transaction) batch of writes — the all-or-nothing
+;; checkpoint at an episode/session boundary. Because sqlite persists on disk,
+;; the checkpoint survives process death: a later run reopens the same path and
+;; restores. This is the across-SESSION effect (the one thing not free).
+
+(defn open-session
+  "Open (or create) the durable store at `path` for a named session, stamping
+   `:session-id` and an open timestamp into `meta`. Returns the store."
+  [path session-id]
+  (let [store (open-store path)]
+    (meta-put! (:db store) "session_id" session-id)
+    (meta-put! (:db store) "session_opened_at" (now-ms))
+    store))
+
+(defn snapshot!
+  "Atomically persist many objects in a SINGLE synchronous `db.transaction` —
+   the session-boundary checkpoint. `writes` is a seq of maps
+   `{:key :kind :payload :score-type? :created-at?}`. All-or-nothing: a throw
+   inside rolls the whole batch back. Returns the number of objects written."
+  [{:keys [db] :as store} writes]
+  (let [writes (vec writes)
+        tx (.transaction db
+             (fn [ws]
+               (doseq [{:keys [key kind payload score-type created-at]} ws]
+                 (put! store key kind payload score-type (or created-at (now-ms))))))]
+    (tx writes)
+    (count writes)))
+
+(defn restore-session
+  "A manifest of what is recoverable from a (re)opened session store:
+   `{:session-id .. :schema-version .. :opened-at .. :keys [..] :count n}`.
+   The actual values are fetched with the typed `restore-*` functions. This is
+   the across-process-death entry point: open the same path, read the manifest,
+   restore the carried accumulator."
+  [{:keys [db] :as store}]
+  {:session-id     (meta-get db "session_id")
+   :schema-version (schema-version store)
+   :opened-at      (some-> (meta-get db "session_opened_at") js/parseInt)
+   :keys           (list-keys store)
+   :count          (count-objects store)})

--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -40,6 +40,87 @@
 (def core c)
 
 ;; =========================================================================
+;; Install guard — Tier-A native-core capability probe (genmlx-91b3)
+;;
+;; The mlx-node native-binary install has a silent trap (bean genmlx-7siy): the
+;; napi loader tries the local ./mlx-core.*.node build first and SILENTLY falls
+;; back to a (possibly stale/incompatible) prebuilt. A fundamentally broken or
+;; incompatible core then surfaces as a cryptic NAPI error deep inside some op,
+;; far from the cause. This guard asserts — at require time, fail fast — that the
+;; representative native exports the membrane needs are present, and otherwise
+;; throws a CLEAR ex-info naming the missing capability + the rebuild steps + the
+;; resolved @mlx-node/core version. It asserts CAPABILITY, not version: mlx-node
+;; exports no runtime version, so a version-equality guard would be a lie. (The
+;; LLM forward/forwardWithCache surface is checked separately at load time —
+;; Tier-B in genmlx.llm.backend — which is what catches the stale-prebuilt
+;; Qwen3.5 case. This Tier-A probe adds value for a PARTIAL core: one where
+;; MxArray resolves (so line 28's deref succeeds without throwing) but other
+;; required exports are missing — a case that would otherwise surface only as a
+;; cryptic NAPI error deep inside an op much later.) The probe is pure —
+;; property/fn? checks only, no GPU eval — so it is free on the hot path and safe
+;; for tooling to call via `native-core-report`.
+;; =========================================================================
+
+(def ^:private required-core-caps
+  "Representative native exports that MUST resolve for the membrane to work:
+   MxArray (the array constructor), add (a pure graph op), item + evalArrays
+   (the two eval! chokepoints)."
+  ["MxArray" "add" "item" "evalArrays"])
+
+(defn- mlx-core-version
+  "Best-effort @mlx-node/core package version, for DIAGNOSTICS ONLY (never a hard
+   pin — there is no runtime version export). \"unknown\" if it can't be read."
+  []
+  (try (.-version (js/require "@mlx-node/core/package.json"))
+       (catch :default _ "unknown")))
+
+(defn native-report
+  "Pure capability report for an mlx-node core module object + version string:
+   which required exports resolve as functions, what's missing, and whether the
+   core is usable. No GPU eval — safe to call on a partial/broken core. The
+   live-core wrapper is `native-core-report`."
+  [core-module version]
+  (let [present (into {} (map (fn [k] [k (fn? (aget core-module k))])) required-core-caps)
+        missing (->> present (remove (comp true? val)) (mapv key))]
+    {:module-loaded? (some? core-module)
+     :version        version
+     :capabilities   present
+     :missing        missing
+     :ok?            (and (some? core-module) (empty? missing))}))
+
+(defn native-core-report
+  "Capability report for the LIVE loaded @mlx-node/core (for a doctor/README
+   check or diagnostics). `(:ok? (native-core-report))` is true on a healthy
+   install."
+  []
+  (native-report c (mlx-core-version)))
+
+(defn assert-core-capable!
+  "Throw a clear ex-info (Tier-A install guard) unless `report` shows a capable
+   core. Names the missing capabilities + remediation; carries the version in
+   ex-data under :mlx-node-core-version. Returns nil when capable."
+  [report]
+  (when-not (:ok? report)
+    (throw (ex-info
+             (str "genmlx.mlx: the loaded @mlx-node/core (" (:version report) ") is missing "
+                  "native capabilities " (pr-str (:missing report)) ". The local build is "
+                  "absent or stale and the napi loader fell back to an incompatible binary. "
+                  "Rebuild the native layer:\n"
+                  "  git submodule update --init --recursive\n"
+                  "  (cd mlx-node && yarn build:native)\n"
+                  "  bun install\n"
+                  "Then verify the LOCAL .node loaded (not a prebuilt). See README "
+                  "(Requirements / Quick Start).")
+             {:genmlx/error          :native-core-incompatible
+              :missing               (:missing report)
+              :mlx-node-core-version (:version report)
+              :report                report})))
+  nil)
+
+;; Fail fast at require time with an actionable message.
+(assert-core-capable! (native-core-report))
+
+;; =========================================================================
 ;; Dtypes
 ;;
 ;; IMPORTANT: MLX on Apple Silicon has no float64, int64, or bool dtypes.

--- a/src/genmlx/serialize.cljs
+++ b/src/genmlx/serialize.cljs
@@ -179,6 +179,39 @@
     :else           v))
 
 ;; ---------------------------------------------------------------------------
+;; Public composition surface (genmlx.memory composes these codecs)
+;; ---------------------------------------------------------------------------
+;; genmlx.memory is the durable PERSISTENCE face of the Bun membrane; it owns
+;; the backend (bun:sqlite) but reuses these value<->data codecs rather than
+;; re-deriving the dtype/address/MLX-array machinery. They are the same
+;; functions the choices/trace round trip uses, exposed under stable names.
+
+(defn choices->data
+  "ChoiceMap -> JSON-serializable data (the recursive choicemap codec, MLX
+   leaves included). Inverse: `data->choices`."
+  [cm-node]
+  (choicemap->data cm-node))
+
+(defn data->choices
+  "JSON-serializable data -> ChoiceMap. Inverse of `choices->data`."
+  [data]
+  (data->choicemap data))
+
+(defn value->data
+  "Serialize an arbitrary value that may contain MLX arrays plus nested
+   maps/seqs (a score, weight, args vector, or parameter store). Map keys use
+   the prefixed address codec, so keyword/int/string keys survive. Inverse:
+   `data->value`."
+  [v]
+  (serialize-value v))
+
+(defn data->value
+  "Deserialize a value produced by `value->data` back to MLX arrays + CLJS
+   data. Inverse of `value->data`."
+  [v]
+  (deserialize-value v))
+
+;; ---------------------------------------------------------------------------
 ;; Public API: choices-only (recommended)
 ;; ---------------------------------------------------------------------------
 

--- a/test/genmlx/membrane_guard_test.cljs
+++ b/test/genmlx/membrane_guard_test.cljs
@@ -1,0 +1,125 @@
+;; @tier fast
+(ns genmlx.membrane-guard-test
+  "Tests for the two-tier install/startup capability guard (genmlx-91b3):
+   - Tier-A: the native-core probe in genmlx.mlx (require-time fail-fast).
+   - Tier-B: the LLM-forward probe in genmlx.llm.backend (at load-model).
+   Negative cases use FAKE core/model objects + with-redefs, so no GPU eval and
+   no model load are needed; the happy path confirms the LIVE core is capable
+   (the require-time guard having already passed to load this ns). Assertions are
+   on ex-data (capability/version), never on message strings — and the guards
+   assert CAPABILITY, not version."
+  (:require [cljs.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [genmlx.mlx :as mx]
+            [genmlx.llm.backend :as backend]
+            [genmlx.llm.forward :as fwd]))
+
+(def ^:private fs (js/require "fs"))
+(def ^:private path-mod (js/require "path"))
+
+;; ===========================================================================
+;; Tier-A — native-core probe (genmlx.mlx)
+;; ===========================================================================
+
+(deftest tier-a-live-core-capable
+  (testing "the live @mlx-node/core is capable (require-time guard already passed)"
+    (let [r (mx/native-core-report)]
+      (is (:ok? r) "live core ok")
+      (is (empty? (:missing r)) "no missing capabilities")
+      (is (string? (:version r)) "@mlx-node/core version resolved"))))
+
+(deftest tier-a-fully-broken-core-named
+  (testing "an empty core reports every capability missing and asserts loudly"
+    (let [r (mx/native-report #js {} "0.0.0")]
+      (is (false? (:ok? r)))
+      (is (= #{"MxArray" "add" "item" "evalArrays"} (set (:missing r)))
+          "all required capabilities flagged")
+      (is (thrown? js/Error (mx/assert-core-capable! r)))
+      (try
+        (mx/assert-core-capable! r)
+        (is false "assert-core-capable! should have thrown")
+        (catch :default e
+          (let [d (ex-data e)]
+            (is (= :native-core-incompatible (:genmlx/error d)))
+            (is (= "0.0.0" (:mlx-node-core-version d)) "version carried in ex-data")
+            (is (contains? (set (:missing d)) "MxArray")
+                "ex-data names the missing capability")))))))
+
+(deftest tier-a-partial-core-rejected
+  (testing "a partial core (MxArray+add present, item+evalArrays missing) is rejected"
+    (let [fake #js {:MxArray (fn []) :add (fn [])}
+          r    (mx/native-report fake "0.0.7")]
+      (is (false? (:ok? r)))
+      (is (= #{"item" "evalArrays"} (set (:missing r))))
+      (is (thrown? js/Error (mx/assert-core-capable! r))))))
+
+(deftest tier-a-capable-fake-passes
+  (testing "a fake core with all required exports passes (assert returns nil)"
+    (let [fake #js {:MxArray (fn []) :add (fn []) :item (fn []) :evalArrays (fn [])}
+          r    (mx/native-report fake "9.9.9")]
+      (is (:ok? r))
+      (is (empty? (:missing r)))
+      (is (nil? (mx/assert-core-capable! r)) "capable core -> no throw, returns nil"))))
+
+(deftest tier-a-asserts-capability-not-version
+  (testing "the guard never pins a version (capability-only)"
+    ;; a wildly different version with all caps present must still pass
+    (let [fake #js {:MxArray (fn []) :add (fn []) :item (fn []) :evalArrays (fn [])}]
+      (is (nil? (mx/assert-core-capable! (mx/native-report fake "123.456.789")))
+          "version is irrelevant when capabilities are present"))))
+
+;; ===========================================================================
+;; Tier-B — LLM forward probe (genmlx.llm.backend)
+;; ===========================================================================
+
+(deftest tier-b-upstream-forward
+  (testing "a model exposing .forward + .forwardWithCache passes"
+    (is (nil? (backend/assert-upstream-forward!
+                #js {:forward (fn []) :forwardWithCache (fn [])}))))
+  (testing "a stale model missing .forwardWithCache (the genmlx-7siy case) is rejected"
+    (let [bad #js {:forward (fn [])}]
+      (is (thrown? js/Error (backend/assert-upstream-forward! bad)))
+      (try
+        (backend/assert-upstream-forward! bad)
+        (is false "should have thrown")
+        (catch :default e
+          (let [d (ex-data e)]
+            (is (= :upstream-forward-incompatible (:genmlx/error d)))
+            (is (contains? (set (:missing d)) :forwardWithCache)
+                "ex-data names the missing native method"))))))
+  (testing "a model missing both forward methods is rejected"
+    (is (thrown? js/Error (backend/assert-upstream-forward! #js {})))))
+
+(deftest tier-b-owned-forward
+  (testing "the real GenMLX-owned forward surface is complete"
+    (is (nil? (backend/assert-owned-forward!))))
+  (testing "a nil fwd/step is caught and named"
+    (with-redefs [fwd/step nil]
+      (is (thrown? js/Error (backend/assert-owned-forward!)))
+      (try
+        (backend/assert-owned-forward!)
+        (is false "should have thrown")
+        (catch :default e
+          (let [d (ex-data e)]
+            (is (= :owned-forward-incomplete (:genmlx/error d)))
+            (is (contains? (set (:missing d)) :step) "ex-data names :step")))))))
+
+(deftest tier-b-wired-into-load-model
+  ;; A GPU-free source-level contract guard: load-model must invoke BOTH Tier-B
+  ;; guards. This catches the most likely wiring regression (someone deletes an
+  ;; assert call or guards the wrong branch). The FULL success-path behavior
+  ;; ("load-model unchanged on success") is covered end-to-end by the @tier slow
+  ;; LLM suite, which drives load-model with a real model through the guarded
+  ;; path; the JS module singletons aren't writable, so it can't be stubbed
+  ;; GPU-free here.
+  (testing "load-model wires assert-owned-forward! and assert-upstream-forward!"
+    (let [src  (.readFileSync fs
+                              (.join path-mod (.cwd js/process) "src/genmlx/llm/backend.cljs")
+                              "utf8")
+          body (last (str/split src #"\(defn load-model"))]
+      (is (re-find #"assert-owned-forward!" body)
+          "owned path guard wired into load-model")
+      (is (re-find #"assert-upstream-forward!" body)
+          "upstream path guard wired into load-model"))))
+
+(cljs.test/run-tests)

--- a/test/genmlx/world_memory_test.cljs
+++ b/test/genmlx/world_memory_test.cljs
@@ -1,0 +1,392 @@
+;; @tier fast
+(ns genmlx.world-memory-test
+  "Tests for genmlx.memory — the PERSISTENCE face of the Bun world membrane
+   (bun:sqlite). Oracles are INDEPENDENT of the serializer wherever possible:
+   - round-trip scores are reproduced by RE-GENERATION (p/generate on the
+     loaded choices), not by comparing the serializer against itself;
+   - the content hash is pinned to a golden hex computed by an independent
+     shell sha256 over the hand-written canonical string;
+   - the session checkpoint is proven by an actual close+reopen (the
+     across-process-death case)."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.test-helpers :as h]
+            [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.trace :as tr]
+            [genmlx.choicemap :as cm]
+            [genmlx.learning :as learn]
+            [genmlx.sensorimotor :as sm]
+            [genmlx.serialize :as ser]
+            [genmlx.memory :as mem])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(def ^:private os (js/require "os"))
+(def ^:private path-mod (js/require "path"))
+(def ^:private fs (js/require "fs"))
+
+(def ^:private temp-counter (atom 0))
+
+(defn- temp-path []
+  (.join path-mod (.tmpdir os)
+         (str "genmlx-mem-test-" (.-pid js/process) "-" (swap! temp-counter inc) ".db")))
+
+(defn- rm-store! [p]
+  (doseq [suf ["" "-wal" "-shm"]]
+    (try (.unlinkSync fs (str p suf)) (catch :default _ nil))))
+
+(defn- with-temp-db
+  "Run (f path) against a unique on-disk store path, deleting all sqlite files
+   (db, -wal, -shm) afterwards."
+  [f]
+  (let [p (temp-path)]
+    (try (f p) (finally (rm-store! p)))))
+
+(defn- leaf [choices addr]
+  (cm/get-value (cm/get-submap choices addr)))
+
+;; ===========================================================================
+;; Availability + WAL (the sync backend; gotcha: WAL is on-disk only)
+;; ===========================================================================
+
+(deftest availability
+  (testing "bun:sqlite + node:crypto backends present under bun"
+    (is (true? (mem/available?)) "memory face available under bun")))
+
+(deftest wal-engages-on-disk-only
+  (testing "an on-disk store reports journal_mode = wal"
+    (with-temp-db
+      (fn [p]
+        (let [store (mem/open-store p)]
+          (is (= "wal" (mem/journal-mode store)) "on-disk store is WAL")
+          (is (= mem/schema-version-v (mem/schema-version store)) "schema version stamped")
+          (mem/close-store! store)))))
+  (testing "an in-memory store reports 'memory' (NOT wal) — the documented gotcha"
+    (let [store (mem/open-store ":memory:")]
+      (is (= "memory" (mem/journal-mode store)))
+      (mem/close-store! store))))
+
+;; ===========================================================================
+;; Round-trip via re-generation (the independent score oracle)
+;; ===========================================================================
+
+(deftest choices-round-trip-regeneration-oracle
+  (testing "save->restore choices; p/generate on them reproduces the score"
+    (let [model (dyn/auto-key
+                  (gen []
+                    (let [s (trace :slope (dist/gaussian 0 2))]
+                      (trace :y (dist/gaussian s 1))
+                      s)))
+          tr1   (p/simulate model [])
+          orig  (h/realize (:score tr1))
+          store (mem/open-store ":memory:")]
+      (mem/save-choices! store "c1" tr1)
+      (let [choices (mem/restore-choices store "c1")
+            {:keys [trace]} (p/generate model [] choices)
+            regen   (h/realize (:score trace))]
+        (is (h/close? orig regen 1e-5)
+            "re-generated score reproduces the saved trace's score"))
+      (mem/close-store! store))))
+
+(deftest full-trace-round-trip
+  (testing "save-trace!/restore-trace re-generates an equivalent trace"
+    (let [model (dyn/auto-key
+                  (gen [m]
+                    (let [s (trace :slope (dist/gaussian m 1))]
+                      (trace :y (dist/gaussian s 0.5))
+                      s)))
+          tr1   (p/simulate model [3.0])
+          orig  (h/realize (:score tr1))
+          store (mem/open-store ":memory:")]
+      (mem/save-trace! store "t1" tr1)
+      (is (= "trace" (:kind (mem/fetch store "t1"))))
+      (is (= :joint (:score-type (mem/fetch store "t1"))) "score-type recorded")
+      (let [rt (mem/restore-trace store "t1" model)]
+        (is (h/close? orig (h/realize (:score rt)) 1e-5) "trace score reproduced")
+        (is (h/close? (h/realize (leaf (:choices tr1) :slope))
+                      (h/realize (leaf (:choices rt) :slope)) 1e-6)
+            "slope choice preserved"))
+      (mem/close-store! store))))
+
+(deftest collapsed-trace-refused
+  (testing ":collapsed traces (empty choicemap) cannot be persisted"
+    (let [model (dyn/auto-key (gen [] (trace :x (dist/gaussian 0 1))))
+          tr1   (tr/with-score-type (p/simulate model []) :collapsed)
+          store (mem/open-store ":memory:")]
+      (is (thrown? js/Error (mem/save-trace! store "bad" tr1))
+          "save-trace! throws on :collapsed")
+      (mem/close-store! store))))
+
+;; ===========================================================================
+;; Content addressing — THE load-bearing canonicalization law
+;; ===========================================================================
+
+(deftest content-address-canonical
+  (testing "insertion order independent (the load-bearing law)"
+    (let [m1 (array-map :a 1 :b 2 :c 3)
+          m2 (array-map :c 3 :a 1 :b 2)]
+      (is (= (mem/content-hash m1) (mem/content-hash m2))
+          "structurally-equal value, different key order -> same hash")))
+  (testing "JSON payload key order is canonicalized away"
+    (is (= (mem/content-hash-json "{\"b\":1,\"a\":2}")
+           (mem/content-hash-json "{\"a\":2,\"b\":1}"))
+        "reordered JSON object keys -> same content hash"))
+  (testing "nested + set order independence"
+    (is (= (mem/content-hash {:s #{3 1 2} :m {:y 1 :x 2}})
+           (mem/content-hash {:m {:x 2 :y 1} :s #{2 3 1}}))))
+  (testing "collision sensitive (different content -> different hash)"
+    (is (not= (mem/content-hash {:a 1}) (mem/content-hash {:a 2})))
+    (is (not= (mem/content-hash {:a 1}) (mem/content-hash {:b 1}))))
+  (testing "container- and scalar-TYPE collisions are avoided (injective across CLJS types)"
+    (is (not= (mem/content-hash #{1 2 3}) (mem/content-hash [1 2 3]))
+        "a set must not collide with a vector of the same elements")
+    (is (not= (mem/content-hash {:a #{1}}) (mem/content-hash {:a [1]}))
+        "nested set vs vector")
+    (is (not= (mem/content-hash {:tag :red}) (mem/content-hash {:tag "red"}))
+        "a keyword value must not collide with the same-named string value")
+    (is (not= (mem/content-hash {:x js/Infinity}) (mem/content-hash {:x (- js/Infinity)}))
+        "+Inf must not collide with -Inf")
+    (is (not= (mem/content-hash {:x js/NaN}) (mem/content-hash {:x nil}))
+        "NaN must not collide with nil"))
+  (testing "map KEYS deliberately collapse keyword<->string (cross-codec JSON/EDN equivalence)"
+    (is (= (mem/content-hash {:a 1}) (mem/content-hash {"a" 1}))
+        "a JSON string key and the EDN keyword it encodes address identically"))
+  (testing "golden hex pin — cross-process reproducible (independent shell sha256)"
+    (is (= "sha256:99d7061eca4a3858bdd9b2a59beb4e13951e1b638fecc2855ec6c92511ed223f"
+           (mem/content-hash {:a [1 2 3] :b 2 :c {:x 8 :y 9}}))
+        "matches `printf ... | shasum -a 256` over the canonical string"))
+  (testing "put-content! is idempotent by value"
+    (let [store (mem/open-store ":memory:")
+          k1 (mem/put-content! store "trace" "{\"b\":1,\"a\":2}")
+          k2 (mem/put-content! store "trace" "{\"a\":2,\"b\":1}")]
+      (is (= k1 k2) "same logical payload -> same content key")
+      (is (= 1 (mem/count-objects store)) "stored once, not twice")
+      (mem/close-store! store))))
+
+(deftest content-address-real-artifact-path
+  (testing "real serializer output: choicemap key-insertion order does NOT change the content key"
+    (let [v1 (mx/scalar 1.5)
+          v2 (mx/scalar -0.3)
+          ;; the SAME logical choicemap, addresses inserted in opposite order
+          n1 (cm/->Node (array-map :slope (cm/->Value v1) :y (cm/->Value v2)))
+          n2 (cm/->Node (array-map :y (cm/->Value v2) :slope (cm/->Value v1)))
+          j1 (ser/save-choices {:choices n1})
+          j2 (ser/save-choices {:choices n2})]
+      (is (not= j1 j2) "precondition: the two serializations differ in key order")
+      (is (= (mem/content-hash-json j1) (mem/content-hash-json j2))
+          "structurally-equal choicemaps, different insertion order -> SAME content key")))
+  (testing "save-trace-content! addresses by value (idempotent) and refuses :collapsed"
+    (let [model (dyn/auto-key
+                  (gen []
+                    (let [s (trace :slope (dist/gaussian 0 2))]
+                      (trace :y (dist/gaussian s 1))
+                      s)))
+          tr1   (p/simulate model [])
+          store (mem/open-store ":memory:")
+          k1    (mem/save-trace-content! store tr1)
+          k2    (mem/save-trace-content! store tr1)]
+      (is (= k1 k2) "identical trace -> identical content key")
+      (is (= 1 (mem/count-objects store)) "stored once (idempotent by value)")
+      (is (thrown? js/Error
+            (mem/save-trace-content! store (tr/with-score-type tr1 :collapsed)))
+          "save-trace-content! refuses :collapsed traces")
+      (mem/close-store! store))))
+
+;; ===========================================================================
+;; Membrane-boundary invariants (done-means item 5 — enforced, not just prose)
+;; ===========================================================================
+
+(deftest membrane-invariants
+  (testing "memory.cljs source obeys the persistence-membrane contract"
+    (let [src (.readFileSync fs
+                             (.join path-mod (.cwd js/process) "src/genmlx/memory.cljs")
+                             "utf8")]
+      (is (not (re-find #"\[promesa" src))
+          "ZERO promesa require — persistence is the SYNC half of the Bun membrane")
+      (is (not (re-find #"genmlx\.control" src)) "no dependency on genmlx.control")
+      (is (not (re-find #"genmlx\.agents" src)) "no dependency on genmlx.agents")
+      (is (not (re-find #"defrecord|reify|make-gen-fn|extend-protocol|extend-type" src))
+          "memory exports plain fns and reifies no protocol — it is never a GF")))
+  (testing "the public store value is plain data, not a reified protocol object"
+    (let [store (mem/open-store ":memory:")]
+      (is (map? store) "a store is a plain map {:db .. :path ..}")
+      (is (not (tr/trace? store)) "a store is not a trace / GFI value")
+      (mem/close-store! store))))
+
+;; ===========================================================================
+;; Particle set (VectorizedTrace) round-trip
+;; ===========================================================================
+
+(deftest particle-set-round-trip
+  (testing "N=64 particle set round-trips elementwise to 1e-6"
+    (let [model (dyn/auto-key (gen [] (trace :z (dist/gaussian 0 1))))
+          vt0   (dyn/vsimulate model [] 64 (h/deterministic-key 7))
+          ;; exercise the weight codec with a non-trivial [N] array
+          vt    (assoc vt0 :weight (mx/array (mapv double (range 64))))
+          z0    (h/realize-vec (leaf (:choices vt) :z))
+          s0    (h/realize-vec (:score vt))
+          w0    (h/realize-vec (:weight vt))
+          store (mem/open-store ":memory:")]
+      (mem/save-particles! store "p1" vt)
+      (let [rvt (mem/restore-particles store "p1" model)]
+        (is (= 64 (:n-particles rvt)) "n-particles preserved")
+        (is (h/all-close? z0 (h/realize-vec (leaf (:choices rvt) :z)) 1e-6)
+            "[N] choices round-trip")
+        (is (h/all-close? s0 (h/realize-vec (:score rvt)) 1e-6)
+            "[N] score round-trip")
+        (is (h/all-close? w0 (h/realize-vec (:weight rvt)) 1e-6)
+            "[N] weight round-trip"))
+      (mem/close-store! store))))
+
+;; ===========================================================================
+;; Parameter store — named-key OVERWRITE semantics
+;; ===========================================================================
+
+(deftest param-store-overwrite
+  (testing "re-saving under the same key overwrites (mutable threaded slot)"
+    (let [store (mem/open-store ":memory:")
+          ps0   (learn/make-param-store {:w 1.5 :b -2.0})
+          ps1   (learn/set-param ps0 :w 9.0)]
+      (mem/save-param-store! store "model/params" ps0)
+      (is (= 1 (mem/count-objects store)))
+      (let [r0 (mem/restore-param-store store "model/params")]
+        (is (h/close? 1.5 (h/realize (learn/get-param r0 :w)) 1e-6) "w restored")
+        (is (h/close? -2.0 (h/realize (learn/get-param r0 :b)) 1e-6) "b restored")
+        (is (= 0 (:version r0)) "version preserved"))
+      ;; overwrite
+      (mem/save-param-store! store "model/params" ps1)
+      (is (= 1 (mem/count-objects store)) "still one row — overwrite, not append")
+      (let [r1 (mem/restore-param-store store "model/params")]
+        (is (h/close? 9.0 (h/realize (learn/get-param r1 :w)) 1e-6) "w overwritten")
+        (is (= 1 (:version r1)) "version bumped"))
+      (mem/close-store! store))))
+
+;; ===========================================================================
+;; ConceptMemory — field round-trip (pure EDN; records -> plain maps)
+;; ===========================================================================
+
+(deftest concept-memory-round-trip
+  (testing "ConceptMemory fields survive a durable round-trip"
+    (let [cmem  (-> sm/empty-memory
+                    (sm/add-implication (sm/fresh-implication :p1 :op1 :c1 0))
+                    (sm/add-implication (sm/fresh-implication :p2 :op2 :c2 0)))
+          store (mem/open-store ":memory:")]
+      (mem/save-concept-memory! store "world/model" cmem)
+      (let [r (mem/restore-concept-memory store "world/model")]
+        (is (= 2 (count (:by-key r))) "both implications retained")
+        (is (= (into {} (sm/lookup-implication cmem :p1 :op1))
+               (get-in r [:by-key [:p1 :op1]]))
+            "every Implication field round-trips")
+        (is (h/close? 2.0 (get-in r [:by-key [:p1 :op1] :alpha]) 1e-9) "alpha")
+        (is (= (:by-precondition cmem) (:by-precondition r)) "antecedent index")
+        (is (= (:by-consequent cmem) (:by-consequent r)) "consequent index"))
+      (mem/close-store! store))))
+
+;; ===========================================================================
+;; Recall surface — sqlite-indexed list/recent/has?/forget!/count
+;; ===========================================================================
+
+(deftest recall-indices
+  (testing "list-keys / recent / has? / forget! / count-objects"
+    (let [store (mem/open-store ":memory:")]
+      (mem/put! store "a" "choices" "{}" nil 100)
+      (mem/put! store "b" "choices" "{}" nil 200)
+      (mem/put! store "c" "trace" "{}" :joint 300)
+      (is (= ["a" "b" "c"] (mem/list-keys store)) "all keys ascending")
+      (is (= ["a" "b"] (mem/list-keys store "choices")) "keys filtered by kind")
+      (is (= ["b" "a"] (mem/recent store "choices" 2)) "recent newest-first by created_at")
+      (is (mem/has? store "a"))
+      (is (not (mem/has? store "zzz")))
+      (is (= 3 (mem/count-objects store)) "total count")
+      (is (= 2 (mem/count-objects store "choices")) "count by kind")
+      (let [row (mem/fetch store "c")]
+        (is (= "trace" (:kind row)))
+        (is (= :joint (:score-type row)))
+        (is (= 300 (:created-at row))))
+      (is (true? (mem/forget! store "a")) "forget returns true when present")
+      (is (false? (mem/forget! store "a")) "forget returns false when already gone")
+      (is (not (mem/has? store "a")))
+      (is (= 2 (mem/count-objects store)))
+      (mem/close-store! store))))
+
+;; ===========================================================================
+;; EDN experience log (generic save-edn!)
+;; ===========================================================================
+
+(deftest edn-experience-log-round-trip
+  (testing "an experience log (vector of plain maps) round-trips via EDN"
+    (let [store (mem/open-store ":memory:")
+          log   [{:t 0 :obs :red :reward 1.0}
+                 {:t 1 :obs :blue :reward -0.5}]]
+      (mem/save-edn! store "exp/log" "experience" log)
+      (is (= log (mem/restore-edn store "exp/log")) "experience log identical")
+      (mem/close-store! store))))
+
+;; ===========================================================================
+;; Session lifecycle — atomic checkpoint surviving close+reopen
+;; ===========================================================================
+
+(deftest session-checkpoint-survives-reopen
+  (testing "snapshot! then close+reopen recovers the carried accumulator"
+    (with-temp-db
+      (fn [p]
+        ;; --- session 1: open, atomic snapshot, persist a param store, CLOSE ---
+        (let [store (mem/open-session p "sess-A")
+              ps    (learn/make-param-store {:theta 0.75})]
+          (is (= 2 (mem/snapshot! store
+                                  [{:key "k1" :kind "edn" :payload (pr-str {:n 7})}
+                                   {:key "k2" :kind "edn" :payload (pr-str {:n 8})}]))
+              "snapshot! writes the whole atomic batch")
+          (mem/save-param-store! store "acc/params" ps)
+          (mem/close-store! store))
+        ;; --- session 2: simulate process death — fresh open of the SAME path ---
+        (let [store    (mem/open-store p)
+              manifest (mem/restore-session store)
+              acc      (mem/restore-param-store store "acc/params")]
+          (is (= "sess-A" (:session-id manifest)) "session id survived restart")
+          (is (= mem/schema-version-v (:schema-version manifest)))
+          (is (= 3 (:count manifest)) "all three objects present after reopen")
+          (is (h/close? 0.75 (h/realize (learn/get-param acc :theta)) 1e-6)
+              "carried accumulator restored across process death")
+          (is (= {:n 7} (mem/restore-edn store "k1")) "snapshot entry restored")
+          (mem/close-store! store))))))
+
+(deftest snapshot-is-atomic
+  (testing "a throw mid-snapshot rolls back the whole batch"
+    (let [store (mem/open-store ":memory:")]
+      (is (thrown? js/Error
+            (mem/snapshot! store
+                           [{:key "ok" :kind "edn" :payload "{}"}
+                            ;; nil payload violates NOT NULL -> the transaction aborts
+                            {:key "bad" :kind "edn" :payload nil}]))
+          "invalid write aborts the transaction")
+      (is (= 0 (mem/count-objects store)) "nothing committed (atomic rollback)")
+      (mem/close-store! store))))
+
+;; ===========================================================================
+;; Resource boundary — with-store closes on throw
+;; ===========================================================================
+
+(deftest with-store-closes-on-throw
+  (testing "with-store runs its finally (close) even when f throws"
+    (let [captured (atom nil)]
+      (is (thrown? js/Error
+            (mem/with-store ":memory:"
+              (fn [store] (reset! captured store) (throw (ex-info "boom" {})))))
+          "the throw propagates")
+      (is (thrown? js/Error (mem/has? @captured "x"))
+          "the db is closed after the scope (use-after-close throws)"))))
+
+(deftest with-store-returns-value-sync
+  (testing "with-store is synchronous and returns (f store)"
+    (with-temp-db
+      (fn [p]
+        (let [n (mem/with-store p
+                  (fn [store]
+                    (mem/put! store "x" "edn" "{}")
+                    (mem/count-objects store)))]
+          (is (= 1 n) "returns the value of f directly (no promise)")
+          (is (number? n) "result is a plain value, not a promise"))))))
+
+(cljs.test/run-tests)

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -388,6 +388,7 @@ bench test/genmlx/vsmc_validation.cljs
 fast test/genmlx/vupdate_test.cljs
 fast test/genmlx/well_formedness_test.cljs
 fast test/genmlx/wishart_gradient_test.cljs
+fast test/genmlx/world_memory_test.cljs
 fast test/genmlx/wp2_generate_test.cljs
 fast test/genmlx/wp3_update_test.cljs
 fast test/genmlx/wp4_update_test.cljs

--- a/test/tiers.txt
+++ b/test/tiers.txt
@@ -261,6 +261,7 @@ fast test/genmlx/mcmc_elim_filter_test.cljs core
 medium test/genmlx/mcmc_property_test.cljs
 slow test/genmlx/mcmc_stationary_test.cljs
 slow test/genmlx/membrane_churn_test.cljs
+fast test/genmlx/membrane_guard_test.cljs
 fast test/genmlx/membrane_honesty_test.cljs
 fast test/genmlx/memory_test.cljs
 bench test/genmlx/metal_gc_stress.cljs


### PR DESCRIPTION
v1.0 push, ROADMAP **Phase 4** (two world-membrane items, independent of the control-floor ladder in #126). Branch off `main`. Each item: build → independent-oracle tests → adversarial multi-agent review (skeptic-verified) → fixes → commit.

## genmlx-7qbr — genmlx.memory (persistence face of the Bun membrane)
`src/genmlx/memory.cljs` — the **sync** sibling of `genmlx.world.net`, owning ONE effect: durable read/write via synchronous `bun:sqlite` (WAL on-disk). Pure-above; zero promesa; never a GF; requires nothing in control/agents.
- Store lifecycle (`open-store`/`close-store!`/`with-store` blessed try/finally; `journal-mode`/`schema-version`/`migrate!`), sqlite-indexed recall (`put!`/`fetch`/`has?`/`forget!`/`list-keys`/`recent`/`count-objects`).
- Typed save/restore composing `genmlx.serialize`: choices, full trace (re-generate, `:collapsed` refused), particle set (`VectorizedTrace` `[N]`-leaf), param store (named-key overwrite), ConceptMemory + generic EDN.
- Content addressing (`canonical-str` recursive key-sort — **the load-bearing cross-session-recall law**, made injective across CLJS types) + `content-hash`/`content-hash-json`/`put-content!`/`save-trace-content!`.
- Atomic session checkpoint (`open-session`/`snapshot!` db.transaction/`restore-session`).
- `serialize.cljs`: +4 public composition wrappers (additive).

## genmlx-91b3 — two-tier install/startup capability guard
Hardens the mlx-node native install against the genmlx-7siy silent stale-prebuilt fallback. Asserts **capability, not version** (mlx-node exports no runtime version).
- **Tier-A** (`genmlx.mlx`, require-time fail-fast): a pure native-core probe; on a missing/partial core it throws a clear ex-info with the `@mlx-node/core` version + missing capabilities + rebuild steps, instead of a cryptic NAPI error deep in an op. `mx/native-core-report` for tooling + a README verify one-liner.
- **Tier-B** (`genmlx.llm.backend`, at `load-model`): `assert-owned-forward!` (the owned-path fns the backend drives) + `assert-upstream-forward!` (the loaded model's `.forward`/`.forwardWithCache` — catches the 7siy stale prebuilt). Both return nil on success → success path unchanged.

## Tests
- `world_memory_test.cljs` — 17 deftests / 78 assertions. Independent oracles: re-generation reproduces `:score` to 1e-5; golden content-hash pinned to an independent shell sha256; real close+reopen proves across-process persistence; source guards enforce the membrane invariants.
- `membrane_guard_test.cljs` — 8 deftests / 27 assertions, all GPU-free (fake core/model objects + `with-redefs`). `load-model`-unchanged-on-success is additionally covered end-to-end by the `@tier slow` LLM suite.

## Gates
level0 **68/68**, gen_clj_compat **356/356** (with the require-time guard live), test:check **396/396**, + the two new suites.

## Review
Each item went through an adversarial review workflow (21-agent for memory, 10-agent for the guard) with skeptic verification. Confirmed findings applied (canonical-hash injectivity, owned-forward fn set, docstring honesty, added regression/wiring tests); refuted findings rejected — notably a "disambiguate map keys" suggestion that would have *broken* the cross-codec JSON/EDN address equivalence.

## Deferred / follow-ups
- `genmlx-w837` (draft): the mlx-node **packaging** re-pin (publish/pin/drop the `@mlx-node/core` optionalDependency — a separate-repo *install-time* fix). The runtime two-tier guard is the in-repo mitigation.
- Remaining Phase 4: `genmlx-0vwn` (mlx-node surface audit + coverage drift-guard; a partial already on #126).

🤖 Generated with [Claude Code](https://claude.com/claude-code)