### PR TITLE
fix(inference): 3 correctness bugs — spliced-combinator regen weight, MCMC warmup PRNG, NUTS verification

### DIFF
--- a/src/genmlx/handler.cljs
+++ b/src/genmlx/handler.cljs
@@ -438,13 +438,24 @@
                       {:gen-fn gf :args elem-args
                        :choices old-choices :retval nil
                        :score (mx/scalar 0.0)})
+          ;; Child's full OLD joint score, re-scored under old choices (the
+          ;; elem-trace carries score 0, so it must be computed). An EMPTY-
+          ;; selection regenerate retains every site (no sampling) and returns
+          ;; the re-scored old joint as :score, using the SAME key-threading
+          ;; path as the real regenerate below — so it works for keyless spliced
+          ;; kernels. (project/assess route through the kernel's generate/assess
+          ;; ensure-key and throw "No PRNG key" for a keyless kernel — genmlx-1sni.)
+          child-old-score (:score (:trace (p/regenerate gf elem-trace (sel/select))))
           {:keys [trace weight]} (p/regenerate gf elem-trace sub-selection)]
-      ;; The child returns its final MH weight w = ΔS - pr, computed against
-      ;; the constructed old score of 0. The parent's batched regenerate
-      ;; accumulator holds proposal ratios (its final weight is
-      ;; ΔS_total - accumulator), so convert back: pr = S'_child - w.
+      ;; The parent's batched regenerate accumulator holds per-element proposal
+      ;; ratios (its final weight is ΔS_total - Σ pr). The child returns its
+      ;; retained-only weight w = W_child against the constructed old score of 0,
+      ;; so the proposal ratio is pr = S'_child - S_old_child - w (genmlx-1sni).
+      ;; Omitting S_old_child leaked the old combinator joint score into the
+      ;; weight (a full prior resample gave a non-zero weight instead of 0).
       {:choices (:choices trace) :score (:score trace)
-       :weight (mx/subtract (:score trace) weight) :retval (:retval trace)})
+       :weight (mx/subtract (mx/subtract (:score trace) child-old-score) weight)
+       :retval (:retval trace)})
 
     ;; Update mode
     (and old-i (not= old-i cm/EMPTY))

--- a/src/genmlx/inference/mcmc.cljs
+++ b/src/genmlx/inference/mcmc.cljs
@@ -1344,8 +1344,10 @@
   "Run n-warmup steps adapting step-size via dual averaging.
    step-fn: (fn [q eps-val metric key] -> {:state q' :accept-stat alpha})
    warmup-metric: metric to use during warmup (nil = identity).
+   key: PRNG key threaded through warmup steps (nil = no entropy / unseeded).
+        Split per step OUTSIDE tidy-run so warmup is reproducible (genmlx-vv3t).
    Returns {:step-size adapted-eps :state final-q :metric diagonal-or-nil}."
-  [n-warmup target-accept init-q step-fn n-params init-eps adapt-metric? warmup-metric]
+  [n-warmup target-accept init-q step-fn n-params init-eps adapt-metric? warmup-metric key]
   (let [gamma 0.05
         t0 10
         kappa 0.75
@@ -1359,15 +1361,19 @@
            log-eps-bar 0.0
            h-bar 0.0
            current-eps init-eps
-           welford init-welford]
+           welford init-welford
+           rk key]
       (if (> m n-warmup)
         {:step-size (js/Math.exp log-eps-bar)
          :state q
          :metric (when welford (welford-variance (second welford) (nth welford 2)))}
-        (let [;; Wrap step-fn in tidy-run to clean up intermediate MLX arrays
+        (let [;; Split the warmup key BEFORE tidy-run — splitting inside would let
+              ;; tidy free the sub-key arrays. [nil nil] when rk is nil (unseeded).
+              [step-key rk'] (rng/split-or-nils rk)
+              ;; Wrap step-fn in tidy-run to clean up intermediate MLX arrays
               ;; (NUTS builds ~10K arrays per step via binary tree — OOMs without cleanup)
               result (mx/tidy-run
-                      #(step-fn q current-eps warmup-metric nil)
+                      #(step-fn q current-eps warmup-metric step-key)
                       (fn [{:keys [state]}] [state]))
               _ (mx/clear-cache!)
               {:keys [state accept-stat]} result
@@ -1387,7 +1393,7 @@
                                q-js (mx/->clj state)]
                            (welford-update mean-v m2-v n q-js)))]
           (recur (inc m) state log-eps-bar' h-bar' (js/Math.exp log-eps')
-                 welford'))))))
+                 welford' rk'))))))
 
 ;; ---------------------------------------------------------------------------
 ;; MALA step-size adaptation (mirrors HMC's find-reasonable-epsilon)
@@ -1396,14 +1402,14 @@
 (defn- find-reasonable-mala-epsilon
   "Find initial MALA step-size yielding ~50% acceptance via doubling/halving.
    Same algorithm as find-reasonable-epsilon but using MALA proposals."
-  [q val-grad-compiled q-shape]
+  [q val-grad-compiled q-shape key]
   (let [test-accept
         (fn [eps-val]
           (let [eps (mx/scalar eps-val)
                 half-eps2 (mx/scalar (* 0.5 eps-val eps-val))
                 two-eps-sq (mx/scalar (* 2.0 eps-val eps-val))
                 {:keys [accepted?]}
-                (mala-step q val-grad-compiled eps half-eps2 two-eps-sq q-shape nil)]
+                (mala-step q val-grad-compiled eps half-eps2 two-eps-sq q-shape key)]
             (if accepted? 1.0 0.0)))
         init-a (test-accept 1.0)
         dir (if (> init-a 0.5) 1 -1)]
@@ -1419,12 +1425,12 @@
    dual-averaging expects: (fn [q eps-val metric key] -> {:state q' :accept-stat alpha})
    MALA doesn't use a mass matrix, so metric is ignored."
   [val-grad-compiled q-shape]
-  (fn [q eps-val _metric _key]
+  (fn [q eps-val _metric key]
     (let [eps (mx/scalar eps-val)
           half-eps2 (mx/scalar (* 0.5 eps-val eps-val))
           two-eps-sq (mx/scalar (* 2.0 eps-val eps-val))
           {:keys [state accepted?]}
-          (mala-step q val-grad-compiled eps half-eps2 two-eps-sq q-shape nil)]
+          (mala-step q val-grad-compiled eps half-eps2 two-eps-sq q-shape key)]
       {:state state
        :accept-stat (if accepted? 1.0 0.0)})))
 
@@ -1465,12 +1471,17 @@
              {:keys [adapted-eps warmup-q]}
              (if (and adapt-step-size (> burn 0))
                (let [n-warmup (min burn 200)
+                     ;; Derive a warmup key DISJOINT from the sampling stream so
+                     ;; warmup is reproducible under a fixed :key (genmlx-vv3t).
+                     ;; nil-tolerant: [nil nil] when key is nil (unseeded).
+                     [warmup-key _sample-key] (rng/split-or-nils (rng/ensure-key key))
+                     [eps-key wloop-key] (rng/split-or-nils warmup-key)
                      init-eps (find-reasonable-mala-epsilon
-                               init-q val-grad-compiled q-shape)
+                               init-q val-grad-compiled q-shape eps-key)
                      step-fn (make-mala-step-fn val-grad-compiled q-shape)
                      result (dual-averaging-warmup
                              n-warmup target-accept init-q step-fn
-                             n-params init-eps false nil)]
+                             n-params init-eps false nil wloop-key)]
                  (println "Adapted MALA step-size:" (:step-size result))
                  {:adapted-eps (:step-size result)
                   :warmup-q (:state result)})
@@ -1617,12 +1628,15 @@
                   {:keys [adapted-eps warmup-q]}
                   (if (and adapt-step-size (nil? chain-fn) (> burn 0))
                     (let [n-warmup (min warmup-steps burn)
+                          ;; Warmup key DISJOINT from the sampling stream (genmlx-vv3t).
+                          [warmup-key _sample-key] (rng/split-or-nils (rng/ensure-key key))
+                          [eps-key wloop-key] (rng/split-or-nils warmup-key)
                           init-eps (find-reasonable-mala-epsilon
-                                    init-params val-grad-compiled q-shape)
+                                    init-params val-grad-compiled q-shape eps-key)
                           step-fn (make-mala-step-fn val-grad-compiled q-shape)
                           result (dual-averaging-warmup
                                   n-warmup target-accept init-params step-fn
-                                  n-params init-eps false nil)]
+                                  n-params init-eps false nil wloop-key)]
                       (println "Adapted MALA step-size:" (:step-size result))
                       {:adapted-eps (:step-size result)
                        :warmup-q (:state result)})
@@ -1996,11 +2010,11 @@
 
 (defn- find-reasonable-epsilon
   "Find initial step-size yielding ~50% acceptance via doubling/halving."
-  [q neg-U-fn grad-neg-U q-shape metric]
+  [q neg-U-fn grad-neg-U q-shape metric key]
   (let [half (mx/scalar 0.5)
         test-accept
         (fn [eps]
-          (let [p0 (let [p (sample-momentum metric q-shape nil)] (mx/materialize! p) p)
+          (let [p0 (let [p (sample-momentum metric q-shape key)] (mx/materialize! p) p)
                 current-H (hamiltonian neg-U-fn q p0 half metric)
                 [q' p'] (leapfrog-step grad-neg-U q p0
                                        (mx/scalar eps) (mx/scalar (* 0.5 eps)) metric)
@@ -2067,25 +2081,28 @@
            ;; Adaptive warmup: dual averaging + optional metric estimation
              {:keys [adapted-eps warmup-q adapted-metric]}
              (if (and (or adapt-step-size adapt-metric) (> burn 0))
-               (let [hmc-step-fn
-                     (fn [q eps-val m _key]
+               (let [;; Warmup key DISJOINT from the sampling stream (genmlx-vv3t).
+                     [warmup-key _sample-key] (rng/split-or-nils (rng/ensure-key key))
+                     [eps-key wloop-key] (rng/split-or-nils warmup-key)
+                     hmc-step-fn
+                     (fn [q eps-val m step-key]
                        (let [eps-mx (mx/scalar eps-val)
                              half-eps-mx (mx/scalar (* 0.5 eps-val))
                              half-mx (mx/scalar 0.5)
                              {:keys [state log-accept]}
                              (hmc-step q neg-U-compiled grad-neg-U
                                        eps-mx half-eps-mx half-mx q-shape
-                                       leapfrog-steps m nil)]
+                                       leapfrog-steps m step-key)]
                          {:state state
                           :accept-stat (let [a (js/Math.exp log-accept)]
                                          (if (js/isNaN a) 0.0 (min 1.0 a)))}))
                      init-eps (if adapt-step-size
                                 (find-reasonable-epsilon init-q neg-U-compiled grad-neg-U
-                                                         q-shape metric)
+                                                         q-shape metric eps-key)
                                 step-size)
                      result (dual-averaging-warmup
                              burn target-accept init-q hmc-step-fn n-params init-eps
-                             adapt-metric (when-not adapt-metric metric))]
+                             adapt-metric (when-not adapt-metric metric) wloop-key)]
                  {:adapted-eps (when adapt-step-size (:step-size result))
                   :warmup-q (:state result)
                   :adapted-metric (:metric result)})
@@ -2250,24 +2267,27 @@
                   {:keys [adapted-eps warmup-q]}
                   (if (and adapt-step-size (nil? chain-fn) (> burn 0))
                     (let [n-warmup (min warmup-steps burn)
+                          ;; Warmup key DISJOINT from the sampling stream (genmlx-vv3t).
+                          [warmup-key _sample-key] (rng/split-or-nils (rng/ensure-key key))
+                          [eps-key wloop-key] (rng/split-or-nils warmup-key)
                           init-eps (find-reasonable-epsilon
                                     init-params neg-U-compiled grad-neg-U
-                                    q-shape nil)
+                                    q-shape nil eps-key)
                           half-mx (mx/scalar 0.5)
                           hmc-step-fn
-                          (fn [q eps-val _m _key]
+                          (fn [q eps-val _m step-key]
                             (let [eps-mx (mx/scalar eps-val)
                                   half-eps-mx (mx/scalar (* 0.5 eps-val))
                                   {:keys [state log-accept]}
                                   (hmc-step q neg-U-compiled grad-neg-U
                                             eps-mx half-eps-mx half-mx q-shape
-                                            leapfrog-steps nil nil)]
+                                            leapfrog-steps nil step-key)]
                               {:state state
                                :accept-stat (let [a (js/Math.exp log-accept)]
                                               (if (js/isNaN a) 0.0 (min 1.0 a)))}))
                           result (dual-averaging-warmup
                                   n-warmup target-accept init-params hmc-step-fn
-                                  n-params init-eps false nil)]
+                                  n-params init-eps false nil wloop-key)]
                       (println "Adapted HMC step-size:" (:step-size result))
                       {:adapted-eps (:step-size result)
                        :warmup-q (:state result)})
@@ -2533,15 +2553,20 @@
            ;; Adaptive warmup: dual averaging + optional metric estimation
              {:keys [adapted-eps warmup-q adapted-metric]}
              (if (and (or adapt-step-size adapt-metric) (> burn 0))
-               (let [nuts-step-fn
-                     (fn [q eps-val m _key]
+               (let [;; Warmup key DISJOINT from the sampling stream (genmlx-vv3t).
+                     [warmup-key-outer _sample-key] (rng/split-or-nils (rng/ensure-key key))
+                     [eps-key wloop-key] (rng/split-or-nils warmup-key-outer)
+                     nuts-step-fn
+                     (fn [q eps-val m step-key]
                        (let [eps-mx (mx/scalar eps-val)
                              half-eps-mx (mx/scalar (* 0.5 eps-val))
                              half-mx (mx/scalar 0.5)
                              local-ctx {:neg-ld neg-ld-compiled :grad grad-neg-ld
                                         :eps eps-mx :half-eps half-eps-mx
                                         :half half-mx :metric m}
-                             warmup-key (rng/fresh-key)
+                             ;; Use the threaded warmup sub-key instead of fresh
+                             ;; entropy so warmup is reproducible (genmlx-vv3t).
+                             warmup-key (rng/ensure-key step-key)
                              [momentum-key slice-key dir-key tree-key] (rng/split-n warmup-key 4)
                              p0 (let [p (sample-momentum m q-shape momentum-key)] (mx/materialize! p) p)
                              current-H (hamiltonian neg-ld-compiled q p0 half-mx m)
@@ -2585,11 +2610,11 @@
                                       dk-next tk-next))))))
                      init-eps (if adapt-step-size
                                 (find-reasonable-epsilon init-q neg-ld-compiled grad-neg-ld
-                                                         q-shape metric)
+                                                         q-shape metric eps-key)
                                 step-size)
                      result (dual-averaging-warmup
                              burn target-accept init-q nuts-step-fn n-params init-eps
-                             adapt-metric (when-not adapt-metric metric))]
+                             adapt-metric (when-not adapt-metric metric) wloop-key)]
                  {:adapted-eps (when adapt-step-size (:step-size result))
                   :warmup-q (:state result)
                   :adapted-metric (:metric result)})

--- a/test/genmlx/mcmc_warmup_reproducibility_test.cljs
+++ b/test/genmlx/mcmc_warmup_reproducibility_test.cljs
@@ -1,0 +1,108 @@
+;; @tier fast core
+(ns genmlx.mcmc-warmup-reproducibility-test
+  "Regression test for genmlx-vv3t: adaptive-warmup step-size + warmup
+   end-state must be reproducible under a fixed :key.
+
+   Before the fix, dual-averaging-warmup, find-reasonable-epsilon /
+   find-reasonable-mala-epsilon, and the per-algorithm warmup step-fns drew
+   fresh entropy independent of the user :key, so two runs with the SAME seed
+   diverged (the adapted step-size + warmup q were non-deterministic). The
+   fix threads the user key through warmup (disjoint from the sampling stream),
+   so a fixed seed now produces bit-identical runs, while a different seed
+   produces a different run (the key actually matters)."
+  (:require [cljs.test :refer [deftest is testing run-tests]]
+            [genmlx.test-helpers :as h]
+            [genmlx.choicemap :as cm]
+            [genmlx.mlx.random :as rng]
+            [genmlx.gen :refer [gen]]
+            [genmlx.dist :as dist]
+            [genmlx.inference.mcmc :as mcmc]))
+
+;; ---------------------------------------------------------------------------
+;; Trivial model: mu ~ N(0, 5), y ~ N(mu, 1), observe y = 2.0
+;; Posterior on mu is a simple Gaussian — enough to exercise the gradient
+;; warmup path without large graphs.
+;; ---------------------------------------------------------------------------
+
+(def model
+  (gen []
+    (let [mu (trace :mu (dist/gaussian 0 5))]
+      (trace :y (dist/gaussian mu 1)))))
+
+(def obs (cm/choicemap :y 2.0))
+
+;; Small workload that exercises the eager (compile? false) dual-averaging
+;; warmup path: ~30 burn-in steps, 3 collected samples.
+(def base-opts
+  {:samples 3 :burn 30 :step-size 0.05 :addresses [:mu]
+   :adapt-step-size true :compile? false :device :cpu})
+
+(defn- run-alg
+  "Run an adaptive-warmup MCMC algorithm with the given key, return the
+   collected sample values (first slot of each sample row) as a Clojure vector
+   of JS numbers — a deterministic run summary."
+  [alg-fn key]
+  (let [samples (alg-fn (assoc base-opts :key key) model [] obs)]
+    (mapv first samples)))
+
+(defn- identical-runs?
+  "Two run summaries are bit-identical (tolerance 0.0)."
+  [a b]
+  (and (= (count a) (count b))
+       (every? true? (map #(h/close? %1 %2 0.0) a b))))
+
+(defn- runs-differ?
+  "Run summaries differ in at least one position."
+  [a b]
+  (not (identical-runs? a b)))
+
+;; ---------------------------------------------------------------------------
+;; Per-algorithm reproducibility: same seed → bit-identical, different seed →
+;; different run.
+;; ---------------------------------------------------------------------------
+
+(deftest nuts-warmup-reproducible
+  (testing "NUTS adaptive warmup is reproducible under a fixed key"
+    (let [a (run-alg mcmc/nuts (rng/fresh-key 7))
+          b (run-alg mcmc/nuts (rng/fresh-key 7))
+          c (run-alg mcmc/nuts (rng/fresh-key 99))]
+      (is (identical-runs? a b)
+          (str "same seed → identical: " a " vs " b))
+      (is (runs-differ? a c)
+          (str "different seed → different: seed7=" a " seed99=" c)))))
+
+(deftest hmc-warmup-reproducible
+  (testing "HMC adaptive warmup is reproducible under a fixed key"
+    (let [a (run-alg mcmc/hmc (rng/fresh-key 7))
+          b (run-alg mcmc/hmc (rng/fresh-key 7))
+          c (run-alg mcmc/hmc (rng/fresh-key 99))]
+      (is (identical-runs? a b)
+          (str "same seed → identical: " a " vs " b))
+      (is (runs-differ? a c)
+          (str "different seed → different: seed7=" a " seed99=" c)))))
+
+(deftest mala-warmup-reproducible
+  (testing "MALA adaptive warmup is reproducible under a fixed key"
+    (let [a (run-alg mcmc/mala (rng/fresh-key 7))
+          b (run-alg mcmc/mala (rng/fresh-key 7))
+          c (run-alg mcmc/mala (rng/fresh-key 99))]
+      (is (identical-runs? a b)
+          (str "same seed → identical: " a " vs " b))
+      (is (runs-differ? a c)
+          (str "different seed → different: seed7=" a " seed99=" c)))))
+
+;; ---------------------------------------------------------------------------
+;; nil-key path still works (no determinism asserted — unseeded is fresh
+;; entropy by design). Guards against the new key threading breaking the
+;; nil-tolerant callers.
+;; ---------------------------------------------------------------------------
+
+(deftest nil-key-still-works
+  (testing "adaptive warmup with :key nil runs without error for all algorithms"
+    (doseq [[label alg-fn] [["nuts" mcmc/nuts] ["hmc" mcmc/hmc] ["mala" mcmc/mala]]]
+      (let [samples (alg-fn (assoc base-opts :key nil) model [] obs)]
+        (is (= 3 (count samples)) (str label " returns 3 samples with nil key"))
+        (is (every? #(h/finite? (first %)) samples)
+            (str label " produces finite samples with nil key"))))))
+
+(run-tests)

--- a/test/genmlx/nuts_noncentered_funnel_test.cljs
+++ b/test/genmlx/nuts_noncentered_funnel_test.cljs
@@ -1,0 +1,73 @@
+;; @tier medium
+(ns genmlx.nuts-noncentered-funnel-test
+  "Positive control for genmlx-gp5i.
+
+   The centered Neal funnel (paper_bench_funnel: v ~ N(0,3), x_i ~ N(0,exp(v/2)))
+   gives NUTS a high R-hat (~2.2) at low ESS. That is NOT a NUTS bug — it is the
+   canonical pathological GEOMETRY (the neck at negative v has exponentially small
+   x-scale). An independent textbook NUTS reproduces the same bias, and the GenMLX
+   U-turn (inv-mass-multiply / genmlx-o78h), slice, and energy-error divergence
+   logic are all correct.
+
+   This test pins the positive control: on the NON-CENTERED reparameterization of
+   the SAME funnel — v ~ N(0,3), xr_i ~ N(0,1), so the SAMPLED latents are
+   independent and well-conditioned (no funnel geometry) — NUTS converges cleanly
+   (multi-chain R-hat on v near 1, v marginal recovers N(0,3)). If this ever
+   regresses, the NUTS sampler itself is broken; the centered-funnel R-hat is not
+   a regression signal."
+  (:require [genmlx.mlx :as mx]
+            [genmlx.mlx.random :as rng]
+            [genmlx.dist :as dist]
+            [genmlx.dynamic :as dyn]
+            [genmlx.choicemap :as cm]
+            [genmlx.inference.mcmc :as mcmc]
+            [genmlx.inference.diagnostics :as diag]
+            [cljs.test :refer [deftest is testing run-tests]]
+            [genmlx.test-helpers :as h])
+  (:require-macros [genmlx.gen :refer [gen]]))
+
+(def D 5)
+
+(def noncentered-funnel
+  ;; Non-centered Neal's funnel: the funnel transform x_i = xr_i * exp(v/2) is
+  ;; deterministic, so the SAMPLED space (v, xr_i) carries no funnel geometry.
+  (dyn/auto-key
+    (gen [d]
+      (let [v (trace :v (dist/gaussian 0 3))]
+        (doseq [i (range d)]
+          (trace (keyword (str "xr" i)) (dist/gaussian 0 1)))
+        v))))
+
+(def addresses (vec (cons :v (map #(keyword (str "xr" %)) (range D)))))
+
+(defn- v-chain
+  "One NUTS chain; returns the :v samples as a vector of MLX scalars."
+  [seed]
+  (let [samples (mcmc/nuts {:samples 300 :burn 200 :addresses addresses
+                            :adapt-step-size true :adapt-metric true
+                            :target-accept 0.8 :key (rng/fresh-key seed)}
+                           noncentered-funnel [D] cm/EMPTY)
+        chain (mapv #(mx/scalar (nth % 0)) samples)]
+    (mx/clear-cache!) (mx/force-gc!)
+    chain))
+
+(deftest nuts-converges-on-noncentered-funnel
+  (testing "NUTS converges on the well-conditioned non-centered funnel (algorithm is sound)"
+    (let [chains (mapv v-chain [42 43 44 45])
+          rhat (diag/r-hat chains)
+          all (mapcat #(map mx/item %) chains)
+          v-mean (/ (reduce + all) (count all))
+          v-std (let [m v-mean
+                      n (count all)]
+                  (js/Math.sqrt (/ (reduce + (map #(let [d (- % m)] (* d d)) all)) n)))]
+      (println (str "  non-centered funnel: R-hat(v)=" (.toFixed rhat 3)
+                    "  v-mean=" (.toFixed v-mean 3) " (truth 0)"
+                    "  v-std=" (.toFixed v-std 3) " (truth 3)"))
+      (is (< rhat 1.1)
+          "multi-chain R-hat on v is near 1 — NUTS mixes on the well-conditioned reparameterization")
+      (is (h/close? 0.0 v-mean 0.7)
+          "v marginal mean recovers ~0 (no bias when geometry is well-conditioned)")
+      (is (< 2.2 v-std 3.8)
+          "v marginal std recovers ~3 (N(0,3) prior is the marginal — no observations)"))))
+
+(run-tests)

--- a/test/genmlx/splice_weight_test.cljs
+++ b/test/genmlx/splice_weight_test.cljs
@@ -179,4 +179,46 @@
       (is (h/close? 0.0 (mx/realize (mx/amax (mx/abs weight))) 1e-3)
           "every particle weight is 0"))))
 
+(def ab-kernel
+  ;; Two-site kernel: b depends on a. A partial selection (resample :a, retain
+  ;; :b) yields a genuinely non-zero retained-only weight.
+  (gen [_mu]
+    (let [a (trace :a (dist/gaussian 0 1))]
+      (trace :b (dist/gaussian a 1)))))
+
+(def ab-map-spliced
+  (let [mgf (comb/map-combinator (dyn/auto-key ab-kernel))]
+    (gen []
+      (splice :m mgf [(mx/scalar 0.0) (mx/scalar 0.0)]))))
+
+(deftest vregenerate-spliced-combinator-fallback-partial-retained-oracle
+  (testing "combinator-batched-fallback regen, PARTIAL select (resample :a, retain :b):
+            batched weight == analytical retained-only Gaussian oracle (genmlx-1sni anti-vacuity)"
+    ;; Guards against a vacuous fix: the all-zero test passes even if the path
+    ;; zeroed ALL weights. Here the retained :b under the resampled parent :a
+    ;; gives W = Σ_i [lp_N(b; a_new,1) - lp_N(b; a_old,1)], a real non-zero value.
+    (let [n 6
+          vt (dyn/vsimulate ab-map-spliced [] n (rng/fresh-key 211))
+          sel-a (sel/hierarchical :m (sel/from-paths [[0 :a] [1 :a]]))
+          {:keys [vtrace weight]} (dyn/vregenerate ab-map-spliced vt sel-a
+                                                   (rng/fresh-key 212))
+          mget (fn [choices i k]
+                 (cm/get-value (cm/get-submap (cm/get-submap (cm/get-submap choices :m) i) k)))
+          sq (fn [x] (mx/multiply x x))
+          ;; W = Σ_i 0.5*((b-a_old)^2 - (b-a_new)^2); the s=1 normalizers cancel.
+          oracle (reduce (fn [acc i]
+                           (let [a-old (mget (:choices vt) i :a)
+                                 a-new (mget (:choices vtrace) i :a)
+                                 b     (mget (:choices vt) i :b)]
+                             (mx/add acc (mx/multiply (mx/scalar 0.5)
+                                          (mx/subtract (sq (mx/subtract b a-old))
+                                                       (sq (mx/subtract b a-new)))))))
+                         (mx/scalar 0.0) [0 1])]
+      (mx/eval! weight oracle)
+      (is (= [n] (mx/shape weight)))
+      (is (> (mx/realize (mx/amax (mx/abs oracle))) 0.1)
+          "anti-vacuity: the partial-regen retained weight is genuinely non-zero")
+      (is (h/close? 0.0 (mx/realize (mx/amax (mx/abs (mx/subtract weight oracle)))) 1e-4)
+          "batched retained-only weight matches the analytical Gaussian oracle"))))
+
 (cljs.test/run-tests)


### PR DESCRIPTION
## Three inference-correctness bugs

Independent of #137 (both branch off `main`; the shared files `handler.cljs`/`mcmc.cljs` are touched in non-overlapping hunks).

### `genmlx-1sni` — silent wrong weights in batched spliced-combinator regenerate
`run-batched-particle`'s regenerate branch set the per-element proposal ratio to `S'_child − w_child`, **omitting `child_old_score`**, so the parent fast vregenerate formula `(new − old − pr)` collapsed to `−old_score` and leaked the old combinator joint score (a full prior resample gave weight `4.929` instead of `0`).

**Fix:** `pr = S'_child − child_old_score − w_child`, with `child_old_score` computed via an **empty-selection regenerate** (retains all, no sampling, threads the per-particle key the fallback attaches). `project`/`assess` were tried first but route through a keyless spliced kernel's `generate`/`assess` → `ensure-key` and throw — caught by `audit_gaps_test` (an Unfold of a non-`auto-key`'d kernel).
**Tests:** existing all-zero assertion now passes + new **anti-vacuity oracle** (partial select matches the analytical Gaussian retained-only weight to 1e-4).

### `genmlx-vv3t` — adaptive warmup ignored the PRNG key
HMC/MALA/NUTS warmup (`:adapt-step-size`) drew fresh entropy independent of the user `:key`, so the adapted step-size + warmup end-state were non-deterministic under a fixed seed.

**Fix:** threaded the user key through `dual-averaging-warmup` (split per step, outside `tidy-run`), `find-reasonable-epsilon`/`-mala-epsilon`, all warmup step-fns, and all 5 call sites; NUTS `(rng/fresh-key)` → `(rng/ensure-key step-key)`. Nil-tolerant (unseeded callers unchanged); sampling stream unchanged.
**Test:** `mcmc_warmup_reproducibility_test` — same seed → bit-identical, different seed → differs, nil key → still runs.

### `genmlx-gp5i` — NUTS funnel R-hat 2.2 → NOT a bug (verified)
An independent textbook NUTS reproduces the same centered-funnel bias, and the U-turn / slice / energy-error-divergence logic is correct (NaN-safe). The proposed divergence-criterion change was **backwards** (the current Stan-style energy-error form is already the more conservative detector) and was **not** applied.
**Deliverable:** a non-centered positive-control test — NUTS converges perfectly on the well-conditioned reparameterization of the same funnel (R-hat **1.000**, v-mean −0.079, v-std 2.991). The centered-funnel difficulty is geometry; the remedy is non-centered reparameterization.

### Gate
Fast tier **159 passed / 3 not-passed** — down from 4 on `main` (1sni resolved `splice_weight`). The 3 remaining (`gfi_gaps`/`gfi_universal` napi `MxArray`-recovery, `vectorized_property`) are pre-existing and a separate stale-binary/membrane class. Zero new failures. `combinators`/`vectorized`/`gfi_combinator_invariants`(334 assertions)/`handler`/`audit_gaps`/`combinator_compile` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
