### PR TITLE
fix: spliced general-path combinator regen weight (genmlx-1a23) + vsmc vector-latent mask (genmlx-3nme)

### DIFF
--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -109,6 +109,25 @@
           ZERO
           results))
 
+(defn- rehydrate-element-meta
+  "Recover a combinator's per-element/per-step score metadata when it was lost
+   across a splice boundary (execute-sub reconstructs the child trace with only
+   ::splice-scores) or a serialize round-trip. We re-generate the trace fully
+   constrained from its own choices: generate re-threads sequential carry/state
+   and re-attaches ::element-scores / ::step-scores (recursively, for nested
+   combinators), reproducing the exact old per-element scores. The downstream
+   regenerate then takes its metadata-PRESENT path — which is correct for both
+   fast-eligible and general (project-based) kernels — instead of the
+   -(:score trace) re-base that ONLY undid the fast path's ZERO-old inflation
+   and was spurious (too low/high by the old combinator score) for a spliced
+   general-path kernel (genmlx-1a23). No-op when the metadata is already present
+   or there are no choices to reconstruct from."
+  [comb meta-key trace]
+  (if (or (meta-key (meta trace))
+          (empty? (cm/addresses (:choices trace))))
+    trace
+    (:trace (p/generate (ensure-kernel-key comb) (:args trace) (:choices trace)))))
+
 (defn- values->choices
   "Convert compiled result {:values {addr->val}} to a ChoiceMap."
   [values]
@@ -365,7 +384,8 @@
   ;; (:score trace). Correct at the end instead of silently returning wrong
   ;; weights (genmlx-v740). When metadata is present the path is unchanged.
   (regenerate [this trace selection]
-    (let [trace (ensure-joint-self this :regenerate trace)]
+    (let [trace (ensure-joint-self this :regenerate trace)
+          trace (rehydrate-element-meta this ::element-scores trace)]
      (if-let [cregen (cops/get-compiled-regenerate kernel)]
       ;; WP-9A: compiled regenerate path
       (let [old-choices (:choices trace)
@@ -743,6 +763,7 @@
   ;; recorded on (:score trace). Correct at the end (genmlx-v740).
   (regenerate [this trace selection]
     (let [trace (ensure-joint-self this :regenerate trace)
+          trace (rehydrate-element-meta this ::step-scores trace)
           kern (:kernel this)
           cregen (cops/get-compiled-regenerate kern)
           {:keys [args choices]} trace
@@ -1823,6 +1844,7 @@
   ;; Same ::step-scores-loss correction as Unfold regenerate (genmlx-v740).
   (regenerate [this trace selection]
     (let [trace (ensure-joint-self this :regenerate trace)
+          trace (rehydrate-element-meta this ::step-scores trace)
           kern (:kernel this)
           cregen (cops/get-compiled-regenerate kern)
           {:keys [args choices]} trace

--- a/src/genmlx/vectorized.cljs
+++ b/src/genmlx/vectorized.cljs
@@ -147,6 +147,22 @@
 ;; Merge two VectorizedTraces by boolean mask (for per-particle MH accept/reject)
 ;; ---------------------------------------------------------------------------
 
+(defn- mask->leaf-rank
+  "Reshape an [N] particle accept-mask to [N,1,...,1] matching the rank of a
+   leaf value v, so (mx/where ...) selects whole particles along the leading
+   particle axis and broadcasts over the trailing latent dims. Without this,
+   MLX right-aligned broadcasting aligns the [N] mask against the leaf's
+   trailing axis — a hard crash when N != D and a silent feature-axis mix when
+   N == D for vector-valued latents ([N,D]: gaussian-vec/broadcasted-normal/
+   dirichlet) (genmlx-3nme). Mirrors the leading-axis gather semantics that
+   reindex-choicemap already uses via take-idx. A rank-1 ([N]) leaf — the
+   scalar-latent case — needs no reshape, so this is identity there."
+  [mask v]
+  (let [r (count (mx/shape v))]
+    (if (> r 1)
+      (mx/reshape mask (into [(first (mx/shape mask))] (repeat (dec r) 1)))
+      mask)))
+
 (defn- merge-choicemap-by-mask
   "Recursively merge two identically-structured choicemaps using an [N] boolean mask.
    Where mask=true takes from proposed, where false keeps current."
@@ -154,7 +170,7 @@
   (walk-choicemap current
                   (fn [cv]
                     (let [pv (cm/get-value proposed)]
-                      (mx/where mask pv cv)))
+                      (mx/where (mask->leaf-rank mask cv) pv cv)))
                   (fn [k sub] (merge-choicemap-by-mask
                                 sub (cm/-get-submap proposed k) mask))))
 
@@ -165,7 +181,7 @@
   [cur prop mask]
   (cond
     (and (mx/array? cur) (mx/array? prop))
-    (mx/where mask prop cur)
+    (mx/where (mask->leaf-rank mask cur) prop cur)
 
     (and (map? cur) (map? prop))
     (into {} (map (fn [[k v]] [k (merge-state-by-mask v (get prop k) mask)])) cur)

--- a/test/genmlx/combinator_splice_general_regen_test.cljs
+++ b/test/genmlx/combinator_splice_general_regen_test.cljs
@@ -127,23 +127,23 @@
 ;; :m <per-index>). execute-sub reconstructs the child without ::element-scores,
 ;; so the rehydration path is exercised for real (not a manual strip).
 
+;; splice SPREADS its trailing args, so the Map's single arg (the input vector)
+;; is passed directly — (splice :m mcomb [0 1 2]) gives the Map args [[0 1 2]].
 (def parent
-  (dyn/auto-key (gen [] (splice :m (comb/map-combinator map-kernel) [[0.0 1.0 2.0]]))))
+  (dyn/auto-key (gen [] (splice :m (comb/map-combinator map-kernel) [0.0 1.0 2.0]))))
 
 (deftest map-through-real-splice-regen-weight
-  ;; This exercises the rehydration through a REAL splice (execute-sub drops
-  ;; ::element-scores). The genmlx-1a23 VALUE fix is verified here: the
-  ;; through-splice weight equals the project oracle. NOTE: a separate
-  ;; pre-existing bug (genmlx-d8j4) makes a spliced Map's weight/score [N]-
-  ;; broadcast rather than scalar — the value is correct in every entry, so we
-  ;; reduce both sides with mx/mean to compare the (broadcast) scalar value.
+  ;; Exercises the rehydration through a REAL splice (execute-sub drops
+  ;; ::element-scores). The genmlx-1a23 fix is verified end-to-end: the
+  ;; through-splice regen weight is scalar AND equals the project oracle.
   (let [sel-ab (sel/hierarchical :m (idx-paths 3 :a :b))
         ret    (sel/hierarchical :m (idx-paths 3 :c))
         tr     (p/simulate parent [])
         {tr2 :trace w :weight} (p/regenerate parent tr sel-ab)
         oracle (mx/subtract (p/project parent tr2 ret) (p/project parent tr ret))]
-    (is (close? (num (mx/mean w)) (num (mx/mean oracle)))
-        (str "through-splice weight = delta-project, got " (num (mx/mean w))
-             " vs oracle " (num (mx/mean oracle))))))
+    (is (= [] (mx/shape w)) "parent regen weight is scalar")
+    (is (close? (num w) (num oracle))
+        (str "through-splice weight = delta-project, got " (num w)
+             " vs oracle " (num oracle)))))
 
 (cljs.test/run-tests)

--- a/test/genmlx/combinator_splice_general_regen_test.cljs
+++ b/test/genmlx/combinator_splice_general_regen_test.cljs
@@ -1,0 +1,149 @@
+;; @tier fast core
+(ns genmlx.combinator-splice-general-regen-test
+  "genmlx-1a23: a Map/Unfold/Scan combinator spliced inside a parent gen-fn (or
+   serialize-round-tripped) loses its ::element-scores / ::step-scores metadata
+   at the splice boundary (execute-sub reconstructs the child trace with only
+   ::splice-scores). Before the fix the combinator regenerate fell into a
+   metadata-loss branch that returned `Σ_i W_i - (:score trace)`. The
+   -(:score trace) re-base ONLY undoes the FAST per-site path's ZERO-old
+   inflation; for a GENERAL (project-based, retained-only) kernel each W_i is
+   already correct, so the subtraction made the combinator (and the parent it
+   feeds) wrong by exactly the old combinator score.
+
+   The fix rehydrates the lost metadata by re-generating the trace fully
+   constrained from its own choices, so regenerate takes its correct
+   metadata-present path for both fast and general kernels.
+
+   ORACLE (independent of the code under test): a prior-proposal regenerate
+   weight equals Δ over the RETAINED leaf densities, i.e.
+   project(new, retained) - project(old, retained). Validated below against a
+   bare DynamicGF kernel whose weight has an independent hand-computed value.
+
+   NOTE: per-element/per-step sites live UNDER an integer index, so the proper
+   selection is `(from-paths [[i :addr] ...])`, NOT a flat `(select :addr)`
+   (which descends to nothing per element — the reason the prior
+   combinator_nested_regen_test asserted 0==0 vacuously)."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.combinators :as comb]
+            [genmlx.gfi :as gfi]
+            [genmlx.mlx.random :as rng])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(defn- num [x] (mx/eval! x) (mx/item x))
+(defn- close? [a b] (< (js/Math.abs (- a b)) 1e-3))
+(defn- idx-paths [n & addrs] (sel/from-paths (mapcat (fn [i] (map (fn [a] [i a]) addrs)) (range n))))
+(defn- strip [k trace] (with-meta trace (dissoc (meta trace) k)))
+
+(def ELEM ::comb/element-scores)
+(def STEP ::comb/step-scores)
+
+;; ── Oracle sanity: bare general-path kernel ────────────────────────────────
+;; a→b→c chain; select {:a :b} (interdependent ⇒ general path), retain {:c}.
+;; Hand value: lp(c0; b') - lp(c0; b0). Confirms delta-project is the right oracle.
+
+(def chain
+  (dyn/auto-key (gen [m] (let [a (trace :a (dist/gaussian m 1))
+                               b (trace :b (dist/gaussian a 1))
+                               c (trace :c (dist/gaussian b 1))]
+                           c))))
+
+(deftest bare-kernel-oracle-is-valid
+  (is (not (#'dyn/regen-fast-eligible? chain (sel/select :a :b)))
+      "chain + {:a :b} must force the general path (anti-vacuity)")
+  (let [tr  (p/simulate (dyn/with-key chain (rng/fresh-key 7)) [0.0])
+        cv  (fn [t a] (num (cm/get-value (cm/get-submap (:choices t) a))))
+        r   (p/regenerate chain tr (sel/select :a :b))
+        tr2 (:trace r)
+        hand (- (num (dist/log-prob (dist/gaussian (mx/scalar (cv tr2 :b)) 1) (mx/scalar (cv tr :c))))
+                (num (dist/log-prob (dist/gaussian (mx/scalar (cv tr :b)) 1)  (mx/scalar (cv tr :c)))))
+        dproj (mx/subtract (p/project chain tr2 (sel/select :c))
+                           (p/project chain tr  (sel/select :c)))]
+    (is (not= (cv tr :b) (cv tr2 :b)) ":b resampled")
+    (is (= (cv tr :c) (cv tr2 :c)) ":c retained")
+    (is (close? (num (:weight r)) hand) "bare weight = hand density ratio")
+    (is (close? (num (:weight r)) (num dproj)) "bare weight = delta-project")))
+
+;; ── Generic checker: combinator regenerate weight = delta-project, both with
+;;    metadata intact AND with it stripped (splice/serialize loss). ──────────
+
+(defn- check-meta-loss [label comb meta-key sel-sites ret-sites args resampled-path]
+  (let [comb (dyn/with-key comb (rng/fresh-key 7))
+        dp   (fn [old new] (mx/subtract (p/project comb new ret-sites)
+                                        (p/project comb old ret-sites)))
+        tr   (p/simulate comb args)
+        cval (fn [t path] (num (cm/get-value (reduce cm/get-submap (:choices t) path))))
+        ;; metadata intact (control)
+        r1   (p/regenerate comb tr sel-sites)
+        ;; metadata stripped (the spliced / serialize-loss condition)
+        tr0  (strip meta-key tr)
+        r2   (p/regenerate comb tr0 sel-sites)]
+    (testing (str label " — metadata intact")
+      (is (not= (cval tr resampled-path) (cval (:trace r1) resampled-path))
+          (str label " resampled a selected site (anti-vacuity)"))
+      (is (close? (num (:weight r1)) (num (dp tr (:trace r1))))
+          (str label " intact: weight = delta-project")))
+    (testing (str label " — metadata stripped (splice / serialize loss)")
+      (is (close? (num (:weight r2)) (num (dp tr0 (:trace r2))))
+          (str label " stripped: weight = delta-project, got " (num (:weight r2))
+               " vs oracle " (num (dp tr0 (:trace r2))))))))
+
+;; general-path kernels (a→b chain forces general; the combinator state/carry is
+;; decoupled from the resampled sites so each element/step is independent).
+(def map-kernel    (dyn/auto-key (gfi/strip-compiled chain)))
+(def unfold-kernel (dyn/auto-key (gfi/strip-compiled
+                                   (gen [_t _prev]
+                                        (let [a (trace :a (dist/gaussian 0 1))
+                                              b (trace :b (dist/gaussian a 1))]
+                                          (trace :c (dist/gaussian b 1))
+                                          (mx/scalar 0.0))))))
+(def scan-kernel   (dyn/auto-key (gfi/strip-compiled
+                                   (gen [carry _input]
+                                        (let [a (trace :a (dist/gaussian 0 1))
+                                              b (trace :b (dist/gaussian a 1))]
+                                          (trace :c (dist/gaussian b 1))
+                                          [carry (mx/scalar 0.0)])))))
+
+(deftest map-spliced-general-regen-weight
+  (check-meta-loss "Map" (comb/map-combinator map-kernel) ELEM
+                   (idx-paths 3 :a :b) (idx-paths 3 :c) [[0.0 1.0 2.0]] [0 :a]))
+
+(deftest unfold-spliced-general-regen-weight
+  (check-meta-loss "Unfold" (comb/unfold-combinator unfold-kernel) STEP
+                   (idx-paths 3 :a :b) (idx-paths 3 :c) [3 (mx/scalar 0.0)] [0 :a]))
+
+(deftest scan-spliced-general-regen-weight
+  (check-meta-loss "Scan" (comb/scan-combinator scan-kernel) STEP
+                   (idx-paths 3 :a :b) (idx-paths 3 :c)
+                   [(mx/scalar 0.0) [(mx/scalar 0.0) (mx/scalar 1.0) (mx/scalar 2.0)]] [0 :a]))
+
+;; ── End-to-end THROUGH A REAL SPLICE (the actual reported condition) ───────
+;; A parent gen-fn that only splices the combinator; regenerate (hierarchical
+;; :m <per-index>). execute-sub reconstructs the child without ::element-scores,
+;; so the rehydration path is exercised for real (not a manual strip).
+
+(def parent
+  (dyn/auto-key (gen [] (splice :m (comb/map-combinator map-kernel) [[0.0 1.0 2.0]]))))
+
+(deftest map-through-real-splice-regen-weight
+  ;; This exercises the rehydration through a REAL splice (execute-sub drops
+  ;; ::element-scores). The genmlx-1a23 VALUE fix is verified here: the
+  ;; through-splice weight equals the project oracle. NOTE: a separate
+  ;; pre-existing bug (genmlx-d8j4) makes a spliced Map's weight/score [N]-
+  ;; broadcast rather than scalar — the value is correct in every entry, so we
+  ;; reduce both sides with mx/mean to compare the (broadcast) scalar value.
+  (let [sel-ab (sel/hierarchical :m (idx-paths 3 :a :b))
+        ret    (sel/hierarchical :m (idx-paths 3 :c))
+        tr     (p/simulate parent [])
+        {tr2 :trace w :weight} (p/regenerate parent tr sel-ab)
+        oracle (mx/subtract (p/project parent tr2 ret) (p/project parent tr ret))]
+    (is (close? (num (mx/mean w)) (num (mx/mean oracle)))
+        (str "through-splice weight = delta-project, got " (num (mx/mean w))
+             " vs oracle " (num (mx/mean oracle))))))
+
+(cljs.test/run-tests)

--- a/test/genmlx/vectorized_mask_merge_test.cljs
+++ b/test/genmlx/vectorized_mask_merge_test.cljs
@@ -1,0 +1,88 @@
+;; @tier fast core
+(ns genmlx.vectorized-mask-merge-test
+  "genmlx-3nme: vsmc rejuvenation merges accepted/rejected particles with an
+   [N] boolean mask via (mx/where mask proposed current). For a VECTOR-valued
+   latent leaf shaped [N,D] (dist/gaussian-vec / broadcasted-normal / dirichlet)
+   MLX right-aligned broadcasting aligned the [N] mask against the trailing D
+   axis: N != D crashed through NAPI; N == D silently broadcast to [N,N] and
+   applied the accept/reject decision along the FEATURE axis (mixing components
+   within a particle). The fix reshapes the [N] mask to [N,1,...] so it selects
+   whole particles along the leading axis and broadcasts over latent dims —
+   matching reindex-choicemap's take-idx gather semantics.
+
+   ORACLE: a host-side per-particle select (row i from proposed if mask[i] else
+   from current), independent of the code under test."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.mlx :as mx]
+            [genmlx.choicemap :as cm]
+            [genmlx.vectorized :as vz]))
+
+(defn- ->clj [x] (mx/eval! x) (mx/->clj x))
+
+(defn- mask-from [bits] (mx/greater (mx/array (mapv double bits)) (mx/scalar 0.5)))
+
+(defn- host-merge
+  "Reference: row i = proposed-rows[i] if bits[i] else current-rows[i]."
+  [bits current-rows proposed-rows]
+  (mapv (fn [b c p] (if (pos? b) p c)) bits current-rows proposed-rows))
+
+(defn- leaf [merged addr] (->clj (cm/get-value (cm/get-submap merged addr))))
+
+(defn- vtrace [choices score retval]
+  {:choices choices :score score :retval retval :n-particles (first (mx/shape score))})
+
+;; ── [N,D] vector latent, N != D : crashed before the fix ────────────────────
+
+(deftest vector-latent-mask-merge-N-not-D
+  (let [bits [1 0 1 0]                           ; N=4
+        cur-rows [[0.0 0.0 0.0] [0.0 0.0 0.0] [0.0 0.0 0.0] [0.0 0.0 0.0]]  ; D=3
+        prop-rows [[1.0 1.0 1.0] [1.0 1.0 1.0] [1.0 1.0 1.0] [1.0 1.0 1.0]]
+        cur  (vtrace (cm/set-choice cm/EMPTY [:mu] (mx/array cur-rows))  (mx/array [0.0 0.0 0.0 0.0]) nil)
+        prop (vtrace (cm/set-choice cm/EMPTY [:mu] (mx/array prop-rows)) (mx/array [1.0 1.0 1.0 1.0]) nil)
+        merged (vz/merge-vtraces-by-mask cur prop (mask-from bits))]
+    (testing "no NAPI broadcast crash, whole-particle selection"
+      (is (= (host-merge bits cur-rows prop-rows) (leaf (:choices merged) :mu))
+          "row i taken whole from proposed iff mask[i]")
+      (is (= [4 3] (mx/shape (cm/get-value (cm/get-submap (:choices merged) :mu))))
+          "leaf shape preserved [N,D]"))))
+
+;; ── [N,D] vector latent, N == D : silently feature-mixed before the fix ─────
+
+(deftest vector-latent-mask-merge-N-equals-D
+  (let [bits [1 0 1]                              ; N=3
+        cur-rows [[0.0 0.0 0.0] [0.0 0.0 0.0] [0.0 0.0 0.0]]  ; D=3
+        prop-rows [[1.0 1.0 1.0] [1.0 1.0 1.0] [1.0 1.0 1.0]]
+        cur  (vtrace (cm/set-choice cm/EMPTY [:mu] (mx/array cur-rows))  (mx/array [0.0 0.0 0.0]) nil)
+        prop (vtrace (cm/set-choice cm/EMPTY [:mu] (mx/array prop-rows)) (mx/array [1.0 1.0 1.0]) nil)
+        merged (vz/merge-vtraces-by-mask cur prop (mask-from bits))]
+    (testing "no feature-axis mixing — each row is wholly current or proposed"
+      (is (= [[1.0 1.0 1.0] [0.0 0.0 0.0] [1.0 1.0 1.0]] (leaf (:choices merged) :mu))
+          "accept along the particle axis, not the feature axis"))))
+
+;; ── retval (merge-state-by-mask) with [N,D] arrays ──────────────────────────
+
+(deftest vector-retval-mask-merge
+  (let [bits [0 1 1]
+        cur-rows [[0.0 0.0] [0.0 0.0] [0.0 0.0]]
+        prop-rows [[1.0 1.0] [1.0 1.0] [1.0 1.0]]
+        cur  (vtrace cm/EMPTY (mx/array [0.0 0.0 0.0]) (mx/array cur-rows))
+        prop (vtrace cm/EMPTY (mx/array [1.0 1.0 1.0]) (mx/array prop-rows))
+        merged (vz/merge-vtraces-by-mask cur prop (mask-from bits))]
+    (is (= (host-merge bits cur-rows prop-rows) (->clj (:retval merged)))
+        "retval [N,D] merged whole-particle")))
+
+;; ── scalar [N] latent : reshape is a no-op, behaviour unchanged ─────────────
+
+(deftest scalar-latent-mask-merge-unchanged
+  (let [bits [1 0 1 1]
+        cur-v  [10.0 20.0 30.0 40.0]
+        prop-v [11.0 21.0 31.0 41.0]
+        cur  (vtrace (cm/set-choice cm/EMPTY [:x] (mx/array cur-v))  (mx/array [0.0 0.0 0.0 0.0]) nil)
+        prop (vtrace (cm/set-choice cm/EMPTY [:x] (mx/array prop-v)) (mx/array [1.0 1.0 1.0 1.0]) nil)
+        merged (vz/merge-vtraces-by-mask cur prop (mask-from bits))]
+    (is (= [11.0 20.0 31.0 41.0] (leaf (:choices merged) :x))
+        "scalar [N] leaf still selected element-wise by the mask")
+    (is (= [1.0 0.0 1.0 1.0] (->clj (:score merged)))
+        "[N] score selected by the same mask")))
+
+(cljs.test/run-tests)


### PR DESCRIPTION
Fixes two HIGH-severity correctness bugs surfaced by an adversarially-verified bug hunt over the GFI/inference paths. Both live in the vector-latent / spliced-combinator blind spot that prior vmap fixes (nt0c/v740) never reached.

## genmlx-1a23 — spliced general-path combinator regenerate weight

A `Map`/`Unfold`/`Scan` combinator spliced inside a parent gen-fn (or serialize-round-tripped) loses its `::element-scores`/`::step-scores` at the splice boundary — `execute-sub` reconstructs the child trace with only `::splice-scores`. Regenerate then fell into a metadata-loss branch returning `Σ_i W_i − (:score trace)`. That `−(:score trace)` re-base only undoes the **fast** per-site path's ZERO-old inflation; for a **general** (project-based, retained-only) kernel each `W_i` is already correct, so the subtraction made the weight — and the parent MH/IS weight it feeds — wrong by exactly the old combinator score.

**Fix** (`combinators.cljs`): `rehydrate-element-meta` re-generates the trace fully constrained from its own choices when the metadata is absent, restoring `::element-scores`/`::step-scores` (re-threads sequential carry/state; self-heals nested combinators recursively). Regenerate then takes its correct metadata-present path for both fast and general kernels — no splice-boundary plumbing needed.

Root cause confirmed empirically (strip-compiled forces the fallback): the stripped weight was off by exactly `(:score trace)`; after the fix `weight == project oracle`.

## genmlx-3nme — vsmc rejuvenation mask vs vector latents

vsmc rejuvenation merged accepted/rejected particles with `(mx/where [N]-mask ...)` applied directly to `[N,D]` vector latents (`gaussian-vec`/`broadcasted-normal`/`dirichlet`). MLX right-aligned broadcasting aligned the `[N]` mask against the trailing `D` axis: **N≠D crashed** through NAPI; **N==D silently mixed feature components** within each particle.

**Fix** (`vectorized.cljs`): `mask->leaf-rank` reshapes the `[N]` mask to `[N,1,…]` so it selects whole particles along the leading axis (matching `reindex-choicemap`'s `take-idx` gather). Scalar `[N]` leaves are a rank-1 no-op, so the scalar path is byte-identical.

## Tests

- `combinator_splice_general_regen_test` — Map/Unfold/Scan, direct metadata-loss **and** through a real splice; oracle = `delta-project` validated against a bare-kernel hand value, with **non-vacuous per-index selections** (which exposed that 7opt's `map-single`/`map-of-map` tests asserted `0==0` — a flat `(select :a :b)` selects nothing per indexed Map element).
- `vectorized_mask_merge_test` — `[N,D]` merge vs a host oracle: N≠D (no crash), N==D (no feature mixing), `[N,D]` retval, scalar `[N]` no-op.

## A scrapped finding (genmlx-d8j4)

While verifying, a follow-up "shape leak" filed during the hunt turned out to be a **repro artifact, not a defect**: `splice` *spreads* its trailing args, so a double-wrapped `(splice :m mcomb [[0 1 2]])` ran one Map element with a `[3]`-vector latent (a scalar gaussian over a `[3]` mean legitimately gives `[3]` per-component log-probs). With correct args `(splice :m mcomb [0 1 2])` the spliced regen weight is scalar and equals the oracle. The through-splice test now uses correct arg-spread and asserts both scalar shape and value. d8j4 scrapped.

## Verification — no regressions

combinator_nested_regen (9) · combinator_regen_weight (11) · combinators/compile **92/92** · partial_compile **92/92** · gfi_combinator_invariants (334) · serialize · SMC · vectorized · MCMC · all batched/combinator variants · level0 **68/68** · l4 **41/41** · gen_clj **356/356** · genjax **73/73**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)