### PR TITLE
test(vectorized): fix stale vgenerate empty-constraints weight-shape assertion (genmlx-01ce)

### DIFF
--- a/test/genmlx/vectorized_property_test.cljs
+++ b/test/genmlx/vectorized_property_test.cljs
@@ -116,14 +116,18 @@
           x-arr (cm/get-value (cm/get-submap (:choices vt) :x))]
       (shape= x-arr [n]))))
 
-(defspec vgenerate-empty-constraints-weight-is-scalar-0 50
+(defspec vgenerate-empty-constraints-weight-is-zero 50
   (prop/for-all [n gen-n
                  k gen-key]
     (let [vt (dyn/vgenerate ind-model [] cm/EMPTY n k)
           w (:weight vt)
           _ (mx/eval! w)]
-      ;; Empty constraints -> weight = 0 (scalar)
-      (close? 0.0 (mx/item w) 0.01))))
+      ;; Empty constraints -> weight = 0 for EVERY particle. The weight is
+      ;; [N]-shaped by the vgenerate batch-axis convention (the [N]-zeros init,
+      ;; genmlx-x93e/fgb6), not a scalar — so assert all elements are ~0
+      ;; (mx/item would need size 1 and throws for n>1).
+      (and (= [n] (mx/shape w))
+           (close? 0.0 (mx/item (mx/amax (mx/abs w))) 0.01)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Statistical Equivalence (1)


### PR DESCRIPTION
## Fix stale `vgenerate` empty-constraints weight-shape assertion

The last fast-tier red (`vectorized_property_test`, `vgenerate-empty-constraints-weight-is-scalar-0`) was a **stale test**, not a source bug.

`vgenerate` *intentionally* initializes `:weight` to `(mx/zeros [n])` — an `[N]`-shaped weight — to preserve the batch axis for fully-observed models (the documented genmlx-x93e/fgb6/5nch/v4mz contract; a scalar init would collapse to shape `[]`). The defspec predated that contract and called `(mx/item w)` expecting a scalar; since `gen-n` only draws `n ∈ [5 10 15 20]`, `mx/item` threw `array must have size 1` on the `[N]`-zeros weight **every run**.

**Fix (test-only):** assert the weight is `[N]`-shaped **and** every element is `~0` (the correct empty-constraints contract — values verified, not just the shape relaxed), and rename to `…-weight-is-zero`. No source change — `vgenerate`'s `[N]` weight is the deliberate, documented behavior.

`vectorized_property_test` 13/13, 0 errors. This was the last remaining fast-tier failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
