### PR TITLE
fix(compiled): ensure-array delta log-prob param — fixes napi MxArray error on compiled assess

### DIFF
--- a/src/genmlx/compiled.cljs
+++ b/src/genmlx/compiled.cljs
@@ -704,7 +704,15 @@
                 ;; (compiled != handler — genmlx-kftc). Event rank is taken from
                 ;; the dist arg (param), so any leading batch axis is preserved;
                 ;; a scalar point mass (ev=0) is unchanged.
-                (let [eq (mx/equal v param)
+                ;; A bare numeric-literal delta arg (dist/delta 1) compiles to a
+                ;; raw JS number; mx/shape (.shapeOf) is &MxArray-only, so taking
+                ;; (count (mx/shape param)) on it throws "Failed to recover MxArray
+                ;; type from napi value" on the compiled-assess path. Wrap it —
+                ;; the assess-side sibling of the simulate-side genmlx-lcka fix
+                ;; (compiled.cljs delta site step). ensure-array is identity on a
+                ;; real array (vector point mass), so event-rank logic is unchanged.
+                (let [param (mx/ensure-array param)
+                      eq (mx/equal v param)
                       ev (count (mx/shape param))
                       joint (reduce (fn [m _] (mx/all m (dec (count (mx/shape m)))))
                                     eq (range ev))]

--- a/test/genmlx/compiled_simulate_test.cljs
+++ b/test/genmlx/compiled_simulate_test.cljs
@@ -417,6 +417,37 @@
       (is (cm/has-value? (cm/get-submap (:choices t) :y)) "multi-param: has :y"))))
 
 ;; ---------------------------------------------------------------------------
+;; 11. Compiled-assess of a delta-literal site (genmlx-hkwi regression)
+;; ---------------------------------------------------------------------------
+
+(deftest compiled-assess-delta-literal-test
+  (testing "compiled assess of a (dist/delta <literal>) site does not throw the
+            napi MxArray-recovery error and matches the handler path"
+    ;; Static model -> compiled path. The delta literal `1` compiles to a raw JS
+    ;; number; pre-fix, delta's compiled log-prob called (mx/shape param) on it
+    ;; and threw "Failed to recover MxArray type from napi value" on ASSESS
+    ;; (simulate was fine — it wraps via ensure-array). This is the assess-side
+    ;; sibling of the simulate-side genmlx-lcka fix. genmlx-hkwi.
+    (let [m       (gen [] (let [a (trace :a (dist/gaussian 0 1))]
+                            (trace :b (dist/delta 1))
+                            a))
+          schema  (:schema m)
+          gf      (dyn/auto-key m)
+          choices (:choices (p/simulate gf []))
+          ;; assess via the COMPILED path (was the throwing case). mx/realize
+          ;; materializes + extracts to a JS number.
+          w-compiled (mx/realize (:weight (p/assess gf [] choices)))
+          ;; force the HANDLER path (drop the compiled-assess key) for parity
+          handler-gf (dyn/auto-key
+                       (dyn/->DynamicGF (:body-fn m) (:source m)
+                                        (dissoc schema :compiled-assess)))
+          w-handler  (mx/realize (:weight (p/assess handler-gf [] choices)))]
+      (is (some? (:compiled-assess schema)) "model is on the compiled-assess path")
+      (is (h/finite? w-compiled) "compiled assess weight is finite (no napi throw)")
+      (is (h/close? w-compiled w-handler 1e-5)
+          "compiled assess weight matches the handler path (delta contributes 0)"))))
+
+;; ---------------------------------------------------------------------------
 ;; Run
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Compiled-assess of a `delta` site threw `Failed to recover MxArray type from napi value`

Root-cause + fix for the pre-existing `gfi_gaps_test` / `gfi_universal_test` failures. **Not a stale binary** — rebuilding `@mlx-node` produced a byte-identical `.node` and the failures persisted, so this is a genuine compiled-vs-handler parity gap.

### Root cause
A static model with a `(dist/delta <literal>)` site takes the **L1-M2 compiled** path. `compile-expr` turns the numeric literal `1` into a closure returning a **raw JS number**, and the compiled-assess step doesn't wrap it. Delta's compiled log-prob (`compiled.cljs`) then calls `(count (mx/shape param))` on that raw number — and `mx/shape` → `shape_of(a: &MxArray)` (`genmlx.rs`) is a **bare `&MxArray`** parameter under non-strict napi codegen, so it skips validation and `napi_unwrap` fails with `Failed to recover MxArray type from napi value`. `(mx/equal v param)` survived because that op accepts `Either<&MxArray, f64>`.

**Why simulate worked but assess threw:** the compiled simulate/generate delta step already wraps the arg via `mx/ensure-array` (the genmlx-lcka fix) and never calls `mx/shape`. This is the **assess-direction sibling** of that fix.

### Fix
One line in delta's compiled log-prob: `(let [param (mx/ensure-array param) ...]`. `ensure-array` is identity on a real array, so vector point-mass / event-rank logic is unchanged. Matches the handler path (the `defdist` constructor wraps params via `ensure-array`).

### Verification
- `gfi_gaps_test` **12/12** (was 3 fail — gap4 + both gap5 argdiffs were the same delta-assess issue); `gfi_universal_test` **14/14** (was 10 fail). One fix cleared all the napi failures.
- New regression test `compiled-assess-delta-literal-test` — compiled-assess of a delta-literal site doesn't throw and **matches the handler path** (parity).
- Compiled-path regression green (compiled_simulate, combinator_compile, partial_compile, dist, exact, schema, gen_clj_compat). Fast tier 160/2 — the 2 reds are pre-existing (`splice_weight`, fixed in #138, and `vectorized_property`).
- Independent Rust-membrane analysis corroborated the root cause (`shape_of`'s narrow `&MxArray` signature). Optional follow-up (not in this PR): `#[napi(strict)]` on the bare-`&MxArray` query ops (`shape_of`/`dtype_of`/`ndim_of`/…) for a cleaner error message — a diagnostics-only improvement needing a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
