### PR TITLE
feat(train): genmlx.world.train — the training eval! boundary (Phase 0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ structure. No GPU work occurs until `mx/eval!` is called. This means most of
 (or wrappers like `item`, `->clj`, `materialize!`). Everything else — arithmetic,
 reductions, autograd, vmap, compile — builds lazy graphs.
 
-**mlx-node is at the heart of GenMLX.** The Rust/NAPI layer (212 @mlx-node/core function exports, pinned by the coverage matrix; 5 crates)
+**mlx-node is at the heart of GenMLX.** The Rust/NAPI layer (214 @genmlx/core function exports, pinned by the coverage matrix; 5 crates)
 is not "mutable substrate we contain" — it is a functional graph engine that aligns
 naturally with ClojureScript's value semantics. `mlx.cljs` is the thin membrane
 between them; `Either<&MxArray, f64>` in Rust handles type coercion so CLJS
@@ -172,7 +172,7 @@ The implementation layers map onto the three-layer purity model:
 
 ```
 ── Layer C (GPU execution) ──────────────────────────────────────────────
-  mlx-node Rust/C++   5 crates; 212 @mlx-node/core function exports (coverage-matrix-pinned). MxArray = Arc<lazy graph node>.
+  mlx-node Rust/C++   5 crates; 214 @genmlx/core function exports (coverage-matrix-pinned). MxArray = Arc<lazy graph node>.
                       eval! is the only operation that dispatches to Metal.
 
 ── Membrane (mlx.cljs) ─────────────────────────────────────────────────
@@ -228,6 +228,16 @@ direct import of dynamic.cljs).
      face of the Bun world membrane (`world/net.cljs`): created by `serve!`, scoped
      and torn down by `with-server`'s `p/finally` (the blessed path) — analogous to
      the KV-cache try/finally. A bare `serve!` hands the lifecycle to the caller.
+   - The native `GrpoTrainingEngine` handle in the TRAINING face of the world
+     membrane (`world/train.cljs`, genmlx-zftr): an externally-mutating native engine
+     that updates model weights + AdamW moments IN PLACE — the training `eval!`
+     -equivalent, the sole side effect of that face. Fenced by the `with-trainer`
+     blessed scope whose `p/handle` teardown disposes it on success OR throw
+     (mirroring `llm/backend.cljs`'s KV-cache try/finally and `world/net.cljs`'s
+     `with-server`); a bare `make-trainer!`/`dispose!` hands the lifecycle to the
+     caller. Per-trainer mutable state lives in one `atom` (`:disposed?`), mirroring
+     `CljsForwardModel`'s cache atom. The in-place weight updates are a *parallel*
+     path that never composes back into the pure GFI-score gradient flow.
 2. **Data-driven, open for extension.** Distributions are a single `Distribution`
    record with open multimethods. New distributions via `defdist`. New execution
    strategies via `dispatch/with-handler` or `dispatch/with-dispatch`. Grammar

--- a/docs/membrane-coverage.md
+++ b/docs/membrane-coverage.md
@@ -1,6 +1,6 @@
 # Compute-membrane coverage matrix (`@mlx-node/core` → `mlx.cljs`)
 
-*Audit: `genmlx-0vwn` / `genmlx-e3jg`. Snapshot grounded 2026-06-15.*
+*Audit: `genmlx-0vwn` / `genmlx-e3jg`. Snapshot grounded 2026-06-20.*
 
 The `@mlx-node/core` package is GenMLX's compute substrate (Layer C). The
 **membrane** — `src/genmlx/mlx.cljs` + `src/genmlx/mlx/random.cljs` (Layer 0) —
@@ -17,32 +17,38 @@ stubs; the membrane stays thin and honest.
 
 ## Source of truth for the surface
 
-The export surface is read from **`packages/core/index.d.cts`** (the `types`
-target in `@mlx-node/core`'s `package.json`). The older `index.d.ts` (Apr 1) is
-**stale** — it still lists `getParameters`/`applyGradients`, which no longer
-exist; the training surface is now engine-class-only. Any audit that reads
-`.d.ts` is wrong on day one.
+The export surface is enumerated from the **live `@genmlx/core` runtime module**
+(`Object.keys(require("@genmlx/core")).filter(k => typeof core[k] === "function")`) —
+this is what `membrane_coverage_test` partitions, and it is the authority. The package
+ships **no `types` field**; its `index.d.ts` is a regenerated snapshot that can lag the
+runtime, so any audit that reads a `.d.ts` can be wrong. Concretely, the live surface
+has **214** function exports while the d.ts declares 213 — the one runtime-only name is
+`Gradients` (a real class export, correctly on the `:training-orchestration` omission
+allowlist). When the doc and the live test disagree, the test is right.
 
 ## Summary
 
 | | Count |
 |---|---:|
-| Function exports (`typeof === "function"`, incl. classes) | **212** |
-| → Wrapped in the membrane | **164** |
-| → Intentionally omitted | **48** |
+| Function exports (`typeof === "function"`, incl. classes) | **214** |
+| → Wrapped in the membrane | **167** |
+| → Intentionally omitted | **47** |
 
-`wrapped ⊎ omitted = 212` — the partition tiles the surface exactly (asserted by
+`wrapped ⊎ omitted = 214` — the partition tiles the surface exactly (asserted by
 `coverage-accounting-test`). Non-function exports (DType constants etc.) and
 per-class *method* coverage (e.g. `MxArray.addmm` / `argpartition` /
 `putAlongAxis`) are out of scope for this floor — see *Deferred* below.
 
-## Wrapped (162)
+## Wrapped (167)
 
 Not enumerated here (a static list would drift). The membrane binds every export
 not on the omission allowlist below — covering the full pure-math / reduction /
 linalg / FFT-free array surface, RNG keys (`mlx/random.cljs`), autograd
 (`value_and_grad` / `grad`), memory introspection + control, and the LLM
-forward-pass primitives. Recently completed (this audit): the trig/hyperbolic
+forward-pass primitives. As of `genmlx-zftr` (Phase 0) the **training membrane
+face** `world/train.cljs` also wraps `GrpoTrainingEngine` and
+`createRandomQwen35Checkpoint` behind its mutable-state quarantine (the GRPO
+engine is NOT in the pure compute membrane). Recently completed (this audit): the trig/hyperbolic
 family (`arcsin`/`arctan`/`sinh`/`cosh`), `log-softmax`, `logical-and/or/not`,
 `isfinite`, `cumprod`, `roll`, `pad`, the memory introspection ops
 (`get-memory-limit`/`get-wired-limit`/`memory-stats`/`get-memory-snapshot`,
@@ -52,7 +58,7 @@ architecture generation).
 To list the wrapped set, run the audit recipe and take the complement of the
 omissions.
 
-## Intentionally omitted (50)
+## Intentionally omitted (47)
 
 Each export below is deliberately **not** in the pure compute membrane. The
 category records where the capability belongs instead.
@@ -63,27 +69,30 @@ category records where the capability belongs instead.
 |---|---|---|
 | `broadcastTo` | `:broken` | Native op mis-fills size-1 dims. `mx/broadcast-to` is a custom reconstruction; pinned by `broadcast-to-omission-test`. |
 | `getProfilingData`, `isProfilingEnabled`, `setProfilingEnabled`, `resetProfilingData` | `:profiling-gated-i0s4` | Profiling instrumentation; wire-on-demand behind the `genmlx-i0s4` cost meter. |
-| `buildRewardOutputs`, `createRandomQwen3Checkpoint`, `createRandomQwen35Checkpoint`, `createRandomQwen35MoeCheckpoint` | `:training-orchestration` | GRPO/SFT training surface — bind at engine level in a future `@mlx-node/trl` Layer-6 ns with the mutable-state quarantine, never the pure membrane (`genmlx-706r`). |
+| `buildRewardOutputs`, `createRandomQwen3Checkpoint`, `createRandomQwen35MoeCheckpoint` | `:training-orchestration` | Remaining native training surface — bind in `world/train.cljs` as Phase 1-4 tap them, behind the mutable-state quarantine (`genmlx-zftr`/`genmlx-706r`). The GRPO engine + `createRandomQwen35Checkpoint` are already **wrapped** there. |
 | `convertForeignWeights`, `convertGgufToSafetensors`, `convertModel`, `convertParquetToJsonl` | `:model-conversion` | Offline weight/format conversion tooling — not graph ops. |
 | `createPaddleocrVlConfig`, `createQianfanOcrConfig`, `documentToXlsx`, `formatDocument`, `saveToXlsx`, `parsePaddleResponse`, `parseToolCallsFromText`, `parseVlmOutput` | `:ocr-vlm-document` | OCR / vision-language / document pipelines — bind via `@mlx-node/lm` vision (`llm/vision.cljs`). |
+| `compileFn` | `:compile-strategy-bypass` | Native MLX graph-caching compile, deliberately bypassed — GenMLX compilation uses noise transforms + the expression compiler (Level 1), not MLX's compile. |
 
-### Classes (27)
+### Classes (26)
 
 A JS `class` is a function export, so it counts toward the runtime surface and
 must be accounted for. None are wrapped as compute ops.
 
 | Exports | Category | Reason |
 |---|---|---|
-| `GrpoTrainingEngine`, `SftTrainingEngine`, `NativeRewardRegistry`, `Gradients`, `OutputStore`, `ResponseStore` | `:training-orchestration` | Training engines + result/registry types — engine-level, mutable-state quarantine (future `@mlx-node/trl` Layer-6). |
+| `SftTrainingEngine`, `NativeRewardRegistry`, `Gradients`, `OutputStore`, `ResponseStore` | `:training-orchestration` | Remaining training engines + result/registry types — bind in `world/train.cljs` as Phase 1-4 tap them. `GrpoTrainingEngine` is already **wrapped** there (`genmlx-zftr`). |
 | `Gemma4Model`, `HarrierModel`, `Lfm2Model`, `Qwen3Model`, `Qwen35Model`, `Qwen35MoeModel`, `Qwen3Tokenizer`, `BatchGenerationResult`, `GenerationResult`, `ChatStreamHandle` | `:llm-orchestration` | Loaded-model / tokenizer / generation classes — bound via `@mlx-node/lm` ChatSession (`msa.cljs` / `backend.cljs`). The per-token GFI path reaches the low-level forward, not these. |
 | `DocLayoutModel`, `DocOrientationModel`, `DocUnwarpModel`, `PrivacyFilterModel`, `QianfanOCRModel`, `TextDetModel`, `TextRecModel`, `VLModel`, `VlmChatResult`, `VlmProcessedImage` | `:ocr-vlm-document` | OCR / vision-language pipeline classes — `@mlx-node/lm` vision. |
 | `Tensor` | `:foreign-tensor-type` | A foreign tensor class distinct from `MxArray` (the membrane's value type). |
 
 ## Deferred (separate beans, not part of this floor)
 
-- **`@mlx-node/trl` training engines** — bind `GrpoTrainingEngine` / `SftTrainingEngine`
-  at engine level in a Layer-6 ns with the mutable-state quarantine. This is the
-  real GRPO/SFT work and feeds the self-training-coder flywheel (`genmlx-706r`).
+- **Native training engines** — `GrpoTrainingEngine` is now wrapped in the
+  `world/train.cljs` training face behind the mutable-state quarantine
+  (`genmlx-zftr` Phase 0). `SftTrainingEngine` + the reward/result types bind there
+  incrementally as Phase 1-4 tap them; this feeds the GFI-reward GRPO flywheel
+  (`genmlx-ugkv` / `genmlx-706r`).
 - **Profiling data** — gate on the `genmlx-i0s4` cost meter.
 - **`MxArray` array-method gaps** — `addmm` / `argpartition` / `putAlongAxis` and
   the rest of the ~150-method class surface (category-b appendix).

--- a/docs/phase0-world-train-spec.md
+++ b/docs/phase0-world-train-spec.md
@@ -166,3 +166,60 @@ This is the surface-drift guard recognizing the newly-tapped stack.
 
 **Per the milestone protocol, this spec is presented for review. No code will be written until it is
 approved.** The natural review questions are the three open decisions in §9.
+
+---
+
+## 11. Spec corrections after native-surface verification (2026-06-20, IMPLEMENTED)
+
+The spec above was written from inspection. Before writing the membrane, the actual `@genmlx/core`
+training surface was verified against the typings + reflection, which forced the following corrections.
+The implementation (`src/genmlx/world/train.cljs`, `test/genmlx/world_train_test.cljs`) is built against
+the **verified** surface, not the inspected one. All Phase-0 acceptance assertions pass (25/25 on Metal).
+
+**Module + naming (factual fixes):**
+1. **Bind `@genmlx/core`, not `@mlx-node/core`** (§2/§9.1 named the wrong module). GenMLX loads
+   `@genmlx/core` (mlx.cljs:27); both expose an identical training surface but they are separate addons.
+   `train.cljs` requires `@genmlx/core` for consistency.
+2. **Class is `GrpoTrainingEngine`** (not `GRPOEngine`); config is `GrpoEngineConfig` (camelCase);
+   factories `fromQwen35`/`fromQwen35Moe`, ctor `(Qwen3Model, config)`.
+3. **`step`/`epoch` are getters**, `startEpoch()` is no-arg, `endEpoch(secs)` takes seconds.
+
+**Capability gaps (forced API changes):**
+4. **No native `saveCheckpoint`/`loadCheckpoint`.** The engine persists only OPTIMIZER moments via
+   `saveOptimizerState`/`loadOptimizerState`; model WEIGHTS are saved on the model handle (`saveModel`).
+   So the face exposes honest `save-optimizer-state!`/`load-optimizer-state!` (not a lying "checkpoint").
+5. **No native `dispose`.** `dispose!` is implemented in CLJS via the engine's terminal `reset()` — which
+   releases the model-thread training run so the model can host a NEW trainer — plus marking the handle
+   disposed. (The native model thread hosts only ONE active training run; freeing it on teardown is
+   required for `with-trainer` re-entry.)
+6. **No `:seed` in `GrpoEngineConfig`.** §8's "config :seed controls reproducibility" is unsupported;
+   the engine owns its MLX sampler RNG (training RNG ≠ GenMLX inference RNG). `:seed` is dropped.
+7. **`:beta` → `klCoef`.** Mapped explicitly. NOTE the §8 framing "accepted but no-op-under-autograd"
+   is wrong: native autograd **errors** on `klCoef > 0` (`grpo/autograd.rs:75` returns
+   `Err("KL penalty (beta > 0) requires reference model logprobs ... not yet supported")`). So a
+   `train-step!` with `:kl-coef`/`:beta` > 0 **rejects**; leave it 0 (default) for KL-free training.
+   `world_train_test` asserts this rejection.
+8. **`registerBuiltinReward` is an instance method** (not a standalone export); `BuiltinRewardType`
+   values are the strings `Length`/`ToolUse`/`XmlFormat`/`JsonSchema`.
+
+**Reward bridge (design improvement, §5):** the spec's all-in-one `trainStepAuto` ThreadsafeFunction
+callback is **not** used. `trainStepAuto` filters out `finish_reason='length'` completions as an
+OOM guard (`engine.rs:1067`), which skips the entire step for any model whose rollouts never emit EOS
+(e.g. a tiny random checkpoint). Instead `train-step!` composes the explicit
+**`generateBatchForTraining` → score-in-CLJS → `trainStepWithGenerations`** flow: it keeps the pure
+reward scorer in CLJS between two awaits (a cleaner Phase-1 GFI-reward seam, no native callback
+marshalling) and trains UNCONDITIONALLY. The pure reward-fn is `(prompt, completion-text) -> number`,
+mapped over completions in prompt-major order.
+
+**Teardown primitive (§3/§4):** `with-trainer` uses **`p/handle`**, not `p/finally`. Under nbb a
+`p/finally` teardown followed by a downstream `p/catch` double-settles (the catch handler runs yet the
+promise stays rejected — verified). `p/handle` disposes on both arms and re-raises exactly once.
+(`world/net.cljs`'s `with-server` shares the latent `p/finally` quirk — captured as a follow-up.)
+
+**Quarantine record (§9.3):** `defrecord Trainer [engine model state]` where `state` is an `atom`
+(CLJS `defrecord` has no `^:mutable`; the atom mirrors `CljsForwardModel`'s cache atom).
+
+**Phase-0 test vehicle:** a tiny random Qwen3.5 checkpoint (`createRandomQwen35Checkpoint`, 2 layers /
+hidden 64) with the **real Qwen3.5 vocab (248320) + a real tokenizer copied in** (generation needs a
+tokenizer; the random checkpoint writes none). The length/content reward must give the group nonzero
+variance (a constant reward ⇒ zero advantage ⇒ no update).

--- a/docs/phase1-gfi-reward-spec.md
+++ b/docs/phase1-gfi-reward-spec.md
@@ -1,0 +1,144 @@
+# Phase 1 Spec — GRPO where the REWARD is a GFI quantity (`genmlx-ugkv`)
+
+> **Bean:** `genmlx-ugkv` (Phase 1 of milestone `genmlx-nv1t`). **Blocked-by:** `genmlx-zftr` (Phase 0, DONE).
+> **Status:** SPEC — presented for review per the milestone protocol. **No implementation until approved.**
+> **Date:** 2026-06-20. Built ON the verified Phase-0 `genmlx.world.train` boundary.
+
+## 1. The idea (the highest-leverage novelty)
+
+GenMLX already computes exactly the scalars policy-gradient RL wants as a reward. An LLM (the policy)
+writes a **probabilistic program**; GenMLX evaluates it and returns **Bayesian model evidence** — the
+marginal log-likelihood `log p(data | program)` — and GRPO uses that as the reward to update the policy
+weights. This is, as far as we know, the **first system where Bayesian model evidence is the RL signal
+for an LLM** — the *wake phase* of wake/sleep, operating at the level of program space.
+
+The whole of Phase 1 is a **pure CLJS reward function** `(fn [prompt completion] -> number)` plugged into
+the Phase-0 `train-step!` bridge. **No new Rust, no new autograd, no change to `world.train`.** The
+reward-fn: parse the completion → SCI-eval the program → wrap as a GenMLX GF → score it → return the
+scalar. The estimator family is the same REINFORCE-with-baseline already in `inference/adev.cljs` (GRPO's
+group-mean baseline = the variance-reduction baseline).
+
+## 2. Where it lands & dependencies
+
+- **New ns:** `src/genmlx/world/train_reward.cljs` (Layer 9-ish, an LLM/training composition) — builds
+  the reward-fn(s). It depends on `genmlx.llm.msa` (`score-model`), `genmlx.llm.codegen`
+  (`verify-transition-fn`, `score-structure`), `genmlx.inspect` (compilation level), and the SCI eval
+  helpers already in `msa.cljs`/`codegen.cljs`. It does NOT depend on `world.train` — it just produces a
+  reward-fn that the caller passes to `train/train-step!`.
+- **No new native dep.** Phase 0 already wraps the GRPO engine. Phase 1 is pure CLJS on top.
+- **Real model required.** Unlike Phase 0's tiny random checkpoint, Phase 1 needs a model that emits
+  *parseable programs*, so the reward signal is meaningful. Default: `qwen3.5-0.8b-mlx-bf16` (loads via
+  the o94r loader; small enough for a single-box fine-tune). `qwen3.5-4b` is a config swap.
+
+## 3. The reward functions (the GFI quantities)
+
+Two reward families, each a pure `(fn [prompt completion] -> number)`. Both already return number-shaped
+scalars and **neither forward-passes the policy model** (respecting the §7 model-ownership constraint):
+
+### 3a. Bayesian model evidence (the headline) — `model-evidence-reward`
+```
+(prompt, completion) ->
+  extract program text  →  SCI eval to a DynamicGF  →  msa/score-model gf observations
+  →  log-ML  (+ λc · compilation-bonus  − λk · complexity)   [floored on failure]
+```
+- `observations` comes from the task (a fixed dataset the program must explain) — see §4.
+- `msa/score-model` returns exact analytical marginal evidence for conjugate/eliminable models, else
+  log-mean-exp IS (`msa.cljs:495`). Returns `##-Inf` on a nil/erroring GF.
+- **Compilation bonus** (`λc · level`): `inspect/inspect` reports L1–L4; reward a program that compiles
+  to a higher level (a structural prior toward GenMLX-idiomatic models). Optional, off by default.
+- **Complexity penalty** (`λk · size`): subtract a small multiple of the program's form-size (Occam
+  pressure). Optional.
+
+### 3b. Program correctness + idiomaticity — `transition-fn-reward`
+```
+(prompt, completion) ->
+  extract code  →  codegen/verify-transition-fn code transitions  →  :accuracy ∈ [0,1]
+  (+ λs · normalized score-structure)                                [floored on failure]
+```
+- `verify-transition-fn` runs the generated fn against held transitions (`codegen.cljs:304`);
+  `score-structure` rewards idiomatic ClojureScript (`codegen.cljs:455`).
+
+### Invalid-program floor (critical for GRPO)
+A parse/eval failure must map to a **finite floor** (e.g. `reward-floor = -100.0`), NOT `##-Inf` — GRPO
+normalizes advantages by group std, and a `-Inf` in the group poisons the whole step (NaN advantages →
+skipped step, the Phase-0 lesson). `score-model`'s `##-Inf` and `verify`'s `0.0`-on-error are clamped to
+the floor by the reward-fn wrapper.
+
+## 4. The task (what the policy generates, what it's scored against)
+
+Phase 1 ships ONE task to prove the loop, parameterized so more can be added:
+- **A task is `{:prompt-template, :observations, :system-prompt}`** (evidence reward) or
+  `{:prompt-template, :transitions}` (correctness reward).
+- **Model-synthesis task (default):** a small regression/mixture dataset; the prompt asks the LLM to
+  "write a GenMLX `gen` model that explains this data"; reward = `score-model` log-ML against the held
+  `observations`. The dataset is fixed CLJS data in the test (no I/O).
+- The policy sees the prompt; the engine samples `group-size` completions; each is scored; group-relative
+  advantages drive the update.
+
+## 5. The training loop (composition, not new mechanism)
+
+```clojure
+(train/with-trainer model {:learning-rate 1e-5 :group-size 8 :max-completion-length 256
+                           :temperature 0.8 :kl-coef 0.0}        ; KL-free (see §6)
+  (fn [trainer]
+    (p/loop [step 0, history []]
+      (if (= step N)
+        (p/resolved history)
+        (p/let [r (train/train-step! trainer (batch-of task) (model-evidence-reward task))]
+          (log-progress step r)
+          (p/recur (inc step) (conj history (:reward-mean r))))))))
+```
+The loop is plain promesa over the Phase-0 effect. The **proof** is that `:reward-mean` (mean log-ML)
+**trends up** over steps — the policy learns to write better-fitting programs.
+
+## 6. Edge cases & invariants
+
+- **KL is KL-free in Phase 1.** Native autograd ERRORS on `klCoef > 0` (`grpo/autograd.rs:75`, verified
+  in Phase 0). So `:kl-coef` stays `0.0`. Wiring reference-model log-probs through autograd (true
+  KL-to-base regularization) is **Phase 1.5** (a native change + clean upstream PR), explicitly deferred.
+- **Reward purity / model ownership.** The reward-fn must be pure and must NOT run a forward pass on the
+  *policy* model (the training thread owns it). Both reward families satisfy this: `score-model` runs
+  GenMLX inference over the *generated* program (a fresh GF), `verify` runs the generated fn — neither
+  touches the policy LLM. (If a future reward needs LLM scoring, it must use a *different* model handle.)
+- **SCI sandbox.** Generated code is eval'd via the existing `msa.cljs`/`codegen.cljs` SCI evaluators
+  (same sandbox the MSA/codegen paths already trust); eval errors → reward floor, never a crash.
+- **Determinism.** The engine owns generation RNG (`config :seed` does not exist — Phase 0 finding); runs
+  are not bit-reproducible across the native sampler. The reward-fn itself is deterministic given a
+  completion.
+- **Cost.** A real-model GRPO step (generate `group-size` × `max-completion-length` tokens + backprop on
+  0.8B) is heavyweight; Phase 1's acceptance run is a SMALL number of steps on the small model, serial
+  (no parallel GPU — the Metal-wedge constraint).
+
+## 7. Done means
+
+- [ ] `world/train_reward.cljs` with `model-evidence-reward` (and `transition-fn-reward`) — pure
+      `(fn [prompt completion] -> number)` closures, with the invalid-program **finite floor**.
+- [ ] A reward-fn, passed to the Phase-0 `train/train-step!`, drives a real `qwen3.5-0.8b` GRPO step whose
+      reward is `msa/score-model` log-ML — the loop closes with **no new Rust**.
+- [ ] **Reward improves:** over N steps, `:reward-mean` (mean log-ML) trends upward on the task — the
+      policy demonstrably learns (the Phase-1 claim). Asserted with a tolerance, not a single noisy step.
+- [ ] Invalid/un-parseable completions score the finite floor (no `##-Inf` poisoning the group).
+- [ ] Reward purity test: the reward-fn does not touch the policy model handle; it is a pure
+      `(prompt, completion) -> number`.
+- [ ] KL-free documented; `:kl-coef 0.0`; Phase-1.5 (ref-logprob autograd) captured as a follow-up bean.
+- [ ] Docs: the "Bayesian model evidence as RL signal = wake-phase" framing + the reward-shaping knobs.
+
+## 8. Open decisions (for review)
+
+1. **Reward signal for the Phase-1 proof:** (a) Bayesian model evidence (`score-model` log-ML) — the
+   crown novelty; (b) program correctness (`verify` accuracy + `score-structure`); (c) ship both.
+   **Recommendation: (a)** as the headline, with (b) implemented but exercised only lightly.
+2. **Base model:** `qwen3.5-0.8b-mlx-bf16` (cheap, the point is the loop + reward trend) vs `qwen3.5-4b`
+   (better programs, heavier). **Recommendation: 0.8b** for the proof; 4b is a one-line config swap.
+3. **Reward shaping:** ship plain log-ML first, or include the compilation-bonus / complexity-penalty
+   knobs from day one? **Recommendation:** ship plain log-ML + the finite floor; add λc/λk as
+   off-by-default knobs (so the shaping is available but the proof is clean).
+4. **Acceptance bar for "reward improves":** a strict monotonic-ish trend over N steps can be noisy on a
+   0.8B model. **Recommendation:** assert `mean(last k) > mean(first k)` over a modest N, plus the loop
+   closing + finite-floor + purity tests as the hard gates (the *capability* is the deliverable; the
+   *magnitude* of improvement is model/compute-bound).
+
+---
+
+**Per the milestone protocol, this spec is presented for review. No code will be written until it is
+approved.** The natural review questions are the four open decisions in §8.

--- a/src/genmlx/world/train.cljs
+++ b/src/genmlx/world/train.cljs
@@ -1,0 +1,424 @@
+(ns genmlx.world.train
+  "The TRAINING face of the world membrane (Phase 0, bean genmlx-zftr) — a thin,
+   honest boundary over the native GRPO training engine, a sibling to `genmlx.mlx`
+   (the COMPUTE membrane), `genmlx.world.net` (the NETWORK membrane) and
+   `genmlx.world.proc` (the SCHEDULER).
+
+   THE ONE EFFECT — training is RL's `eval!`-equivalent. A GRPO step generates a
+   group of completions, scores them with a PURE reward, computes group-relative
+   advantages + a clipped surrogate, and applies an AdamW update that MUTATES the
+   model's weights and the optimizer's moment state IN PLACE on the model thread.
+   That in-place mutation is the sole side effect of this face. Everything above it
+   stays pure: the reward is a pure `(prompt, completion) -> number`, the rollout is
+   the engine's own generation, and the policy is a GF.
+
+   Same architectural MOVE as mlx.cljs, different substrate GRADE:
+
+     mlx-node : compute effect  : eval! -> Metal      SYNC dispatch to a TRANSPARENT
+                                                       substrate (your own values,
+                                                       realized exactly)
+     training : learning effect : train-step! -> AdamW ASYNC crossing that MUTATES a
+                                                       borrowed model IN PLACE; the
+                                                       updated weights are observable
+                                                       state OWNED BY THE CALLER (like
+                                                       the KV cache), not hidden global
+                                                       state
+
+   THE MUTABLE BOUNDARY (the quarantine). The native `GrpoTrainingEngine` handle is
+   the ONE mutable resource of this face — created inside a blessed scope, consumed
+   locally, torn down on exit. It never escapes into pure code, and its in-place
+   weight updates are a PARALLEL path that never composes back into the pure
+   GFI-score gradient flow. Fenced exactly like the two existing precedents:
+   `world.net`'s `with-server` (a live Bun.serve listener) and `llm/backend.cljs`'s
+   KV-cache atom (mutation inside try/finally). `with-trainer` is the blessed scope
+   (p/finally teardown); `make-trainer!` is the low-level escape hatch.
+
+   GOTCHA (load-bearing): the native `trainStepAuto` reward callback awaits a NATIVE
+   `js/Promise<number[]>`. A promesa promise is NOT `instanceof js/Promise`, so the
+   reward bridge resolves with a native `js/Promise.resolve` (NOT promesa) — the same
+   native-callback rule that bites `world.net`'s Bun fetch handler. Client-side
+   promesa (the `train-step!` return, `with-trainer`) is fine.
+
+   THE REWARD BRIDGE (the seam to Phase 1). `train-step!` marshals a PURE CLJS
+   reward-fn into the native callback. Phase 0 ships a trivial reward (completion
+   length) to prove the round-trip mutates weights. Phase 1 (genmlx-ugkv) swaps in a
+   GFI quantity — `msa/score-model` marginal log-ML or `codegen/verify` accuracy —
+   through the SAME seam, no new native code.
+
+   sync/async split: a training step crosses to a native promise, so `train-step!` /
+   `generate-batch` / `with-trainer` return promesa promises (CLAUDE.md's 'sync math,
+   async events', like model load / `.chat`). The reward math itself is pure & sync.
+
+   Native surface VERIFIED 2026-06-20 against @genmlx/core/index.d.ts (the addon
+   GenMLX loads — NOT @mlx-node/core, which the original spec named): the runtime
+   class is `GrpoTrainingEngine` (factory `fromQwen35`/`fromQwen35Moe`, ctor takes a
+   Qwen3 model); checkpointing of WEIGHTS lives on the model handle (`saveModel`),
+   the engine only persists OPTIMIZER moments (`saveOptimizerState`); there is no
+   native `dispose`/`saveCheckpoint`, and `GrpoEngineConfig` has no `seed` field."
+  (:require [promesa.core :as p]))
+
+;; ===========================================================================
+;; Native binding (lazy, off the @genmlx/core object `c` — mirrors mlx.cljs:27).
+;; The two names bound here off `c` (GrpoTrainingEngine, createRandomQwen35Checkpoint)
+;; are the Phase-0 training surface; membrane_coverage_test scans this file and
+;; classifies them WRAPPED. The remaining training exports (Sft engine, the reward
+;; registry, the result/persistence types, the other random-checkpoint helpers)
+;; stay on the omission allowlist until Phase 1-4 tap them.
+;; ===========================================================================
+
+(defonce ^:private c (js/require "@genmlx/core"))
+
+(def ^:private GrpoTrainingEngine (.-GrpoTrainingEngine c))
+(def ^:private create-random-qwen35-checkpoint (.-createRandomQwen35Checkpoint c))
+
+(defn available?
+  "True when the native GRPO training engine backing this face is present. Pure flow
+   above can branch on this to skip cleanly when @genmlx/core lacks the training
+   surface (mirrors world.net/proc `available?`)."
+  []
+  (boolean (and c (fn? GrpoTrainingEngine))))
+
+;; ===========================================================================
+;; Config marshalling — CLJS map -> native camelCase config objects.
+;; ===========================================================================
+
+(def ^:private loss-type->native
+  {:grpo "grpo" :dapo "dapo" :dr-grpo "dr_grpo" :bnpo "bnpo"})
+
+(defn- ->engine-config
+  "Map a CLJS config to a native GrpoEngineConfig (#js, camelCase). The curated kebab
+   keys below are mapped explicitly; ANY OTHER native GrpoEngineConfig field (e.g.
+   :gradientClipValue, :weightDecay, :optimizerType, :presencePenalty, :adamwBeta1)
+   can be passed camelCase under `:raw` and is merged verbatim. Unrecognized TOP-LEVEL
+   keys are IGNORED. Only set keys are sent, so native defaults apply for the rest.
+
+   Supported kebab keys: :learning-rate :group-size :kl-coef (alias :beta) :loss-type
+   :max-completion-length :temperature :top-p :top-k :clip-epsilon :gradient-clip-norm
+   :gradient-accumulation-steps :repetition-penalty.
+
+   `:beta`/`:kl-coef` -> klCoef. Setting it > 0 makes `train-step!` ERROR under autograd
+   (reference-model KL is not yet supported natively); leave it 0 (default) for KL-free
+   training. There is no `:seed` — the engine owns its MLX sampler RNG (training RNG ≠
+   GenMLX inference RNG; no native config field exists to seed it)."
+  [config]
+  (clj->js
+    (merge
+      (cond-> {}
+        (contains? config :learning-rate)               (assoc :learningRate (:learning-rate config))
+        (contains? config :group-size)                  (assoc :groupSize (:group-size config))
+        (or (contains? config :kl-coef)
+            (contains? config :beta))                   (assoc :klCoef (or (:kl-coef config) (:beta config)))
+        (contains? config :loss-type)                   (assoc :lossType (get loss-type->native (:loss-type config)
+                                                                             (name (:loss-type config))))
+        (contains? config :max-completion-length)       (assoc :maxCompletionLength (:max-completion-length config))
+        (contains? config :temperature)                 (assoc :temperature (:temperature config))
+        (contains? config :top-p)                       (assoc :topP (:top-p config))
+        (contains? config :top-k)                       (assoc :topK (:top-k config))
+        (contains? config :clip-epsilon)                (assoc :clipEpsilon (:clip-epsilon config))
+        (contains? config :gradient-clip-norm)          (assoc :gradientClipNorm (:gradient-clip-norm config))
+        (contains? config :gradient-accumulation-steps) (assoc :gradientAccumulationSteps (:gradient-accumulation-steps config))
+        (contains? config :repetition-penalty)          (assoc :repetitionPenalty (:repetition-penalty config)))
+      (:raw config))))
+
+(def ^:private reward-type->native
+  {:length "Length" :tool-use "ToolUse" :xml-format "XmlFormat" :json-schema "JsonSchema"})
+
+(defn- ->builtin-reward
+  "Map a CLJS reward config to a native BuiltinRewardConfig (#js)."
+  [{:keys [reward-type weight min-length max-length use-chars? required-tags
+           allowed-tools required-fields required?]}]
+  (clj->js
+    (cond-> {:rewardType (get reward-type->native reward-type (name reward-type))}
+      (some? weight)         (assoc :weight weight)
+      (some? min-length)     (assoc :minLength min-length)
+      (some? max-length)     (assoc :maxLength max-length)
+      (some? use-chars?)     (assoc :useChars use-chars?)
+      (some? required-tags)  (assoc :requiredTags required-tags)
+      (some? allowed-tools)  (assoc :allowedTools allowed-tools)
+      (some? required-fields)(assoc :requiredFields required-fields)
+      (some? required?)      (assoc :required required?))))
+
+;; Tiny default Qwen3.5 architecture for the random-checkpoint test/example helper.
+(def ^:private tiny-qwen35-defaults
+  {:vocabSize 256 :hiddenSize 64 :numLayers 2 :numHeads 4 :numKvHeads 2
+   :intermediateSize 128 :rmsNormEps 1e-6 :headDim 16
+   :tieWordEmbeddings true :attentionBias false :maxPositionEmbeddings 512
+   :padTokenId 0 :eosTokenId 1 :bosTokenId 2
+   :linearNumValueHeads 4 :linearNumKeyHeads 2 :linearKeyHeadDim 16 :linearValueHeadDim 16
+   :linearConvKernelDim 4 :fullAttentionInterval 2 :partialRotaryFactor 0.5 :ropeTheta 10000.0})
+
+;; ===========================================================================
+;; Prompt + result marshalling.
+;; ===========================================================================
+
+(defn- ->chat-msg [m]
+  (cond
+    (string? m) #js {:role "user" :content m}
+    (map? m)    #js {:role (name (:role m :user)) :content (:content m)}
+    :else       m))
+
+(defn- ->prompt
+  "A prompt is one chat conversation. A bare string becomes a single user turn."
+  [p]
+  (if (string? p)
+    #js [(->chat-msg p)]
+    (into-array (map ->chat-msg p))))
+
+(defn- ->prompts
+  "vector of prompts -> native ChatMessage[][]."
+  [prompts]
+  (into-array (map ->prompt prompts)))
+
+(defn- ->metrics
+  "Native EngineStepMetrics -> CLJS metrics map."
+  [m]
+  {:step               (.-step m)
+   :loss               (.-loss m)
+   :reward-mean        (.-meanReward m)
+   :reward-std         (.-stdReward m)
+   :advantage-mean     (.-meanAdvantage m)
+   :advantage-std      (.-stdAdvantage m)
+   :total-tokens       (.-totalTokens m)
+   :gradients-applied? (.-gradientsApplied m)
+   :generation-ms      (.-generationTimeMs m)
+   :training-ms        (.-trainingTimeMs m)
+   :peak-memory-mb     (.-peakMemoryMb m)
+   :active-memory-mb   (.-activeMemoryMb m)})
+
+(defn- ->epoch-metrics [m]
+  {:epoch          (.-epoch m)
+   :avg-loss       (.-avgLoss m)
+   :avg-reward     (.-avgReward m)
+   :total-steps    (.-totalSteps m)
+   :total-tokens   (.-totalTokens m)
+   :epoch-time-secs (.-epochTimeSecs m)})
+
+;; ===========================================================================
+;; The Trainer — a quarantine record mirroring CljsForwardModel (backend.cljs:34).
+;;   engine : the IMMUTABLE native GrpoTrainingEngine handle (the borrowed resource)
+;;   model  : the IMMUTABLE borrowed native model handle (must outlive the trainer;
+;;            the engine mutates ITS weights in place — see dispose!)
+;;   state  : the ONE mutable cell (an atom), holding {:disposed? bool}
+;; ===========================================================================
+
+(defrecord Trainer [engine model state])
+
+(defn trainer?
+  "True iff `x` is a Trainer handle from this face."
+  [x]
+  (instance? Trainer x))
+
+(defn disposed?
+  "True once `trainer` has been disposed (or reset, which is terminal natively)."
+  [trainer]
+  (boolean (:disposed? @(:state trainer))))
+
+(defn- ensure-live! [trainer]
+  (when (disposed? trainer)
+    (throw (ex-info "trainer is disposed (or reset); construct a new one"
+                    {:genmlx/error :trainer-disposed}))))
+
+;; ===========================================================================
+;; Construction — blessed scope + low-level escape hatch (mirrors with-server).
+;; ===========================================================================
+
+(defn make-trainer!
+  "[low-level] Build a GRPO training engine over an ALREADY-LOADED native model
+   handle (`model`) and a CLJS `config` (see `->engine-config` for keys). The model
+   handle must OUTLIVE the trainer — the engine borrows it and mutates its weights in
+   place. `:family` selects the native factory: `:qwen35` (default) / `:qwen35-moe` /
+   `:qwen3`. The caller OWNS teardown via `(dispose! trainer)`. Prefer `with-trainer`,
+   which guarantees teardown."
+  ([model config] (make-trainer! model config {}))
+  ([model config {:keys [family] :or {family :qwen35}}]
+   (when-not (available?)
+     (throw (ex-info "world.train unavailable: @genmlx/core training engine absent"
+                     {:genmlx/error :train-unavailable})))
+   (let [cfg    (->engine-config config)
+         engine (case family
+                  :qwen35     (.fromQwen35 GrpoTrainingEngine model cfg)
+                  :qwen35-moe (.fromQwen35Moe GrpoTrainingEngine model cfg)
+                  :qwen3      (js/Reflect.construct GrpoTrainingEngine #js [model cfg])
+                  (throw (ex-info (str "unknown :family " family)
+                                  {:genmlx/error :bad-family :family family})))]
+     (->Trainer engine model (atom {:disposed? false})))))
+
+(defn dispose!
+  "Tear down `trainer`: drop the model-thread training state (the engine's terminal
+   `reset` — optimizer moments + step counter; the model thread and its already-trained
+   weights stay live) so the borrowed model can host a NEW trainer, and mark this
+   handle disposed so further effectful ops throw. Idempotent. Does NOT free the
+   borrowed `model` (the caller owns it) or revert its weights.
+
+   The native model thread hosts only ONE active training run, so freeing it on
+   teardown is required for `with-trainer` to be re-enterable over the same model.
+
+   A `reset` failure (e.g. the model thread already exited) is NOT raised — raising
+   would mask a body error when dispose! runs inside `with-trainer`'s teardown — but it
+   IS recorded as `:teardown-error` on the trainer state (read it with `teardown-error`).
+   In that case the model-thread run was NOT released and a new trainer over the same
+   model may be rejected."
+  [trainer]
+  (when-not (disposed? trainer)
+    (try (.reset (:engine trainer))
+         (catch :default e (swap! (:state trainer) assoc :teardown-error e))))
+  (swap! (:state trainer) assoc :disposed? true)
+  nil)
+
+(defn teardown-error
+  "The error captured if `dispose!`'s native `reset` failed (the model-thread training
+   run was not released), else nil."
+  [trainer]
+  (:teardown-error @(:state trainer)))
+
+(defn with-trainer
+  "[blessed scope] Build a trainer over `model`+`config`, call `(f trainer)` — which
+   MUST return a promise — and GUARANTEE the trainer is disposed afterwards, on
+   success OR failure (the p/finally runs even when f's promise rejects). Returns the
+   promise of `(f trainer)`'s result. This is the only place a trainer lifecycle
+   should live in tests/examples."
+  ([model config f] (with-trainer model config {} f))
+  ([model config opts f]
+   (let [trainer (make-trainer! model config opts)]
+     ;; p/handle (not p/finally): under nbb a `p/finally` teardown followed by a
+     ;; downstream `p/catch` double-settles — the catch handler runs yet the promise
+     ;; stays rejected. p/handle disposes on BOTH arms and re-raises exactly once.
+     (-> (p/let [r (f trainer)] r)
+         (p/handle (fn [r e] (dispose! trainer) (if e (throw e) r)))))))
+
+;; ===========================================================================
+;; THE ONE EFFECT — a GRPO step (the reward bridge to Phase 1 lives here).
+;; ===========================================================================
+
+(defn train-step!
+  "Run one GRPO training step (the training `eval!`-equivalent — the sole
+   weight-mutating effect of this face) as an EXPLICIT generate -> score -> train
+   round-trip:
+     1. the engine generates `group-size` completions per prompt,
+     2. the PURE `reward-fn` scores each completion in CLJS (the reward bridge),
+     3. the engine computes group-relative advantages + a clipped surrogate and
+        applies an AdamW update IN PLACE on the model thread.
+
+     trainer   : a Trainer (from make-trainer!/with-trainer)
+     prompts   : vector of prompt strings, or vectors of {:role :content} chat maps
+     reward-fn : a PURE (fn [prompt completion-text] -> number), called once per
+                 completion across all prompts*group-size rollouts. THE Phase-1 seam:
+                 swap in a GFI-quantity scorer (msa/score-model, codegen/verify) with
+                 no change to this bridge.
+
+   Returns a promesa promise of a metrics map: {:step :loss :reward-mean :reward-std
+   :advantage-mean :advantage-std :total-tokens :gradients-applied? :completions
+   :rewards :completion-lengths :generation-ms :training-ms :peak-memory-mb
+   :active-memory-mb}.
+
+   This composes generateBatchForTraining + trainStepWithGenerations rather than the
+   all-in-one native trainStepAuto: it keeps the GFI reward scorer in CLJS between the
+   two awaits (no ThreadsafeFunction marshalling) and trains UNCONDITIONALLY — the
+   trainStepAuto path additionally filters out `finish_reason='length'` completions as
+   an OOM guard, which would skip the step for a model whose rollouts never emit EOS."
+  [trainer prompts reward-fn]
+  (ensure-live! trainer)
+  (let [engine     (:engine trainer)
+        js-prompts (->prompts prompts)
+        n-prompts  (count prompts)
+        gen-start  (.now js/Date)]
+    (-> (.generateBatchForTraining engine js-prompts)
+        (p/then
+          (fn [gen]
+            (let [texts   (vec (.-completionTexts gen))
+                  g       (quot (count texts) (max 1 n-prompts))
+                  ;; prompt-major: completion i belongs to prompt (i // group-size)
+                  rewards (mapv (fn [i] (double (reward-fn (nth prompts (quot i g))
+                                                           (nth texts i))))
+                                (range (count texts)))
+                  gen-ms  (- (.now js/Date) gen-start)]
+              (-> (.trainStepWithGenerations engine js-prompts (clj->js rewards) gen)
+                  (p/then (fn [m]
+                            (assoc (->metrics m)
+                                   :generation-ms gen-ms
+                                   :completions texts
+                                   :rewards rewards
+                                   :completion-lengths (vec (.-completionLengths gen))))))))))))
+
+(defn register-builtin-reward!
+  "Register a NATIVE built-in reward on the engine (e.g. {:reward-type :length
+   :max-length 64 :use-chars? true}). `:reward-type` ∈ #{:length :tool-use
+   :xml-format :json-schema}. An alternative to the CLJS reward bridge for cheap
+   length/format rewards."
+  [trainer reward-config]
+  (ensure-live! trainer)
+  (.registerBuiltinReward (:engine trainer) (->builtin-reward reward-config))
+  nil)
+
+;; ===========================================================================
+;; Lifecycle passthroughs (native GrpoTrainingEngine methods/getters).
+;; ===========================================================================
+
+(defn step
+  "Current global step count (native getter)."
+  [trainer]
+  (.-step (:engine trainer)))
+
+(defn epoch
+  "Current epoch (native getter)."
+  [trainer]
+  (.-epoch (:engine trainer)))
+
+(defn start-epoch!
+  "Mark the start of a training epoch."
+  [trainer]
+  (ensure-live! trainer)
+  (.startEpoch (:engine trainer))
+  nil)
+
+(defn end-epoch!
+  "Mark the end of a training epoch (`epoch-secs` = wall time in seconds). Returns a
+   CLJS epoch-metrics map."
+  [trainer epoch-secs]
+  (ensure-live! trainer)
+  (->epoch-metrics (.endEpoch (:engine trainer) epoch-secs)))
+
+(defn generate-batch
+  "Generate completions for `prompts` WITHOUT any weight update (inspection only).
+   Returns a promise of a vector of completion strings."
+  [trainer prompts]
+  (ensure-live! trainer)
+  (-> (.generateBatch (:engine trainer) (->prompts prompts))
+      (p/then vec)))
+
+;; ===========================================================================
+;; Checkpointing — OPTIMIZER state only (the engine's resumable AdamW moments +
+;; step). Model WEIGHTS are checkpointed on the model handle (its own `saveModel`),
+;; NOT here — the native engine exposes no weight save.
+;; ===========================================================================
+
+(defn save-optimizer-state!
+  "Persist the AdamW optimizer moments + step to `path` (NOT model weights — save
+   those via the model handle's own `saveModel`). Returns a promise. No-op natively
+   if the engine uses SGD."
+  [trainer path]
+  (ensure-live! trainer)
+  (.saveOptimizerState (:engine trainer) path))
+
+(defn load-optimizer-state!
+  "Restore AdamW optimizer moments + step from `path`. Returns a promise."
+  [trainer path]
+  (ensure-live! trainer)
+  (.loadOptimizerState (:engine trainer) path))
+
+;; ===========================================================================
+;; Test/example helper — spin up a tiny RANDOM Qwen3.5 checkpoint so the membrane
+;; round-trip is exercisable without a real >3GB checkpoint (real-checkpoint
+;; training is gated by genmlx-o94r). Load the result with Qwen35Model.load.
+;; ===========================================================================
+
+(defn random-qwen35-checkpoint!
+  "[test/example helper] Write a RANDOM tiny Qwen3.5 dense checkpoint to directory
+   `dir`. `config` is a CLJS map of Qwen35Config fields (camelCase keyword keys, e.g.
+   {:numLayers 2 :hiddenSize 64}); it is merged over a tiny default architecture.
+   Returns a promise of `dir`. Load it with `(.load Qwen35Model dir)` to get a
+   trainable model handle."
+  ([dir] (random-qwen35-checkpoint! dir {}))
+  ([dir config]
+   (-> (create-random-qwen35-checkpoint (clj->js (merge tiny-qwen35-defaults config)) dir)
+       (p/then (fn [_] dir)))))

--- a/test/genmlx/membrane_coverage_test.cljs
+++ b/test/genmlx/membrane_coverage_test.cljs
@@ -2,7 +2,7 @@
 (ns genmlx.membrane-coverage-test
   "genmlx-0vwn / genmlx-e3jg: compute-membrane coverage drift-guard.
 
-   The @mlx-node/core surface is the substrate (Layer C) the GenMLX membrane
+   The @genmlx/core surface is the substrate (Layer C) the GenMLX membrane
    (Layer 0 = mlx.cljs + mlx/random.cljs) binds to. This test PARTITIONS the
    full runtime function-export surface into:
 
@@ -22,9 +22,12 @@
    to do about it. The count is kept as a coarse canary (catches an add+omit done
    in one commit, which A/B/C alone would pass).
 
-   SoT for the surface = packages/core/index.d.cts (the current types target in
-   package.json) — NOT the stale index.d.ts (Apr 1). NO no-op stubs: an export is
-   either genuinely wrapped or honestly omitted with a category + reason."
+   SoT for the surface = the LIVE @genmlx/core runtime module (what `core` below reads
+   via js/require, and what this test partitions). The package ships no `types` field;
+   its `index.d.ts` is a regenerated snapshot that can lag the runtime (e.g. `Gradients`
+   is a live export absent from the d.ts), so the runtime — not any .d.ts — is authority.
+   NO no-op stubs: an export is either genuinely wrapped or honestly omitted with a
+   category + reason."
   (:require [cljs.test :refer [deftest is testing]]
             [genmlx.test-helpers :as h]
             [genmlx.mlx :as mx]))
@@ -32,16 +35,20 @@
 (def ^:private core (js/require "@genmlx/core"))
 (def ^:private fs (js/require "fs"))
 
-;; The membrane = both Layer-0 files that bind @mlx-node/core. An export is
-;; WRAPPED iff its native name is referenced here as a property (.-name) or a
-;; method call (.name ...) — the only ways a NAPI export can be reached.
+;; The membrane = the Layer-0 files that bind @genmlx/core: the pure COMPUTE
+;; membrane (mlx.cljs + mlx/random.cljs) plus the TRAINING membrane face
+;; (world/train.cljs, genmlx-zftr — the GRPO engine behind its mutable-state
+;; quarantine). An export is WRAPPED iff its native name is referenced in one of
+;; these as a property (.-name c) or a method call (.name c …).
 (def ^:private membrane-src
   (str (.readFileSync fs "src/genmlx/mlx.cljs" "utf8")
        "\n"
-       (.readFileSync fs "src/genmlx/mlx/random.cljs" "utf8")))
+       (.readFileSync fs "src/genmlx/mlx/random.cljs" "utf8")
+       "\n"
+       (.readFileSync fs "src/genmlx/world/train.cljs" "utf8")))
 
 (defn- referenced?
-  "True if the membrane BINDS native export `nm` off the @mlx-node/core object
+  "True if the membrane BINDS native export `nm` off the @genmlx/core object
    `c` — as a property ref (.-nm c) or a method head (.nm c …), the uniform wrap
    convention in both Layer-0 files (each `(defonce ^:private c (js/require ...))`).
    Scoping to the `c` receiver (rather than any object) is deliberate: it stops a
@@ -56,14 +63,14 @@
 
    Known limitation (genmlx-0vwn, accepted): a 'dangling wrap' — a (.-x c) left in
    the source after upstream DELETES export x — is not flagged here directly; the
-   212 count canary + tiling invariant in coverage-accounting-test catch it
+   214 count canary + tiling invariant in coverage-accounting-test catch it
    indirectly (a deletion drops the surface count below the pin)."
   [nm]
   (some? (re-find (re-pattern (str "\\.-?" nm "\\s+c[^A-Za-z0-9_]")) membrane-src)))
 
 ;; ---------------------------------------------------------------------------
 ;; INTENTIONAL OMISSIONS — the coverage matrix, machine-checked.
-;; Each entry is an @mlx-node/core export deliberately NOT wrapped in the pure
+;; Each entry is an @genmlx/core export deliberately NOT wrapped in the pure
 ;; compute membrane, with the reason it belongs elsewhere (or nowhere). Classes
 ;; appear here too: a JS `class` is a function export, so it counts toward the
 ;; runtime surface and must be accounted for. Categories double as the "where
@@ -78,13 +85,15 @@
    :profiling-gated-i0s4
    #{"getProfilingData" "isProfilingEnabled" "setProfilingEnabled" "resetProfilingData"}
 
-   ;; GRPO/SFT training surface — to be bound at ENGINE level in a future
-   ;; @mlx-node/trl Layer-6 ns WITH the mutable-state quarantine (in-place weight
-   ;; + optimizer-state mutation), never in the pure membrane. (genmlx-706r)
+   ;; Native training surface. The GRPO engine + the random-Qwen3.5 checkpoint helper
+   ;; are now WRAPPED in genmlx.world.train (genmlx-zftr Phase 0) behind the
+   ;; mutable-state quarantine — never the pure compute membrane. The remainder bind
+   ;; incrementally as Phase 1-4 tap them (SFT engine, reward registry, result/
+   ;; persistence types, the Qwen3/MoE random-checkpoint helpers). (genmlx-706r)
    :training-orchestration
    #{"buildRewardOutputs"
-     "createRandomQwen3Checkpoint" "createRandomQwen35Checkpoint" "createRandomQwen35MoeCheckpoint"
-     "GrpoTrainingEngine" "SftTrainingEngine" "NativeRewardRegistry"
+     "createRandomQwen3Checkpoint" "createRandomQwen35MoeCheckpoint"
+     "SftTrainingEngine" "NativeRewardRegistry"
      "Gradients" "OutputStore" "ResponseStore"}
 
    ;; offline weight/format conversion tooling — not graph ops
@@ -184,17 +193,17 @@
 ;; The drift guard proper — the e3jg/0vwn floor deliverable.
 ;; ---------------------------------------------------------------------------
 (deftest coverage-partition-test
-  (testing "every @mlx-node/core export is WRAPPED ∪ INTENTIONAL-OMISSIONS (two-directional)"
+  (testing "every @genmlx/core export is WRAPPED ∪ INTENTIONAL-OMISSIONS (two-directional)"
     ;; A — nothing unaccounted: an export neither wrapped nor on the allowlist
     (let [unaccounted (sort (remove referenced? (remove omitted exported-fns)))]
       (is (empty? unaccounted)
-          (str "Unaccounted @mlx-node/core exports — wire them into the membrane "
+          (str "Unaccounted @genmlx/core exports — wire them into the membrane "
                "or add to intentional-omissions with a reason (genmlx-0vwn): "
                (vec unaccounted))))
     ;; B — no stale omissions: an allowlisted name no longer exported upstream
     (let [stale (sort (remove exported-fns omitted))]
       (is (empty? stale)
-          (str "Stale omissions — these were deleted from @mlx-node/core (the "
+          (str "Stale omissions — these were deleted from @genmlx/core (the "
                "rebase tax surfacing); remove them from the allowlist: " (vec stale))))
     ;; C — clean partition: an omission that is now actually wrapped
     (let [misclassified (sort (filter referenced? omitted))]
@@ -207,10 +216,10 @@
     (let [wrapped (filter referenced? exported-fns)]
       ;; Coarse canary: catches a surface change even when add+omit happen together.
       (is (= 214 (count exported-fns))
-          (str "@mlx-node/core surface size changed: " (count exported-fns)
+          (str "@genmlx/core surface size changed: " (count exported-fns)
                " fns (pinned at 214) — the partition test above pinpoints what moved."))
-      (is (= 49 (count omitted))
-          (str "intentional-omissions size changed: " (count omitted) " (pinned at 49)."))
+      (is (= 47 (count omitted))
+          (str "intentional-omissions size changed: " (count omitted) " (pinned at 47)."))
       (is (= (count exported-fns) (+ (count wrapped) (count omitted)))
           (str "partition must tile exactly: wrapped " (count wrapped)
                " + omitted " (count omitted) " = exports " (count exported-fns))))))

--- a/test/genmlx/mutation_boundary_test.cljs
+++ b/test/genmlx/mutation_boundary_test.cljs
@@ -14,6 +14,7 @@
             [genmlx.selection :as sel]
             [genmlx.protocols :as p]
             [genmlx.gfi :as gfi]
+            [genmlx.world.train :as train]
             [genmlx.test-helpers :as th])
   (:require-macros [genmlx.gen :refer [gen]]))
 
@@ -355,6 +356,29 @@
               "handler score must be finite")
           (is (th/close? compiled-score handler-score 1e-4)
               "compiled simulate score must equal handler assess weight"))))))
+
+;; =========================================================================
+;; Test 10: world.train (the native training engine) is a quarantined boundary
+;;   — the training membrane's mutable state (the engine handle + the per-trainer
+;;   `state` atom) never leaks into pure GFI results. This is the LIGHT, no-GPU
+;;   guard (genmlx-zftr Phase 0); the heavy "a train-step doesn't leak" behavioral
+;;   proof runs in world_train_test.cljs on the slow tier.
+;; =========================================================================
+
+(deftest world-train-boundary-is-quarantined
+  (testing "the training membrane exposes a boolean availability probe (no throw)"
+    (is (boolean? (train/available?))
+        "train/available? must return a boolean at the boundary"))
+  (testing "probing the training membrane does not perturb pure simulate results"
+    (let [key (rng/fresh-key 1000)
+          t1  (p/simulate (dyn/with-key simple-model key) [2.0])
+          r1  (th/realize (:retval t1))
+          _   (train/available?)            ; touch the training boundary
+          _   (train/trainer? r1)           ; a pure predicate over the boundary's type
+          t2  (p/simulate (dyn/with-key simple-model key) [2.0])
+          r2  (th/realize (:retval t2))]
+      (is (th/close? r1 r2 1e-10)
+          "touching the training membrane must not affect pure GFI results"))))
 
 ;; =========================================================================
 ;; Run

--- a/test/genmlx/world_train_test.cljs
+++ b/test/genmlx/world_train_test.cljs
@@ -1,0 +1,191 @@
+;; @tier slow
+(ns genmlx.world-train-test
+  "Phase-0 acceptance (bean genmlx-zftr) for the genmlx.world.train TRAINING membrane.
+
+   Proves the training `eval!`-equivalent round-trip end-to-end WITHOUT a real >3GB
+   checkpoint (real-checkpoint training is gated by genmlx-o94r): write a tiny RANDOM
+   Qwen3.5 checkpoint -> load it -> build a GRPO trainer -> run one `train-step!` with
+   a PURE length reward -> assert the reward bridge fired, gradients applied, and the
+   model's weights MEASURABLY changed (forward-logits L1 delta > 0). Also covers
+   generate-batch (no update), the lifecycle passthroughs, optimizer-state
+   checkpointing, dispose! quarantine, and with-trainer teardown-on-throw.
+
+   Style 2 (self-contained assert + println; @tier slow) because it loads native and
+   runs GPU training. Run serially: `bun run --bun nbb test/genmlx/world_train_test.cljs`."
+  (:require [genmlx.world.train :as train]
+            [genmlx.mlx :as mx]
+            [promesa.core :as p]))
+
+;; @genmlx/core's main is index.node (a Node-API addon) — it must be js/require'd,
+;; not ESM-imported (mirrors mlx.cljs). Same for the node builtins.
+(def ^:private gcore (js/require "@genmlx/core"))
+(def ^:private os (js/require "os"))
+(def ^:private path (js/require "path"))
+(def ^:private fs (js/require "fs"))
+
+(def ^:private pass (atom 0))
+(def ^:private fail (atom 0))
+
+(defn assert-true [label v]
+  (if v
+    (do (swap! pass inc) (println "  PASS" label))
+    (do (swap! fail inc) (println "  FAIL" label))))
+
+(def ^:private dir (.join path (.tmpdir os) "genmlx-phase0-world-train"))
+
+;; The random tiny model keeps compute small (2 layers, hidden 64) but uses the REAL
+;; Qwen3.5 vocab + a copied-in REAL tokenizer so the generation path inside a GRPO
+;; step actually works (the random checkpoint itself writes no tokenizer).
+(def ^:private real-tok-dir
+  (.join path (.homedir os) ".cache" "models" "qwen3.5-0.8b-mlx-bf16"))
+(def ^:private qwen35-vocab 248320)
+
+(defn- clean-dir! []
+  (.rmSync fs dir #js {:recursive true :force true}))
+
+(defn- ids []
+  (mx/astype (mx/array [[2 3 4 5]]) mx/int32))
+
+(defn- l1
+  "L1 distance between two nested CLJS number trees (forward-logits)."
+  [a b]
+  (reduce + (map (fn [x y] (js/Math.abs (- x y))) (flatten a) (flatten b))))
+
+(def ^:private group-size 4)
+
+(def ^:private cfg
+  {:learning-rate 0.5 :group-size group-size :max-completion-length 12 :loss-type :grpo})
+
+(defn- summary []
+  (println (str "\n== world.train Phase 0: " @pass " passed, " @fail " failed =="))
+  (when (pos? @fail) (set! (.-exitCode js/process) 1)))
+
+(defn run-all []
+  (println "\n== genmlx.world.train — Phase 0 acceptance ==")
+  (assert-true "available? true on this box (native GRPO engine present)"
+               (train/available?))
+  (clean-dir!)
+  (if-not (.existsSync fs (.join path real-tok-dir "tokenizer.json"))
+    (do (println "  SKIP train-step round-trip — no Qwen3.5 tokenizer at" real-tok-dir
+                 "(needed to make a trainable random checkpoint)")
+        (summary)
+        (p/resolved nil))
+   (p/let [_       (train/random-qwen35-checkpoint! dir {:vocabSize qwen35-vocab})
+          _       (assert-true "random-qwen35-checkpoint! wrote a checkpoint dir"
+                               (.existsSync fs dir))
+          ;; drop a REAL tokenizer next to the random weights so generation works
+          _       (.copyFileSync fs (.join path real-tok-dir "tokenizer.json")
+                                 (.join path dir "tokenizer.json"))
+          _       (.copyFileSync fs (.join path real-tok-dir "tokenizer_config.json")
+                                 (.join path dir "tokenizer_config.json"))
+          model   (.load (.-Qwen35Model gcore) dir)
+          _       (assert-true "tiny Qwen3.5 model loads from the random checkpoint"
+                               (some? model))
+          ;; --- weight-change proof: materialize forward logits BEFORE training ---
+          in      (ids)
+          before  (mx/->clj (.forward model in))
+          calls   (atom 0)
+          ;; distinct-char count — small, varies with completion CONTENT, so the group
+          ;; has nonzero reward variance (a constant reward => zero advantage => no update).
+          ;; PURE (prompt, completion)->number; deliberately does NOT forward-pass `model`
+          ;; (the training thread owns it) — this is exactly the Phase-1 GFI-reward seam.
+          reward-fn (fn [_prompt completion]
+                      (swap! calls inc)
+                      (double (count (distinct (seq completion)))))
+          tr      (train/make-trainer! model cfg)
+          _       (assert-true "make-trainer! returns a Trainer" (train/trainer? tr))
+          _       (assert-true "fresh trainer is not disposed" (not (train/disposed? tr)))
+          ;; --- THE ONE EFFECT: a GRPO step through the pure-reward bridge ---
+          res     (train/train-step! tr ["Hi there"] reward-fn)
+          _       (assert-true "train-step! resolves to a metrics map" (map? res))
+          _       (assert-true "gradients were applied" (true? (:gradients-applied? res)))
+          _       (assert-true "loss is finite" (js/isFinite (:loss res)))
+          _       (assert-true "reward bridge invoked the PURE reward-fn once per completion"
+                               (= group-size @calls))
+          _       (assert-true "reward array length = num completions"
+                               (= group-size (count (:rewards res))))
+          _       (assert-true "completions returned" (= group-size (count (:completions res))))
+          _       (assert-true "reward-mean is a number" (number? (:reward-mean res)))
+          _       (assert-true "advantage-std > 0 (varied group rewards produced a learning signal)"
+                               (> (:advantage-std res) 0.0))
+          after   (mx/->clj (.forward model in))
+          delta   (l1 before after)
+          _       (println "    forward-logits L1 weight Δ =" delta)
+          _       (assert-true "train-step! MEASURABLY changed the model's weights (forward-logits Δ > 0)"
+                               (> delta 0.0))
+          ;; --- optimizer-state checkpoint round-trip (moments only) ---
+          optpath (.join path dir "opt-state.safetensors")
+          _       (train/save-optimizer-state! tr optpath)
+          _       (assert-true "save-optimizer-state! wrote a non-empty AdamW moment file"
+                               (and (.existsSync fs optpath) (pos? (.-size (.statSync fs optpath)))))
+          _       (train/load-optimizer-state! tr optpath)
+          _       (assert-true "load-optimizer-state! restores without error" true)
+          ;; --- generate-batch: completions, NO weight update ---
+          before2 (mx/->clj (.forward model in))
+          comps   (train/generate-batch tr ["Hi there"])
+          after2  (mx/->clj (.forward model in))
+          _       (assert-true "generate-batch returns a non-empty vector of completions"
+                               (and (vector? comps) (pos? (count comps))))
+          _       (assert-true "generate-batch does NOT change weights (Δ = 0)"
+                               (= 0.0 (l1 before2 after2)))
+          ;; --- lifecycle passthroughs ---
+          _       (assert-true "step is a number (getter)" (number? (train/step tr)))
+          _       (assert-true "epoch is a number (getter)" (number? (train/epoch tr)))
+          _       (train/start-epoch! tr)
+          em      (train/end-epoch! tr 0.01)
+          _       (assert-true "end-epoch! returns an epoch-metrics map"
+                               (and (map? em) (contains? em :avg-loss)))
+          ;; --- native built-in reward registration ---
+          _       (train/register-builtin-reward! tr {:reward-type :length :max-length 64 :use-chars? true})
+          _       (assert-true "register-builtin-reward! registers a native builtin reward"
+                               (true? (.-hasBuiltinRewards (:engine tr))))
+          ;; --- dispose! quarantine ---
+          _       (train/dispose! tr)
+          _       (assert-true "dispose! marks the trainer disposed" (train/disposed? tr))
+          _       (assert-true "an effectful op after dispose throws"
+                               (try (train/start-epoch! tr) false (catch :default _ true)))
+          ;; --- with-trainer: teardown on throw ---
+          captured (atom nil)
+          threw    (atom false)
+          _       (-> (train/with-trainer model {:group-size 2}
+                        (fn [t] (reset! captured t) (p/rejected (ex-info "boom" {}))))
+                      (p/catch (fn [_] (reset! threw true))))
+          _       (assert-true "with-trainer propagates f's rejection" @threw)
+          _       (assert-true "with-trainer disposed the trainer on throw"
+                               (train/disposed? @captured))
+          ;; --- with-trainer: happy path returns f's value, then disposes ---
+          ok      (train/with-trainer model {:group-size 2}
+                    (fn [t] (p/resolved (train/step t))))
+          _       (assert-true "with-trainer returns f's resolved value" (number? ok))
+          ;; --- re-entry over the SAME model + multi-prompt prompt-major demux ---
+          re-calls (atom 0)
+          re-pairs (atom [])
+          re2     (train/with-trainer model {:group-size 2 :max-completion-length 12}
+                    (fn [t]
+                      (train/train-step! t ["alpha" "beta"]
+                        (fn [p c] (swap! re-calls inc) (swap! re-pairs conj p)
+                          (double (count (distinct (seq c))))))))
+          _       (assert-true "re-entry: a NEW trainer trains over the same model (dispose! freed the run)"
+                               (true? (:gradients-applied? re2)))
+          _       (assert-true "multi-prompt demux: reward-fn called num-prompts*group-size = 4 times"
+                               (= 4 @re-calls))
+          _       (assert-true "multi-prompt demux: prompt-major pairing (group 0 -> prompt 0, group 1 -> prompt 1)"
+                               (= ["alpha" "alpha" "beta" "beta"] @re-pairs))
+          ;; --- KL under autograd is rejected (the honest contract: klCoef>0 errors) ---
+          klres   (train/with-trainer model {:group-size 2 :kl-coef 0.1 :max-completion-length 12}
+                    (fn [t]
+                      (-> (train/train-step! t ["Hi there"] (fn [_ c] (double (count (distinct (seq c))))))
+                          (p/then (fn [_] :no-throw))
+                          (p/catch (fn [_] :rejected)))))
+          _       (assert-true "kl-coef>0 makes train-step! reject under autograd (reference-model KL unsupported)"
+                               (= :rejected klres))
+          _       (clean-dir!)]
+    (summary))))
+
+(-> (run-all)
+    (p/catch (fn [e]
+               (swap! fail inc)
+               (println "  FAIL (uncaught)" (.-message e))
+               (println (.-stack e))
+               (clean-dir!)
+               (set! (.-exitCode js/process) 1))))


### PR DESCRIPTION
## Phase 0 of the GRPO/training milestone (`genmlx-zftr`)

A new **Layer-0 membrane face** `genmlx.world.train` — sibling to `genmlx.mlx` (compute), `world.net` (network), `world.proc` (scheduler). It wraps the native GRPO engine behind a mutable-state quarantine, exposing **one new effect: a training step that mutates model weights + AdamW moments in place** — RL's `eval!`-equivalent. Reward, rollout, and policy stay pure above it. This unblocks Phase 1 (GFI-quantity rewards) and the rest of the training roadmap.

**No new native dependency, no native rebuild** — the GRPO surface already exists in `@genmlx/core`.

### What's here
- **`src/genmlx/world/train.cljs`** — `available?`, `make-trainer!`/`with-trainer`/`dispose!`/`teardown-error`, `train-step!` (the reward bridge), `register-builtin-reward!`, lifecycle passthroughs (`step`/`epoch`/`start-epoch!`/`end-epoch!`/`generate-batch`), `save-optimizer-state!`/`load-optimizer-state!`, and a `random-qwen35-checkpoint!` test helper. The `Trainer` is a `defrecord` with a single `state` atom (mirroring `CljsForwardModel`'s KV-cache atom).
- **`test/genmlx/world_train_test.cljs`** (`@tier slow`) — **31/31** acceptance on Metal: a real GRPO step on a tiny random Qwen3.5 checkpoint (2 layers, real vocab + tokenizer) measurably changes the model's weights (forward-logits Δ≈1e6); reward bridge fires once per completion; re-entry over the same model; multi-prompt prompt-major demux; `kl-coef>0` rejection; `with-trainer` teardown on throw + happy path.
- **Coverage matrix** (`membrane_coverage_test` + `docs/membrane-coverage.md`) — `GrpoTrainingEngine` + `createRandomQwen35Checkpoint` moved omitted→wrapped; `world/train.cljs` added to the scanned membrane; re-pinned **214/167/47**; corrected stale `@mlx-node/core`→`@genmlx/core` and the source-of-truth prose (the live runtime is authority, not the `.d.ts`).
- **`mutation_boundary_test` + CLAUDE.md** — registered the new audited mutable boundary (a no-GPU quarantine cluster + the boundaries-list entry).
- **`docs/phase0-world-train-spec.md` §11** — records the **10 native-surface discrepancies** the inspected spec had, and how each was resolved.
- **`docs/phase1-gfi-reward-spec.md`** — the Phase 1 spec (GRPO where the reward is `msa/score-model` marginal log-ML), spec-first, **awaiting approval** (no Phase 1 code in this PR).

### Key reality-corrections (the spec was inspected, not verified)
- Bind **`@genmlx/core`**, not `@mlx-node/core`; the class is `GrpoTrainingEngine`; `step`/`epoch` are getters.
- **No native `saveCheckpoint`/`dispose`/`:seed`.** Checkpointing is optimizer-moments-only; weights are the model handle's job. `dispose!` = the engine's terminal `reset()` (frees the one-per-model-thread run so `with-trainer` is re-enterable) + honest `teardown-error` recording.
- The reward bridge is the explicit **`generateBatchForTraining` → score-in-CLJS → `trainStepWithGenerations`** flow, not `trainStepAuto` (whose `finish_reason=length` OOM-filter skips every step for a model that never emits EOS). Cleaner Phase-1 GFI-reward seam.
- `with-trainer` uses **`p/handle`**, not `p/finally` (which double-settles under nbb — captured as a follow-up).
- **`klCoef>0` errors under autograd** (no reference model) — corrected from the spec's wrong "accepted but no-op"; asserted in the test.

### Verification
`world_train` 31/31 · `membrane_coverage` 5/32 · `mutation_boundary` 13/34 · core gate (choicemap/trace/selection/handler/dist/combinators/inference) 7/7 — all 0 failures. A 5-agent adversarial review (fidelity & purity clean; honesty/coverage/test-completeness `should-fix`s all addressed).

### Not in this PR
Pre-existing unrelated working-tree changes (`src/genmlx/edit.cljs`, `test/genmlx/edit_composition_test.cljs`) and the `mlx-node` submodule were deliberately left out. Follow-up: the `world.net` `with-server` `p/finally` double-settle quirk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)