### PR TITLE
Complete genmlx-0vwn floor: membrane coverage matrix + two-directional drift guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,14 +79,18 @@ for f in choicemap_test trace_test selection_test handler_test dist_test combina
   bun run --bun nbb "test/genmlx/${f}.cljs"
 done
 
-# Native/membrane contract guard — MUST run after any mlx-node rebuild.
+# Native/membrane contract guard — MUST run after any mlx-node rebuild/bump.
 # These exercise mx/array JS-array shaping (take/squeeze, value_and_grad,
 # multivariate-normal cholesky) and the mx/clip Either<&MxArray,f64> bounds
 # contract. A stricter MLX binary turns a malformed-array CLJS bug into a hard
 # SIGTRAP; a more lenient one silently produces NaN/garbage; a narrowed NAPI
 # signature rejects valid bounds. Either way these suites catch it, so a stale
-# or drifted binary can never silently mask the regression.
-for f in exact_test gradient_fd_test score_gradient_test clip_contract_test; do
+# or drifted binary can never silently mask the regression. membrane_coverage_test
+# is the SURFACE drift guard (genmlx-0vwn): it partitions every @mlx-node/core
+# function export into wrapped ∪ intentional-omissions (both directions), so an
+# upstream add/delete/rename surfaces as a red test naming exactly what moved.
+# See docs/membrane-coverage.md for the matrix.
+for f in exact_test gradient_fd_test score_gradient_test clip_contract_test membrane_coverage_test; do
   bun run --bun nbb "test/genmlx/${f}.cljs"
 done
 

--- a/docs/membrane-coverage.md
+++ b/docs/membrane-coverage.md
@@ -1,0 +1,108 @@
+# Compute-membrane coverage matrix (`@mlx-node/core` → `mlx.cljs`)
+
+*Audit: `genmlx-0vwn` / `genmlx-e3jg`. Snapshot grounded 2026-06-15.*
+
+The `@mlx-node/core` package is GenMLX's compute substrate (Layer C). The
+**membrane** — `src/genmlx/mlx.cljs` + `src/genmlx/mlx/random.cljs` (Layer 0) —
+binds it. This document is the coverage matrix: every export is either **wrapped**
+in the membrane or **intentionally omitted** with a reason. There are no no-op
+stubs; the membrane stays thin and honest.
+
+> **This document is a snapshot. The authority is the test.**
+> `test/genmlx/membrane_coverage_test.cljs` partitions the *live* export surface
+> at runtime and fails if any export is neither wrapped nor on the omission
+> allowlist (both directions — additions and deletions). When this doc and the
+> test disagree, the test is right; regenerate this doc from the audit recipe
+> below.
+
+## Source of truth for the surface
+
+The export surface is read from **`packages/core/index.d.cts`** (the `types`
+target in `@mlx-node/core`'s `package.json`). The older `index.d.ts` (Apr 1) is
+**stale** — it still lists `getParameters`/`applyGradients`, which no longer
+exist; the training surface is now engine-class-only. Any audit that reads
+`.d.ts` is wrong on day one.
+
+## Summary
+
+| | Count |
+|---|---:|
+| Function exports (`typeof === "function"`, incl. classes) | **212** |
+| → Wrapped in the membrane | **164** |
+| → Intentionally omitted | **48** |
+
+`wrapped ⊎ omitted = 212` — the partition tiles the surface exactly (asserted by
+`coverage-accounting-test`). Non-function exports (DType constants etc.) and
+per-class *method* coverage (e.g. `MxArray.addmm` / `argpartition` /
+`putAlongAxis`) are out of scope for this floor — see *Deferred* below.
+
+## Wrapped (162)
+
+Not enumerated here (a static list would drift). The membrane binds every export
+not on the omission allowlist below — covering the full pure-math / reduction /
+linalg / FFT-free array surface, RNG keys (`mlx/random.cljs`), autograd
+(`value_and_grad` / `grad`), memory introspection + control, and the LLM
+forward-pass primitives. Recently completed (this audit): the trig/hyperbolic
+family (`arcsin`/`arctan`/`sinh`/`cosh`), `log-softmax`, `logical-and/or/not`,
+`isfinite`, `cumprod`, `roll`, `pad`, the memory introspection ops
+(`get-memory-limit`/`get-wired-limit`/`memory-stats`/`get-memory-snapshot`,
+`synchronize!`), and `gpu-architecture-gen` (the sole native source of the GPU
+architecture generation).
+
+To list the wrapped set, run the audit recipe and take the complement of the
+omissions.
+
+## Intentionally omitted (50)
+
+Each export below is deliberately **not** in the pure compute membrane. The
+category records where the capability belongs instead.
+
+### Functions (21)
+
+| Export | Category | Reason |
+|---|---|---|
+| `broadcastTo` | `:broken` | Native op mis-fills size-1 dims. `mx/broadcast-to` is a custom reconstruction; pinned by `broadcast-to-omission-test`. |
+| `getProfilingData`, `isProfilingEnabled`, `setProfilingEnabled`, `resetProfilingData` | `:profiling-gated-i0s4` | Profiling instrumentation; wire-on-demand behind the `genmlx-i0s4` cost meter. |
+| `buildRewardOutputs`, `createRandomQwen3Checkpoint`, `createRandomQwen35Checkpoint`, `createRandomQwen35MoeCheckpoint` | `:training-orchestration` | GRPO/SFT training surface — bind at engine level in a future `@mlx-node/trl` Layer-6 ns with the mutable-state quarantine, never the pure membrane (`genmlx-706r`). |
+| `convertForeignWeights`, `convertGgufToSafetensors`, `convertModel`, `convertParquetToJsonl` | `:model-conversion` | Offline weight/format conversion tooling — not graph ops. |
+| `createPaddleocrVlConfig`, `createQianfanOcrConfig`, `documentToXlsx`, `formatDocument`, `saveToXlsx`, `parsePaddleResponse`, `parseToolCallsFromText`, `parseVlmOutput` | `:ocr-vlm-document` | OCR / vision-language / document pipelines — bind via `@mlx-node/lm` vision (`llm/vision.cljs`). |
+
+### Classes (27)
+
+A JS `class` is a function export, so it counts toward the runtime surface and
+must be accounted for. None are wrapped as compute ops.
+
+| Exports | Category | Reason |
+|---|---|---|
+| `GrpoTrainingEngine`, `SftTrainingEngine`, `NativeRewardRegistry`, `Gradients`, `OutputStore`, `ResponseStore` | `:training-orchestration` | Training engines + result/registry types — engine-level, mutable-state quarantine (future `@mlx-node/trl` Layer-6). |
+| `Gemma4Model`, `HarrierModel`, `Lfm2Model`, `Qwen3Model`, `Qwen35Model`, `Qwen35MoeModel`, `Qwen3Tokenizer`, `BatchGenerationResult`, `GenerationResult`, `ChatStreamHandle` | `:llm-orchestration` | Loaded-model / tokenizer / generation classes — bound via `@mlx-node/lm` ChatSession (`msa.cljs` / `backend.cljs`). The per-token GFI path reaches the low-level forward, not these. |
+| `DocLayoutModel`, `DocOrientationModel`, `DocUnwarpModel`, `PrivacyFilterModel`, `QianfanOCRModel`, `TextDetModel`, `TextRecModel`, `VLModel`, `VlmChatResult`, `VlmProcessedImage` | `:ocr-vlm-document` | OCR / vision-language pipeline classes — `@mlx-node/lm` vision. |
+| `Tensor` | `:foreign-tensor-type` | A foreign tensor class distinct from `MxArray` (the membrane's value type). |
+
+## Deferred (separate beans, not part of this floor)
+
+- **`@mlx-node/trl` training engines** — bind `GrpoTrainingEngine` / `SftTrainingEngine`
+  at engine level in a Layer-6 ns with the mutable-state quarantine. This is the
+  real GRPO/SFT work and feeds the self-training-coder flywheel (`genmlx-706r`).
+- **Profiling data** — gate on the `genmlx-i0s4` cost meter.
+- **`MxArray` array-method gaps** — `addmm` / `argpartition` / `putAlongAxis` and
+  the rest of the ~150-method class surface (category-b appendix).
+- **Non-function exports** — DType constants and class instances (a separate spike).
+
+## Re-audit recipe
+
+The drift guard runs every time the membrane suite runs. To regenerate this
+matrix by hand after an `@mlx-node/core` bump:
+
+1. Enumerate the surface: `Object.keys(require("@mlx-node/core")).filter(k => typeof core[k] === "function")`.
+2. Cross-reference against `(.-name c)` / `(.name c …)` references — bound off the
+   `@mlx-node/core` object `c` — in `mlx.cljs` + `mlx/random.cljs`. The test's
+   `referenced?` scopes to the `c` receiver so a same-named method on another
+   object (`.vmap` on `M`, `.gcAndSweep` on `jsc`) is not counted as a wrap.
+3. For each new export: wire it (if pure-math/introspection capability) or add an
+   omission entry with a category + reason. For each deleted export: remove its
+   omission entry.
+4. Update the counts above and run `membrane_coverage_test.cljs`.
+
+The test fails with an actionable message naming exactly which exports are
+unaccounted, stale, or misclassified.

--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -425,6 +425,11 @@
   (let [a (if (instance? M a) a (.scalar c a))]
     (add (.zeros c (clj->js sh) (.dtypeOf c a)) a)))
 (defn tile       [a reps] (.tile c a (clj->js reps)))
+(defn pad
+  "Pad array `a` with `const-val`. `pad-width` is a flat vector of 2*ndim
+   [before_0 after_0 before_1 after_1 …] (Vec<f64>-coerced at the NAPI boundary).
+   Pure array op; a thin one-liner like tile (genmlx-0vwn)."
+  [a pad-width const-val] (.pad c a (clj->js pad-width) const-val))
 (defn repeat-arr [a repeats axis] (.repeat c a repeats axis))
 (defn stack
   ([arrs]      (.stack c (to-array arrs)))
@@ -832,6 +837,16 @@
     (when (seq mx-arrs)
       (apply eval! mx-arrs))))
 
+(defn synchronize!
+  "Block until all already-dispatched GPU work on the default stream completes.
+   EFFECTFUL: a Metal barrier (native synchronize()). Distinct from eval! — it
+   does NOT force pending graph nodes to evaluate; it only fences work already
+   in flight (e.g. to bound a wall-clock timing read in the cost meter). A no-op
+   when nothing is dispatched. Wired here, not as a graph builder, because a
+   barrier is a Layer-C effect (genmlx-0vwn)."
+  []
+  (.synchronize c))
+
 ;; =========================================================================
 ;; MEMORY MANAGEMENT — the mutable boundary
 ;;
@@ -884,6 +899,14 @@
 (defn get-cache-memory   [] (.getCacheMemory c))
 (defn get-peak-memory    [] (.getPeakMemory c))
 (defn reset-peak-memory! [] (.resetPeakMemory c))
+;; Configured limits (read side of set-memory-limit! / set-wired-limit!),
+;; completing the introspection family (genmlx-0vwn).
+(defn get-memory-limit
+  "The MLX soft memory limit in bytes (0 = unset). Read side of set-memory-limit!."
+  [] (.getMemoryLimit c))
+(defn get-wired-limit
+  "The MLX wired (resident) memory limit in bytes. Read side of set-wired-limit!."
+  [] (.getWiredLimit c))
 
 (defn get-num-resources
   "Live Metal buffer allocation count (active + cached). Each counts toward the
@@ -939,6 +962,13 @@
 (defn clear-cache!      []  (.clearCache c))
 
 (defn metal-is-available? [] (.metalIsAvailable c))
+(defn gpu-architecture-gen
+  "The Metal GPU architecture generation as an integer (e.g. 16 = M4). This is
+   the SOLE native source of the arch generation — metalDeviceInfo does NOT
+   expose it (it returns only availability + working-set size), so the
+   :architecture string in metal-device-info below is a fallback placeholder.
+   Read-only introspection (genmlx-0vwn)."
+  [] (.gpuArchitectureGen c))
 (defn metal-device-info []
   (let [info (js/JSON.parse (.metalDeviceInfo c))]
     {:architecture (or (.-architecture info) "apple")
@@ -951,6 +981,28 @@
   {:active-bytes (get-active-memory)
    :cache-bytes  (get-cache-memory)
    :peak-bytes   (get-peak-memory)})
+
+;; Single-call allocator snapshots (read-only; no GPU dispatch). These are the
+;; native superset of the individual getters above — wired for the cost meter
+;; and memory diagnostics (genmlx-0vwn). Keys kebab-cased from the native
+;; MemoryStats / GpuMemorySnapshot interfaces.
+(defn memory-stats
+  "Allocator stats in one call: {:active :peak :cache :wired-limit} (bytes)."
+  []
+  (let [s (.memoryStats c)]
+    {:active      (.-active s)
+     :peak        (.-peak s)
+     :cache       (.-cache s)
+     :wired-limit (.-wiredLimit s)}))
+
+(defn get-memory-snapshot
+  "GPU-buffer snapshot: {:active-bytes :peak-bytes :cache-bytes}. The buffer-pool
+   view paired with clear-cache! (cache-bytes is what clear-cache! releases)."
+  []
+  (let [s (.getMemorySnapshot c)]
+    {:active-bytes (.-activeBytes s)
+     :peak-bytes   (.-peakBytes s)
+     :cache-bytes  (.-cacheBytes s)}))
 
 ;; --- Cleanup heuristics (global mutable counters) ---
 ;;

--- a/test/genmlx/membrane_coverage_test.cljs
+++ b/test/genmlx/membrane_coverage_test.cljs
@@ -1,9 +1,30 @@
 ;; @tier fast
 (ns genmlx.membrane-coverage-test
-  "genmlx-0vwn: compute-membrane coverage. Verifies the newly-wired pure ops,
-   guards the deliberately-OMITTED broken native broadcastTo, and pins the
-   @mlx-node/core export count as an upstream-drift signal (a count change means
-   re-run the coverage audit: a new export may need wiring or an omission entry)."
+  "genmlx-0vwn / genmlx-e3jg: compute-membrane coverage drift-guard.
+
+   The @mlx-node/core surface is the substrate (Layer C) the GenMLX membrane
+   (Layer 0 = mlx.cljs + mlx/random.cljs) binds to. This test PARTITIONS the
+   full runtime function-export surface into:
+
+     WRAPPED              — bound somewhere in the membrane source, AND
+     INTENTIONAL-OMISSIONS — every other export, each with an honest reason
+
+   and asserts the partition TILES the surface in BOTH directions:
+
+     A. nothing unaccounted  — a new/unwrapped export not on the allowlist FAILS
+                               (re-audit: wire it, or add an omission entry)
+     B. no stale omissions   — an allowlisted name deleted upstream FAILS
+                               (the f6ov/dbce rebase tax surfacing as a diff)
+     C. clean partition      — an omission that became wrapped FAILS (reclassify)
+
+   This is the real drift guard the bare export-count pin could not be: a count
+   only flags THAT the surface moved; the partition pinpoints WHAT moved and what
+   to do about it. The count is kept as a coarse canary (catches an add+omit done
+   in one commit, which A/B/C alone would pass).
+
+   SoT for the surface = packages/core/index.d.cts (the current types target in
+   package.json) — NOT the stale index.d.ts (Apr 1). NO no-op stubs: an export is
+   either genuinely wrapped or honestly omitted with a category + reason."
   (:require [cljs.test :refer [deftest is testing]]
             [genmlx.test-helpers :as h]
             [genmlx.mlx :as mx]))
@@ -11,6 +32,95 @@
 (def ^:private core (js/require "@mlx-node/core"))
 (def ^:private fs (js/require "fs"))
 
+;; The membrane = both Layer-0 files that bind @mlx-node/core. An export is
+;; WRAPPED iff its native name is referenced here as a property (.-name) or a
+;; method call (.name ...) — the only ways a NAPI export can be reached.
+(def ^:private membrane-src
+  (str (.readFileSync fs "src/genmlx/mlx.cljs" "utf8")
+       "\n"
+       (.readFileSync fs "src/genmlx/mlx/random.cljs" "utf8")))
+
+(defn- referenced?
+  "True if the membrane BINDS native export `nm` off the @mlx-node/core object
+   `c` — as a property ref (.-nm c) or a method head (.nm c …), the uniform wrap
+   convention in both Layer-0 files (each `(defonce ^:private c (js/require ...))`).
+   Scoping to the `c` receiver (rather than any object) is deliberate: it stops a
+   phantom match on a same-named method read off a DIFFERENT object — e.g.
+   .valueAndGrad / .vmap / .computeGradients on the MxArray module `M`, or
+   .gcAndSweep on bun:jsc — none of which bind a core export. (Verified: the
+   c-scoped and unscoped predicates select the identical wrapped set today; the
+   scoping only forecloses a future upstream rename TO one of those phantom names
+   silently classifying as wrapped.) The trailing non-identifier guard stops a
+   short name matching as a substring of a longer export (e.g. `sum` in
+   `.logsumexp`).
+
+   Known limitation (genmlx-0vwn, accepted): a 'dangling wrap' — a (.-x c) left in
+   the source after upstream DELETES export x — is not flagged here directly; the
+   212 count canary + tiling invariant in coverage-accounting-test catch it
+   indirectly (a deletion drops the surface count below the pin)."
+  [nm]
+  (some? (re-find (re-pattern (str "\\.-?" nm "\\s+c[^A-Za-z0-9_]")) membrane-src)))
+
+;; ---------------------------------------------------------------------------
+;; INTENTIONAL OMISSIONS — the coverage matrix, machine-checked.
+;; Each entry is an @mlx-node/core export deliberately NOT wrapped in the pure
+;; compute membrane, with the reason it belongs elsewhere (or nowhere). Classes
+;; appear here too: a JS `class` is a function export, so it counts toward the
+;; runtime surface and must be accounted for. Categories double as the "where
+;; does a new export of this kind belong" map for the next re-audit.
+;; ---------------------------------------------------------------------------
+(def ^:private intentional-omissions
+  {;; native op is INCORRECT — a custom reconstruction is used instead
+   :broken
+   #{"broadcastTo"}            ; mis-fills size-1 dims; mx/broadcast-to reconstructs (guarded below)
+
+   ;; profiling instrumentation — wire-on-demand behind the i0s4 cost meter
+   :profiling-gated-i0s4
+   #{"getProfilingData" "isProfilingEnabled" "setProfilingEnabled" "resetProfilingData"}
+
+   ;; GRPO/SFT training surface — to be bound at ENGINE level in a future
+   ;; @mlx-node/trl Layer-6 ns WITH the mutable-state quarantine (in-place weight
+   ;; + optimizer-state mutation), never in the pure membrane. (genmlx-706r)
+   :training-orchestration
+   #{"buildRewardOutputs"
+     "createRandomQwen3Checkpoint" "createRandomQwen35Checkpoint" "createRandomQwen35MoeCheckpoint"
+     "GrpoTrainingEngine" "SftTrainingEngine" "NativeRewardRegistry"
+     "Gradients" "OutputStore" "ResponseStore"}
+
+   ;; offline weight/format conversion tooling — not graph ops
+   :model-conversion
+   #{"convertForeignWeights" "convertGgufToSafetensors" "convertModel" "convertParquetToJsonl"}
+
+   ;; OCR / vision-language / document pipelines — bind via @mlx-node/lm vision (llm/vision.cljs)
+   :ocr-vlm-document
+   #{"createPaddleocrVlConfig" "createQianfanOcrConfig"
+     "documentToXlsx" "formatDocument" "saveToXlsx"
+     "parsePaddleResponse" "parseToolCallsFromText" "parseVlmOutput"
+     "DocLayoutModel" "DocOrientationModel" "DocUnwarpModel" "PrivacyFilterModel"
+     "QianfanOCRModel" "TextDetModel" "TextRecModel"
+     "VLModel" "VlmChatResult" "VlmProcessedImage"}
+
+   ;; loaded-model / tokenizer / generation classes — bound via @mlx-node/lm
+   ;; ChatSession (msa.cljs / backend.cljs), the LLM orchestration boundary, not
+   ;; the pure compute membrane. The per-token GFI path reaches the low-level
+   ;; forward, not these high-level classes.
+   :llm-orchestration
+   #{"Gemma4Model" "HarrierModel" "Lfm2Model" "Qwen3Model" "Qwen35Model" "Qwen35MoeModel"
+     "Qwen3Tokenizer"
+     "BatchGenerationResult" "GenerationResult" "ChatStreamHandle"}
+
+   ;; a foreign tensor class distinct from MxArray (the membrane's value type)
+   :foreign-tensor-type
+   #{"Tensor"}})
+
+(def ^:private omitted (reduce into #{} (vals intentional-omissions)))
+
+(def ^:private exported-fns
+  (set (filter #(fn? (aget core %)) (js-keys core))))
+
+;; ---------------------------------------------------------------------------
+;; Op-correctness oracles for the wired ops (genmlx-0vwn)
+;; ---------------------------------------------------------------------------
 (defn- i32 [a] (mx/->clj (mx/astype a mx/int32)))
 
 (deftest new-ops-correctness-test
@@ -26,27 +136,75 @@
     ;; cumprod / roll
     (is (= [1 2 6 24] (mx/->clj (mx/cumprod (mx/array [1.0 2.0 3.0 4.0]) 0))))
     (is (= [3 0 1 2] (mx/->clj (mx/roll (mx/array [0.0 1.0 2.0 3.0]) 1))))
+    ;; pad: [1,2,3] with 1-before/1-after, const 0 → [0,1,2,3,0]
+    (is (= [0 1 2 3 0] (mx/->clj (mx/pad (mx/array [1.0 2.0 3.0]) [1 1] 0.0))))
     ;; trig / hyperbolic vs Math
     (is (h/close? 0.0 (mx/item (mx/sinh (mx/scalar 0.0))) 1e-5))
     (is (h/close? 1.0 (mx/item (mx/cosh (mx/scalar 0.0))) 1e-5))
     (is (h/close? (/ js/Math.PI 6) (mx/item (mx/arcsin (mx/scalar 0.5))) 1e-5))
     (is (h/close? (/ js/Math.PI 4) (mx/item (mx/arctan (mx/scalar 1.0))) 1e-5))))
 
+(deftest wired-introspection-test
+  (testing "the newly-wired memory introspection + Metal barrier (read-only / effectful)"
+    (is (number? (mx/get-memory-limit)) "get-memory-limit returns a byte count")
+    (is (number? (mx/get-wired-limit)) "get-wired-limit returns a byte count")
+    (let [s (mx/memory-stats)]
+      (is (every? #(contains? s %) [:active :peak :cache :wired-limit])
+          "memory-stats keys are kebab-cased from MemoryStats")
+      (is (every? number? (vals s)) "memory-stats values are numbers")
+      (is (>= (:active s) 0)))
+    (let [snap (mx/get-memory-snapshot)]
+      (is (every? #(contains? snap %) [:active-bytes :peak-bytes :cache-bytes])
+          "get-memory-snapshot keys are kebab-cased from GpuMemorySnapshot")
+      (is (>= (:active-bytes snap) 0)))
+    ;; synchronize() returns void → nil; the barrier must not throw
+    (is (nil? (mx/synchronize!)) "synchronize! is a void Metal barrier")
+    ;; gpu-architecture-gen: the real M-generation integer (e.g. 16 = M4)
+    (is (number? (mx/gpu-architecture-gen)) "gpu-architecture-gen returns an integer")
+    (is (>= (mx/gpu-architecture-gen) 0))))
+
 (deftest broadcast-to-omission-test
   (testing "native broadcastTo is OMITTED (broken: mis-fills size-1 dims); the custom broadcast-to stays"
     (let [src (.readFileSync fs "src/genmlx/mlx.cljs" "utf8")]
       (is (nil? (re-find #"\.-broadcastTo c" src)) "mlx.cljs does NOT wrap native (.-broadcastTo c)")
       (is (nil? (re-find #"\.broadcastTo " src)) "mlx.cljs does NOT call native (.broadcastTo ...)")
-      (is (some? (re-find #"defn broadcast-to" src)) "the custom broadcast-to reconstruction is present"))))
+      (is (some? (re-find #"defn broadcast-to" src)) "the custom broadcast-to reconstruction is present")
+      (is (contains? (:broken intentional-omissions) "broadcastTo")
+          "broadcastTo is on the :broken omission allowlist"))))
 
-(deftest export-surface-drift-test
-  (testing "the @mlx-node/core function-export count is pinned as a drift signal"
-    (let [fns (filter #(fn? (aget core %)) (js-keys core))]
-      ;; If this fails the upstream surface CHANGED — re-run the genmlx-0vwn
-      ;; coverage audit: a newly-added export may need wiring or an omission entry,
-      ;; or a deletion is the f6ov/dbce rebase tax surfacing.
-      (is (= 212 (count fns))
-          (str "@mlx-node/core now exports " (count fns)
-               " functions (pinned at 212). Re-audit membrane coverage (genmlx-0vwn).")))))
+;; ---------------------------------------------------------------------------
+;; The drift guard proper — the e3jg/0vwn floor deliverable.
+;; ---------------------------------------------------------------------------
+(deftest coverage-partition-test
+  (testing "every @mlx-node/core export is WRAPPED ∪ INTENTIONAL-OMISSIONS (two-directional)"
+    ;; A — nothing unaccounted: an export neither wrapped nor on the allowlist
+    (let [unaccounted (sort (remove referenced? (remove omitted exported-fns)))]
+      (is (empty? unaccounted)
+          (str "Unaccounted @mlx-node/core exports — wire them into the membrane "
+               "or add to intentional-omissions with a reason (genmlx-0vwn): "
+               (vec unaccounted))))
+    ;; B — no stale omissions: an allowlisted name no longer exported upstream
+    (let [stale (sort (remove exported-fns omitted))]
+      (is (empty? stale)
+          (str "Stale omissions — these were deleted from @mlx-node/core (the "
+               "rebase tax surfacing); remove them from the allowlist: " (vec stale))))
+    ;; C — clean partition: an omission that is now actually wrapped
+    (let [misclassified (sort (filter referenced? omitted))]
+      (is (empty? misclassified)
+          (str "These are on the omission allowlist but ARE referenced in the "
+               "membrane now — they got wired; reclassify as WRAPPED: " (vec misclassified))))))
+
+(deftest coverage-accounting-test
+  (testing "the partition tiles the full surface (wrapped ⊎ omitted = exports)"
+    (let [wrapped (filter referenced? exported-fns)]
+      ;; Coarse canary: catches a surface change even when add+omit happen together.
+      (is (= 212 (count exported-fns))
+          (str "@mlx-node/core surface size changed: " (count exported-fns)
+               " fns (pinned at 212) — the partition test above pinpoints what moved."))
+      (is (= 48 (count omitted))
+          (str "intentional-omissions size changed: " (count omitted) " (pinned at 48)."))
+      (is (= (count exported-fns) (+ (count wrapped) (count omitted)))
+          (str "partition must tile exactly: wrapped " (count wrapped)
+               " + omitted " (count omitted) " = exports " (count exported-fns))))))
 
 (cljs.test/run-tests)


### PR DESCRIPTION
Completes the v1.0 **Phase 4 / compute-membrane** floor for `genmlx-0vwn` (and its executable-deliverable child `genmlx-e3jg`). Builds on the partial 0vwn (11 ops + count-pin) that landed via #126.

## What changed
- **Wired 7 genuinely-useful `@mlx-node/core` ops** into `mlx.cljs` (all oracle-tested):
  - read-only introspection: `get-memory-limit`, `get-wired-limit`, `memory-stats`, `get-memory-snapshot`, `gpu-architecture-gen`
  - effectful: `synchronize!` (Metal barrier)
  - pure array: `pad`
- **Upgraded `membrane_coverage_test.cljs`** from a bare export-count pin → a **categorized two-directional partition**: every function export ∈ `WRAPPED ∪ INTENTIONAL-OMISSIONS`, asserted against (A) unaccounted additions, (B) stale deletions, (C) misclassification, plus a count canary + tiling invariant. `referenced?` is scoped to the core binding `c` (forecloses phantom matches like `.vmap`/`.valueAndGrad` on other objects).
- **`docs/membrane-coverage.md`** — the human-readable matrix: 212 fn exports = **164 wrapped + 48 intentionally-omitted** (categorized, honest reasons). Test is authoritative; doc is a snapshot. SoT = `index.d.cts` (the `.d.ts` is stale).
- **CLAUDE.md** membrane-guard run list now includes `membrane_coverage_test`.

## Verification
- 4-agent adversarial workflow — verdict **SHIP**. It caught two false omission-reason texts (`pad` "not a one-liner"; `gpuArchitectureGen` "metalDeviceInfo covers it"); both fixed by **wiring** them (genuine one-liners). Confirmed the `:broken broadcastTo` reconstruction is honest.
- Gates green: `membrane_coverage` 5 tests / 32 assertions; contract guard (`clip_contract`/`exact`/`gradient_fd`/`score_gradient`) + L0 **68/68**.

## Deferred (separate beans, post-floor)
`@mlx-node/trl` training engines (Layer-6 mutable-state quarantine), OCR/VLM/document, profiling wraps (gate on `i0s4`), `MxArray` array-method gaps, and the `metal-device-info` placeholder honesty fix (`genmlx-r3u4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)