### PR TITLE
refactor(idiomatic): second idiomatic-cljs sweep — 91 behavior-preserving fixes across 62 files

### DIFF
--- a/src/genmlx/affine.cljs
+++ b/src/genmlx/affine.cljs
@@ -46,8 +46,7 @@
   [args target-sym env]
   (let [results (mapv #(analyze-affine % target-sym env) args)]
     (if (every? :affine? results)
-      (let [target-results (filter :has-target? results)
-            const-results (filter (complement :has-target?) results)]
+      (let [target-results (filter :has-target? results)]
         (if (empty? target-results)
           ;; No target dependency — pure constant addition
           (affine-constant (cons 'mx/add (map :offset results)))

--- a/src/genmlx/agents/belief.cljs
+++ b/src/genmlx/agents/belief.cljs
@@ -132,9 +132,8 @@
         ;; that explicitly so a WORLD-DEPENDENT nil observe model — where other
         ;; worlds yield non-nil at s' — can't make L disagree with the host. The
         ;; emergent all-ones only held when nil was world-independent.
-        is-nil   (mx/equal true-obs (mx/scalar nil-obs-id))                         ; []
-        L        (mx/where is-nil (mx/ones [W] mx/float32) match)]                  ; [W]
-    L))
+        is-nil   (mx/equal true-obs (mx/scalar nil-obs-id))]                        ; []
+    (mx/where is-nil (mx/ones [W] mx/float32) match)))                              ; [W]
 
 ;; -- belief <-> vector seam (host map/vector callers <-> [W] MLX) --------------
 

--- a/src/genmlx/agents/biased_planners.cljs
+++ b/src/genmlx/agents/biased_planners.cljs
@@ -49,7 +49,6 @@
    independent of d, so perceivedDelay is irrelevant and `biased-eu` reproduces
    `agent/recursive-eu` and the tensor `Q` exactly (the limit-recovery anchor)."
   (:require [genmlx.mlx :as mx]
-            [genmlx.dist :as dist]
             [genmlx.protocols :as p]
             [genmlx.dynamic :as dyn]
             [genmlx.inference.exact :as exact]

--- a/src/genmlx/agents/gridworld.cljs
+++ b/src/genmlx/agents/gridworld.cljs
@@ -86,7 +86,7 @@
         g->idx (zipmap goals-vec (range))]
     (mx/array
       (clj->js (vec (for [s (range S)]
-                      (let [gi (get g->idx (get terminals s))]
+                      (let [gi (g->idx (terminals s))]
                         (vec (for [g (range (count goals-vec))] (if (= g gi) 1.0 0.0)))))))
       mx/float32)))
 
@@ -115,7 +115,7 @@
   [{:keys [grid utilities start gamma noise] :or {utilities {} gamma 1.0 noise 0.0}}]
   (let [{:keys [W H S walls terminals]} (parse-grid grid)
         A          (count action-deltas)
-        time-cost  (get utilities :timeCost 0.0)
+        time-cost  (:timeCost utilities 0.0)
         ns-fn      (fn [s a] (next-state W H walls s a))
         ;; geometry (host-side, pure CLJS) -> [S,A] table of next-state indices
         ns-rows    (vec (for [s (range S)] (vec (for [a (range A)] (ns-fn s a)))))

--- a/src/genmlx/agents/helpers.cljs
+++ b/src/genmlx/agents/helpers.cljs
@@ -20,8 +20,7 @@
             [genmlx.choicemap :as cm]
             [genmlx.combinators :as comb]
             [genmlx.inference.exact :as exact])
-  (:require-macros [genmlx.gen :refer [gen]]
-                   [genmlx.dist.macros :refer [defdist]]))
+  (:require-macros [genmlx.dist.macros :refer [defdist]]))
 
 ;; ---------------------------------------------------------------------------
 ;; factor-dist — soft conditioning

--- a/src/genmlx/agents/inverse.cljs
+++ b/src/genmlx/agents/inverse.cljs
@@ -55,9 +55,9 @@
    POMDP belief filter (genmlx.agents.pomdp) reuses the same normalization."
   [logm]
   (let [hi (apply max (vals logm))
-        ex (into {} (map (fn [[g l]] [g (Math/exp (- l hi))]) logm))
+        ex (update-vals logm (fn [l] (Math/exp (- l hi))))
         z  (reduce + (vals ex))]
-    (into {} (map (fn [[g e]] [g (/ e z)]) ex))))
+    (update-vals ex (fn [e] (/ e z)))))
 
 (defn- stack-log-policies
   "Stack the goal policies into one [G,S,A] log-action-probability tensor (bean

--- a/src/genmlx/agents/pomdp.cljs
+++ b/src/genmlx/agents/pomdp.cljs
@@ -100,13 +100,13 @@
         act (fn [belief s]
               (let [q (belief-Q belief s)]
                 (int (mx/item (:retval (p/simulate (dyn/auto-key policy) [q]))))))]
-    {:worlds (vec worlds) :world-agents world-agents :prior prior :observe observe
+    {:worlds worlds-vec :world-agents world-agents :prior prior :observe observe
      :belief-Q belief-Q :update-belief update-belief :act act
      ;; tensor belief kernel (bean genmlx-kpuo): same map-in/map-out contract as
      ;; :update-belief but the filter runs as pure MLX [W] ops (no per-step host
      ;; map arithmetic, no mx/item). Opt-in via simulate-pomdp :belief-mode :tensor.
      :update-belief-tensor (fn [belief loc obs]
-                             (belief/update-belief-map observe (vec worlds) belief loc obs))
+                             (belief/update-belief-map observe worlds-vec belief loc obs))
      :expected-utility (fn [belief s a]
                          (reduce + (map (fn [[w b]]
                                           (* b ((:expected-utility (world-agents w)) s a)))

--- a/src/genmlx/agents/pomdp_env.cljs
+++ b/src/genmlx/agents/pomdp_env.cljs
@@ -98,8 +98,7 @@
      ;; adjacency-gated local reveal: observe the open/closed status of every
      ;; restaurant the agent is currently adjacent to (nil if none).
      :observe     (fn [world loc]
-                    (let [o (vec (for [r restaurants :when (contains? (adj r) loc)] [r (world r)]))]
-                      (when (seq o) o)))}))
+                    (not-empty (vec (for [r restaurants :when (contains? (adj r) loc)] [r (world r)]))))}))
 
 (defn bandit-pomdp
   "Multi-armed bandit POMDP (agentmodels Ch 3c/3d). The hidden state is the

--- a/src/genmlx/agents/remote.cljs
+++ b/src/genmlx/agents/remote.cljs
@@ -133,7 +133,7 @@
         ;; EDN-encode the observation for the wire (JSON has no keywords/vectors):
         ;; pr-str round-trips ANY observe range (a keyword, nil, or a [restaurant
         ;; open?] vector) — remote-pomdp-rollout decodes with reader/read-string.
-        enc        (fn [o] (pr-str o))
+        enc        pr-str
         s0         (or start (:start-idx env))
         st         (atom s0)
         kref       (atom key)]

--- a/src/genmlx/choicemap.cljs
+++ b/src/genmlx/choicemap.cljs
@@ -196,12 +196,10 @@
   "Build a ChoiceMap from a flat {keyword -> value} map.
    Each key becomes a top-level Value entry."
   [m]
-  (if (seq m)
-    (reduce-kv
-      (fn [cm addr val] (set-value cm addr val))
-      EMPTY
-      m)
-    EMPTY))
+  (reduce-kv
+    (fn [cm addr val] (set-value cm addr val))
+    EMPTY
+    m))
 
 ;; ---------------------------------------------------------------------------
 ;; Stack/Unstack for batched execution

--- a/src/genmlx/combinators.cljs
+++ b/src/genmlx/combinators.cljs
@@ -239,8 +239,7 @@
                                      cm (:values r)))
                         cm/EMPTY (map-indexed vector results))
         retvals (mapv :retval results)
-        score (reduce (fn [acc r] (mx/add acc (:score r)))
-                      ZERO results)
+        score (sum-field results :score)
         element-scores (mapv :score results)]
     (tag-joint
       (with-meta
@@ -2160,11 +2159,10 @@
     (let [log-w (log-weights-fn args)
           ;; Check if component index is constrained
           idx-constraint (cm/get-submap constraints :component-idx)
+          idx-dist (dc/->Distribution :categorical {:logits log-w})
           idx-result (if (cm/has-value? idx-constraint)
-                       (let [d (dc/->Distribution :categorical {:logits log-w})]
-                         (dc/dist-generate d idx-constraint))
-                       (let [d (dc/->Distribution :categorical {:logits log-w})]
-                         {:trace (dc/dist-simulate d) :weight ZERO}))
+                       (dc/dist-generate idx-dist idx-constraint)
+                       {:trace (dc/dist-simulate idx-dist) :weight ZERO})
           idx (mx/item (cm/get-value (:choices (:trace idx-result))))
           component (nth components (int idx))
           comp-constraints (without-component-idx constraints)]

--- a/src/genmlx/compiled.cljs
+++ b/src/genmlx/compiled.cljs
@@ -14,7 +14,7 @@
   (:require [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
             [genmlx.mlx.constants :refer [ZERO ONE TWO HALF NEG-INF
-                                          LOG-2PI-HALF LOG-2 LOG-PI MLX-PI]]
+                                          LOG-2PI LOG-2PI-HALF LOG-2 LOG-PI MLX-PI]]
             [genmlx.choicemap :as cm]
             [genmlx.trace :as tr]
             [genmlx.vectorized :as vec]
@@ -42,7 +42,7 @@
      (mx/subtract
       (mx/subtract (mx/multiply (mx/scalar -0.5) quad-sum)
                    (mx/sum (mx/log std)))
-      (mx/scalar (* 0.5 dim (js/Math.log (* 2 js/Math.PI))))))))
+      (mx/scalar (* 0.5 dim LOG-2PI))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Core: compiled unfold step loop
@@ -1328,8 +1328,7 @@
              (= "let" (name (first form)))
              (vector? (second form)))
         (let [result (walk-rewrite-bindings (partition 2 (second form)) sites)]
-          (if (:failed? result)
-            nil
+          (when-not (:failed? result)
             (walk-rewrite-forms (concat (drop 2 form) rest-forms) (:sites result))))
 
         ;; do form
@@ -1342,16 +1341,14 @@
         (let [addr (second form)
               dist-form (nth form 2)
               info (extract-dist-info dist-form)]
-          (if info
-            (walk-rewrite-forms rest-forms (conj sites (assoc info :addr addr)))
-            nil))
+          (when info
+            (walk-rewrite-forms rest-forms (conj sites (assoc info :addr addr)))))
 
         ;; if/if-not → try to rewrite
         (and (seq? form) (seq form) (symbol? (first form))
              (let [n (name (first form))] (or (= n "if") (= n "if-not"))))
-        (if-let [branch (analyze-rewritable-branch form)]
-          (walk-rewrite-forms rest-forms (conj sites branch))
-          nil)
+        (when-let [branch (analyze-rewritable-branch form)]
+          (walk-rewrite-forms rest-forms (conj sites branch)))
 
         ;; Contains gen calls → fail
         (contains-gen-call-any? form)

--- a/src/genmlx/compiled_ops.cljs
+++ b/src/genmlx/compiled_ops.cljs
@@ -632,8 +632,8 @@
             {:values (:values result)
              :score (:score result)
              :weight (:weight result)
-             :retval (when retval-fn
-                       (retval-fn (:values result) mlx-args))}))))))
+             ;; retval-fn proven truthy by the outer guard (every? some? + retval-fn)
+             :retval (retval-fn (:values result) mlx-args)}))))))
 
 (defn make-branch-rewritten-regenerate
   "Build a compiled regenerate for models with rewritable branches (L1-M4).
@@ -777,13 +777,18 @@
 
         :else nil))))
 
+(defn- noise-fn-site?
+  "True when a site-spec exists and its dist-type has a :noise-fn transform."
+  [s]
+  (boolean (and s (:noise-fn (get compiled/noise-transforms-full (:dist-type s))))))
+
 (defn- assign-noise-indices
   "Assign sequential noise indices to site-specs that have noise-fns.
    Returns vector of indices (nil for delta/unsupported sites)."
   [site-specs]
   (second
    (reduce (fn [[idx acc] s]
-             (if (and s (:noise-fn (get compiled/noise-transforms-full (:dist-type s))))
+             (if (noise-fn-site? s)
                [(inc idx) (conj acc idx)]
                [idx (conj acc nil)]))
            [0 []] site-specs)))
@@ -791,8 +796,7 @@
 (defn- extract-noise-site-types
   "Filter site-specs to those with noise-fns."
   [site-specs]
-  (filterv (fn [s] (and s (:noise-fn (get compiled/noise-transforms-full (:dist-type s)))))
-           site-specs))
+  (filterv noise-fn-site? site-specs))
 
 (defn generate-noise-matrix
   "Generate [T, K] noise matrix where each column has the correct distribution.

--- a/src/genmlx/control/decision_value.cljs
+++ b/src/genmlx/control/decision_value.cljs
@@ -38,10 +38,16 @@
                                          traces)))]
     {:probs probs :values values}))
 
-(defn weighted-mean [{:keys [probs values]}]
+(defn weighted-mean
+  "Posterior mean E_posterior[theta] = sum_i p_i * value_i over a weighted-latent
+   map {:probs [N] :values [N]}."
+  [{:keys [probs values]}]
   (reduce + 0.0 (map * probs values)))
 
-(defn weighted-variance [{:keys [probs values] :as wl}]
+(defn weighted-variance
+  "Posterior variance Var_posterior(theta) = sum_i p_i * (value_i - mean)^2 over a
+   weighted-latent map. Used by `neg-bayes-risk` as the squared-error decision-value."
+  [{:keys [probs values] :as wl}]
   (let [m (weighted-mean wl)]
     (reduce + 0.0 (map (fn [p v] (let [d (- v m)] (* p d d))) probs values))))
 

--- a/src/genmlx/dep_graph.cljs
+++ b/src/genmlx/dep_graph.cljs
@@ -20,8 +20,8 @@
    NOTE: Drops skip edges (a→c when a→b→c also exists). This is a known
    limitation — fix requires schema to track direct vs transitive deps separately."
   [trace-sites addr-set]
-  (let [site-map (into {} (map (juxt :addr identity))
-                        (filter #(contains? addr-set (:addr %)) trace-sites))]
+  (let [relevant (filter #(contains? addr-set (:addr %)) trace-sites)
+        site-map (into {} (map (juxt :addr identity)) relevant)]
     (into {}
       (map (fn [site]
              (let [transitive (set/intersection (:deps site) addr-set)
@@ -32,7 +32,7 @@
                                     #{}
                                     transitive)]
                [(:addr site) (set/difference transitive indirect)]))
-           (filter #(contains? addr-set (:addr %)) trace-sites)))))
+           relevant))))
 
 (defn build-dep-graph
   "Build a directed acyclic graph from schema trace sites.
@@ -52,7 +52,7 @@
                          parent parents]
                      [parent child]))
         children (reduce (fn [m [from to]] (update m from (fnil conj #{}) to))
-                         (into {} (map (fn [a] [a #{}]) addr-set))
+                         (zipmap addr-set (repeat #{}))
                          edges)]
     (->DepGraph addr-set edges direct-parents children)))
 
@@ -218,7 +218,7 @@
                                               (update nbr (fnil conj #{}) node)))
                               adj
                               neighbors)))
-                  (into {} (map (fn [n] [n #{}]) unobserved))
+                  (zipmap unobserved (repeat #{}))
                   unobserved)
             ;; Find connected components via BFS
             components (loop [remaining unobserved

--- a/src/genmlx/dev.cljs
+++ b/src/genmlx/dev.cljs
@@ -27,10 +27,10 @@
 (defn- compile-validators
   "Precompile a {key -> schema} map into {key -> {:validate :explain :schema}}."
   [schema-map]
-  (into {} (map (fn [[k schema]] [k {:validate (m/validator schema)
-                                     :explain  (m/explainer schema)
-                                     :schema   schema}]))
-        schema-map))
+  (update-vals schema-map
+               (fn [schema] {:validate (m/validator schema)
+                             :explain  (m/explainer schema)
+                             :schema   schema})))
 
 (def ^:private op->validator
   (compile-validators

--- a/src/genmlx/dist.cljs
+++ b/src/genmlx/dist.cljs
@@ -636,7 +636,7 @@
    Zero weights get a large negative logit (-100) with zero gradient.
    Positive weights get log(weights) with correct gradients."
   [weights]
-  (let [weights (.astype weights mx/float32)
+  (let [weights (mx/astype weights mx/float32)
         positive (mx/greater weights (mx/scalar 0))
         ;; Safe log: only compute log for positive weights
         safe-log (mx/log (mx/maximum weights (mx/scalar 1e-10)))
@@ -1515,10 +1515,11 @@
 (defn- wrap-angle
   "Wrap value to [-π, π)."
   [x]
-  (mx/subtract x
-               (mx/multiply (mx/scalar (* 2.0 js/Math.PI))
-                            (mx/floor (mx/divide (mx/add x MLX-PI)
-                                                 (mx/scalar (* 2.0 js/Math.PI)))))))
+  (let [two-pi (mx/scalar (* 2.0 js/Math.PI))]
+    (mx/subtract x
+                 (mx/multiply two-pi
+                              (mx/floor (mx/divide (mx/add x MLX-PI)
+                                                   two-pi))))))
 
 (defdist von-mises
   "Von Mises distribution on [-π, π) with mean direction mu and concentration kappa."

--- a/src/genmlx/encapsulated.cljs
+++ b/src/genmlx/encapsulated.cljs
@@ -59,7 +59,7 @@
    Use it directly, not wrapped in a combinator."
   (:require [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
-            [genmlx.mlx.constants :refer [ZERO]]
+            [genmlx.mlx.constants :refer [ZERO LOG-2PI]]
             [genmlx.choicemap :as cm]
             [genmlx.selection :as sel]
             [genmlx.protocols :as p]
@@ -268,8 +268,6 @@
 ;; Gaussian log-density helper (estimator-internal; the TEST oracle is an
 ;; independent JS implementation, never this).
 ;; ---------------------------------------------------------------------------
-
-(def ^:private LOG-2PI (js/Math.log (* 2 js/Math.PI)))
 
 (defn- gauss-logpdf
   "logN(x; mu, sigma), elementwise over MLX arrays. sigma is an MLX scalar."

--- a/src/genmlx/fit.cljs
+++ b/src/genmlx/fit.cljs
@@ -24,7 +24,7 @@
 (defn- observation-addr-set
   "Set of top-level observation addresses from a constraints ChoiceMap."
   [data]
-  (if (and data (instance? cm/Node data))
+  (if (instance? cm/Node data)
     (set (keys (:m data)))
     #{}))
 

--- a/src/genmlx/gfi.cljs
+++ b/src/genmlx/gfi.cljs
@@ -1339,7 +1339,7 @@
     :theorem "Simulate distribution matches the analytical Dist⟦E⟧.
               Sample moments converge to analytical moments."
     :tags #{:semantics}
-    :check (fn [{:keys [_model _args]}]
+    :check (fn [_]
              ;; Tests on a fixed reference model (gaussian chain)
              ;; x ~ N(0,1), y ~ N(x, 0.5)
              ;; Analytical: E[y]=0, Var[y]=1.25, Cov(x,y)=1
@@ -1370,7 +1370,7 @@
     :theorem "The gen body maps to P = (X, Y, p, f) where all four
               components agree with the analytical denotation."
     :tags #{:semantics}
-    :check (fn [{:keys [_model _args]}]
+    :check (fn [_]
              ;; Fixed reference: x ~ N(0,1), y ~ N(x, 0.5)
              ;; At tau = {:x 0.5, :y 1.0}:
              ;;   p: score = log N(0.5;0,1) + log N(1.0;0.5,0.5)
@@ -1405,7 +1405,7 @@
     :theorem "For conjugate models with analytical handler, generate weight
               equals the log marginal likelihood."
     :tags #{:inference :internal-proposal}
-    :check (fn [{:keys [_model _args]}]
+    :check (fn [_]
              ;; Fixed conjugate model: mu ~ N(0,2), y ~ N(mu,1)
              ;; Analytical: log N(3; 0, sqrt(5))
              (let [conj-model (dyn/auto-key
@@ -1467,7 +1467,7 @@
               and cycle of same components converge to the analytical
               posterior mean."
     :tags #{:inference :mcmc}
-    :check (fn [{:keys [_model _args]}]
+    :check (fn [_]
              ;; Fixed model: x ~ N(0,1), y ~ N(0,1), obs ~ N(x+y, 0.5), obs=2
              ;; Analytical posterior mean of x+y = 8/4.5 = 1.778
              (let [kern-model (dyn/auto-key
@@ -1541,7 +1541,7 @@
               checked on a 3-component Gaussian mixture whose exact density is
               an independent closed form."
     :tags #{:encapsulated :inference}
-    :check (fn [{:keys [_model _args]}]
+    :check (fn [_]
              (let [w [0.3 0.5 0.2] mu [-2 0 3] sg [1 0.5 2]
                    {:keys [gf]} (enc/mixture-density
                                  {:weights w :means mu :sigmas sg :k 32})
@@ -1572,7 +1572,7 @@
               weight is EXACTLY 0. Without stored omega a fresh xi would inject
               nonzero weight into SMC/MH."
     :tags #{:encapsulated :inference}
-    :check (fn [{:keys [_model _args]}]
+    :check (fn [_]
              (let [{:keys [gf]} (enc/marginalized-gaussian
                                  {:n 2 :tau 1.0 :sigma 1.0 :k 16})
                    theta (mx/scalar 0.4)
@@ -1593,7 +1593,7 @@
               distribution. Normal-Normal conjugate: posterior mean recovered to
               tolerance (independent closed form 24/13)."
     :tags #{:encapsulated :mcmc :inference}
-    :check (fn [{:keys [_model _args]}]
+    :check (fn [_]
              (let [{:keys [gf]} (enc/marginalized-gaussian
                                  {:n 3 :tau 0.6 :sigma 0.8 :k 8})
                    y (mx/array [1.0 2.0 3.0])
@@ -2371,7 +2371,8 @@
                  :or {n-trials 10}}]
   (let [model (dyn/auto-key model)
         selected (cond
-                   law-names (filter #(contains? (set law-names) (:name %)) laws)
+                   law-names (let [name-set (set law-names)]
+                               (filter #(contains? name-set (:name %)) laws))
                    tags (let [tag-set (set tags)]
                           (filter #(some tag-set (:tags %)) laws))
                    :else laws)

--- a/src/genmlx/handler.cljs
+++ b/src/genmlx/handler.cljs
@@ -395,7 +395,7 @@
   (-> state
       (update :choices cm/set-submap addr (:choices sub-result))
       (update :score mx/add (:score sub-result))
-      (update :splice-scores (fn [ss] (assoc (or ss {}) addr (:score sub-result))))
+      (update :splice-scores (fnil assoc {}) addr (:score sub-result))
       (update :score-type tr/combine-score-types (:score-type sub-result))
       (cond->
        (and (contains? state :weight) (:weight sub-result))

--- a/src/genmlx/inference/amortized.cljs
+++ b/src/genmlx/inference/amortized.cljs
@@ -73,13 +73,6 @@
   [encoder]
   (if (instance? Atom encoder) encoder (atom encoder)))
 
-(defn- fwd
-  "Get the current forward function from an encoder (atom or map)."
-  [encoder]
-  (if (instance? Atom encoder)
-    (:forward @encoder)
-    (:forward encoder)))
-
 ;; ---------------------------------------------------------------------------
 ;; ELBO loss for training
 ;; ---------------------------------------------------------------------------
@@ -121,8 +114,8 @@
    Returns (fn [forward-fn data] -> scalar loss) for use with nn/value-and-grad."
   [encoder model latent-addrs & {:keys [model-args-fn observations-fn posterior-family
                                          log-joint-fn]
-                                  :or {model-args-fn (fn [x] [x])
-                                       observations-fn (fn [_] cm/EMPTY)
+                                  :or {model-args-fn vector
+                                       observations-fn (constantly cm/EMPTY)
                                        posterior-family gaussian-posterior}}]
   (let [model (dyn/auto-key model)
         d (count latent-addrs)

--- a/src/genmlx/inference/compiled_gradient.cljs
+++ b/src/genmlx/inference/compiled_gradient.cljs
@@ -14,7 +14,6 @@
    - make-differentiable-chain: build a differentiable MH chain function"
   (:require [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
-            [genmlx.inference.util :as u]
             [genmlx.inference.differentiable-resample :as dr]
             [genmlx.compiled-ops :as cops]))
 

--- a/src/genmlx/inference/compiled_optimizer.cljs
+++ b/src/genmlx/inference/compiled_optimizer.cljs
@@ -21,7 +21,7 @@
 ;; Shared Adam recurrence + loop policies
 ;; ---------------------------------------------------------------------------
 
-(defn adam-scalars
+(defn- adam-scalars
   "Pre-build the MLX scalar constants used by the Adam recurrence.
    Returns a map consumed by `adam-update`."
   [{:keys [lr beta1 beta2 epsilon]
@@ -33,7 +33,7 @@
    :one-minus-b1 (mx/scalar (- 1.0 beta1))
    :one-minus-b2 (mx/scalar (- 1.0 beta2))})
 
-(defn adam-update
+(defn- adam-update
   "One Adam parameter update. Given current `params`, first/second moments
    `m`/`v`, the `grad`, the scalar constants from `adam-scalars`, and the
    bias-correction denominators `bias1` = 1 - beta1^t and `bias2` = 1 - beta2^t,
@@ -54,12 +54,12 @@
         new-params (mx/subtract params (mx/multiply lr-s update-vec))]
     [new-params new-m new-v]))
 
-(defn log-iter?
+(defn- log-iter?
   "True on the first iteration and every `log-every` iterations thereafter."
   [i log-every]
   (or (zero? i) (zero? (mod (inc i) log-every))))
 
-(defn maybe-cleanup!
+(defn- maybe-cleanup!
   "Periodic Metal cleanup: clear the cache and sweep dead arrays every 50
    iterations (skipping iteration 0)."
   [i]
@@ -318,7 +318,8 @@
         (u/make-tensor-score-fn model args observations addresses)
         ;; Get initial trace for extracting init-params
         {:keys [trace]} (p/generate model-keyed args observations)]
-    (if tensor-native?
+    (cond
+      tensor-native?
       ;; Path 1: Tensor-native — fully compiled gradient
       (let [init-params (u/extract-params-by-index trace latent-index)
             n-params (count latent-index)
@@ -331,35 +332,38 @@
          :n-params n-params
          :compilation-level :tensor-native
          :latent-index latent-index})
-      (if compiled-generate?
-        ;; Path 2: Compiled-generate — exact AD, not compiled
-        (let [init-params (u/extract-params trace addresses)
-              n-params (first (mx/shape init-params))
-              neg-score (fn [params] (mx/negative (score-fn params)))
-              vg (mx/value-and-grad neg-score)]
-          {:loss-grad-fn vg
-           :score-fn score-fn
-           :init-params init-params
-           :n-params n-params
-           :compilation-level :compiled-generate
-           :latent-index latent-index})
-        ;; Path 3: Handler-based — finite-difference gradients
-        (let [layout (u/compute-param-layout trace addresses)
-              init-params (u/extract-params trace addresses layout)
-              n-params (:total-size layout)
-              gfi-score-fn (u/make-score-fn model args observations addresses layout)
-              neg-score (fn [params] (mx/negative (gfi-score-fn params)))
-              loss-grad (fn [params]
-                          (let [loss (neg-score params)
-                                grad (finite-diff-grad neg-score params 1e-4)]
-                            (mx/materialize! loss grad)
-                            [loss grad]))]
-          {:loss-grad-fn loss-grad
-           :score-fn gfi-score-fn
-           :init-params init-params
-           :n-params n-params
-           :compilation-level :handler
-           :latent-index latent-index})))))
+
+      compiled-generate?
+      ;; Path 2: Compiled-generate — exact AD, not compiled
+      (let [init-params (u/extract-params trace addresses)
+            n-params (first (mx/shape init-params))
+            neg-score (fn [params] (mx/negative (score-fn params)))
+            vg (mx/value-and-grad neg-score)]
+        {:loss-grad-fn vg
+         :score-fn score-fn
+         :init-params init-params
+         :n-params n-params
+         :compilation-level :compiled-generate
+         :latent-index latent-index})
+
+      :else
+      ;; Path 3: Handler-based — finite-difference gradients
+      (let [layout (u/compute-param-layout trace addresses)
+            init-params (u/extract-params trace addresses layout)
+            n-params (:total-size layout)
+            gfi-score-fn (u/make-score-fn model args observations addresses layout)
+            neg-score (fn [params] (mx/negative (gfi-score-fn params)))
+            loss-grad (fn [params]
+                        (let [loss (neg-score params)
+                              grad (finite-diff-grad neg-score params 1e-4)]
+                          (mx/materialize! loss grad)
+                          [loss grad]))]
+        {:loss-grad-fn loss-grad
+         :score-fn gfi-score-fn
+         :init-params init-params
+         :n-params n-params
+         :compilation-level :handler
+         :latent-index latent-index}))))
 
 (defn learn
   "Learn model parameters via compiled gradient optimization.

--- a/src/genmlx/inference/compiled_smc.cljs
+++ b/src/genmlx/inference/compiled_smc.cljs
@@ -62,7 +62,7 @@
   [extend-fn noise-t current-state obs-t all-addrs t N]
   (let [kernel-args [(mx/ensure-array t) current-state]
         {:keys [obs-log-prob values-map retval]} (extend-fn noise-t kernel-args obs-t)
-        new-particles (mx/stack (mapv #(get values-map %) all-addrs) 1)
+        new-particles (mx/stack (mapv values-map all-addrs) 1)
         new-state (or retval (get values-map (first all-addrs)))
         ml-inc (mx/subtract (mx/logsumexp obs-log-prob)
                              (mx/scalar (js/Math.log N)))]

--- a/src/genmlx/inference/conjugate.cljs
+++ b/src/genmlx/inference/conjugate.cljs
@@ -74,10 +74,11 @@
                    (mx/add (mx/multiply inv-prior mean)
                            (mx/multiply inv-obs obs)))
         ;; Masked: if mask=0, posterior unchanged, ll=0
+        one-minus-mask (mx/subtract (mx/scalar 1.0) mask)
         final-mean (mx/add (mx/multiply mask new-mean)
-                           (mx/multiply (mx/subtract (mx/scalar 1.0) mask) mean))
+                           (mx/multiply one-minus-mask mean))
         final-var (mx/add (mx/multiply mask new-var)
-                          (mx/multiply (mx/subtract (mx/scalar 1.0) mask) var))]
+                          (mx/multiply one-minus-mask var))]
     {:posterior {:mean final-mean :var final-var}
      :ll (mx/multiply mask ll)}))
 

--- a/src/genmlx/inference/cost.cljs
+++ b/src/genmlx/inference/cost.cljs
@@ -47,7 +47,7 @@
   "Additive merge of CostMeters (associative + commutative on every field).
    Always returns a meter with the full key set."
   [& meters]
-  (reduce (fn [acc m] (merge-with + acc m)) zero meters))
+  (apply merge-with + zero meters))
 
 (def ^:dynamic *wall-clock?*
   "When true, `measure` brackets the thunk with Bun.nanoseconds and reports
@@ -91,4 +91,4 @@
    chain a->b->c gives 2 + 1 + 0 = 3."
   [model]
   (let [g (dg/build-dep-graph (:schema model))]
-    (reduce + 0 (map (fn [n] (count (dg/find-descendants g n))) (:nodes g)))))
+    (reduce + (map (fn [n] (count (dg/find-descendants g n))) (:nodes g)))))

--- a/src/genmlx/inference/diagnostics.cljs
+++ b/src/genmlx/inference/diagnostics.cljs
@@ -70,10 +70,9 @@
   "Materialize a chain (vector of MLX scalars or plain numbers) to doubles."
   [chain]
   (mapv (fn [s]
-          (cond
-            (number? s) s
-            (mx/array? s) (do (mx/materialize! s) (mx/item s))
-            :else s))
+          (if (mx/array? s)
+            (do (mx/materialize! s) (mx/item s))
+            s))
         chain))
 
 (defn- quantile

--- a/src/genmlx/inference/ekf.cljs
+++ b/src/genmlx/inference/ekf.cljs
@@ -102,7 +102,7 @@
         [f-mean A] (ekf-linearize transition-fn mean)]
     {:mean f-mean
      :var  (mx/add (mx/multiply A (mx/multiply A var))
-                   (mx/multiply process-noise process-noise))}))
+                   (mx/square process-noise))}))
 
 (defn ekf-update
   "EKF update step: linearize h at belief mean, then Kalman update.

--- a/src/genmlx/inference/ekf_nd.cljs
+++ b/src/genmlx/inference/ekf_nd.cljs
@@ -320,6 +320,7 @@
          (let [{:keys [obs-fn jacobian-fn noise-std mask]} (:params dist)]
            (ekf-nd-update-j addrs means covs obs obs-fn jacobian-fn
                             noise-std mask))))}))
+
 (defn make-multi-ekf-transition
   "Handler middleware: wraps generate-transition for multi-dim EKF."
   [latent-addrs]

--- a/src/genmlx/inference/enumerate.cljs
+++ b/src/genmlx/inference/enumerate.cljs
@@ -43,7 +43,7 @@
                            "use approximate inference.")
                       {:n-combinations n-combos
                        :max-combinations max-combos
-                       :addr-supports (into {} (map (fn [[a s]] [a (count s)]) addr-supports))})))
+                       :addr-supports (update-vals addr-supports count)})))
     (mapv (fn [combo]
             (let [combo-cm (cm/from-flat-map (zipmap addrs combo))
                   full-cm (if observations (cm/merge-cm observations combo-cm) combo-cm)

--- a/src/genmlx/inference/exact.cljs
+++ b/src/genmlx/inference/exact.cljs
@@ -245,7 +245,7 @@
    with merge-sub-result. Only supports simulate/generate contexts — throws
    on update/regenerate (which require trace-level operations incompatible
    with full marginalization)."
-  [gf args {:keys [constraints key old-choices selection param-store]}]
+  [gf args {:keys [constraints old-choices selection param-store]}]
   (when (or (and old-choices (not= old-choices cm/EMPTY))
             selection)
     (throw (ex-info "Exact sub-models do not support update/regenerate"
@@ -369,11 +369,10 @@
   [log-probs axes target-addr support]
   (let [m-lp (marginal log-probs axes target-addr)
         m-p (mx/exp m-lp)
-        _ (mx/eval! m-p)
-        k (count support)]
-    (into {} (map (fn [i sv]
-                    [(mx/item sv) (mx/item (mx/slice m-p i (inc i)))])
-                  (range k) support))))
+        _ (mx/eval! m-p)]
+    (into {} (map-indexed (fn [i sv]
+                            [(mx/item sv) (mx/item (mx/slice m-p i (inc i)))])
+                          support))))
 
 ;; ---------------------------------------------------------------------------
 ;; Expectation, entropy, variance

--- a/src/genmlx/inference/fisher.cljs
+++ b/src/genmlx/inference/fisher.cljs
@@ -10,6 +10,7 @@
    Composes with differentiable.cljs for gradient computation and
    compiled-gen.cljs for optional Metal kernel fusion."
   (:require [genmlx.mlx :as mx]
+            [genmlx.mlx.constants :as constants]
             [genmlx.mlx.random :as rng]
             [genmlx.inference.differentiable :as diff]
             [genmlx.compiled-gen :as cg]))
@@ -171,9 +172,8 @@
         ;; Trace-adaptive damping: λ = max(floor, 1e-4·tr(F)/D)
         _ (mx/materialize! fisher-sym)
         tr-F (mx/item (mx/sum (mx/diag fisher-sym)))
-        lambda (if damping
-                 damping
-                 (max 1e-6 (* 1e-4 (/ (js/Math.abs tr-F) D))))
+        lambda (or damping
+                   (max 1e-6 (* 1e-4 (/ (js/Math.abs tr-F) D))))
         fisher (mx/add fisher-sym (mx/multiply (mx/scalar lambda) (mx/eye D)))]
     (mx/materialize! fisher)
     {:fisher fisher
@@ -208,7 +208,7 @@
         log-ml-val (mx/item log-ml)
         log-det-val (mx/item log-det)
         log-evidence (+ log-ml-val
-                        (* 0.5 D (js/Math.log (* 2 js/Math.PI)))
+                        (* 0.5 D constants/LOG-2PI)
                         (* -0.5 log-det-val))]
     (cond-> {:log-evidence log-evidence
              :log-ml log-ml-val
@@ -262,7 +262,7 @@
         diag-clj (mx/->clj diag-cov)
         ;; Scale the negativity threshold to the matrix so float32 round-off near
         ;; zero is not flagged, while a real negative variance is.
-        max-abs (reduce (fn [m x] (max m (js/Math.abs x))) 0.0 diag-clj)
+        max-abs (reduce max 0.0 (map js/Math.abs diag-clj))
         tol (* 1e-8 (max 1.0 max-abs))
         neg-idxs (vec (keep-indexed (fn [i x] (when (< x (- tol)) i)) diag-clj))
         se-clj (mapv (fn [x] (if (< x (- tol))

--- a/src/genmlx/inference/importance.cljs
+++ b/src/genmlx/inference/importance.cljs
@@ -38,7 +38,7 @@
 
    Returns {:traces [Trace ...] :log-weights [MLX-scalar ...]
             :log-ml-estimate MLX-scalar}"
-  [{:keys [samples key gc-every] :or {samples 100}} model args observations]
+  [{:keys [samples key gc-every] :or {samples 100 gc-every 50}} model args observations]
   (let [model (-> model dyn/auto-key strip-analytical)
         keys (rng/split-n (rng/ensure-key key) samples)
         ;; Deep-materialize EACH FULL trace (all choice leaves + retval + score),
@@ -49,7 +49,6 @@
         ;; evaluates every leaf, detaching it so the per-sample intermediates
         ;; become dead + sweepable (genmlx-py4a). mh already does this via
         ;; collect-samples/tidy-step.
-        gc-every (or gc-every 50)
         results (into []
                       (map-indexed
                        (fn [i ki]

--- a/src/genmlx/inference/mcmc.cljs
+++ b/src/genmlx/inference/mcmc.cljs
@@ -7,6 +7,7 @@
             [genmlx.choicemap :as cm]
             [genmlx.selection :as sel]
             [genmlx.mlx :as mx]
+            [genmlx.mlx.constants :refer [LOG-2PI]]
             [genmlx.mlx.random :as rng]
             [genmlx.trace :as tr]
             [genmlx.dynamic :as dyn]
@@ -1759,10 +1760,6 @@
                       next-key))))))))
 
 ;; ---------------------------------------------------------------------------
-;; Shared Hamiltonian helper
-;; ---------------------------------------------------------------------------
-
-;; ---------------------------------------------------------------------------
 ;; Mass matrix helpers for HMC / NUTS
 ;; ---------------------------------------------------------------------------
 
@@ -2469,7 +2466,7 @@
     (let [key (rng/ensure-key key)
           [k1 k2 k3] (rng/split-n key 3)
           tree1 (build-tree ctx q p log-u v (dec j) current-H k1)]
-      (if (not (:s' tree1))
+      (if-not (:s' tree1)
         tree1
         (let [[q2 p2] (if (pos? v)
                         [(:q-plus tree1) (:p-plus tree1)]
@@ -2655,7 +2652,7 @@
   [params prior-std d]
   (let [z (mx/divide params (mx/scalar prior-std))]
     (+ (* -0.5 (mx/realize (mx/sum (mx/square z))))
-       (* (- d) (+ (js/Math.log prior-std) (* 0.5 (js/Math.log (* 2 js/Math.PI))))))))
+       (* (- d) (+ (js/Math.log prior-std) (* 0.5 LOG-2PI))))))
 
 (defn elliptical-slice-step
   "One elliptical slice sampling step for models with Gaussian priors.
@@ -2850,11 +2847,11 @@
              (let [final-scores (score-fn params)
                    _ (mx/materialize! final-scores params)
                    ;; Handle scalar (0-dim) scores — single restart or collapsed batch
-                   scalar? (= 0 (count (mx/shape final-scores)))
+                   scalar? (empty? (mx/shape final-scores))
                    best-idx (if scalar? 0 (mx/item (mx/argmax final-scores)))
                    best-params-raw (mx/take-idx params (mx/array best-idx mx/int32))
                    ;; take-idx may squeeze to 0-dim for D=1; ensure 1D for indexing
-                   best-params (if (= 0 (count (mx/shape best-params-raw)))
+                   best-params (if (empty? (mx/shape best-params-raw))
                                  (mx/reshape best-params-raw [1])
                                  best-params-raw)
                    best-score (if scalar? (mx/item final-scores) (mx/item (mx/index final-scores best-idx)))

--- a/src/genmlx/inference/pmcmc.cljs
+++ b/src/genmlx/inference/pmcmc.cljs
@@ -92,7 +92,7 @@
                (repeat (count param-addrs) proposal-std)
                proposal-std)
         ;; Initialize
-        [init-key loop-key] (rng/split (rng/ensure-key key))
+        [_init-key loop-key] (rng/split (rng/ensure-key key))
         init-vals (or init-params
                       (let [trace (:trace (p/generate model args observations))]
                         (extract-param-vals trace param-addrs)))

--- a/src/genmlx/inference/smc.cljs
+++ b/src/genmlx/inference/smc.cljs
@@ -608,7 +608,7 @@
   [state indices]
   (cond
     (nil? state) nil
-    (map? state) (into {} (map (fn [[k v]] [k (mx/take-idx v indices)]) state))
+    (map? state) (update-vals state #(mx/take-idx % indices))
     :else (mx/take-idx state indices)))
 
 (defn- materialize-state! [state]

--- a/src/genmlx/inference/smcp3.cljs
+++ b/src/genmlx/inference/smcp3.cljs
@@ -158,7 +158,7 @@
         ;; Rejuvenation
         final-traces (if rejuvenation-fn
                        (let [rkeys (rng/split-n-or-nils rejuv-key particles)]
-                         (mapv (fn [t rk] (rejuvenation-fn t rk)) new-traces rkeys))
+                         (mapv rejuvenation-fn new-traces rkeys))
                        new-traces)
         ;; log-ML increment: against the post-resample weights the step
         ;; started from (see smc/log-ml-increment-from — subtracting the

--- a/src/genmlx/inference/translator.cljs
+++ b/src/genmlx/inference/translator.cljs
@@ -224,9 +224,9 @@
   "Indices of moves whose :applicable? predicate accepts `trace` (a move with no
    predicate is always applicable)."
   [moves trace]
-  (filterv (fn [i] (let [pred (:applicable? (nth moves i))]
-                     (or (nil? pred) (pred trace))))
-           (range (count moves))))
+  (vec (keep-indexed (fn [i {pred :applicable?}]
+                       (when (or (nil? pred) (pred trace)) i))
+                     moves)))
 
 (defn reversible-jump-mh-step
   "One reversible-jump MH step. `moves` is a vector of maps

--- a/src/genmlx/inference/vi.cljs
+++ b/src/genmlx/inference/vi.cljs
@@ -4,6 +4,7 @@
    and gradient estimators (reparameterization, REINFORCE)."
   (:require [genmlx.protocols :as p]
             [genmlx.mlx :as mx]
+            [genmlx.mlx.constants :refer [LOG-2PI]]
             [genmlx.mlx.random :as rng]
             [genmlx.dynamic :as dyn]
             [genmlx.inference.util :as u]
@@ -25,7 +26,7 @@
         eps (rng/normal (rng/ensure-key key) [n-samples d])
         samples (mx/add mu (mx/multiply sigma eps))
         ;; log q(z) for each sample
-        log-2pi-scalar (mx/scalar (js/Math.log (* 2 js/Math.PI)))
+        log-2pi-scalar (mx/scalar LOG-2PI)
         diff-norm (mx/divide (mx/subtract samples mu) sigma)
         log-q-per-dim (mx/multiply (mx/scalar -0.5)
                                    (mx/add log-2pi-scalar

--- a/src/genmlx/inspect.cljs
+++ b/src/genmlx/inspect.cljs
@@ -16,8 +16,8 @@
    :compiled-prefix-regenerate :compiled-prefix-assess :compiled-prefix-project])
 
 (defn- compilation-level [schema]
-  (let [has-compiled? (some #(get schema %) compiled-schema-keys)
-        has-prefix?   (some #(get schema %) prefix-schema-keys)]
+  (let [has-compiled? (some schema compiled-schema-keys)
+        has-prefix?   (some schema prefix-schema-keys)]
     (cond
       (and has-compiled? (:static? schema))       :L1-M2
       (and has-compiled? (:has-branches? schema))  :L1-M4

--- a/src/genmlx/learning.cljs
+++ b/src/genmlx/learning.cljs
@@ -16,9 +16,7 @@
    Initial params can be a map of {name -> MLX-array}."
   ([] {:params {} :version 0})
   ([init-params]
-   {:params (into {} (map (fn [[k v]]
-                            [k (if (mx/array? v) v (mx/scalar v))])
-                          init-params))
+   {:params (update-vals init-params #(if (mx/array? %) % (mx/scalar %)))
     :version 0}))
 
 (defn get-param

--- a/src/genmlx/linear_gaussian.cljs
+++ b/src/genmlx/linear_gaussian.cljs
@@ -87,9 +87,8 @@
    Returns {:marginal-ll scalar :post-mean [p] :post-cov [p p]}."
   [m0 S0 obs-specs]
   (let [final (reduce (fn [{:keys [mean cov ll]} ob]
-                        (let [r (lg-kalman-step {:mean mean :cov cov} ob)]
-                          {:mean (:mean r) :cov (:cov r)
-                           :ll (mx/add ll (:ll r))}))
+                        (let [step (lg-kalman-step {:mean mean :cov cov} ob)]
+                          (assoc step :ll (mx/add ll (:ll step)))))
                       {:mean m0 :cov S0 :ll (mx/scalar 0.0)}
                       obs-specs)]
     {:marginal-ll (:ll final) :post-mean (:mean final) :post-cov (:cov final)}))

--- a/src/genmlx/llm/backend.cljs
+++ b/src/genmlx/llm/backend.cljs
@@ -269,7 +269,7 @@
           ;; 1-row matrix → out-of-range garbage (decoded to "导图" instead of the
           ;; real next token). Using (dec t) is correct whether .forward returns
           ;; [1 1 vocab] or a full [1 T vocab].
-          t (nth (mx/shape logits) 1)]
+          t (second (mx/shape logits))]
       (-> logits (mx/index 0) (mx/index (dec t))))))
 
 (defn next-token-logprobs

--- a/src/genmlx/llm/bytes.cljs
+++ b/src/genmlx/llm/bytes.cljs
@@ -75,7 +75,7 @@
   (->> token-index
        (map-indexed vector)
        (reduce (fn [trie [id tok]]
-                 (if (and tok (pos? (count tok)))
+                 (if (seq tok)
                    (trie-insert trie id tok)
                    trie))
                {:children {} :token-ids #{}})

--- a/src/genmlx/llm/codegen.cljs
+++ b/src/genmlx/llm/codegen.cljs
@@ -30,7 +30,6 @@
             [genmlx.protocols :as p]
             [genmlx.choicemap :as cm]
             [genmlx.llm.backend :as llm]
-            [genmlx.llm.core :as llm-core]
             [genmlx.llm.bytes :as bytes]
             [promesa.core :as pr])
   (:require-macros [genmlx.gen :refer [gen]]))

--- a/src/genmlx/llm/grammar.cljs
+++ b/src/genmlx/llm/grammar.cljs
@@ -101,7 +101,7 @@
                        "t" [:lit "\t"]
                        "r" [:lit "\r"]
                        [:lit c]))
-       :class-char (fn [c] c)
+       :class-char identity
        :range      (fn [from to] (char-range from to))
        :class-body (fn [& items]
                      (reduce (fn [acc item]

--- a/src/genmlx/llm/schema_grammar.cljs
+++ b/src/genmlx/llm/schema_grammar.cljs
@@ -113,9 +113,9 @@
   "Quantifier `{lo,hi}` / `*` for a vector tail group, from optional min/max."
   [min* max*]
   (let [lo (max 0 (dec (or min* 1)))]
-    (cond
-      (and max* (>= max* 1)) (str "{" lo "," (dec max*) "}")
-      :else (if (zero? lo) "*" (str "{" lo ",}")))))
+    (if (and max* (>= max* 1))
+      (str "{" lo "," (dec max*) "}")
+      (if (zero? lo) "*" (str "{" lo ",}")))))
 
 ;; ============================================================
 ;; schema -> regex

--- a/src/genmlx/llm/structured.cljs
+++ b/src/genmlx/llm/structured.cljs
@@ -21,8 +21,7 @@
    byte-tokenization conditional), NOT the raw model evidence p_LM(text). It is
    the correct importance weight for THIS GF and is comparable across values of
    the same schema; it is not a model-marginal likelihood."
-  (:require [genmlx.mlx :as mx]
-            [genmlx.protocols :as p]
+  (:require [genmlx.protocols :as p]
             [genmlx.dynamic :as dyn]
             [genmlx.llm.backend :as llm]
             [genmlx.llm.bytes :as bytes]
@@ -37,7 +36,7 @@
 (defn- logsumexp-vals
   "logsumexp over a seq of JS numbers. -Inf for empty."
   [xs]
-  (let [m (reduce (fn [a b] (if (> b a) b a)) js/Number.NEGATIVE_INFINITY xs)]
+  (let [m (reduce max js/Number.NEGATIVE_INFINITY xs)]
     (if (= m js/Number.NEGATIVE_INFINITY)
       js/Number.NEGATIVE_INFINITY
       (+ m (js/Math.log (reduce (fn [s x] (+ s (js/Math.exp (- x m)))) 0.0 xs))))))

--- a/src/genmlx/memory.cljs
+++ b/src/genmlx/memory.cljs
@@ -295,7 +295,7 @@
   [{:keys [db]} key]
   (let [row (.get (.query db "SELECT key, kind, payload, score_type, created_at
                               FROM objects WHERE key = ?") key)]
-    (when (and row (not (undefined? row)))
+    (when row
       {:key        (.-key row)
        :kind       (.-kind row)
        :payload    (.-payload row)

--- a/src/genmlx/method_selection.cljs
+++ b/src/genmlx/method_selection.cljs
@@ -16,11 +16,6 @@
   [schema]
   (count (:trace-sites schema)))
 
-(defn- count-splice-sites
-  "Number of splice sites in the schema."
-  [schema]
-  (count (:splice-sites schema)))
-
 (defn- has-splice?
   "Does the model have any splice sites (sub-model calls)?"
   [schema]

--- a/src/genmlx/mlx.cljs
+++ b/src/genmlx/mlx.cljs
@@ -1377,8 +1377,3 @@
 (def cpu "cpu")
 (def gpu "gpu")
 
-(def pi    (.-PI js/Math))
-(def e-val (.-E js/Math))
-(def inf   js/Infinity)
-(def nan   js/NaN)
-

--- a/src/genmlx/mlx/random.cljs
+++ b/src/genmlx/mlx/random.cljs
@@ -28,40 +28,40 @@
    dtype is not float32. A fresh key is uint32[2]; the float 0-scalar that an
    autograd boundary can produce (shape [], float32) is rejected. Shape/dtype
    are lazy-graph metadata, so this is a cheap check (no GPU eval)."
-  [k]
-  (and (mx/array? k)
-       (= [2] (mx/shape k))
-       (not= mx/float32 (mx/dtype k))))
+  [key]
+  (and (mx/array? key)
+       (= [2] (mx/shape key))
+       (not= mx/float32 (mx/dtype key))))
 
 (defn- check-key
   "Raise a clear error if k is non-nil but not a valid PRNG key. Catches a
    mis-typed key (e.g. a float scalar from a coerced-nil autograd arg) at the
    rng boundary with an actionable message, instead of letting it reach NAPI
    and crash Metal with a C++ exception (SIGTRAP)."
-  [k where]
-  (when (and (some? k) (not (valid-key? k)))
+  [key where]
+  (when (and (some? key) (not (valid-key? key)))
     (throw (ex-info (str "rng/" where ": malformed PRNG key — expected a uint32 "
                          "array of shape [2], got "
-                         (if (mx/array? k)
-                           (str "shape " (mx/shape k) " dtype " (mx/dtype k))
-                           (pr-str k))
+                         (if (mx/array? key)
+                           (str "shape " (mx/shape key) " dtype " (mx/dtype key))
+                           (pr-str key))
                          ". A float scalar here usually means a nil key was "
                          "coerced at an autograd boundary; thread a real key.")
-                    {:key-shape (when (mx/array? k) (mx/shape k))
-                     :key-dtype (when (mx/array? k) (mx/dtype k))}))))
+                    {:key-shape (when (mx/array? key) (mx/shape key))
+                     :key-dtype (when (mx/array? key) (mx/dtype key))}))))
 
 (defn- check-key-present
   "Like check-key, but nil is also an error: split/split-n require a real key.
    Raising here gives an actionable message instead of the raw NAPI error a
    nil reaching .randomSplit produces. Nil-tolerant call sites use
    split-or-nils / split-n-or-nils."
-  [k where]
-  (when (nil? k)
+  [key where]
+  (when (nil? key)
     (throw (ex-info (str "rng/" where ": key is nil — thread a real PRNG key "
                          "(rng/fresh-key), or use rng/" where "-or-nils for "
                          "nil-as-no-entropy call sites.")
                     {:key nil})))
-  (check-key k where))
+  (check-key key where))
 
 (defn split
   "Split a key into two independent sub-keys. Returns [k1 k2]."
@@ -158,12 +158,3 @@
   ([key mean cov shape]
    (.keyMultivariateNormal c key
      (mx/array mean) (mx/array cov) (clj->js shape))))
-
-(defn- permutation
-  ([key n]
-   (let [rand-vals (uniform key [n])]
-     (mx/argsort rand-vals)))
-  ([key arr axis]
-   (let [n (nth (mx/shape arr) axis)
-         perm (permutation key n)]
-     (mx/take-idx arr perm axis))))

--- a/src/genmlx/nn.cljs
+++ b/src/genmlx/nn.cljs
@@ -14,11 +14,11 @@
    pure-function optimizers. `NeuralNetGF` wraps layers as
    deterministic generative functions for the GFI."
   (:require [genmlx.mlx :as mx]
+            [genmlx.mlx.constants :refer [ZERO]]
             [genmlx.mlx.random :as rng]
             [genmlx.protocols :as p]
             [genmlx.trace :as tr]
-            [genmlx.choicemap :as cm]
-))
+            [genmlx.choicemap :as cm]))
 
 ;; Forward declarations for rebuild functions (defined after constructors).
 (declare make-linear-rebuild make-layer-norm-rebuild make-embedding-rebuild
@@ -73,7 +73,7 @@
 ;; Activation layers (no parameters)
 ;; ---------------------------------------------------------------------------
 
-(defn relu [] {:params {} :forward (fn [x] (mx/maximum x (mx/scalar 0.0))) :type :relu})
+(defn relu [] {:params {} :forward (fn [x] (mx/maximum x ZERO)) :type :relu})
 (defn gelu []
   {:params {}
    :forward (fn [x]
@@ -216,7 +216,6 @@
 ;; ---------------------------------------------------------------------------
 
 ;; Deterministic GF: score and all weights/projections are zero.
-(def ^:private ZERO (mx/scalar 0.0))
 
 (defn- run-forward
   "Run the wrapped layer's forward pass on the first arg."

--- a/src/genmlx/program.cljs
+++ b/src/genmlx/program.cljs
@@ -170,7 +170,7 @@
                                     " (trace :sigma-" (name v)
                                     " (dist/exponential 1))"))
                              var-names)]
-    (into [] (concat ar-bindings cross-bindings sigma-bindings))))
+    (vec (concat ar-bindings cross-bindings sigma-bindings))))
 
 (defn build-transition-source
   "Build a transition model source string from variable names and edge structure.
@@ -488,25 +488,24 @@
   [{:keys [y cols]}]
   (let [n (count y)
         p (count cols)]
-    (if (<= n p)
-      1.0
-      (if (= p 1)
-        (let [x (:values (first cols))
-              xx (dot x x)
-              xy (dot x y)
-              beta-hat (/ xy xx)
-              residuals (mapv (fn [yi xi] (- yi (* beta-hat xi))) y x)]
-          (/ (dot residuals residuals) n))
-        (let [x1 (:values (first cols))
-              x2 (:values (second cols))
-              g00 (dot x1 x1) g01 (dot x1 x2) g11 (dot x2 x2)
-              det-g (- (* g00 g11) (* g01 g01))
-              xy1 (dot x1 y) xy2 (dot x2 y)
-              b1 (/ (- (* g11 xy1) (* g01 xy2)) det-g)
-              b2 (/ (- (* g00 xy2) (* g01 xy1)) det-g)
-              residuals (mapv (fn [yi x1i x2i] (- yi (* b1 x1i) (* b2 x2i)))
-                              y x1 x2)]
-          (/ (dot residuals residuals) n))))))
+    (cond
+      (<= n p) 1.0
+      (= p 1) (let [x (:values (first cols))
+                    xx (dot x x)
+                    xy (dot x y)
+                    beta-hat (/ xy xx)
+                    residuals (mapv (fn [yi xi] (- yi (* beta-hat xi))) y x)]
+                (/ (dot residuals residuals) n))
+      :else   (let [x1 (:values (first cols))
+                    x2 (:values (second cols))
+                    g00 (dot x1 x1) g01 (dot x1 x2) g11 (dot x2 x2)
+                    det-g (- (* g00 g11) (* g01 g01))
+                    xy1 (dot x1 y) xy2 (dot x2 y)
+                    b1 (/ (- (* g11 xy1) (* g01 xy2)) det-g)
+                    b2 (/ (- (* g00 xy2) (* g01 xy1)) det-g)
+                    residuals (mapv (fn [yi x1i x2i] (- yi (* b1 x1i) (* b2 x2i)))
+                                    y x1 x2)]
+                (/ (dot residuals residuals) n)))))
 
 (defn- log-ml-variable
   "Analytical log marginal likelihood for one variable's transition.
@@ -855,7 +854,7 @@
    ar-prior-mean ar-var beta-var]
   (mapv
    (fn [parents]
-     (let [preds (into [target] (vec (sort-by name parents)))
+     (let [preds (into [target] (sort-by name parents))
            [t1 t2 t3] (log-ml-suffstat-terms
                        target preds n all-dots xty-dots yty
                        known-sigma ar-prior-mean ar-var beta-var)]
@@ -903,7 +902,7 @@
          per-variable
          (into {}
                (map (fn [target]
-                      (let [candidates (vec (filter #(not= % target) var-names))
+                      (let [candidates (vec (remove #{target} var-names))
                             parent-sets (score-parent-sets-for-variable
                                          target candidates n all-dots xty-dots yty known-sigma
                                          ar-prior-mean ar-var beta-var)
@@ -1044,7 +1043,7 @@
                                     " (trace :sigma-" (name v)
                                     " (dist/exponential 1))"))
                              var-names)
-        all-bindings (into [] (concat ar-bindings cross-bindings sigma-bindings))
+        all-bindings (vec (concat ar-bindings cross-bindings sigma-bindings))
         binding-str (str/join "\n        " all-bindings)
         destructure-keys (str/join " " (map #(str (name %) "-prev") var-names))
         hint ";; mean: use mx/multiply, mx/add with ar-VAR, VAR-prev, optionally beta-SRC->TGT\n      ;; e.g. (mx/add (mx/multiply ar-y y-prev) (mx/multiply beta-x->y x-prev))\n      "

--- a/src/genmlx/rewrite.cljs
+++ b/src/genmlx/rewrite.cljs
@@ -36,7 +36,7 @@
    edge originating at an eliminated node."
   [graph eliminated]
   (-> graph
-      (update :nodes #(reduce disj % eliminated))
+      (update :nodes set/difference eliminated)
       (update :edges (fn [edges]
                        (into #{} (remove (fn [[a _]] (contains? eliminated a))) edges)))))
 

--- a/src/genmlx/sensorimotor.cljs
+++ b/src/genmlx/sensorimotor.cljs
@@ -231,13 +231,12 @@
   (mx/array
     (mapv (fn [memory]
             (mapv (fn [op-key]
-                    (if (nil? goal)
-                      0.5
-                      (if-let [impl (lookup-implication memory pkey op-key)]
-                        (if (= (:consequent impl) goal)
-                          (beta-mean impl)
-                          (- 1.0 (beta-mean impl)))
-                        0.5)))
+                    (let [impl (lookup-implication memory pkey op-key)]
+                      (cond
+                        (nil? goal)                 0.5
+                        (nil? impl)                 0.5
+                        (= (:consequent impl) goal) (beta-mean impl)
+                        :else                       (- 1.0 (beta-mean impl)))))
                   op-keys))
           particle-memories)))
 

--- a/src/genmlx/serialize.cljs
+++ b/src/genmlx/serialize.cljs
@@ -10,7 +10,8 @@
             [genmlx.choicemap :as cm]
             [genmlx.trace :as tr]
             [genmlx.protocols :as p]
-            [cljs.reader :as reader]))
+            [cljs.reader :as reader]
+            [clojure.string :as str]))
 
 (def ^:private fs (js/require "fs"))
 
@@ -97,9 +98,9 @@
   [s]
   (let [s (if (keyword? s) (subs (str s) 1) s)]
     (cond
-      (= "k:" (subs s 0 (min 2 (count s)))) (keyword (subs s 2))
-      (= "i:" (subs s 0 (min 2 (count s)))) (js/parseInt (subs s 2) 10)
-      (= "s:" (subs s 0 (min 2 (count s)))) (subs s 2)
+      (str/starts-with? s "k:") (keyword (subs s 2))
+      (str/starts-with? s "i:") (js/parseInt (subs s 2) 10)
+      (str/starts-with? s "s:") (subs s 2)
       :else (keyword s))))
 
 ;; ---------------------------------------------------------------------------
@@ -301,7 +302,7 @@
 ;; File I/O convenience
 ;; ---------------------------------------------------------------------------
 
-(defn save-choices-to-file
+(defn save-choices-to-file!
   "Save a trace's choices to a JSON file."
   [trace path & {:keys [gen-fn-id]}]
   (let [json (save-choices trace :gen-fn-id gen-fn-id)]
@@ -319,7 +320,7 @@
   (let [json (.readFileSync fs path "utf8")]
     (reconstruct-trace gen-fn args json)))
 
-(defn save-trace-to-file
+(defn save-trace-to-file!
   "Save a full trace to a JSON file."
   [trace path & {:keys [gen-fn-id]}]
   (let [json (save-trace trace :gen-fn-id gen-fn-id)]

--- a/src/genmlx/trace.cljs
+++ b/src/genmlx/trace.cljs
@@ -66,7 +66,7 @@
   "The score encoding of a trace: its ::score-type metadata, or :joint when
    untagged (hand-rolled traces in tests, deserialized traces)."
   [trace]
-  (get (meta trace) ::score-type :joint))
+  (::score-type (meta trace) :joint))
 
 (defn with-score-type
   "Return trace tagged with score-type st, preserving other metadata."

--- a/src/genmlx/verify.cljs
+++ b/src/genmlx/verify.cljs
@@ -177,17 +177,15 @@
           ;; Check score finiteness
           _ (mx/materialize! (:score result))
           score-val (mx/item (:score result))
-          violations (if (js/Number.isFinite score-val)
-                       violations
-                       (conj violations {:type :non-finite-score
-                                         :severity :error
-                                         :message (str "Model score is " score-val)}))
-          ;; Check empty model
-          violations (if (= (:choices result) cm/EMPTY)
-                       (conj violations {:type :empty-model
-                                         :severity :warning
-                                         :message "Model body contains no trace calls"})
-                       violations)]
+          violations (cond-> violations
+                       (not (js/Number.isFinite score-val))
+                       (conj {:type :non-finite-score
+                              :severity :error
+                              :message (str "Model score is " score-val)})
+                       (= (:choices result) cm/EMPTY)
+                       (conj {:type :empty-model
+                              :severity :warning
+                              :message "Model body contains no trace calls"}))]
       {:violations violations :trace trace})
     (catch :default e
       {:violations [{:type :execution-error

--- a/src/genmlx/vmap.cljs
+++ b/src/genmlx/vmap.cljs
@@ -15,16 +15,12 @@
 ;; Helpers
 ;; ---------------------------------------------------------------------------
 
-(def ^:private mlx-arr?
-  "Check if x is an MLX array."
-  mx/array?)
-
 (defn- axis-size-of
   "Get the leading dimension size of an arg."
   [a]
   (cond
     (nil? a) nil
-    (mlx-arr? a) (first (mx/shape a))
+    (mx/array? a) (first (mx/shape a))
     (sequential? a) (count a)
     :else nil))
 
@@ -57,7 +53,7 @@
   "Index into an arg at position i."
   [a i]
   (cond
-    (mlx-arr? a) (mx/index a i)
+    (mx/array? a) (mx/index a i)
     (sequential? a) (nth a i)
     :else a))
 
@@ -87,10 +83,10 @@
     true
 
     (nil? in-axes)
-    (every? mlx-arr? args)
+    (every? mx/array? args)
 
     :else
-    (every? (fn [[a ax]] (or (nil? ax) (mlx-arr? a)))
+    (every? (fn [[a ax]] (or (nil? ax) (mx/array? a)))
             (map vector args in-axes))))
 
 (defn- scalar-leaf?
@@ -100,7 +96,7 @@
     (= cm cm/EMPTY) true
     (cm/has-value? cm)
     (let [v (cm/get-value cm)]
-      (or (not (mlx-arr? v)) (= [] (mx/shape v))))
+      (or (not (mx/array? v)) (= [] (mx/shape v))))
     (instance? cm/Node cm)
     (every? (fn [[_ sub]] (scalar-leaf? sub)) (:m cm))
     :else true))
@@ -128,7 +124,7 @@
 (defn- scalar-value-leaf?
   "Check if a single leaf value is scalar (not [N]-shaped)."
   [v]
-  (or (not (mlx-arr? v)) (= [] (mx/shape v))))
+  (or (not (mx/array? v)) (= [] (mx/shape v))))
 
 (defn- stack-choices
   "Stack N choicemaps into one with [N]-shaped leaves.

--- a/src/genmlx/world/proc.cljs
+++ b/src/genmlx/world/proc.cljs
@@ -37,7 +37,7 @@
 (defn- now-ns
   "The sole clock read: Bun.nanoseconds as a JS number (0 off-Bun)."
   []
-  (if (and Bun (fn? (.-nanoseconds Bun)))
+  (if (available?)
     (js/Number (.nanoseconds Bun))
     0))
 

--- a/test/genmlx/serialize_test.cljs
+++ b/test/genmlx/serialize_test.cljs
@@ -100,7 +100,7 @@
                       x)))
           tr1 (p/simulate model [])
           path "/tmp/genmlx_serialize_test.json"]
-      (ser/save-choices-to-file tr1 path :gen-fn-id "file-test")
+      (ser/save-choices-to-file! tr1 path :gen-fn-id "file-test")
       (let [choices (ser/load-choices-from-file path)
             x-orig (mx/item (cm/get-value (cm/get-submap (:choices tr1) :x)))
             x-loaded (mx/item (cm/get-value (cm/get-submap choices :x)))]
@@ -113,7 +113,7 @@
                     (trace :x (dist/gaussian mu 1))))
           tr1 (p/simulate model [2.0])
           path "/tmp/genmlx_trace_test.json"]
-      (ser/save-trace-to-file tr1 path)
+      (ser/save-trace-to-file! tr1 path)
       (let [tr2 (ser/load-trace-from-file model path)
             x-orig (mx/item (cm/get-value (cm/get-submap (:choices tr1) :x)))
             x-loaded (mx/item (cm/get-value (cm/get-submap (:choices tr2) :x)))]
@@ -151,7 +151,7 @@
                       (mx/add x y))))
           tr1 (p/simulate model [0.0])
           path "/tmp/genmlx_reconstruct_test.json"]
-      (ser/save-choices-to-file tr1 path)
+      (ser/save-choices-to-file! tr1 path)
       (let [tr2 (ser/reconstruct-trace-from-file model [0.0] path)
             x-orig (mx/item (cm/get-value (cm/get-submap (:choices tr1) :x)))
             x-recon (mx/item (cm/get-value (cm/get-submap (:choices tr2) :x)))


### PR DESCRIPTION
## Idiomatic ClojureScript — second sweep (milestone `genmlx-dtju`)

Follow-on to the completed `genmlx-b3nx` idiomatic milestone (PR #33/#34), which swept the original 76 source files. The codebase has since grown to 108 src files; this sweep re-audits **all** of them (the ~32 newer files in `agents/`, `control/`, `world/`, `memory`, `encapsulated`, `program`, and recent `llm/`+`inference/` additions were never reviewed for idiom).

### Method
Multi-agent audit: one `cljs-purist` reviewer per file → adversarial verifier per finding → categorize apply-vs-bean, plus 5 cross-cutting passes. Reviewers were briefed on GenMLX's documented intentional patterns (the `volatile!`/atoms mutation boundary, hot-loop `materialize!`, `mx/compile-fn` identity, float aliasing, the executor indirection, uniform-signature combinator params) so findings never fight the architecture.

### Result
Ratings: **37 exemplary / 69 good / 2 minor-nits / 0 needs-work.** 139 raw findings → **91 behavior-preserving fixes applied across 62 files (net −41 lines)**; 24 false positives rejected; 33 substantive items filed as 11 child beans under the milestone. One `LOG-2PI` fix was auto-skipped (it would have changed `program.cljs` numerics — `sigma-sq` was inside the log).

Categories: dead-code removal, `get`→keyword access, `when-not`/`when-let`/`cond`/`cond->`, `update-vals`, map-as-fn, naked-fn elimination, `LOG-2PI`/`ZERO` constant reuse, unused-require removal, `!` on disk-write fns, `.astype`→`mx/astype` membrane consistency, `keep-indexed`/`map-indexed`, `defn-` privacy markers.

### Verification
Full diff hand-reviewed (all behavior-preserving). Fast-tier parity with `main` (only pre-existing failures). 10 certification + membrane-guard suites pass clean: `level0_certification`, `serialize`, `handler`, `dist`, `combinators`, `combinator_compile`, `compiled_simulate`, `membrane_coverage`, `clip_contract`, `gen_clj_compat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
