### PR TITLE
docs: v1.0 doc-truth pass + API-freeze manifest (genmlx-zp46)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -197,7 +197,7 @@ State is an immutable Clojure map. The exact keys depend on the GFI operation be
 | regenerate | `:key` `:choices` `:score` `:weight` `:old-choices` `:selection` `:executor` |
 | project    | `:key` `:choices` `:score` `:weight` `:old-choices` `:selection` `:constraints` `:executor` |
 
-GenMLX defines ten transitions: six scalar and four batched. The scalar transitions implement the core GFI semantics. Here is `simulate-transition`, the simplest:
+GenMLX defines thirteen transitions: seven scalar and six batched. The seventh scalar transition is `regenerate-transition-general` (the retained-only general regenerate path, genmlx-hmch/yep2), used when a selection is not fast-path-eligible (i.e., the model has branches, or selected sites are not mutually independent). The scalar transitions implement the core GFI semantics. Here is `simulate-transition`, the simplest:
 
 ```clojure
 (defn simulate-transition [state addr dist]
@@ -227,7 +227,7 @@ Split the PRNG key. Sample a value. Compute the log-probability. Thread all thre
       (simulate-transition state addr dist))))
 ```
 
-The four batched transitions (`batched-simulate-transition`, `batched-generate-transition`, `batched-update-transition`, `batched-regenerate-transition`) are structurally identical to their scalar counterparts. The sole difference: they call `dist-sample-n` to draw `[N]`-shaped tensors instead of scalars. Because MLX arithmetic broadcasts, an `[N]`-shaped sample paired with a scalar distribution parameter produces `[N]`-shaped log-probabilities. The state threading logic is unchanged. The handler never inspects value shapes -- this is precisely what makes shape-based vectorization transparent.
+The six batched transitions (`batched-simulate-transition`, `batched-generate-transition`, `batched-update-transition`, `batched-regenerate-transition`, `batched-project-transition`, `batched-regenerate-transition-general`) are structurally identical to their scalar counterparts. The main difference: they call `dist-sample-n` to draw `[N]`-shaped tensors instead of scalars. They also add a per-site `check-batched-lp!` shape-invariant guard (no scalar counterpart) — a no-eval, O(1) check that fails loudly if a site's log-prob is not `[]` or `[N]`. Because MLX arithmetic broadcasts, an `[N]`-shaped sample paired with a scalar distribution parameter produces `[N]`-shaped log-probabilities. The state threading logic is unchanged. The handler never inspects value shapes -- this is precisely what makes shape-based vectorization transparent.
 
 The mutable boundary of handler execution sits in `runtime.cljs`. The function `run-handler` wraps a transition in a single `volatile!` cell. (System-wide, a small audited set of other mutable points exists outside the execution path — resource-management counters in `mlx.cljs`, dev-mode extension atoms, memoization caches, caller-owned training state; CLAUDE.md "Key design principles" carries the full inventory. None of them affect computation results.)
 
@@ -256,9 +256,12 @@ There are three fundamental interpretations:
 
 **Constrain.** The transition fixes the value to an observation. `generate-transition` constrains at addresses present in the constraint map. `assess-transition` constrains at all addresses. The model receives the observed value, and the log-probability is accumulated into both `:score` and `:weight`.
 
-**Enumerate.** The transition expands the entire support of the distribution as a new tensor axis. Instead of returning a single scalar, `enumerate-transition` returns a tensor of shape `[K, 1, 1, ...]` where K is the support size and the trailing 1s broadcast against all previously enumerated axes:
+**Enumerate.** The transition expands the entire support of the distribution as a new tensor axis. Instead of returning a single scalar, `enumerate-transition` returns a tensor of shape `[K, 1, 1, ...]` where K is the support size and the trailing 1s broadcast against all previously enumerated axes.
+
+The snippet below is a **simplified illustration** of the structure (not literal source — see `inference/exact.cljs:51-104` for the full implementation, which includes a k=1 deterministic short-circuit, correct lp broadcast-dim insertion between K and param dims, and `:support` in the `:axes` entry):
 
 ```clojure
+;; Simplified illustration — see exact.cljs for the full implementation
 (defn enumerate-transition [state addr dist]
   (let [constraint (cm/get-submap (:constraints state) addr)]
     (if (cm/has-value? constraint)
@@ -279,13 +282,13 @@ There are three fundamental interpretations:
         [values-nd (-> state
                        (update :choices cm/set-value addr values-nd)
                        (update :score #(mx/add % lp-nd))
-                       (update :axes conj {:addr addr :size k :dim ndim})
+                       (update :axes conj {:addr addr :size k :dim ndim :support support})
                        (update :ndim inc))]))))
 ```
 
 The model code is identical in all three cases. The same `gen` body runs under `simulate-transition`, `generate-transition`, or `enumerate-transition` without modification. The handler determines the semantics. This is algebraic effects in the Plotkin-Pretnar sense: the effectful operation (`trace`) is syntax; the handler provides the denotation.
 
-A critical architectural point: **enumerate is not a new GFI protocol operation**. It is an alternative *implementation* of the existing operations. A generative function using `enumerate-transition` internally still exposes the standard GFI interface externally. Callers see `simulate`, `generate`, `update`, `regenerate`, `assess`, `project` -- the same seven operations defined in Part I. The enumeration is invisible to callers.
+A critical architectural point: **enumerate is not a new GFI protocol operation**. It is an alternative *implementation* of the existing operations. A generative function using `enumerate-transition` internally still exposes the standard GFI interface externally. Callers see `simulate`, `generate`, `update`, `regenerate`, `assess`, `project`, `propose` -- the same seven operations defined in Part I. The enumeration is invisible to callers.
 
 
 ## 2.3 Middleware Composition
@@ -406,7 +409,7 @@ This is not a pipeline where each level feeds the next. It is a set of independe
 
 **Level 0: The handler-dispatcher.** The base transition functions in `handler.cljs` are pure functions of type `(fn [state addr dist] -> [value state'])`. They operate on scalar arrays. Their batched variants operate on `[N]`-shaped arrays. MLX broadcasting handles all arithmetic. Level 0 is the identity dispatcher -- it always works, for any model, with any distribution, under any GFI operation.
 
-**Level 1: The compiled-dispatcher.** The `gen` macro captures source forms. At construction time, `schema.cljs` walks the quoted form to extract trace sites, classify the model, and compute a topological sort of trace addresses. For static models, `compiled.cljs` uses noise transforms to bypass multimethod dispatch: distribution-specific transforms (Gaussian: `mean + std * noise`) compile into a pure function. `mx/compile-fn` fuses this into a single Metal kernel. Partial compilation (L1-M3) handles mixed models: the static prefix compiles, the dynamic suffix falls back to the handler. Branch rewriting (L1-M4) converts conditionals to `mx/where` operations.
+**Level 1: The compiled-dispatcher.** The `gen` macro captures source forms. At construction time, `schema.cljs` walks the quoted form to extract trace sites, classify the model, and compute a topological sort of trace addresses. For static models, `compiled.cljs` uses noise transforms to bypass multimethod dispatch: distribution-specific transforms (Gaussian: `mean + std * noise`) compile into a pure function. The result is a single lazy MLX graph that dispatches to Metal in one `eval!` (note: `mx/compile-fn` is currently an identity pass-through — GenMLX's fusion comes from lazy-graph construction plus the noise-transform expression compiler, not from MLX kernel-caching compile). Partial compilation (L1-M3) handles mixed models: the static prefix compiles, the dynamic suffix falls back to the handler. Branch rewriting (L1-M4) converts conditionals to `mx/where` operations.
 
 **Level 2: The compiled-sweep-dispatcher.** At L0 and L1, the inference loop is host-driven. Level 2 eliminates this. Pre-generated randomness (all noise tensors allocated upfront as `[T, N, K]`) makes the entire sweep deterministic given its inputs. The compiled particle filter unrolls the loop into one lazy graph. Differentiable resampling enables gradient flow through the sweep via Gumbel-softmax.
 
@@ -507,8 +510,7 @@ symmetric special case (*P₁*=*P₂*, *Q₁*=*Q₂*, *h* an involution, §3.7).
 
 `genmlx.inference.translator` provides `trace-translator` (the constructor),
 `apply-translator`/`translator-weight` (Eq 3.12), an AD Jacobian
-(`jacobian-logdet`, via `mx/grad`; the log|det| is computed on the host because
-the native determinant is unreliable for non-diagonal matrices) with a
+(`jacobian-logdet`, via `mx/grad`; the log|det| uses `mx/logabsdet` — a QR-based, lazy on-device determinant correct for the non-symmetric Jacobians bijections produce, where the SPD-only Cholesky path would be silently wrong, genmlx-rqp9) with a
 sparsity-aware variant (`sparse-jacobian-logdet`, §3.6.2: coordinates *h* copies
 unchanged are identity columns excluded from the determinant block), a
 `read`/`write`/`copy` introspection API for writing bijections,
@@ -552,7 +554,7 @@ Four dispatcher implementations (defined in `dynamic.cljs` where they access the
 
 ```clojure
 (def ^:private default-dispatcher-stack
-  [custom-transition-dispatcher    ;; with-handler metadata
+  [custom-dispatcher               ;; with-handler / with-dispatch metadata
    analytical-dispatcher           ;; L3 conjugacy
    compiled-dispatcher             ;; L1 compiled paths
    handler-dispatcher])            ;; L0 fallback (always succeeds)
@@ -582,7 +584,7 @@ validating wrapper, which is where Malli return-schema validation lives.)
 
 The dispatch layer is internal. Every external surface below is independent of it.
 
-- **`handler.cljs`**: All 10 transitions remain as-is. They are already pure functions with the right signature.
+- **`handler.cljs`**: All 13 transitions (11 core + 2 regenerate-general variants) remain as-is. They are already pure functions with the right signature.
 - **`runtime.cljs`**: The `volatile!` boundary stays. `run-handler` stays.
 - **`protocols.cljs`**: The 7 GFI protocols are unchanged. This IS the composition boundary.
 - **`dist/core.cljs`**: The distribution-as-GF pattern stays. It's the template for domain integrations.
@@ -598,21 +600,27 @@ src/genmlx/
   ;; Layer 0: MLX + Runtime (unchanged)
   mlx.cljs                    ;; MLX bindings, lazy graph, eval, tidy, auto-cleanup
   mlx/random.cljs             ;; Functional PRNG: split, fresh-key, ensure-key
+  mlx/constants.cljs          ;; MLX dtype/device constants
   runtime.cljs                ;; run-handler, volatile! boundary
 
   ;; Layer 1: Data Algebra (unchanged)
   choicemap.cljs              ;; Value/Node, hierarchical address->value maps
   trace.cljs                  ;; Immutable Trace record
   selection.cljs              ;; Composable address selection algebra
+  diff.cljs                   ;; Argdiff types for update-with-args
 
   ;; Layer 2: GFI Protocols + Dispatch
   protocols.cljs              ;; GFI protocols
-  handler.cljs                ;; 10 pure transitions
+  handler.cljs                ;; 13 pure transitions (7 scalar + 6 batched, including 2 regenerate-general variants)
   dispatch.cljs               ;; IDispatcher protocol, stack walk, with-handler
+  edit.cljs                   ;; Edit interface (ConstraintEdit, SelectionEdit, ProposalEdit)
+  tensor_trace.cljs           ;; VectorizedTrace for shape-based batching
 
   ;; Layer 3: DSL + Schema
   gen.cljc                    ;; gen macro
   schema.cljs                 ;; Schema extraction
+  schemas.cljs                ;; Malli schemas for GFI types
+  inspect.cljs                ;; inspect API (compilation level, dispatch map)
   dynamic.cljs                ;; DynamicGF + the four dispatchers (dispatch/resolve)
 
   ;; Layer 4: Distributions (unchanged)
@@ -621,44 +629,86 @@ src/genmlx/
   ;; Layer 5: Combinators (unchanged)
   combinators.cljs, vmap.cljs
 
-  ;; Layer 6: Compiled Paths (unchanged)
+  ;; Layer 6: Compiled Paths
   compiled.cljs, compiled_ops.cljs, compiled_gen.cljs
-  tensor_trace.cljs, rewrite.cljs
 
   ;; Layer 7: Inference
+  inference.cljs              ;; public aggregator namespace
   inference/
     importance.cljs, mcmc.cljs, smc.cljs, vi.cljs, adev.cljs
     kernel.cljs, smcp3.cljs, pmcmc.cljs
     exact.cljs                 ;; enumerate-transition
+    enumerate.cljs             ;; enumerate support helpers
     analytical.cljs            ;; wrap-analytical middleware
     auto_analytical.cljs       ;; Address-dispatch analytical handlers
     conjugate.cljs, kalman.cljs, ekf.cljs, ekf_nd.cljs, hmm_forward.cljs
     compiled_smc.cljs, compiled_optimizer.cljs, compiled_gradient.cljs
     differentiable.cljs, differentiable_resample.cljs, amortized.cljs
     translator.cljs            ;; General trace translators (§3.6-3.7): Eq 3.12, RJMCMC, coarse-to-fine
+    util.cljs                  ;; inference utilities (materialize-weights, etc.)
+    diagnostics.cljs           ;; ESS, convergence diagnostics
+    fisher.cljs                ;; Fisher information / Laplace approximation
+    cost.cljs                  ;; computational cost estimation
+    steppable.cljs             ;; steppable/budgeted inference (SMC-first)
 
   ;; Layer 8: LLM Integration
   llm/
     core.cljs                  ;; make-llm-gf: wrap LLM as DynamicGF (token = trace site)
     backend.cljs               ;; mlx-node loader, forward pass, KV cache
+    forward.cljs               ;; generic LLM forward pass
+    qwen3_forward.cljs         ;; Qwen3 architecture forward pass
+    qwen35_forward.cljs        ;; Qwen3.5 architecture forward pass
     grammar.cljs               ;; DFA-constrained generation (regex → token mask)
     bytes.cljs                 ;; byte-level marginalization via TokenByteTrie
     codegen.cljs               ;; reader-as-grammar for valid ClojureScript
+    schema_grammar.cljs        ;; Malli schema → grammar constraint
+    structured.cljs            ;; structured generation API
     msa.cljs                   ;; Model Synthesis Architecture (LLM proposes programs)
     vision.cljs                ;; VLM input adaptation
 
   ;; Layer 9: Analysis
-  affine.cljs, conjugacy.cljs, dep_graph.cljs, rewrite.cljs
+  affine.cljs, conjugacy.cljs, dep_graph.cljs, rewrite.cljs   ;; rewrite.cljs: build-analytical-plan; used by compiled + schema pipelines
   method_selection.cljs, fit.cljs
+  linear_gaussian.cljs        ;; joint linear-Gaussian elimination (L3 linreg)
 
   ;; Layer 10: Verification
   gfi.cljs                     ;; the GFI algebraic law catalog from the Cusumano-Towner thesis
   verify.cljs                  ;; static validator (validate-gen-fn)
 
   ;; Support
-  edit.cljs, diff.cljs, gradients.cljs, learning.cljs
+  gradients.cljs, learning.cljs
   custom_gradient.cljs, nn.cljs, vectorized.cljs, serialize.cljs
   encapsulated.cljs           ;; Encapsulated randomness (§4.5): EncapsulatedGF, estimators, pseudo-marginal-mh
+  memory.cljs                 ;; memory management / GC utilities
+  program.cljs                ;; program representation
+  sensorimotor.cljs           ;; sensorimotor loop utilities
+  dev.cljs                    ;; dev mode start!/stop! (swaps dispatch-fn/validate-fn atoms)
+
+  ;; Agents
+  agents/
+    agent.cljs                 ;; agent record + act/step API
+    belief.cljs                ;; belief state representation
+    biased_planners.cljs       ;; biased/MC planner baselines
+    differentiable.cljs        ;; differentiable agent utilities
+    gridworld.cljs             ;; gridworld environment
+    helpers.cljs               ;; agent utility functions
+    inverse.cljs               ;; inverse planning / IRL
+    pomdp.cljs                 ;; POMDP agent
+    pomdp_env.cljs             ;; POMDP environment protocol
+    presentation.cljs          ;; result presentation / formatting
+    remote.cljs                ;; remote/async agent interface
+    rollout.cljs               ;; trajectory rollout
+    worlds.cljs                ;; world environment utilities
+
+  ;; Control
+  control/
+    decision_value.cljs        ;; decision-theoretic value functions
+    meta_mdp.cljs              ;; meta-MDP / rational metareasoning
+
+  ;; World (effect membranes)
+  world/
+    net.cljs                   ;; Bun network membrane (Bun.serve / HTTP)
+    proc.cljs                  ;; process/scheduler membrane
 ```
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ ClojureScript's immutable data, open multimethods, and macro system map perfectl
 onto the GFI's mathematical structure. MLX's lazy graphs, unified memory, and
 broadcasting reinforce this — functional-style array programming without penalty.
 
-~31,900 lines of ClojureScript across 76 source files. Purely functional,
+~43,100 lines of ClojureScript across 105 source files. Purely functional,
 data-driven, GPU end-to-end.
 
 ## Three-layer purity architecture
@@ -35,7 +35,7 @@ structure. No GPU work occurs until `mx/eval!` is called. This means most of
 (or wrappers like `item`, `->clj`, `materialize!`). Everything else — arithmetic,
 reductions, autograd, vmap, compile — builds lazy graphs.
 
-**mlx-node is at the heart of GenMLX.** The Rust/NAPI layer (328 exports, 5 crates)
+**mlx-node is at the heart of GenMLX.** The Rust/NAPI layer (212 @mlx-node/core function exports, pinned by the coverage matrix; 5 crates)
 is not "mutable substrate we contain" — it is a functional graph engine that aligns
 naturally with ClojureScript's value semantics. `mlx.cljs` is the thin membrane
 between them; `Either<&MxArray, f64>` in Rust handles type coercion so CLJS
@@ -131,7 +131,7 @@ src/genmlx/
   # Layer 1: Core Data (pure immutable structures)
   choicemap.cljs, trace.cljs, selection.cljs, diff.cljs
 
-  # Layer 2: GFI & Execution (11 protocols, 6+4 handler transitions)
+  # Layer 2: GFI & Execution (11 protocols, 7+6 handler transitions)
   protocols.cljs, handler.cljs, edit.cljs, tensor_trace.cljs
 
   # Layer 3: DSL + Schema (gen macro, DynamicGF, 4-level dispatcher)
@@ -143,11 +143,12 @@ src/genmlx/
   # Layer 5: Combinators (Map, Unfold, Switch, Scan, Mask, Mix, Recurse, etc.)
   combinators.cljs, vmap.cljs
 
-  # Layer 6: Inference (35+ algorithms across 26 files)
+  # Layer 6: Inference (35+ algorithms across 29 files)
   inference/ — importance, mcmc, smc, smcp3, vi, adev, amortized, kernel,
   util, diagnostics, analytical, conjugate, auto_analytical, kalman, ekf,
   ekf_nd, hmm_forward, enumerate, exact, fisher, compiled_gradient,
-  compiled_optimizer, compiled_smc, differentiable, differentiable_resample, pmcmc
+  compiled_optimizer, compiled_smc, differentiable, differentiable_resample,
+  pmcmc, cost, steppable, translator
 
   # Layer 7: Compiled Paths (L1-L4 compilation pipeline)
   compiled.cljs, compiled_ops.cljs, compiled_gen.cljs, rewrite.cljs,
@@ -171,7 +172,7 @@ The implementation layers map onto the three-layer purity model:
 
 ```
 ── Layer C (GPU execution) ──────────────────────────────────────────────
-  mlx-node Rust/C++   5 crates, 328 NAPI exports. MxArray = Arc<lazy graph node>.
+  mlx-node Rust/C++   5 crates; 212 @mlx-node/core function exports (coverage-matrix-pinned). MxArray = Arc<lazy graph node>.
                       eval! is the only operation that dispatches to Metal.
 
 ── Membrane (mlx.cljs) ─────────────────────────────────────────────────
@@ -184,7 +185,7 @@ The implementation layers map onto the three-layer purity model:
   Layer 3: DSL + Schema     (gen macro, dynamic, schema, schemas, inspect — pure)
   Layer 4: Distributions    (dist/core, dist/macros, dist — 36 constructors, pure)
   Layer 5: Combinators      (combinators, vmap — 10 combinators, pure)
-  Layer 6: Inference         (26 files, 35+ algorithms — pure)
+  Layer 6: Inference         (29 files, 35+ algorithms — pure)
   Layer 7: Compiled Paths   (compiled, compiled_ops, rewrite, affine, conjugacy, dep_graph,
                              method_selection — pure)
   Layer 8: Supporting       (vectorized, gradients, learning, nn, serialize, gfi, verify,
@@ -252,7 +253,7 @@ direct import of dynamic.cljs).
    infrastructure — no parallel implementations. The handler is ground truth.
 
 7. **The GFI algebraic laws.** The GFI algebraic theory (`gfi.cljs`) encodes
-   the laws from the thesis (68 as of 2026-06; count the `laws` vector for the
+   the laws from the thesis (86 as of 2026-06; count the `laws` vector for the
    current number) covering all operations, compositionality, gradients, and
    compiled path equivalence. `strip-compiled` forces handler path for testing.
 
@@ -332,8 +333,9 @@ Key properties:
 
 The handler system has two parts:
 
-1. **Pure transitions** in `handler.cljs` — 6 scalar state transition functions
-   (simulate, generate, assess, update, regenerate, project) + 4 batched variants.
+1. **Pure transitions** in `handler.cljs` — 7 scalar state transition functions
+   (the 6 GFI modes simulate/generate/assess/update/regenerate/project + a general
+   retained-only `regenerate-transition-general`) + 6 batched variants.
    Each is `(fn [state addr dist] -> [value state'])`. Zero side effects.
 
 2. **Execution runtime** in `runtime.cljs` — `run-handler` wraps a transition
@@ -466,7 +468,7 @@ candidates by log-ML. Two modes: template (fine-tuned + regex) and knowledge
 
 ## Rust NAPI boundary (genmlx.rs)
 
-~105 NAPI-exported functions in `mlx-node/crates/mlx-core/src/genmlx.rs`.
+~85 NAPI-exported functions in `mlx-node/crates/mlx-core/src/genmlx.rs`.
 The core pattern: `Either<&MxArray, f64>` accepts both MLX arrays and JS numbers
 transparently. `Vec<f64>` for shapes (no BigInt64Array needed). This makes
 `mlx.cljs` extremely thin — most ops are direct property references to Rust exports.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,7 @@ direct import of dynamic.cljs).
    infrastructure — no parallel implementations. The handler is ground truth.
 
 7. **The GFI algebraic laws.** The GFI algebraic theory (`gfi.cljs`) encodes
-   the laws from the thesis (86 as of 2026-06; count the `laws` vector for the
+   the laws from the thesis (85 as of 2026-06; count the `laws` vector for the
    current number) covering all operations, compositionality, gradients, and
    compiled path equivalence. `strip-compiled` forces handler path for testing.
 

--- a/docs/api-freeze.md
+++ b/docs/api-freeze.md
@@ -1,0 +1,218 @@
+# GenMLX v1.0 API Freeze
+
+This document is the concrete realization of ROADMAP.md's *"What the v1.0 freeze
+commits to"*. It is the **semver contract**: the surfaces below are frozen for the
+1.x line — signatures do not change incompatibly, and extensions are **additive**.
+Each commitment names its concrete surface (the actual protocols / functions /
+files) and the test(s) and/or `gfi.cljs` laws that **pin** it — so a change that
+breaks the contract turns a specific test red.
+
+The freeze covers the *public* contract only. Internals (handler transition
+internals, compiled-path implementations, membrane resource heuristics) may change
+freely as long as the pinned public behavior holds. Surfaces explicitly fenced as
+**provisional** (below) are outside the freeze.
+
+> Counts in this document (protocols, laws, distributions, exports) are stated as
+> "count the live definition" wherever a number would drift; where a number is
+> given it is accurate as of the v1.0 freeze and re-derivable from the cited file.
+
+---
+
+## 1. The GFI protocols + edit interface
+
+**Frozen surface.** `src/genmlx/protocols.cljs` defines **11 single-operation
+protocols** — the 10 core GFI operations plus the vectorized-splice protocol:
+
+| Protocol | Operation |
+|---|---|
+| `IGenerativeFunction` | `simulate` |
+| `IGenerate` | `generate` |
+| `IAssess` | `assess` |
+| `IUpdate` | `update` |
+| `IRegenerate` | `regenerate` |
+| `IPropose` | `propose` |
+| `IProject` | `project` |
+| `IUpdateWithDiffs` | `update-with-diffs` |
+| `IUpdateWithArgs` | `update-with-args` |
+| `IHasArgumentGrads` | `has-argument-grads` |
+| `IBatchedSplice` | `batched-splice` (vectorized inference) |
+
+The **edit interface** is `src/genmlx/edit.cljs`: the `IEdit` protocol
+(`edit [gf trace edit-request]`), the four `EditRequest` constructors
+(`constraint-edit`, `selection-edit`, `args-update-edit`, `proposal-edit`), the
+`edit-dispatch` multimethod, and the backward-request round-trip contract.
+
+Protocol *signatures* are frozen; new generative-function/distribution
+implementations of these protocols are additive.
+
+**Pinned by.** The `gfi.cljs` `laws` vector (one law per weight-semantics theorem,
+each citing the thesis), executed by `gfi_laws_test.cljs` (+ the `_p1..p10` splits)
+which iterates `gfi/laws` and calls `gfi/verify`; the per-op suites
+`gfi_simulate_test`, `gfi_generate_test`, `gfi_assess_test`, `gfi_update_test`,
+`gfi_regenerate_test`, `gfi_project_test`, `update_args_test`, `vupdate_test`, and
+the contract suites `gfi_contract_test` / `gfi_contracts_test` / `gfi_universal_test`.
+The edit interface is pinned by `edit_property_test`, `edit_purity_test`,
+`proposal_edit_test`, and the `:edit-backward-request-roundtrip` law.
+
+---
+
+## 2. The choicemap / trace / selection data algebra
+
+**Frozen surface.** `choicemap.cljs`, `trace.cljs`, `selection.cljs` (and
+`diff.cljs` for argdiffs): hierarchical keyword/vector addresses, leaf-value
+identity, and the `get-value` / `get-submap` / `merge` / `filter` algebra. The
+**durable-key discipline** (cross-session addressing) is realized in `memory.cljs`:
+content-hash identity (`put-content!`, sha256 over a canonical serialization) and
+named-key (program-name) upsert — explicitly mirroring the choicemap-address
+discipline (content = leaf-value identity; named = the address slot).
+
+**Pinned by.** `choicemap_algebra_test`(`2`), `choicemap_property_test`,
+`choicemap_test`; `selection_algebra_test2`, `selection_property_test`,
+`selection_test`, `selection_regenerate_test`; `trace_test`,
+`trace_immutability_test`(`_property`), `tensor_trace_test`(`_property`); the
+`:address-uniqueness` and `:simulate-address-set-consistency` laws. Durable keys:
+`world_memory_test` / `memory_test` — the content hash is pinned to a golden hex
+computed by an **independent** shell `sha256` over the hand-written canonical
+string, and session checkpointing is proven by an actual close+reopen
+(across-process-death).
+
+---
+
+## 3. `defdist`, `with-handler` / `with-dispatch`, and the dispatcher stack
+
+**Frozen surface.** `defdist` (`dist/macros.cljc`) + the open multimethods
+`dist-sample*` / `dist-log-prob` (`dist/core.cljs`) — the extension point for new
+distributions. `with-handler` / `with-dispatch` (`dispatch.cljs`) — the
+execution-strategy extension points. The **4-level dispatcher stack**
+(custom → analytical → compiled → handler, `dynamic.cljs`), extended via
+`::custom-dispatch` / `::custom-transition` metadata.
+
+**Pinned by.** `defdist`: every distribution test transitively
+(`dist_test`, `new_dist_test`, `dist_logprob_test`, `dist_property_test`,
+`dist_normalization_test`, …) plus custom-distribution definitions in
+`gfi_gradient_test` and `kalman_test`. `with-dispatch`: `gfi_laws_test_p7`
+("Alg-16 proposal override via with-dispatch" — pins importance-sampling
+correctness through the custom-dispatch path). The analytical/compiled dispatcher
+levels: `exact_test`, `l3_5_gate_test`, `auto_analytical_test`, and the
+`compiled_*` equivalence/parity suites.
+
+> **Known gap (honest).** `with-handler` is pinned only *indirectly* — through
+> `wrap-grammar` (`llm/grammar.cljs`, exercised by `llm_grammar_test` /
+> `grammar_per_op_test`) and the analytical wrap — no test names
+> `dispatch/with-handler` directly. (CLAUDE.md's "canonical example" for
+> `with-handler` is `exact.cljs`, which actually uses `with-dispatch`; the real
+> `with-handler` example is `grammar.cljs`.) The contract is behaviorally pinned;
+> a direct unit test would harden it. Tracked, not a blocker.
+
+---
+
+## 4. The agents env / agent / solver / belief surface
+
+**Frozen surface.** Frozen as **tests-as-contracts** (per-constructor return-map
+shapes + family-specific `:act`/belief signatures), documented in
+`src/genmlx/agents/CONTRACTS.md` — **not** formal `defprotocol`s. The minimal
+guaranteed contract is `{:act :params}`; everything else is family-specific by
+design: `make-mdp-agent` (`{:mdp :Q :V :policy :act :expected-utility :params}`),
+`make-biased-mdp-agent` (no `:Q`/`:V`), `make-pomdp-agent` (belief keys),
+`make-bandit-agent`. Belief filters in `agents/belief.cljs`; envs in
+`agents/gridworld.cljs`, `pomdp_env.cljs`, `worlds.cljs`.
+
+**Pinned by.** `agents_contracts_test` (per-constructor return-map shapes + family
+`:act` signatures), `agents_api_test` (namespace reachability, agent-as-GF / GFI
+ops, tensor-VI `Q == recursive-EU`, inverse-planning host==batched),
+`belief_tensor_test` (belief filter math, host==tensor equivalence). All three are
+named in `CONTRACTS.md`'s "Enforcing tests".
+
+> **Provisional fence.** `genmlx.agents.remote` is explicitly **outside** the
+> frozen surface (`CONTRACTS.md`) — pinned only by behavioral self-checks
+> (`external_env_test`, `examples/external_env.cljs`), not a contracts test.
+> Consumers must not treat `remote` as a v1.0 contract.
+
+---
+
+## 5. The two-membrane effect contract
+
+**Frozen surface.** Everything above the two membranes is **pure values** (Layers
+1–9 referentially transparent). The two effect faces:
+
+- **Compute membrane** (`mlx.cljs`): `eval!` is the sole GPU side effect;
+  `item` / `->clj` / `materialize!` / `realize` / `tidy-run` / `tidy-materialize`
+  are the boundary wrappers, all dispatching through `eval!`.
+- **World membrane** (Bun): `world/net.cljs` (network face — `serve!` /
+  `with-server`), `world/proc.cljs` (scheduler face — `with-deadline`),
+  `memory.cljs` (persistence face — `bun:sqlite`).
+
+The mutable boundaries are the **audited, enumerated** set (CLAUDE.md: the runtime
+`volatile!`, the `mlx.cljs` resource atoms, the KV cache, the `Bun.serve`
+listener). The control scheduler (`world.proc/with-deadline`) is the sole
+control-layer effect and is **never** a generative function (`control/CONTRACTS.md`).
+
+**Pinned by.** Purity above the membrane: `mutation_boundary_test` (property tests
++ AST check via `verify/check-no-mutation`) and the `:no-mutation` /
+`:no-external-randomness` laws. Compute-membrane honesty/drift:
+`membrane_coverage_test` (the genmlx-0vwn two-directional drift guard — partitions
+every `@mlx-node/core` function export into wrapped ∪ intentional-omission and
+fails on any unaccounted upstream change), `membrane_honesty_test`,
+`membrane_guard_test`, `membrane_churn_test`, `clip_contract_test`,
+`det_contract_test`, `native_guard_test`. World membrane: `world_proc_test`
+(deadline logic with an injected fake clock; `with-server`/`with-deadline`
+teardown), `world_memory_test` / `memory_test`.
+
+> **Note (honest).** "`eval!` is the sole side effect" is enforced *structurally*
+> (the coverage partition leaves no unwrapped NAPI compute export; the mutation
+> property tests find no hidden mutation) rather than by a single literal
+> assertion. The structural guarantee is the stronger one.
+
+---
+
+## 6. Docs that match code + the tiered test runner as the release gate
+
+**Frozen surface.** The doc-truth contract is enforced where it can be mechanically
+pinned: `docs/membrane-coverage.md` (the coverage matrix, pinned to
+`packages/core/index.d.cts`), `agents/CONTRACTS.md` and `control/CONTRACTS.md`
+(every claim test-backed). The **tiered test runner** (`test/run.sh`, tiers
+core/fast/medium/slow/bench/all/check, wired as `package.json` `test:*` scripts)
+is the release gate; `test:check` is the zero-GPU gate. Test files carry `@tier`
+markers.
+
+**Pinned by.** `membrane_coverage_test` reads `packages/core/index.d.cts` directly
+and fails on any upstream add/delete/rename not reflected in the membrane — the
+live doc-vs-code pin for the compute surface. The CONTRACTS.md claims are pinned by
+the agents/control contract suites. `membrane_honesty_test` pins the membrane
+honesty fixes.
+
+> **Known gap (honest).** Prose docs (CLAUDE.md / ROADMAP.md / ARCHITECTURE.md /
+> README.md) are **not** mechanically lint-pinned; they are human-maintained and
+> kept in sync by the Phase-1 truth pass (an adversarially-verified
+> ARCHITECTURE.md↔code sweep). The membrane surface and the agents/control
+> contracts *are* mechanically pinned. The tiered runner is operational, not
+> test-pinned (no test asserts the runner config itself).
+
+---
+
+## What is **not** frozen (provisional / internal)
+
+- `genmlx.agents.remote` — provisional external-environment bridge (§4).
+- `switch-method` live SMC↔MCMC translation in the metareasoner — deferred
+  (`control/meta_mdp.cljs` raises `:not-implemented`); the v1.0 control action set
+  is `{:continue :stop}`.
+- Compiled-path internals, handler transition internals, membrane resource-cleanup
+  heuristics — free to change behind the pinned public behavior.
+- The `gen.core` substrate-protocol / incremental-substrate (fGen) factoring — a
+  post-1.0 direction; v1.0 deliberately does not freeze APIs that would block it.
+
+---
+
+## Extending without breaking the freeze
+
+- **New distribution** → `defdist` + `dist-sample*` / `dist-log-prob`. Additive.
+- **New execution strategy** → a handler transition `(fn [state addr dist])` via
+  `with-handler`, or full op-level control via `with-dispatch`. Additive.
+- **New combinator / generative function** → implement the GFI protocols (and
+  `IBatchedSplice` for vectorized support). Additive.
+- **New agent family** → a `make-*-agent` constructor returning at least
+  `{:act :params}`, documented in `agents/CONTRACTS.md` with an enforcing test.
+
+Every new execution path must land with a law pinning it to the handler (the
+handler is ground truth; everything else is optimization) — the structural
+mitigation for "semantics enforced by convention" (ROADMAP Risk 3).


### PR DESCRIPTION
The Phase-1 **doc-truth pass** + **API-freeze manifest** — the last v1.0 documentation gate (bean genmlx-zp46, Task 2).

## What this is
An adversarially-verified ARCHITECTURE.md↔code sweep (multi-agent: every claimed divergence was *refuted* before applying — 5 audit findings were stale and correctly rejected). **15 confirmed divergences fixed; 58 claims verified accurate.** Load-bearing counts independently re-verified against the code (105 files, 43,066 lines, 212 @mlx-node/core exports, 85 genmlx.rs fns, 29 inference files, 11 protocols, 13 handler transitions).

## ARCHITECTURE.md
- handler-transition count 10 → **13** (7 scalar + 6 batched; names the general/retained-only regenerate paths)
- §3.1: corrected the "`mx/compile-fn` fuses a Metal kernel" claim — it is an **identity pass-through**; fusion comes from lazy-graph construction + the noise-transform compiler
- §4.2: trace-translator Jacobian uses `mx/logabsdet` (QR, on-device), not a host determinant
- §5.1: dispatcher name `custom-transition-dispatcher` → `custom-dispatcher`
- §5.3: **file-level map rewritten to the as-built tree** (adds `agents/`, `control/`, `world/`, `memory`, `steppable`, `cost`, `translator`, … — verified complete against `find src/genmlx`; `rewrite.cljs` de-duplicated)
- minor: enumerate snippet marked illustrative; `propose` added to the ops list

## CLAUDE.md
Stale counts refreshed as the codebase grew: 31,900/76 → **43,100/105** lines/files; `@mlx-node/core` exports 328 → **212** (coverage-matrix-pinned, scope clarified); `genmlx.rs` ~105 → **~85**; inference 26 → **29** files; law count dated; handler transitions 6+4 → **7+6**.

## docs/api-freeze.md (new)
The concrete v1.0 freeze manifest: each of the 6 ROADMAP commitments mapped to its **frozen surface + the tests/laws that pin it**, with honest gaps (`with-handler` pinned only indirectly; `eval!`-sole-effect enforced *structurally*) and provisional fences (`agents.remote`, `switch-method`) called out.

## Notes
- **Prose-only** (no code changed) — no test gates required.
- The companion gdtq anytime-control work (IBIS degeneracy fix + per-instance heterogeneity; honest result: adaptive VOC beats every fixed budget, hysteresis is a documented wash on conjugate schedules) lives in the gitignored local bench and is tracked on bean genmlx-gdtq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)