### PR TITLE
docs: fork-minimization plan + Phase 0 world.train spec

### DIFF
--- a/docs/mlx-node-fork-minimization-plan.md
+++ b/docs/mlx-node-fork-minimization-plan.md
@@ -1,0 +1,114 @@
+# mlx-node Fork-Minimization Plan (validated)
+
+> **Bean:** `genmlx-nldo` (spike `genmlx-53lu` — GREEN). Part of milestone `genmlx-nv1t`.
+> **Status:** architecture **empirically validated**; the remaining port is mechanical.
+> **Date:** 2026-06-20.
+
+## Goal
+
+Shrink the mlx-node fork toward **zero** so GenMLX rides on stock mlx-node, while keeping the
+PPL-specific native surface in a **GenMLX-owned crate**. The end-state is: stock MLX + stock
+mlx-node + one `@genmlx/core` superset `.node` addon that GenMLX owns.
+
+## What the spike proved (genmlx-53lu)
+
+A separate crate (`crate-type = ["cdylib"]`) depending on **stock `mlx-core` (rlib)** compiles into
+**one superset addon** (220 exports). Decisive results:
+
+- **mlx-core's `#[napi]` registration ctors survive the rlib→cdylib link with NO `-force_load`**
+  (DCE survival = true): `MxArray`, `memoryStats`, `setCacheLimit`, `randomKey`, `zeros` all present
+  alongside the new `genmlxSpike*` fns.
+- **Round-trip OK:** an `MxArray` minted by an mlx-core op flowed through a *new* genmlx `#[napi]`
+  fn in the same addon — one NAPI type registry, one MLX runtime (no "Failed to recover MxArray").
+- **Two separate addons remain DEFINITIVELY BROKEN** (proven from source): per-addon NAPI type-tag
+  registries + per-dylib MLX Meyers-singleton statics (two Metal `Device`/`Allocator`). So the
+  superset addon is the *only* viable shape — which is exactly what ships today (genmlx.rs is
+  already compiled *into* mlx-core via `pub mod genmlx;` at `mlx-core/src/lib.rs:32`).
+
+## The export-surface contract (validated against source)
+
+What the genmlx NAPI surface touches in mlx-core / mlx-sys, and what each needs:
+
+### Tier 1 — mlx-core Rust items
+| Item | Current visibility | Action |
+|---|---|---|
+| `MxArray::scalar_float` (`array/creation.rs:109`) | `pub` | none ✓ |
+| `MxArray::as_raw_ptr` (`array/mod.rs:108`) | `pub` | use instead of `handle.0` ✓ |
+| `MxArray` (`Clone`, `array/mod.rs:113`) | `pub` | use `arr.clone()` instead of `arr.handle.clone()` ✓ |
+| `nn::Activations::silu` (`nn/activations.rs:16`) | `pub` | none ✓ |
+| `utils::functional::rms_norm_functional` (`utils/functional.rs:77`) | `pub` | none ✓ |
+| `array::scaled_dot_product_attention` (`array/attention.rs:25`) | `pub` | none ✓ |
+| `utils::safetensors::load_safetensors_lazy` (`utils/safetensors.rs:685`) | `pub` | none ✓ |
+| `array::take_last_native_error` (`array/handle.rs:9`) | **`pub(crate)`** | **→ `pub`** |
+| `MxArray::scalar_float_like` (`array/creation.rs:116`) | **`pub(crate)`** | **→ `pub`** (if used) |
+
+**Net Tier-1 fork change: ~2 add-only `pub` lines.** Cleanly upstreamable as a "let downstream
+crates build on `MxArray`" PR. The `MxArray.handle` field (`pub(crate)`) does **not** need to leak
+— `as_raw_ptr()` + `MxArray: Clone` cover the two uses (`genmlx.rs:21`, `:515`).
+
+### Tier 2/3 — mlx-sys C++ shims + FFI
+The keyed-PRNG / linalg / transform shims live in **separate, movable files**
+(`mlx-sys/src/mlx_random.cpp`, `mlx_linalg.cpp`, `mlx_transforms.cpp`) and use the **MLX C++ API**
+(`#include "mlx/random.h"`, `mlx::core::random::`, plus `mlx_common.h` and — transitively on macOS —
+metal_cpp headers). Their `extern "C"` symbols (`mlx_random_key`, `mlx_random_normal_key`, …) are
+declared in `mlx-sys/src/lib.rs:587-620` and compiled into `libmlx_ffi.a` by `mlx-sys/build.rs:318-357`.
+
+mlx-sys does **not** export `cargo:include` (no `links` key), so a downstream crate cannot replicate
+the MLX C++ include environment to compile its own shims. Two options:
+
+- **Option A (RECOMMENDED): keep the 3 `.cpp` shims + their FFI decls in mlx-sys.** genmlx-core stays
+  **pure Rust** (calls the mlx-sys FFI through the normal rlib dependency — the same linkage the spike
+  already exercised when `randomKey` surfaced and was callable). Residual mlx-sys fork = 3 C++ files +
+  ~20 `extern "C"` decls — small, self-contained, and upstreamable to mlx-node as "extended FFI for
+  downstream PPL/array consumers."
+- **Option B: move the C++ shims to genmlx-core** with its own `cc::Build`. Requires mlx-sys to add a
+  `links` key + emit `cargo:include` for the MLX header dirs (incl. the *generated* metal_cpp include
+  that only exists post-cmake). ~3 lines in mlx-sys, but the downstream C++ build must mirror
+  `mlx-sys/build.rs:318-357` (c++17, `-DMLX_STATIC`, `mlx_dir`/`mlx_dir/mlx`/generated includes).
+  More moving parts; defer unless Option A's C++ residual is rejected upstream.
+
+**Pick Option A.** It keeps genmlx-core pure Rust and needs no downstream C++ toolchain replication.
+
+## Target fork footprint after migration
+
+| Layer | Before (current fork) | After (Option A) |
+|---|---|---|
+| **mlx-core** | `genmlx.rs` (697) + `transforms.rs` (361) + `memory_napi.rs` + keyed-PRNG `array/random.rs` (+213) | **2 `pub` lines** |
+| **mlx-sys** | 3 C++ shims + FFI decls | 3 C++ shims + FFI decls (unchanged) |
+| **GenMLX repo (new)** | — | `genmlx-core` crate: all the Rust NAPI + keyed-PRNG wrappers |
+
+The ~1271 lines of genmlx Rust **leave the mlx-node tree entirely.** If the two residual PRs (Tier-1
+`pub` + Tier-2/3 C++ FFI) are accepted upstream, **the mlx-node fork goes to zero** and genmlx-core
+consumes fully stock mlx-node.
+
+## Mechanical port steps (the real work, post-approval)
+
+1. **mlx-core:** make `take_last_native_error` + `scalar_float_like` `pub` (2 lines). [PR to mlx-node]
+2. **genmlx-core crate in the GenMLX repo** (`crate-type = ["cdylib"]`), depends on stock `mlx-core` +
+   `mlx-sys` + `napi`/`napi-derive` pinned to the **exact** mlx-core napi version (a version skew
+   silently reintroduces the two-registry failure *inside one addon*). Port `genmlx.rs`,
+   `transforms.rs`, `memory_napi.rs`, and the keyed-PRNG Rust wrappers; rewrite `handle.0`→`as_raw_ptr()`,
+   `handle.clone()`→`clone()`.
+3. **Build** the superset `.node` via `@napi-rs/cli` (manifest = genmlx-core), copy `mlx.metallib`
+   colocated. Validate the full surface (≈ the 212 wrapped exports + genmlx surface) loads.
+4. **Repoint the membrane:** `src/genmlx/mlx.cljs` `(js/require "@genmlx/core")` instead of
+   `"@mlx-node/core"`. Run the contract guards (`exact_test`, `gradient_fd_test`, `clip_contract_test`,
+   `membrane_coverage_test`, `level0_certification_test`) — they exist to catch exactly this.
+5. **Update `package.json`** to build/depend on the genmlx-core addon.
+
+## Upstream PRs that zero the fork
+
+- **PR 1 (mlx-core):** `pub` the 2 accessors — "expose `MxArray` error-drain + scalar-like for
+  downstream crates." Tiny, add-only.
+- **PR 2 (mlx-sys):** keep the keyed-PRNG/linalg/transform C++ shims + FFI as a documented
+  "extended array FFI" — or, if Option B, the `links` + `cargo:include` export.
+
+## Status
+
+- ✅ Superset addon mechanism — **empirically proven** (spike, no `-force_load` needed).
+- ✅ Two-addon failure — **proven from source**.
+- ✅ Tier-1 Rust contract — **mapped to file:line** (~2 pub lines).
+- ✅ Tier-2/3 C++/FFI linkage from a downstream Rust crate — **already exercised** by the spike
+  (`randomKey` callable downstream).
+- ▶ Remaining: the mechanical port + membrane repoint + contract-guard run (a reviewable
+  implementation task; spec-first not required — each step is empirically gated by the build + guards).

--- a/docs/phase0-world-train-spec.md
+++ b/docs/phase0-world-train-spec.md
@@ -1,0 +1,168 @@
+# Phase 0 Spec — `genmlx.world.train` (the training `eval!` boundary)
+
+> **Bean:** `genmlx-zftr` (Phase 0 of milestone `genmlx-nv1t`). **Blocked-by:** `genmlx-o94r`.
+> **Status:** SPEC — presented for review per the milestone protocol. **No implementation until approved.**
+> **Date:** 2026-06-20.
+
+## 1. Scope & goal
+
+`genmlx.world.train` is a new **Layer-0 membrane face** — a sibling to `genmlx.mlx` (compute),
+`genmlx.world.net` (network), `genmlx.world.proc` (scheduler). It binds mlx-node's native training
+engines (`GRPOEngine`, later `SftEngine`) behind a mutable-state quarantine, exposing **one new
+effect: a training step that mutates model weights + optimizer state in place.**
+
+This is **RL's `eval!`-equivalent — the sole training side effect.** Everything above it stays pure:
+the reward is a pure `(trace → scalar)`, the rollout population is pure steppable inference, the
+policy is a pure GF. Phase 0 ships the *boundary + plumbing*; Phase 1 (`genmlx-ugkv`) wires GFI-quantity
+rewards through it.
+
+Non-goals for Phase 0: the GFI reward scorers themselves (Phase 1), VOC rollout allocation (Phase 2),
+multi-GPU, the server. Phase 0 ships a trivial reward (length) to prove the round-trip end-to-end.
+
+## 2. Where it lands & dependencies
+
+- **Namespace:** `src/genmlx/world/train.cljs` (Layer 0). Loads its native binding lazily, like the
+  other faces; `available?` guards presence so non-training code/tests don't require it.
+- **Native dep: NONE new.** *Verified 2026-06-20:* the already-built `@mlx-node/core` addon GenMLX
+  already loads exposes the full training surface directly — `GrpoTrainingEngine`
+  (`fromQwen35`/`fromQwen35Moe`, `trainStep`, `trainStepAuto`), `SftTrainingEngine`,
+  `NativeRewardRegistry`, `buildRewardOutputs` (6 training classes among 224 exports). So Phase 0 binds
+  `@mlx-node/core` directly. `@mlx-node/trl` is **not built** (`dist/` has no `index.js`) and is **not
+  needed** — this resolves §9.1.
+- **Gated by `genmlx-o94r` (sharded safetensors):** real training loads >3GB checkpoints, most sharded;
+  the loader must support `model.safetensors.index.json`. Phase 0 membrane plumbing can be built +
+  tested against a tiny model; *real* fine-tuning is gated by `o94r`.
+- **Interaction with `genmlx-nldo`:** once the superset addon lands, the GRPO surface is reached through
+  `@genmlx/core` like everything else; until then, through `@mlx-node/trl`/`@mlx-node/core`.
+
+## 3. The mutable boundary (the quarantine)
+
+The native `GRPOEngine` mutates the model's weights and the AdamW optimizer's moment state **in place**
+on each step. That in-place mutation is the effect. It is quarantined exactly like the two existing
+precedents:
+
+- `world.net`'s `with-server` (the `Bun.serve` listener — a live external resource, torn down by
+  `p/finally`).
+- `backend.cljs`'s KV-cache atom (`CljsForwardModel.cache`, reset in `init-cache!`/`reset-cache!`,
+  swapped inside a `try`).
+
+**Invariant:** the engine handle is the *one* mutable resource of this face; it is created inside a
+blessed scope, consumed locally, and torn down on exit (success or throw). It never escapes into pure
+code. The trained model's *weights* are observable state owned by the caller (like the KV cache), not
+hidden global state.
+
+## 4. API surface (every public fn)
+
+```clojure
+(available?)                       ;; => bool. Native GRPO/TRL present? (guards the require)
+
+;; Construction — blessed scope + low-level escape hatch (mirrors with-server/serve!)
+(with-trainer model config f)      ;; build engine over a loaded model, call (f trainer),
+                                   ;;   p/finally tears the engine down. THE blessed path.
+(make-trainer! model config)       ;; => trainer. Low-level; caller owns teardown via (dispose! trainer).
+
+;; The one effect — a GRPO step
+(train-step! trainer prompts reward-fn opts)
+  ;; prompts    : vector of prompt strings (or chat-message vectors)
+  ;; reward-fn  : pure CLJS (fn [prompt completion] -> number)   [per-completion], OR
+  ;;              (fn [prompts completions] -> number[])          [batched]
+  ;; opts       : {:group-size N :loss {...} :timeout-ms ...}
+  ;; => promise of {:loss :reward-mean :reward-std :kl :grad-norm :completions [...]}
+  ;; Drives native train_step_auto via a ThreadsafeFunction reward callback (see §5).
+
+;; Lifecycle passthroughs (native GRPOEngine methods)
+(step trainer) (epoch trainer)
+(start-epoch! trainer) (end-epoch! trainer secs)
+(reset! trainer)
+(generate-batch trainer prompts)   ;; for inspection; no weight update
+
+;; Checkpointing (native resumable AdamW — moments + weights)
+(save-checkpoint! trainer path)
+(load-checkpoint! trainer path)
+(dispose! trainer)                 ;; explicit teardown for the make-trainer! path
+```
+
+`config` (→ native `GRPOEngineConfig`): `{:lr :group-size :beta :max-completion-len :temperature
+:loss-type (:grpo|:bnpo|:dr-grpo|:dapo) :seed ...}`.
+
+## 5. The reward bridge (the seam to Phase 1)
+
+The native step takes `reward_fn: ThreadsafeFunction<String, Promise<Vec<f64>>>` (`engine.rs:911`),
+surfaced to JS (verified) as **`trainStepAuto(prompts, rewardFn, recordOutputs)`** where
+`rewardFn: (err: Error | null, outputsJson: string) => Promise<number[]>` (node-style `(err, value)`).
+`train-step!` marshals the **pure CLJS reward-fn** into that callback:
+
+1. native generates a rollout group → invokes the ThreadsafeFunction with each completion (JSON/string),
+2. the CLJS reward-fn is called (synchronously, on the callback) → returns a number,
+3. numbers flow back as `Vec<f64>` → native computes group-relative advantages → clipped surrogate →
+   AdamW update.
+
+**Phase 0 reward:** a trivial pure fn (e.g. completion length, or a `RewardRegistry` built-in via
+`register_builtin_reward`) — enough to prove the round-trip mutates weights.
+
+**Phase 1 reward (`genmlx-ugkv`):** the same seam, reward-fn = a GFI quantity:
+`msa/score-model` exact-or-IS log-evidence (`msa.cljs:495`) and/or `codegen/verify-transition-fn`
+accuracy + `score-structure` idiomaticity (`codegen.cljs:304,455`) — both already return number-shaped
+values. **No new Rust; the bridge is reused verbatim.**
+
+## 6. Coverage matrix
+
+Move the training-orchestration exports (`GRPOEngine`/`GRPOTrainer`, `trainStepAuto`,
+`RewardRegistry`, native optimizers, `OutputStore`) from the **`:training-orchestration` intentional-
+omission** group → **wrapped**, in `docs/membrane-coverage.md` + `test/genmlx/membrane_coverage_test.cljs`.
+This is the surface-drift guard recognizing the newly-tapped stack.
+
+## 7. Purity invariants (and the test)
+
+- Training is the **sole side effect** of this face (the `eval!`-equivalent). Add `world.train`'s engine
+  handle to the audited mutable-boundary list in `test/genmlx/mutation_boundary_test.cljs`.
+- The reward fn passed to `train-step!` must be **pure** `(prompt, completion) → number` — it must NOT
+  mutate, and must NOT run a forward pass on the *model being trained* (mirror the single-execution
+  constraint at `core.cljs:43-45`; the training thread owns that model). A reward that needs LLM scoring
+  must use a *different* model handle.
+- `train-step!` returns a promesa **promise** — training is an *event*, so it crosses to async per the
+  project's "sync math, async events" principle (like model load / `.chat`). The pure GFI math above
+  stays sync.
+
+## 8. Edge cases & invariants
+
+- **KL-to-ref gap:** native `grpo/autograd.rs:76` rejects `beta > 0` under autograd → Phase-0/1 runs are
+  **KL-free** unless `grpo_loss` is driven directly. `config :beta` is accepted but documented as
+  no-op-under-autograd until the ref-logprob autograd path lands (a Phase-1.5 follow-up + upstream PR).
+- **Determinism:** the engine owns its sampler (MLX RNG); this is a *boundary* — GenMLX's
+  `rng/fresh-key` does not thread into native generation. `config :seed` controls native reproducibility;
+  document that training RNG ≠ GenMLX inference RNG.
+- **Teardown:** `with-trainer`'s `p/finally` disposes the engine (frees model + optimizer moments) on
+  success or throw. The `make-trainer!` escape hatch hands that responsibility to the caller.
+- **Model ownership:** the engine borrows the loaded model (`from_qwen35(&model)`); the model handle must
+  outlive the trainer. Document; `with-trainer` should take a loaded model and not free it.
+- **Timeout:** the reward callback can hang (CLJS scorer); `:timeout-ms` bounds it (native
+  `withTimeout`, `grpo-trainer.ts:1280`).
+
+## 9. Open decisions (for review)
+
+1. ~~Bind `@mlx-node/trl` or `@mlx-node/core` directly?~~ **RESOLVED (2026-06-20):** bind
+   `@mlx-node/core` directly — `GrpoTrainingEngine`/`trainStepAuto` are already exported by the addon
+   GenMLX loads; `@mlx-node/trl` is unbuilt and unnecessary. No new dependency.
+2. **Async shape:** confirm `train-step!` returns a promesa promise (vs a blocking deref helper for REPL
+   ergonomics). Recommendation: promise + a `train-step!!` blocking convenience for the REPL.
+3. **Quarantine record:** a `defrecord Trainer [engine model ^:mutable disposed?]` vs a bare JS handle in
+   an atom. Recommendation: a record mirroring `CljsForwardModel`.
+
+## 10. Done means
+
+- [ ] `genmlx.world.train` ns with `available?`, `with-trainer`, `make-trainer!`/`dispose!`,
+      `train-step!`, lifecycle passthroughs, checkpoint save/load.
+- [ ] The reward bridge marshals a pure CLJS reward-fn into the native `ThreadsafeFunction`; a Phase-0
+      length-reward `train-step!` measurably changes a (tiny) model's weights.
+- [ ] `available?` true on this box (binds `GrpoTrainingEngine` from the existing `@mlx-node/core`; no new dep).
+- [ ] Coverage matrix updated (training-orchestration omitted → wrapped); `membrane_coverage_test` green.
+- [ ] `mutation_boundary_test` updated with the new audited boundary; purity property holds.
+- [ ] `with-trainer` teardown verified (engine disposed on throw).
+- [ ] Docs: the reward-bridge seam documented as Phase-1's plug point.
+- [ ] **Gating acknowledged:** real-checkpoint training deferred to `genmlx-o94r`; KL-free documented.
+
+---
+
+**Per the milestone protocol, this spec is presented for review. No code will be written until it is
+approved.** The natural review questions are the three open decisions in §9.


### PR DESCRIPTION
Two design artifacts from the autonomous push on milestone `genmlx-nv1t`, after the single-MLX-runtime spike came back green.

## `docs/mlx-node-fork-minimization-plan.md` (`genmlx-nldo`)
Validated migration to shrink the mlx-node fork toward zero:
- **Spike proven** (no `-force_load`): a separate cdylib over stock `mlx-core` is one superset addon; two separate addons are definitively broken.
- **Export-surface contract mapped to file:line:** Tier-1 = ~2 `pub(crate)→pub` accessors (`take_last_native_error`, `scalar_float_like`); the rest is already `pub`. Tier-2/3 = keep the 3 movable `mlx-sys` C++ shims (Option A), so `genmlx-core` stays pure Rust.
- **Result:** ~1271 Rust lines leave the mlx-node tree into a GenMLX-owned `genmlx-core` crate; two small upstream PRs take the fork to zero.

## `docs/phase0-world-train-spec.md` (`genmlx-zftr`)
Spec for `genmlx.world.train` — the training `eval!` boundary:
- Binds the native `GrpoTrainingEngine` behind a mutable-state quarantine (mirrors `with-server` / the KV-cache atom).
- Full API surface, the reward-bridge seam (Phase 1's plug point for GFI-quantity rewards), purity invariants, edge cases, and a `done means` checklist.
- **Verified:** the native training surface (`GrpoTrainingEngine`/`trainStepAuto`/`SftTrainingEngine`/`NativeRewardRegistry`) is already exported by the `@mlx-node/core` addon GenMLX loads — **no new dependency**.
- **Spec-first:** presented for review per the milestone protocol; no implementation until approved.

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)