### PR TITLE
fix: 5 verified bug-hunt remnants — compiled/analytical parity + batched/diagnostics hygiene

### DIFF
--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -37,6 +37,21 @@
     kern
     (vary-meta kern assoc :genmlx.dynamic/key :genmlx.dynamic/auto-key)))
 
+(defn- splice-key
+  "The entropy seed for a combinator GFI op. Returns a REAL PRNG key threaded in
+   via :genmlx.dynamic/key metadata (the batched-splice fallback attaches a
+   per-particle key so a spliced non-DynamicGF combinator descends entropy from
+   the threaded top-level key instead of self-seeding via js/Math.random —
+   genmlx-9ssv), otherwise a fresh self-seeded key. The :genmlx.dynamic/auto-key
+   sentinel (set by ensure-kernel-key) means 'self-seed', so it falls through to
+   fresh-key. Behaviour is IDENTICAL to the old (rng/fresh-key) for any caller
+   that does not attach a real key."
+  [this]
+  (let [k (:genmlx.dynamic/key (meta this))]
+    (if (and (some? k) (not= k :genmlx.dynamic/auto-key))
+      k
+      (rng/fresh-key))))
+
 ;; ---------------------------------------------------------------------------
 ;; Score-type propagation (genmlx-lbae)
 ;;
@@ -169,7 +184,7 @@
   "Fused Map simulate: all N elements in one call via broadcasting."
   [this args kernel fused-fn addr-order]
   (let [n (count (first args))
-        key (rng/fresh-key)
+        key (splice-key this)
         stacked-args (mapv (fn [arg-col]
                              (mx/stack (mapv mx/ensure-array arg-col)))
                            args)
@@ -191,7 +206,7 @@
   "Compiled Map simulate: call compiled-simulate per element."
   [this args kernel csim]
   (let [n (count (first args))
-        init-key (rng/fresh-key)
+        init-key (splice-key this)
         results (loop [i 0 key init-key acc []]
                   (if (>= i n)
                     acc
@@ -247,7 +262,7 @@
     (if-let [cgen (cops/get-compiled-generate kernel)]
       ;; Compiled path — call compiled-generate directly per element
       (let [n (count (first args))
-            init-key (rng/fresh-key)]
+            init-key (splice-key this)]
         (loop [i 0 key init-key
                choices cm/EMPTY score ZERO weight ZERO
                retvals [] element-scores []]
@@ -295,7 +310,7 @@
       (let [old-choices (:choices trace)
             args (:args trace)
             n (count (first args))
-            init-key (rng/fresh-key)]
+            init-key (splice-key this)]
         (loop [i 0 key init-key
                choices cm/EMPTY score ZERO discard cm/EMPTY
                retvals [] element-scores []]
@@ -372,7 +387,7 @@
             args (:args trace)
             n (count (first args))
             old-element-scores (::element-scores (meta trace))
-            init-key (rng/fresh-key)]
+            init-key (splice-key this)]
         (loop [i 0 key init-key
                choices cm/EMPTY score ZERO weight ZERO
                retvals [] element-scores []]
@@ -505,7 +520,7 @@
   [this args kernel fused-cache n init-state extra]
   (let [{:keys [compiled-fn addr-order noise-site-types state-keys]}  ; noise-dim unused (genmlx-21kt)
         (get-or-build-fused-unfold fused-cache kernel n extra)
-        key (rng/fresh-key)
+        key (splice-key this)
         noise (cops/generate-noise-matrix key n noise-site-types)
         ;; Pack map init-state to flat [N] array for compiled fn
         init-flat (if state-keys
@@ -525,7 +540,7 @@
 (defn- unfold-simulate-compiled
   "Compiled Unfold simulate: call compiled-simulate per step."
   [this args kernel n init-state extra csim]
-  (let [init-key (rng/fresh-key)]
+  (let [init-key (splice-key this)]
     (loop [t 0 state init-state key init-key
            choices cm/EMPTY score ZERO
            states [] step-scores []]
@@ -584,7 +599,7 @@
     (let [[n init-state & extra] args]
       (if-let [cgen (cops/get-compiled-generate kernel)]
         ;; Compiled path
-        (let [init-key (rng/fresh-key)]
+        (let [init-key (splice-key this)]
           (loop [t 0 state init-state key init-key
                  choices cm/EMPTY score ZERO weight ZERO
                  states [] step-scores []]
@@ -670,7 +685,7 @@
               start-state (if (pos? first-changed)
                             (nth (:retval trace) (dec first-changed))
                             init-state)
-              init-key (when cupd (rng/fresh-key))]
+              init-key (when cupd (splice-key this))]
           ;; Execute steps first-changed..n-1. `nf` accumulates the non-fresh
           ;; score: prefix steps are retained verbatim (their non-fresh score
           ;; is the recorded prefix score); compiled steps never sample fresh
@@ -748,7 +763,7 @@
           {:keys [args choices]} trace
           [n init-state & extra] args
           old-step-scores (::step-scores (meta trace))
-          init-key (when cregen (rng/fresh-key))]
+          init-key (when cregen (splice-key this))]
       (loop [t 0 state init-state key init-key
              new-choices cm/EMPTY score ZERO weight ZERO
              states [] step-scores [] st :joint]
@@ -926,7 +941,7 @@
           branch (nth branches idx)]
       (if-let [csim (cops/get-compiled-simulate branch)]
         ;; L1-M5: compiled path
-        (let [key (rng/fresh-key)
+        (let [key (splice-key this)
               result (csim key (vec branch-args))
               choices (cm/from-flat-map (:values result))]
           (tag-joint
@@ -953,7 +968,7 @@
           branch (nth branches idx)]
       (if-let [cgen (cops/get-compiled-generate branch)]
         ;; Compiled path
-        (let [key (rng/fresh-key)
+        (let [key (splice-key this)
               result (cgen key (vec branch-args) constraints)
               choices (values->choices (:values result))]
           {:trace (tag-joint
@@ -989,7 +1004,7 @@
               cupd (cops/get-compiled-update branch)]
           (if cupd
             ;; WP-8: compiled update path
-            (let [key (rng/fresh-key)
+            (let [key (splice-key this)
                   result (cupd key (vec branch-args) constraints (:choices trace))
                   new-choices (values->choices (:values result))
                   new-discard (values->choices (:discard result))]
@@ -1045,7 +1060,7 @@
           branch (nth (:branches this) idx)]
       (if-let [cregen (cops/get-compiled-regenerate branch)]
         ;; WP-9A: compiled regenerate path
-        (let [key (rng/fresh-key)
+        (let [key (splice-key this)
               result (cregen key (vec branch-args) (:choices trace) selection)
               new-choices (values->choices (:values result))
               ;; compiled-regenerate returns proposal_ratio in :weight
@@ -1567,7 +1582,7 @@
   [this args kernel fused-cache init-carry inputs n]
   (let [{:keys [compiled-fn addr-order noise-site-types]}  ; noise-dim unused (genmlx-21kt)
         (get-or-build-fused-scan fused-cache kernel n)
-        key (rng/fresh-key)
+        key (splice-key this)
         noise (cops/generate-noise-matrix key n noise-site-types)
         [outputs-tensor scores-tensor total-score]
         (compiled-fn (mx/ensure-array init-carry)
@@ -1588,7 +1603,7 @@
 (defn- scan-simulate-compiled
   "Compiled Scan simulate: call compiled-simulate per step."
   [this args kernel init-carry inputs n csim]
-  (let [init-key (rng/fresh-key)]
+  (let [init-key (splice-key this)]
     (loop [t 0 carry init-carry key init-key
            choices cm/EMPTY score ZERO
            outputs [] step-scores [] step-carries []]
@@ -1656,7 +1671,7 @@
           n (count inputs)]
       (if-let [cgen (cops/get-compiled-generate kernel)]
         ;; Compiled path
-        (let [init-key (rng/fresh-key)]
+        (let [init-key (splice-key this)]
           (loop [t 0 carry init-carry key init-key
                  choices cm/EMPTY score ZERO weight ZERO
                  outputs [] step-scores [] step-carries []]
@@ -1754,7 +1769,7 @@
               start-carry (if (pos? first-changed)
                             (nth old-step-carries (dec first-changed))
                             init-carry)
-              init-key (when cupd (rng/fresh-key))]
+              init-key (when cupd (splice-key this))]
           ;; Execute steps first-changed..n-1. `nf` accumulates the non-fresh
           ;; score (see Unfold update for the convention); final thesis
           ;; weight = nf - old_total.
@@ -1829,7 +1844,7 @@
           [init-carry inputs] args
           n (count inputs)
           old-step-scores (::step-scores (meta trace))
-          init-key (when cregen (rng/fresh-key))]
+          init-key (when cregen (splice-key this))]
       (loop [t 0 carry init-carry key init-key
              new-choices cm/EMPTY score ZERO weight ZERO
              outputs [] step-scores [] step-carries [] st :joint]
@@ -2095,7 +2110,7 @@
           component (nth components (int idx))]
       (if-let [csim (cops/get-compiled-simulate component)]
         ;; L1-M5: compiled path
-        (let [key (rng/fresh-key)
+        (let [key (splice-key this)
               result (csim key (vec args))
               choices (cm/from-flat-map (:values result))
               choices (cm/set-choice choices [:component-idx]
@@ -2133,7 +2148,7 @@
           comp-constraints (without-component-idx constraints)]
       (if-let [cgen (cops/get-compiled-generate component)]
         ;; Compiled path — only the component generate is compiled
-        (let [key (rng/fresh-key)
+        (let [key (splice-key this)
               result (cgen key (vec args) comp-constraints)
               comp-choices (values->choices (:values result))]
           {:trace (tag-joint
@@ -2290,7 +2305,7 @@
               cupd (cops/get-compiled-update component)]
           (if cupd
             ;; WP-8: compiled update path
-            (let [key (rng/fresh-key)
+            (let [key (splice-key this)
                   result (cupd key (vec args) inner-constraints inner-old-choices)
                   inner-score (:score result)
                   new-score (mx/add inner-score old-idx-score)
@@ -2419,7 +2434,7 @@
               inner-old-choices (without-component-idx old-choices)]
           (if-let [cregen (cops/get-compiled-regenerate component)]
             ;; WP-9A: compiled regenerate path
-            (let [key (rng/fresh-key)
+            (let [key (splice-key this)
                   result (cregen key (vec args) inner-old-choices selection)
                   inner-score (:score result)
                   new-score (mx/add inner-score old-idx-score)

--- a/src/genmlx/compiled.cljs
+++ b/src/genmlx/compiled.cljs
@@ -694,7 +694,21 @@
    {:noise-fn nil ;; no randomness
     :transform nil ;; value = first dist-arg
     :log-prob (fn [v param]
-                (mx/where (mx/equal v param) ZERO NEG-INF))}
+                ;; Reduce the trailing event axes to the JOINT point-mass
+                ;; log-prob: 0 iff ALL elements match, else -Inf. Mirrors the
+                ;; handler delta (dist.cljs, genmlx-exw9). Without this a vector
+                ;; point mass (dist/delta <tensor>) scores an elementwise [T]
+                ;; mask instead of a joint scalar, so two of three mismatched
+                ;; components could read finite while the joint must be -Inf,
+                ;; and the [T] mask broadcasts the scalar accumulator to [T]
+                ;; (compiled != handler — genmlx-kftc). Event rank is taken from
+                ;; the dist arg (param), so any leading batch axis is preserved;
+                ;; a scalar point mass (ev=0) is unchanged.
+                (let [eq (mx/equal v param)
+                      ev (count (mx/shape param))
+                      joint (reduce (fn [m _] (mx/all m (dec (count (mx/shape m)))))
+                                    eq (range ev))]
+                  (mx/where joint ZERO NEG-INF)))}
 
    :laplace
    {:noise-fn (fn [key] (rng/uniform key []))

--- a/src/genmlx/conjugacy.cljs
+++ b/src/genmlx/conjugacy.cljs
@@ -171,6 +171,30 @@
    scored as if rate were lambda."
   #{:normal-normal})
 
+(defn- provably-vector-sigma-form?
+  "Best-effort static check: is this source form a provably non-scalar
+   (vector/tensor) value? Recognizes a bare vector literal and (mx/array
+   <vector-literal>) — the common way a per-element [T] sigma is written in a
+   gen body. EARLY-decline signal only; the runtime backstop in the
+   :normal-iid-normal update-step is the correctness guarantee for any [T] sigma
+   expressed differently (a model arg, a let-binding)."
+  [form]
+  (boolean
+    (or (vector? form)
+        (and (seq? form) (seq form) (symbol? (first form))
+             (= "array" (name (first form)))
+             (vector? (second form))))))
+
+(defn- heteroscedastic-iid-obs?
+  "An :iid-gaussian obs whose sigma (dist-arg index 1) is a provably non-scalar
+   [T] vector. The homoscedastic normal-iid-normal conjugate form (the only
+   closed form GenMLX implements) is INVALID for a per-element sigma — the
+   correct marginal is N(y; m0*1, diag(sigma_i^2)+tau2 11^T), not the scalar-s2
+   form — so it must not be detected as conjugate (genmlx-symr)."
+  [obs-site]
+  (and (= :iid-gaussian (:dist-type obs-site))
+       (provably-vector-sigma-form? (nth (:dist-args obs-site) 1 nil))))
+
 (defn detect-conjugate-pairs
   "Scan schema trace sites for conjugate pairs.
 
@@ -190,6 +214,9 @@
         site-map (into {} (map (juxt :addr identity)) static-sites)]
     (vec
       (for [obs-site static-sites
+            ;; genmlx-symr: a heteroscedastic [T]-sigma iid-gaussian obs is NOT
+            ;; conjugate under the homoscedastic closed form — decline it early.
+            :when (not (heteroscedastic-iid-obs? obs-site))
             prior-addr (:deps obs-site)
             :let [prior-site (get site-map prior-addr)]
             :when prior-site

--- a/src/genmlx/dynamic.cljs
+++ b/src/genmlx/dynamic.cljs
@@ -1407,13 +1407,23 @@
                                (fn [rt] (run-body gf rt exec-args)))
         ;; Thesis update weight: non-fresh score minus old [N]-shaped score —
         ;; the same convention as the scalar run-update path.
-        weight (mx/subtract (:weight result) (:score vtrace))]
+        weight (mx/subtract (:weight result) (:score vtrace))
+        ;; On a structure-shrinking move (e.g. a host-arg branch flip that visits
+        ;; :b under new args, deleting :a), the batched-update-transition writes
+        ;; :discard only for OVERWRITTEN choices, never the un-revisited old
+        ;; addresses. Mirror the scalar p/update / p/update-with-args
+        ;; post-process so deleted old addresses (with their [N]-shaped values)
+        ;; appear in the discard, keeping forward/reverse round-trips recoverable
+        ;; (genmlx-6v3h). The weight is unaffected — the deleted site is already
+        ;; charged via the old [N]-shaped score.
+        discard (add-deleted-to-discard (:discard result)
+                                        (:choices vtrace) (:choices result))]
     {:vtrace (tag-vtrace
                (vec/->VectorizedTrace gf exec-args (:choices result)
                                       (:score result) weight
                                       n (:retval result)))
      :weight weight
-     :discard (:discard result)}))
+     :discard discard}))
 
 (defn vupdate
   "Batched update: run model body ONCE with batched update handler.

--- a/src/genmlx/handler.cljs
+++ b/src/genmlx/handler.cljs
@@ -493,7 +493,14 @@
    Unstacks [N]-particle state, runs combinator GFI N times, stacks results."
   [state addr gf args]
   (let [n (:batch-size state)
-        [k1 k2] (rng/split (:key state))
+        ;; Per-particle keys + one carry key. Attaching each particle's key to
+        ;; the spliced combinator (via :genmlx.dynamic/key metadata, read by
+        ;; combinators/splice-key) makes a spliced non-DynamicGF combinator
+        ;; descend entropy from the threaded top-level key instead of
+        ;; self-seeding via js/Math.random — so two runs under a fixed key are
+        ;; bit-identical (genmlx-9ssv). The carry key replaces the old dead k2.
+        part-keys (rng/split-n (:key state) (inc n))
+        k-carry (nth part-keys n)
         ;; Extract scoped state
         sub-constraints (cm/get-submap (:constraints state) addr)
         sub-old-choices (cm/get-submap (:old-choices state) addr)
@@ -518,11 +525,11 @@
                             ;; Scalar constraints: replicate
                             (vec (repeat n sub-constraints))
                             (cm/unstack-choicemap sub-constraints n mx/index scalar-leaf-val?)))
-        ;; Run per-particle
+        ;; Run per-particle, each with its own threaded key on the combinator
         results (mapv
                  (fn [i]
                    (run-batched-particle
-                    gf
+                    (vary-meta gf assoc :genmlx.dynamic/key (nth part-keys i))
                     (mapv #(extract-scalar-arg % i) args)
                     sub-selection
                     (when per-old-choices (nth per-old-choices i))
@@ -531,6 +538,6 @@
         ;; Stack results and merge into parent state
         sub-result (stack-particle-results results)
         state' (-> state
-                   (assoc :key k1)
+                   (assoc :key k-carry)
                    (merge-sub-result addr sub-result))]
     [state' (:retval sub-result)]))

--- a/src/genmlx/inference/auto_analytical.cljs
+++ b/src/genmlx/inference/auto_analytical.cljs
@@ -264,9 +264,24 @@
    {:init-posterior (fn [{:keys [mu sigma]}] {:mean mu :var (mx/multiply sigma sigma)})
     :posterior-mean :mean
     :update-step (fn [posterior obs-value {:keys [sigma]}]
-                   (let [obs-var (mx/multiply sigma sigma)
-                         {:keys [mean var ll]} (nn-iid-update-step posterior obs-value obs-var)]
-                     {:posterior {:mean mean :var var} :ll ll}))}
+                   (let [obs-var (mx/multiply sigma sigma)]
+                     ;; nn-iid-update-step hard-codes the HOMOSCEDASTIC
+                     ;; normal-iid-normal closed form (det Sigma =
+                     ;; (s2)^(T-1)*(s2+T*tau2), etc.), treating obs-var as a
+                     ;; SCALAR s2. A per-element [T] sigma (heteroscedastic
+                     ;; iid-gaussian) is a different MVN marginal
+                     ;; N(y; m0*1, diag(sigma_i^2)+tau2 11^T); the homoscedastic
+                     ;; form silently mis-scores it as a [T]-shaped ll. Bail to
+                     ;; the handler joint path, which scores the per-element sigma
+                     ;; correctly via dist-log-prob :iid-gaussian (genmlx-symr).
+                     ;; This is the correctness guarantee: it catches a [T] sigma
+                     ;; however it is expressed, even when detect-conjugate-pairs'
+                     ;; static gate could not prove the shape.
+                     (when (seq (mx/shape obs-var))
+                       (throw (ex-info "heteroscedastic [T]-sigma iid-gaussian: homoscedastic conjugate form invalid; bailing analytical elimination to the handler joint path"
+                                       {:genmlx.analytical/bail true})))
+                     (let [{:keys [mean var ll]} (nn-iid-update-step posterior obs-value obs-var)]
+                       {:posterior {:mean mean :var var} :ll ll})))}
    :beta-bernoulli
    {:init-posterior (fn [{:keys [alpha beta-param]}] {:alpha alpha :beta beta-param})
     :posterior-mean (fn [{:keys [alpha beta]}] (mx/divide alpha (mx/add alpha beta)))

--- a/src/genmlx/inference/fisher.cljs
+++ b/src/genmlx/inference/fisher.cljs
@@ -241,12 +241,39 @@
   "Standard errors from the Fisher information matrix.
    SE(θ_i) = sqrt(F⁻¹_ii) — the Cramér-Rao lower bound.
 
-   Returns {:std-errors [D] array, :covariance [D,D] array}."
+   Returns {:std-errors [D] array, :covariance [D,D] array}, plus a :warning
+   string when the Fisher is not positive-definite (see below).
+
+   An observed Fisher built from float32 finite differences of an IS-estimated
+   gradient is not guaranteed PD, so F⁻¹ = robust-solve(F, I) can have a NEGATIVE
+   diagonal entry — i.e. a negative 'variance', which is not a valid covariance.
+   Clamping such an entry to 1e-10 would report a confident ~zero SE (≈1e-5) for
+   a maximally-uncertain direction, INVERTING the truth. Instead a genuinely
+   negative variance is surfaced as NaN (SE undefined — the Cramér-Rao bound
+   does not apply) and the offending indices are reported under :warning. The
+   1e-10 floor is retained ONLY as a sqrt-of-zero guard for non-negative tiny
+   variances (genmlx-ppok)."
   [fisher]
   (let [D (first (mx/shape fisher))
         cov (robust-solve fisher (mx/eye D) D default-solve-schedule)
         _ (mx/materialize! cov)
         diag-cov (mx/diag cov)
-        se (mx/sqrt (mx/maximum diag-cov (mx/scalar 1e-10)))]
+        _ (mx/materialize! diag-cov)
+        diag-clj (mx/->clj diag-cov)
+        ;; Scale the negativity threshold to the matrix so float32 round-off near
+        ;; zero is not flagged, while a real negative variance is.
+        max-abs (reduce (fn [m x] (max m (js/Math.abs x))) 0.0 diag-clj)
+        tol (* 1e-8 (max 1.0 max-abs))
+        neg-idxs (vec (keep-indexed (fn [i x] (when (< x (- tol)) i)) diag-clj))
+        se-clj (mapv (fn [x] (if (< x (- tol))
+                               js/NaN
+                               (js/Math.sqrt (max x 1e-10))))
+                     diag-clj)
+        se (mx/array se-clj)]
     (mx/materialize! se)
-    {:std-errors se :covariance cov}))
+    (cond-> {:std-errors se :covariance cov}
+      (seq neg-idxs)
+      (assoc :warning
+             (str "Fisher not positive-definite: F⁻¹ has a negative variance at "
+                  "parameter index(es) " neg-idxs "; SE is undefined (NaN) there "
+                  "— the Cramér-Rao bound does not apply.")))))

--- a/test/genmlx/combinator_splice_repro_test.cljs
+++ b/test/genmlx/combinator_splice_repro_test.cljs
@@ -1,0 +1,92 @@
+;; @tier fast core
+(ns genmlx.combinator-splice-repro-test
+  "genmlx-9ssv: a non-DynamicGF combinator (Map/Unfold/Scan/Switch/Mix) spliced
+   under vsimulate/vgenerate/vregenerate routes through
+   handler/combinator-batched-fallback, which ran each per-particle combinator
+   GFI op with NO key — so the combinator self-seeded entropy via
+   rng/fresh-key (js/Math.random), and TWO runs under the same fixed top-level
+   key diverged. (The split produced [k1 k2] but k2 was dead.)
+
+   Fix: the fallback now derives per-particle keys (rng/split-n) and attaches
+   each to the spliced combinator via :genmlx.dynamic/key metadata, which the
+   combinator GFI ops read through combinators/splice-key (falling back to a
+   fresh key when no real key is threaded — so direct, non-spliced use is
+   byte-for-byte unchanged). The dead k2 is replaced by a real carry key.
+
+   These tests pin the reproducibility (done-means): same fixed key -> bit
+   identical batched choices; different key -> different; particles stay
+   mutually independent within a run."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.dynamic :as dyn]
+            [genmlx.combinators :as comb]
+            [genmlx.choicemap :as cm]
+            [genmlx.protocols :as p]
+            [genmlx.mlx.random :as rng])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(defn- elem-leaf
+  "[N]-vector at <splice-addr>/<i>/<leaf> in a VectorizedTrace's choices."
+  [vt splice-addr i leaf]
+  (mx/->clj (cm/get-value
+              (cm/get-submap (cm/get-submap (cm/get-submap (:choices vt) splice-addr) i) leaf))))
+
+(defn- all-elems [vt splice-addr leaf n]
+  (vec (for [i (range n)] (elem-leaf vt splice-addr i leaf))))
+
+;; --- Map combinator spliced (the done-means case) ----------------------------
+(def map-kernel (gen [x] (trace :v (dist/gaussian x 1))))
+(def map-model (gen [] (splice :m (comb/map-combinator map-kernel) [0.0 1.0 2.0])))
+
+(deftest map-splice-vsimulate-reproducible
+  (let [n 4
+        k (rng/fresh-key 42)
+        a (dyn/vsimulate map-model [] n k)
+        b (dyn/vsimulate map-model [] n k)
+        c (dyn/vsimulate map-model [] n (rng/fresh-key 99))]
+    (testing "same fixed key -> bit-identical :m choices (3 elements)"
+      (is (= (all-elems a :m :v 3) (all-elems b :m :v 3))
+          "two vsimulate runs under the same key are byte-for-byte identical"))
+    (testing "different key -> different choices (entropy actually descends from the key)"
+      (is (not= (all-elems a :m :v 3) (all-elems c :m :v 3))
+          "a different top-level key produces different draws"))
+    (testing "particles stay mutually independent within a run"
+      (is (apply distinct? (elem-leaf a :m 0 :v))
+          "the N particles of element 0 are not all identical"))
+    (testing "score is [N]-shaped and identical across the two same-key runs"
+      (is (= [n] (mx/shape (:score a))) "score is [N]-shaped")
+      (is (= (mx/->clj (:score a)) (mx/->clj (:score b))) "same-key scores identical"))))
+
+;; --- Unfold combinator spliced (state-threading kernel) ----------------------
+(def unfold-kernel
+  (gen [t state a b]
+    (let [mean (if state (mx/add (mx/multiply a (:x state)) b) (mx/scalar 0.0))
+          x (trace :x (dist/gaussian mean 1.0))]
+      {:x x})))
+(def unfold-model
+  (gen [] (splice :seq (comb/unfold-combinator unfold-kernel) 3 nil (mx/scalar 0.5) (mx/scalar 1.0))))
+
+(deftest unfold-splice-vsimulate-reproducible
+  (let [n 4
+        k (rng/fresh-key 7)
+        a (dyn/vsimulate unfold-model [] n k)
+        b (dyn/vsimulate unfold-model [] n k)
+        c (dyn/vsimulate unfold-model [] n (rng/fresh-key 8))]
+    (testing "same fixed key -> bit-identical :seq choices (3 steps)"
+      (is (= (all-elems a :seq :x 3) (all-elems b :seq :x 3))
+          "two vsimulate runs under the same key are byte-for-byte identical"))
+    (testing "different key -> different choices"
+      (is (not= (all-elems a :seq :x 3) (all-elems c :seq :x 3))
+          "a different top-level key produces different draws"))
+    (testing "score identical across same-key runs"
+      (is (= (mx/->clj (:score a)) (mx/->clj (:score b))) "same-key scores identical"))))
+
+;; --- direct (non-spliced) use is unaffected ----------------------------------
+(deftest direct-combinator-use-unchanged
+  (testing "a directly-simulated combinator still self-seeds (no metadata key) and works"
+    (let [tr (p/simulate (comb/map-combinator map-kernel) [[0.0 1.0 2.0]])]
+      (is (= 3 (count (:retval tr))) "direct Map simulate returns 3 elements")
+      (is (mx/array? (:score tr)) "direct Map simulate has a score"))))
+
+(cljs.test/run-tests)

--- a/test/genmlx/compiled_delta_event_reduce_test.cljs
+++ b/test/genmlx/compiled_delta_event_reduce_test.cljs
@@ -1,0 +1,106 @@
+;; @tier fast core
+(ns genmlx.compiled-delta-event-reduce-test
+  "genmlx-kftc: the COMPILED noise-transform delta :log-prob (compiled.cljs)
+   compared value to point mass elementwise and returned a [T] mask with NO
+   event-axis reduction, while the handler delta (dist.cljs, genmlx-exw9)
+   reduces the trailing event axes to a JOINT scalar (0 iff ALL elements match,
+   else -Inf). For a vector point mass (dist/delta <tensor>) — a legal,
+   compilable static site — the compiled path therefore diverged from the
+   handler ground truth two ways:
+
+     * MATCH:    weight broadcast to [T] instead of a joint scalar.
+     * NO-MATCH: components that happen to match read FINITE while the joint
+                 must be -Inf (e.g. compiled [-0.9, -0.9, -Inf] vs handler -Inf).
+
+   The compiled path is OPTIMIZATION; the handler is GROUND TRUTH. These tests
+   pin compiled == handler (value AND shape) for vector deltas across
+   assess/generate/project, and that the scalar delta path is unchanged. Each
+   model is asserted to actually reach :L1-M2 so the comparison is not vacuous
+   (the compiled path must really be engaged)."
+  (:require [cljs.test :refer [deftest is testing]]
+            [genmlx.mlx :as mx]
+            [genmlx.dist :as dist]
+            [genmlx.dynamic :as dyn]
+            [genmlx.protocols :as p]
+            [genmlx.choicemap :as cm]
+            [genmlx.selection :as sel]
+            [genmlx.gfi :as gfi]
+            [genmlx.inspect :as insp])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(defn- num [x] (mx/eval! x) (mx/item x))
+(defn- shp [x] (mx/shape x))
+(defn- close? [a b] (or (and (not (js/isFinite a)) (not (js/isFinite b)) (= (< a 0) (< b 0)))
+                        (< (js/Math.abs (- a b)) 1e-4)))
+
+;; A static, L1-M2-compilable model with a VECTOR point-mass site (:d) and an
+;; ordinary gaussian (:a) so the delta log-prob is summed into a real scalar
+;; accumulator that the [T] mask would otherwise broadcast.
+(def point (mx/array [1.0 2.0 3.0]))
+(def vec-model0 (gen [] (let [a (trace :a (dist/gaussian 0 1))]
+                          (trace :d (dist/delta point))
+                          a)))
+(def vec-model (dyn/auto-key vec-model0))
+
+(def scalar-model0 (gen [] (let [a (trace :a (dist/gaussian 0 1))]
+                             (trace :d (dist/delta (mx/scalar 5.0)))
+                             a)))
+(def scalar-model (dyn/auto-key scalar-model0))
+
+(deftest models-actually-compile
+  ;; Guard against a vacuous test: if these did not reach :L1-M2 the compiled
+  ;; and handler paths would be identical and the regression would be untested.
+  (is (= :L1-M2 (:compilation (insp/inspect vec-model0))) "vector-delta model is L1-M2")
+  (is (= :L1-M2 (:compilation (insp/inspect scalar-model0))) "scalar-delta model is L1-M2"))
+
+(deftest assess-vector-delta-matches-handler
+  (testing "matching vector delta: compiled weight == handler (joint scalar)"
+    (let [cmatch (cm/choicemap :a (mx/scalar 0.0) :d (mx/array [1.0 2.0 3.0]))
+          rc (p/assess vec-model [] cmatch)
+          rh (p/assess (gfi/strip-compiled vec-model) [] cmatch)]
+      (is (= [] (shp (:weight rc))) "compiled weight is a joint scalar, not [T]")
+      (is (= (shp (:weight rh)) (shp (:weight rc))) "compiled shape == handler shape")
+      (is (close? (num (:weight rc)) (num (:weight rh))) "compiled value == handler value")))
+  (testing "NON-matching vector delta: compiled is joint -Inf, not a partial finite mask"
+    (let [cnomatch (cm/choicemap :a (mx/scalar 0.0) :d (mx/array [1.0 2.0 9.0]))
+          rc (p/assess vec-model [] cnomatch)
+          rh (p/assess (gfi/strip-compiled vec-model) [] cnomatch)]
+      (is (= [] (shp (:weight rc))) "compiled weight is a joint scalar, not [T]")
+      (is (not (js/isFinite (num (:weight rc)))) "compiled joint is -Inf (one component mismatched)")
+      (is (close? (num (:weight rc)) (num (:weight rh))) "compiled -Inf == handler -Inf"))))
+
+(deftest generate-vector-delta-matches-handler
+  (testing "fully-constrained generate weight == handler, scalar, both cases"
+    (doseq [[label dv finite?] [["match"   (mx/array [1.0 2.0 3.0]) true]
+                                ["nomatch" (mx/array [1.0 9.0 3.0]) false]]]
+      (let [c (cm/choicemap :a (mx/scalar 0.25) :d dv)
+            rc (p/generate vec-model [] c)
+            rh (p/generate (gfi/strip-compiled vec-model) [] c)]
+        (is (= [] (shp (:weight rc))) (str label ": compiled generate weight scalar"))
+        (is (= (shp (:weight rh)) (shp (:weight rc))) (str label ": compiled shape == handler shape"))
+        (is (= finite? (js/isFinite (num (:weight rc)))) (str label ": finiteness matches expectation"))
+        (is (close? (num (:weight rc)) (num (:weight rh))) (str label ": compiled value == handler value"))))))
+
+(deftest project-vector-delta-matches-handler
+  (testing "project on :d (delta value == point, always matches) is a joint scalar 0"
+    (let [tr  (p/simulate vec-model [])
+          trh (p/simulate (gfi/strip-compiled vec-model) [])
+          pc  (p/project vec-model tr (sel/select :d))
+          ph  (p/project (gfi/strip-compiled vec-model) trh (sel/select :d))]
+      (is (= [] (shp pc)) "compiled project of vector delta is a joint scalar, not [T]")
+      (is (= (shp ph) (shp pc)) "compiled project shape == handler project shape")
+      (is (close? (num pc) 0.0) "matching delta projects to 0")
+      (is (close? (num pc) (num ph)) "compiled project == handler project"))))
+
+(deftest scalar-delta-unchanged
+  (testing "scalar point mass: compiled == handler, value and shape, both cases"
+    (doseq [[label dv finite?] [["match"   (mx/scalar 5.0) true]
+                                ["nomatch" (mx/scalar 6.0) false]]]
+      (let [c (cm/choicemap :a (mx/scalar 0.0) :d dv)
+            rc (p/assess scalar-model [] c)
+            rh (p/assess (gfi/strip-compiled scalar-model) [] c)]
+        (is (= (shp (:weight rh)) (shp (:weight rc))) (str label ": scalar shape unchanged"))
+        (is (= finite? (js/isFinite (num (:weight rc)))) (str label ": scalar finiteness expected"))
+        (is (close? (num (:weight rc)) (num (:weight rh))) (str label ": scalar value == handler"))))))
+
+(cljs.test/run-tests)

--- a/test/genmlx/fisher_test.cljs
+++ b/test/genmlx/fisher_test.cljs
@@ -129,4 +129,38 @@
         (is (and (> f00 0) (> f11 0)) "Fisher diagonal positive")
         (is (> det-val 0) "Fisher determinant positive")))))
 
+;; ---------------------------------------------------------------------------
+;; Non-PD Fisher: negative F⁻¹ variance must NOT be clamped to a confident ~zero
+;; SE (genmlx-ppok). F = [[1 2][2 1]] is symmetric, invertible (det -3), but
+;; INDEFINITE (eigs 3, -1), so F⁻¹ = [[-1/3 2/3][2/3 -1/3]] has a negative
+;; diagonal — an impossible variance. The old code returned sqrt(max(-1/3,1e-10))
+;; = 1e-5, reporting near-zero uncertainty for a not-estimable direction.
+;; ---------------------------------------------------------------------------
+
+(deftest std-errors-indefinite-fisher-surfaced
+  (testing "negative F⁻¹ variance -> NaN + :warning, not a confident ~zero SE"
+    (let [F (mx/array [[1.0 2.0] [2.0 1.0]])
+          {:keys [std-errors warning]} (fisher/parameter-std-errors F)
+          se (mx/->clj std-errors)]
+      (is (every? #(js/Number.isNaN %) se)
+          "SE is NaN where F⁻¹ variance is negative (not 1e-5)")
+      (is (not-any? #(and (js/isFinite %) (< % 1e-3)) se)
+          "no confident ~zero SE is reported for the indefinite direction")
+      (is (some? warning) "a :warning names the non-PD parameter indices")))
+  (testing "positive-definite Fisher is unchanged (no warning, exact SEs)"
+    (let [F (mx/array [[4.0 0.0] [0.0 100.0]])
+          {:keys [std-errors warning]} (fisher/parameter-std-errors F)
+          se (mx/->clj std-errors)]
+      (is (h/close? 0.5 (first se) 1e-5) "SE0 = sqrt(1/4) = 0.5")
+      (is (h/close? 0.1 (second se) 1e-5) "SE1 = sqrt(1/100) = 0.1")
+      (is (nil? warning) "PD Fisher: no warning")))
+  (testing "the 1e-10 floor is retained for a NON-negative tiny variance (sqrt-of-zero guard)"
+    (let [F (mx/array [[1.0e12 0.0] [0.0 4.0]])  ; F⁻¹ diag = [1e-12, 0.25]
+          {:keys [std-errors warning]} (fisher/parameter-std-errors F)
+          se (mx/->clj std-errors)]
+      (is (h/close? 1e-5 (first se) 1e-7) "tiny non-negative variance floored to sqrt(1e-10)=1e-5")
+      (is (not (js/Number.isNaN (first se))) "floored value is finite, not NaN")
+      (is (h/close? 0.5 (second se) 1e-5) "the other SE = sqrt(1/4) = 0.5")
+      (is (nil? warning) "no warning for a non-negative tiny variance"))))
+
 (cljs.test/run-tests)

--- a/test/genmlx/iid_conjugacy_test.cljs
+++ b/test/genmlx/iid_conjugacy_test.cljs
@@ -289,4 +289,134 @@
       (doseq [r results]
         (is (h/close? (:weight r) (:score r) 1e-6) "score ~ weight")))))
 
+;; ---------------------------------------------------------------------------
+;; 11. Heteroscedastic [T]-sigma iid-gaussian (genmlx-symr)
+;;
+;; nn-iid-update-step hard-codes the HOMOSCEDASTIC normal-iid-normal closed form
+;; (treats obs-var as a SCALAR s2). dist/iid-gaussian also accepts a per-element
+;; [T] sigma, whose correct marginal is the DIFFERENT MVN
+;;   N(y; m0*1, diag(sigma_i^2) + tau2 11^T).
+;; Before the fix a [T]-sigma model was routed to L3 analytical elimination and
+;; silently mis-scored — the ll came out [T]-shaped (not the joint scalar),
+;; flowing into :score/:weight. The fix is defense-in-depth: a static gate in
+;; detect-conjugate-pairs declines a provably-vector sigma, and a runtime
+;; backstop in the :normal-iid-normal update-step throws {:analytical/bail true}
+;; for ANY non-scalar obs-var, re-routing to the handler joint path which scores
+;; the per-element sigma correctly (dist-log-prob :iid-gaussian).
+;;
+;; INDEPENDENT oracles (ke9i discipline): the correct heteroscedastic marginal,
+;; computed two ways that do NOT touch the function under test.
+;; ---------------------------------------------------------------------------
+
+(defn oracle-marginal-het-closed
+  "Closed-form heteroscedastic shared-mu marginal log-evidence via the
+   matrix-determinant lemma / Sherman-Morrison rank-1 update of
+   Sigma = diag(s2s) + tau2 11^T. Reduces to oracle-marginal-closed when all
+   s2s are equal (verified in het-oracle-self-consistency)."
+  [ys m0 tau2 s2s]
+  (let [T (count ys)
+        d (map #(- % m0) ys)
+        w (map #(/ 1.0 %) s2s)                 ; precisions 1/s_i^2
+        A (+ 1.0 (* tau2 (reduce + w)))        ; 1 + tau2 1^T D^{-1} 1
+        sum-dw (reduce + (map * d w))
+        sum-d2w (reduce + (map (fn [di wi] (* di di wi)) d w))
+        logdet (+ (reduce + (map js/Math.log s2s)) (js/Math.log A))
+        quad (- sum-d2w (/ (* tau2 sum-dw sum-dw) A))]
+    (* -0.5 (+ (* T (js/Math.log (* 2 js/Math.PI))) logdet quad))))
+
+(defn oracle-marginal-het-quad
+  "Independent METHOD: numerically marginalise mu for heteroscedastic s_i^2.
+   p(ys) = ∫ N(mu; m0, tau2) * prod_i N(y_i; mu, s2s_i) dmu."
+  [ys m0 tau2 s2s]
+  (let [tau (js/Math.sqrt tau2)
+        lo (- m0 (* 8 tau)) hi (+ m0 (* 8 tau))
+        n 40000 dx (/ (- hi lo) n)
+        lpn (js/Math.log (js/Math.sqrt (* 2 js/Math.PI tau2)))]
+    (loop [k 0 acc 0.0]
+      (if (> k n)
+        (js/Math.log (* dx acc))
+        (let [mu (+ lo (* k dx))
+              lp (- (- (/ (* (- mu m0) (- mu m0)) (* 2 tau2))) lpn)
+              ll (reduce (fn [a [y s2]]
+                           (+ a (* -0.5 (+ (js/Math.log (* 2 js/Math.PI s2))
+                                           (/ (* (- y mu) (- y mu)) s2)))))
+                         0.0 (map vector ys s2s))]
+          (recur (inc k) (+ acc (js/Math.exp (+ lp ll)))))))))
+
+(deftest het-oracle-self-consistency
+  (testing "the heteroscedastic oracle reduces to the homoscedastic one for equal s2s"
+    (let [ys [1.0 2.0 3.0 4.0 5.0]]
+      (is (h/close? (oracle-marginal-closed ys 0 100 1)
+                    (oracle-marginal-het-closed ys 0 100 [1 1 1 1 1]) 1e-6)
+          "het closed-form == homoscedastic closed-form at uniform s2s")))
+  (testing "the two independent heteroscedastic methods agree (trustworthy ground truth)"
+    (let [ys [0.5 1.5 -0.5 2.0 0.0]
+          s2s [1.0 4.0 0.25 1.96 0.49]]
+      (is (h/close? (oracle-marginal-het-closed ys 0 100 s2s)
+                    (oracle-marginal-het-quad ys 0 100 s2s) 1e-3)
+          "het closed-form == numerical-quadrature marginal"))))
+
+;; ys = [0.5 1.5 -0.5 2.0 0.0], sigma = [1 2 0.5 1.4 0.7] -> s2s = [1 4 0.25 1.96 0.49]
+(def het-sigma (mx/array [1.0 2.0 0.5 1.4 0.7]))
+(def het-ys (mx/array [0.5 1.5 -0.5 2.0 0.0]))
+;; INLINE (mx/array [...]) literal so the static gate can prove the [T] shape;
+;; a def'd-symbol or arg sigma is static-blind and is the runtime backstop's job.
+(def het-model
+  (gen [] (let [mu (trace :mu (dist/gaussian 0 10))]
+            (trace :ys (dist/iid-gaussian mu (mx/array [1.0 2.0 0.5 1.4 0.7]) 5))
+            mu)))
+(def sca-model
+  (gen [] (let [mu (trace :mu (dist/gaussian 0 10))]
+            (trace :ys (dist/iid-gaussian mu (mx/scalar 1.0) 5))
+            mu)))
+;; sigma supplied as a model ARG — the static gate cannot prove its shape, so
+;; the RUNTIME backstop is the load-bearing guard for this case.
+(def arg-model
+  (gen [sig] (let [mu (trace :mu (dist/gaussian 0 10))]
+               (trace :ys (dist/iid-gaussian mu sig 5))
+               mu)))
+
+(deftest heteroscedastic-detection-declined
+  (testing "a provably-vector [T] sigma is declined by static detection"
+    (is (empty? (conj/detect-conjugate-pairs (:schema het-model)))
+        "het [T]-sigma: NO conjugate pair detected"))
+  (testing "a scalar sigma is still detected as conjugate (path unchanged)"
+    (is (= 1 (count (conj/detect-conjugate-pairs (:schema sca-model))))
+        "scalar sigma: still :normal-iid-normal conjugate"))
+  (testing "an arg-supplied sigma is NOT declined statically (runtime must guard it)"
+    (is (= 1 (count (conj/detect-conjugate-pairs (:schema arg-model))))
+        "arg sigma: static gate is blind, detection still fires")))
+
+(deftest heteroscedastic-runtime-bails-to-scalar
+  (testing "[T]-sigma literal: detection-declined -> handler scores a JOINT SCALAR weight"
+    (let [gf (dyn/auto-key het-model)
+          w  (:weight (p/generate gf [] (cm/choicemap :ys het-ys)))]
+      (is (= [] (mx/shape w)) "het generate weight is a joint scalar, not [T]")
+      (is (js/isFinite (mx/item w)) "het generate weight is finite")))
+  (testing "[T]-sigma via model arg: runtime backstop bails -> joint SCALAR weight"
+    (let [gf (dyn/auto-key arg-model)
+          w  (:weight (p/generate gf [het-sigma] (cm/choicemap :ys het-ys)))]
+      (is (= [] (mx/shape w)) "arg [T]-sigma generate weight is a joint scalar, not [T]")
+      (is (js/isFinite (mx/item w)) "arg [T]-sigma generate weight is finite"))))
+
+(deftest scalar-sigma-analytical-still-exact
+  ;; The supported (scalar-sigma) analytical path must STILL equal the closed-form
+  ;; MVN marginal exactly — this is the "analytical == closed-form MVN oracle"
+  ;; guarantee, verified against an INDEPENDENT oracle (not nn-iid-update-step).
+  (testing "scalar-sigma generate weight == independent MVN marginal oracle"
+    (let [gf (dyn/auto-key sca-model)
+          w  (mx/item (:weight (p/generate gf [] (cm/choicemap :ys het-ys))))
+          ys [0.5 1.5 -0.5 2.0 0.0]]
+      (is (h/close? w (oracle-marginal-closed ys 0 100 1) 1e-3)
+          "scalar-sigma weight == closed-form oracle")
+      (is (h/close? w (oracle-marginal-het-quad ys 0 100 [1 1 1 1 1]) 1e-3)
+          "scalar-sigma weight == numerical-quadrature oracle")))
+  ;; And the scalar arg path stays analytical-exact too (runtime sees scalar obs-var).
+  (testing "scalar-sigma via model arg stays analytical and exact"
+    (let [gf (dyn/auto-key arg-model)
+          w  (mx/item (:weight (p/generate gf [(mx/scalar 1.0)] (cm/choicemap :ys het-ys))))
+          ys [0.5 1.5 -0.5 2.0 0.0]]
+      (is (h/close? w (oracle-marginal-closed ys 0 100 1) 1e-3)
+          "scalar arg-sigma weight == closed-form oracle"))))
+
 (cljs.test/run-tests)

--- a/test/genmlx/update_discard_branch_test.cljs
+++ b/test/genmlx/update_discard_branch_test.cljs
@@ -116,4 +116,44 @@
           total (+ (mx/item (:weight fwd)) (mx/item (:weight rev)))]
       (is (h/close? 0.0 total 1e-4) "fwd_weight + rev_weight ~ 0"))))
 
+;; -------------------------------------------------------------------------
+;; Batched analogue (genmlx-6v3h): vupdate*/vupdate-args must add deleted old
+;; addresses to the discard on a structure-shrinking move, like the scalar path.
+;; The batch branches on a HOST ARG (per-particle branching / mx/item is not
+;; allowed in a vectorized body), so old args visit :a and new args visit :b.
+;; -------------------------------------------------------------------------
+
+(def arg-branch-model
+  (gen [flag]
+    (if flag
+      (trace :a (dist/gaussian 0 1))
+      (trace :b (dist/gaussian 5 1)))))
+
+(defn- leaf-vec [choices addr]
+  (mx/->clj (cm/get-value (cm/get-submap choices addr))))
+
+(deftest batched-arg-branch-discard
+  (testing "structure-shrinking vupdate-args: deleted :a appears in the discard with its [N] values"
+    (let [n 4
+          vt (dyn/vsimulate arg-branch-model [true] n (rng/fresh-key 1))
+          r  (dyn/vupdate-args arg-branch-model vt [false] cm/EMPTY (rng/fresh-key 2))
+          discard (:discard r)
+          new-choices (:choices (:vtrace r))]
+      (is (cm/has-value? (cm/get-submap (:choices vt) :a)) "old trace has :a")
+      (is (cm/has-value? (cm/get-submap new-choices :b)) "new trace has :b")
+      (is (not (cm/has-value? (cm/get-submap new-choices :a))) "new trace dropped :a")
+      (is (cm/has-value? (cm/get-submap discard :a)) "discard includes the deleted :a")
+      (is (= [n] (mx/shape (cm/get-value (cm/get-submap discard :a)))) "discarded :a is [N]-shaped")
+      (is (= (leaf-vec (:choices vt) :a) (leaf-vec discard :a))
+          "discarded :a values == the original per-particle :a values (round-trip recoverable)")
+      (is (= [n] (mx/shape (:weight r))) "weight is [N]-shaped")
+      (is (every? js/isFinite (mx/->clj (:weight r))) "weight is finite (unaffected by the discard fix)")))
+  (testing "non-shrinking overwrite vupdate: discard carries the overwritten address only"
+    (let [n 4
+          plain (gen [] (trace :x (dist/gaussian 0 1)))
+          vt (dyn/vsimulate plain [] n (rng/fresh-key 3))
+          r  (dyn/vupdate plain vt (cm/choicemap :x (mx/zeros [n])) (rng/fresh-key 4))]
+      (is (cm/has-value? (cm/get-submap (:discard r) :x)) "overwritten :x is in the discard")
+      (is (= '(:x) (keys (:m (:discard r)))) "no spurious deleted addresses added"))))
+
 (cljs.test/run-tests)


### PR DESCRIPTION
The 5 remaining live findings from the **genmlx-ubtm** adversarial hunt (the 2 HIGH findings shipped in #135). Each was **live-reproduced first** (the d8j4 lesson — hunt findings are static-verified, not yet reproduced), fixed against the handler ground truth, then regression-tested. All live in legal-but-rare corners; the scalar/static/compiled happy paths were already clean.

| Bean | Bug | Fix |
|------|-----|-----|
| **genmlx-kftc** | compiled delta log-prob returned an elementwise `[T]` mask for a vector point mass (`[-0.9 -0.9 -Inf]`) vs the handler's joint scalar `-Inf` | mirror the exw9 reduction (`mx/all` over event axes); scalar/batched unchanged |
| **genmlx-symr** | heteroscedastic `[T]`-sigma iid-gaussian routed to the *homoscedastic* normal-iid-normal closed form → silently `[T]`-shaped `ll` | static gate declines a provably-vector sigma **+** runtime backstop bails any non-scalar `obs-var` to the handler joint path. Scalar-sigma stays analytical & exact (== MVN oracle). Optional full het-marginal = follow-up genmlx-tsvg |
| **genmlx-ppok** | `parameter-std-errors` clamped a negative `F⁻¹` variance to `1e-10` → confident ~`1e-5` SE for a not-estimable direction | surface `NaN` + a `:warning`; keep the `1e-10` floor only as a sqrt-of-zero guard for non-negative tiny variances |
| **genmlx-6v3h** | batched `vupdate*`/`vupdate-args` omitted deleted old addresses from `:discard` on a structure-shrinking move | apply `add-deleted-to-discard`, mirroring scalar `p/update`; weight unaffected |
| **genmlx-9ssv** | a spliced non-DynamicGF combinator self-seeded entropy (js/Math.random) → batched runs diverged under a fixed key (dead `k2`) | new `combinators/splice-key` reads a `:genmlx.dynamic/key` threaded by `combinator-batched-fallback` (`rng/split-n` per-particle keys + real carry); behaviour byte-for-byte unchanged for non-spliced use |

## Tests
- **New:** `compiled_delta_event_reduce_test` (26 assert), `combinator_splice_repro_test` (Map + Unfold)
- **Extended:** `iid_conjugacy_test` §11 (+2 independent heteroscedastic MVN oracles), `fisher_test` (indefinite-Fisher), `update_discard_branch_test` (batched arg-branch discard)

## Gate (all green, run serially)
level0 68/68 · l4 41/41 · schema 256 · gen_clj 356 · genjax 73 · all compiled (delta/simulate/generate/partial/combinator) · analytical (conjugacy 80 / auto_analytical 57 / iid* / l3_false_positive 68 / exact 120 / linear_gaussian 73) · combinator suites incl. gfi_combinator_invariants 334 · vectorized · fisher 21.

Each fix preserves the **handler-is-ground-truth** invariant; compiled/analytical/batched paths are optimizations that must match it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)