### PR TITLE
fix(llm): migrate backend + vision off @mlx-node/lm to the single @genmlx/core addon (genmlx-qt34)

### DIFF
--- a/src/genmlx/llm/backend.cljs
+++ b/src/genmlx/llm/backend.cljs
@@ -4,19 +4,79 @@
 
    This is Layer 0 of the LLM integration — everything above (token-transition
    handler, beam search, grammar constraints) builds on these functions."
-  (:require ["@mlx-node/lm" :as mlx-lm :refer [ChatSession]]
-            ;; Qwen3Tokenizer is sourced from @mlx-node/core directly (it is a
-            ;; first-class core export). @mlx-node/lm's re-export of it was
-            ;; removed upstream (mlx-node #57); relying on it broke on a clean
-            ;; `tsc -b`. See bean genmlx-mwm4.
-            ["@genmlx/core" :as mlx-core]
-            [genmlx.mlx :as mx]
+  (:require [genmlx.mlx :as mx]
             [genmlx.mlx.random :as rng]
             ;; f6ov: model-family-dispatching façade over the GenMLX-owned
             ;; forwards (vanilla Qwen3 + Qwen3.5 hybrid GatedDeltaNet). Same
             ;; 6-fn interface either way; routes on config.json model_type.
             [genmlx.llm.forward :as fwd]
-            [promesa.core :as p]))
+            [promesa.core :as p]
+            ["fs" :as fs]))
+
+;; ---------------------------------------------------------------------------
+;; Native LLM surface — the single @genmlx/core addon (bean genmlx-qt34,
+;; finishing the PR #143 genmlx-core migration; backend was the last holdout)
+;;
+;; GenMLX rides on ONE MLX-linking .node addon: @genmlx/core, the GenMLX-owned
+;; superset over stock mlx-core. Loading a SECOND MLX-linking addon in the same
+;; process is the proven-broken case — incompatible MxArray NAPI types + separate
+;; Metal pools → SIGTRAP (bean genmlx-nldo). The former @mlx-node/lm dependency
+;; pulled in exactly such a second core (upstream @mlx-node/core), which is why
+;; every llm/* test crashed once @genmlx/core also loaded. So this backend now
+;; loads, detects, and generates entirely through @genmlx/core's native classes
+;; (Qwen3Model / Qwen35Model / … with .load / .forward / .forwardWithCache /
+;; .initCaches / .resetCaches / .chatSessionStart, plus Qwen3Tokenizer) — exactly
+;; as genmlx.world.train already does.
+;;
+;; js/require (CommonJS), NOT an ESM :require: @genmlx/core's package `main` is a
+;; bare Node-API addon (./index.node) with no "import" export condition, so an ESM
+;; :require compiles to an `import` of a .node file, which bun 1.3.x rejects ("To
+;; load Node-API modules, use require()…"). js/require is the correct .node load.
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private mlx-core (js/require "@genmlx/core"))
+
+(defn- detect-model-type
+  "Read config.json's model_type, mirroring the former @mlx-node/lm detectModelType
+   so the owned/upstream dispatch and the trace-site :type are unchanged: default
+   \"qwen3\"; normalize gemma4_text → gemma4; a Qwen3 backbone exported as a base
+   model (architectures has Qwen3Model but not Qwen3ForCausalLM) is an embedding
+   model → \"harrier\". Returns the model_type string."
+  [model-path]
+  (let [config (-> (.readFileSync fs (str model-path "/config.json") "utf8")
+                   (js/JSON.parse))
+        raw    (or (.-model_type config) "qwen3")
+        mtype  (if (= raw "gemma4_text") "gemma4" raw)
+        archs  (or (.-architectures config) #js [])]
+    (if (and (= mtype "qwen3")
+             (.includes archs "Qwen3Model")
+             (not (.includes archs "Qwen3ForCausalLM")))
+      "harrier"
+      mtype)))
+
+(defn- load-upstream-model
+  "Load a native @genmlx/core model instance for the upstream forward path,
+   dispatching on model_type. Each native class exposes .forward /
+   .forwardWithCache / .initCaches / .resetCaches (driven by forward-pass /
+   forward-prefill / forward-step) and .chatSessionStart (generate-text), so the
+   downstream backend fns are unchanged. Returns a promise of the instance, or
+   throws if @genmlx/core has no model class for this family."
+  [model-type model-path]
+  (if-let [cls (case model-type
+                 "qwen3"       (.-Qwen3Model mlx-core)
+                 "qwen3_5"     (.-Qwen35Model mlx-core)
+                 "qwen3_5_moe" (.-Qwen35MoeModel mlx-core)
+                 "gemma4"      (.-Gemma4Model mlx-core)
+                 "harrier"     (.-HarrierModel mlx-core)
+                 "lfm2"        (.-Lfm2Model mlx-core)
+                 nil)]
+    (.load cls model-path)
+    (throw (ex-info (str "genmlx.llm.backend: @genmlx/core has no native model "
+                         "class for model_type " (pr-str model-type)
+                         " — load a supported family (qwen3 / qwen3_5 / gemma4 / "
+                         "harrier / lfm2 / qwen3_5_moe) or extend load-upstream-model.")
+                    {:genmlx/error :unsupported-upstream-type
+                     :model-type model-type :model-path model-path}))))
 
 ;; ---------------------------------------------------------------------------
 ;; GenMLX-owned forward (f6ov): a value-level CLJS forward over genmlx.rs
@@ -141,7 +201,7 @@
    either). The VLM path (genmlx.llm.vision/load-vlm) is separate and unaffected."
   ([model-path] (load-model model-path {}))
   ([model-path opts]
-   (p/let [model-type (.detectModelType mlx-lm model-path)
+   (p/let [model-type (detect-model-type model-path)
            tokenizer (.fromPretrained (.-Qwen3Tokenizer mlx-core)
                                       (str model-path "/tokenizer.json"))]
      ;; genmlx-5luk: refuse a known-crashing native MoE forward BEFORE the native
@@ -178,7 +238,7 @@
              {:model (->CljsForwardModel (fwd/load-model model-path) (atom nil))
               :tokenizer tokenizer
               :type (keyword model-type)})
-           (p/let [model (.loadModel mlx-lm model-path)]
+           (p/let [model (load-upstream-model model-type model-path)]
              ;; Tier-B (upstream path): assert the loaded instance exposes the
              ;; native forward methods — catches the genmlx-7siy stale prebuilt.
              (assert-upstream-forward! model)
@@ -350,7 +410,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn generate-text
-  "Generate text from a prompt using the ChatSession API.
+  "Generate text from a prompt using the native chatSessionStart API.
    Returns a promise of the generated text string.
 
    opts map:
@@ -361,15 +421,20 @@
   ([{:keys [model]} prompt {:keys [max-tokens temperature system-prompt]
                             :or {max-tokens 100 temperature 0.7}}]
    (when (cljs-forward-model? model)
-     (throw (ex-info (str "generate-text uses ChatSession, which requires the "
-                          "upstream model. Load with {:cljs-forward? false}, or "
-                          "use generate-text-raw (works on the owned forward).")
+     (throw (ex-info (str "generate-text drives the native model's chatSessionStart, "
+                          "which requires the upstream model. Load with "
+                          "{:cljs-forward? false}, or use generate-text-raw (works "
+                          "on the owned forward).")
                      {:model-type (type model)})))
-   (let [session (ChatSession. model
-                               (clj->js (cond-> {:maxNewTokens max-tokens
-                                                 :temperature temperature}
-                                          system-prompt (assoc :system system-prompt))))]
-     (p/let [result (.send session prompt)]
+   ;; chatSessionStart applies the chat template internally and starts a fresh
+   ;; turn-1 conversation per call (system prompt goes in the message list, not a
+   ;; :system config field), so it matches the old new-ChatSession-per-call
+   ;; isolation. ChatResult exposes the decoded text via .text.
+   (let [messages (clj->js (cond-> []
+                             system-prompt (conj {:role "system" :content system-prompt})
+                             :always       (conj {:role "user" :content prompt})))
+         config   (clj->js {:maxNewTokens max-tokens :temperature temperature})]
+     (p/let [result (.chatSessionStart model messages config)]
        (.-text result)))))
 
 (defn generate-text-raw

--- a/src/genmlx/llm/vision.cljs
+++ b/src/genmlx/llm/vision.cljs
@@ -3,8 +3,9 @@
 
    Two layers, one per concern:
 
-   - **Async I/O** wraps `@mlx-node/lm`'s `loadSession` / `send`. Used to load
-     the VLM and classify individual cells. Returns promises.
+   - **Async I/O** wraps the native `@genmlx/core` VL forward (`load` +
+     `chatSessionStart` with image bytes per message). Used to load the VLM and
+     classify individual cells. Returns promises.
    - **Sync GFI** wraps the per-cell categorical structure as a `gen` function.
      Each cell is a trace site at a keyword address; observations from the VLM
      become constraints when invoking via `p/generate`.
@@ -15,32 +16,56 @@
 
    See `examples/vlm_grid_gf.cljs` for the end-to-end demo.
 
-   Operational note: `classify-cell` calls `session.reset()` on every call. Without
-   that, conversation history accumulates across independent classifications and
-   per-call latency grows monotonically with N (verified empirically — 0.6s rises
-   to 116s by the 18th call). With reset, latency is flat. See
-   `../genmlx-lab/dev/docs/INVESTIGATION_VLM_PER_CELL_PROBE.md`."
-  (:require ["@mlx-node/lm" :as mlx-lm]
-            [genmlx.gen :refer [gen]]
+   Operational note: each `classify-cell` runs a fresh turn-1 `chatSessionStart`,
+   so conversation history does not accumulate across independent classifications.
+   (The old @mlx-node/lm session path needed an explicit `session.reset()` per call
+   to stop per-call latency growing monotonically with N — 0.6s rising to 116s by
+   the 18th call; see
+   `../genmlx-lab/dev/docs/INVESTIGATION_VLM_PER_CELL_PROBE.md`.)"
+  (:require [genmlx.gen :refer [gen]]
             [genmlx.dynamic :as dyn]
             [genmlx.dist :as dist]
             [genmlx.mlx :as mx]
             [promesa.core :as pr]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            ["fs" :as fs]))
+
+;; Single @genmlx/core addon (js/require) — bean genmlx-qt34. Same reason as
+;; genmlx.llm.backend: GenMLX rides on ONE MLX-linking .node addon; the former
+;; @mlx-node/lm dependency pulled in a second core (upstream @mlx-node/core) that
+;; SIGTRAPs alongside @genmlx/core. The VL-capable native classes (Qwen35Model /
+;; Qwen35MoeModel / Gemma4Model) accept image bytes per chatSessionStart message.
+(defonce ^:private mlx-core (js/require "@genmlx/core"))
 
 ;; ---------------------------------------------------------------------------
 ;; Async I/O layer
 ;; ---------------------------------------------------------------------------
 
 (defn load-vlm
-  "Load a VLM session via `@mlx-node/lm`'s `loadSession`. Returns a promise.
+  "Load a vision-language model via the native @genmlx/core forward, dispatching on
+   config.json model_type. Returns a promise of the native model instance
+   (Qwen35Model / Qwen35MoeModel / Gemma4Model), whose `chatSessionStart` accepts
+   image bytes per message. The checkpoint's safetensors must include the vision
+   tower; verified target: Qwen3.6-35B-A3B-4bit (model_type qwen3_5_moe).
 
-   Supports any model whose `model_type` is recognized by mlx-node and whose
-   safetensors include vision_tower / visual / embed_vision weights. Verified
-   today: Qwen3.6-35B-A3B-4bit (`Qwen3_5MoeForConditionalGeneration` architecture
-   loaded via `qwen3_5_moe`)."
+   NOTE (bean genmlx-qt34): migrated off @mlx-node/lm's generic loadSession to the
+   single @genmlx/core addon. The VLM *generation* path (classify-cell) has no
+   automated test — the verified VL checkpoint is a large MoE — so this I/O layer
+   is exercised via the live demo (examples/vlm_grid_gf.cljs), not the test suite."
   [model-path]
-  (.loadSession mlx-lm model-path))
+  (let [mt (-> (.readFileSync fs (str model-path "/config.json") "utf8")
+               js/JSON.parse
+               .-model_type)]
+    (if-let [cls (case mt
+                   "qwen3_5"     (.-Qwen35Model mlx-core)
+                   "qwen3_5_moe" (.-Qwen35MoeModel mlx-core)
+                   "gemma4"      (.-Gemma4Model mlx-core)
+                   nil)]
+      (.load cls model-path)
+      (throw (ex-info (str "genmlx.llm.vision/load-vlm: no native VL-capable "
+                           "@genmlx/core model class for model_type " (pr-str mt))
+                      {:genmlx/error :unsupported-vlm-type :model-type mt
+                       :model-path model-path})))))
 
 (defn- option->line
   "Format one option for the classification prompt. Accepts a bare string or a
@@ -66,21 +91,21 @@
    (e.g. \"empty (a blank white cell with thin gray borders)\" beats just
    \"empty\").
 
-   Always calls `session.reset()` before the send so history doesn't accumulate
-   across independent calls. Disables the model's reasoning trace and the
-   default repetition penalty so short single-word answers come through cleanly."
-  [session image-bytes options]
-  (pr/let [_ (.reset session)
-           opts-text (str/join "\n" (map option->line options))
+   `vlm` is a native model from `load-vlm`. Each call runs a fresh turn-1
+   `chatSessionStart` (the image bytes ride in the user message), so history
+   doesn't accumulate across independent calls — no explicit reset needed.
+   Disables the model's reasoning trace and the default repetition penalty so
+   short single-word answers come through cleanly."
+  [vlm image-bytes options]
+  (pr/let [opts-text (str/join "\n" (map option->line options))
            prompt (str "What is shown in this image? Answer with EXACTLY ONE of:\n"
                        opts-text
                        "\n\nOutput ONLY the single word, nothing else.")
+           messages (clj->js [{:role "user" :content prompt :images [image-bytes]}])
            config #js {:maxNewTokens 8
                        :reasoningEffort "none"
                        :repetitionPenalty 1.0}
-           result (.send session prompt
-                          #js {:images #js [image-bytes]
-                               :config config})]
+           result (.chatSessionStart vlm messages config)]
     ;; Keep the WHOLE answer (lowercased, alphanumerics + single spaces):
     ;; taking only the first word made multi-word labels ("fire truck")
     ;; unmatchable in label->index (genmlx-xwxh). label->index normalizes
@@ -95,18 +120,18 @@
   "Classify all cells of an N×M grid. Returns a promise of
    `{:rows N :cols M :labels <2D vector of strings>}`.
 
-   `crop-fn` takes `[r c]` and returns a Uint8Array of cell image bytes (or a
-   promise of one). `options` is the vector of allowed labels.
+   `vlm` is a native model from `load-vlm`. `crop-fn` takes `[r c]` and returns a
+   Uint8Array of cell image bytes (or a promise of one). `options` is the vector
+   of allowed labels.
 
-   Cells are processed strictly sequentially. A single ChatSession does not
-   support concurrent send()s — reset() will throw if one is in flight — and
-   the model's Metal kernels serialize anyway, so concurrency wouldn't help.
+   Cells are processed strictly sequentially — the model's Metal kernels serialize
+   anyway, so concurrency wouldn't help.
 
    `progress-fn` (optional) is called as `(progress-fn r c label dt-ms)` after
    each cell completes."
-  ([session rows cols crop-fn options]
-   (classify-grid session rows cols crop-fn options nil))
-  ([session rows cols crop-fn options progress-fn]
+  ([vlm rows cols crop-fn options]
+   (classify-grid vlm rows cols crop-fn options nil))
+  ([vlm rows cols crop-fn options progress-fn]
    (let [coords (vec (for [r (range rows) c (range cols)] [r c]))]
      (pr/let
       [results (reduce
@@ -114,7 +139,7 @@
                   (pr/let [acc acc-promise
                            t0 (.now js/performance)
                            bytes (crop-fn r c)
-                           label (classify-cell session bytes options)
+                           label (classify-cell vlm bytes options)
                            dt (- (.now js/performance) t0)]
                     (when progress-fn (progress-fn r c label dt))
                     (conj acc [r c label])))

--- a/test/genmlx/membrane_coverage_test.cljs
+++ b/test/genmlx/membrane_coverage_test.cljs
@@ -100,7 +100,9 @@
    :model-conversion
    #{"convertForeignWeights" "convertGgufToSafetensors" "convertModel" "convertParquetToJsonl"}
 
-   ;; OCR / vision-language / document pipelines — bind via @mlx-node/lm vision (llm/vision.cljs)
+   ;; OCR / document-pipeline classes — GenMLX does not use these; its VLM path
+   ;; (llm/vision.cljs) routes through the Qwen VL model classes below, not the
+   ;; PaddleOCR / document-understanding pipeline.
    :ocr-vlm-document
    #{"createPaddleocrVlConfig" "createQianfanOcrConfig"
      "documentToXlsx" "formatDocument" "saveToXlsx"
@@ -109,10 +111,11 @@
      "QianfanOCRModel" "TextDetModel" "TextRecModel"
      "VLModel" "VlmChatResult" "VlmProcessedImage"}
 
-   ;; loaded-model / tokenizer / generation classes — bound via @mlx-node/lm
-   ;; ChatSession (msa.cljs / backend.cljs), the LLM orchestration boundary, not
-   ;; the pure compute membrane. The per-token GFI path reaches the low-level
-   ;; forward, not these high-level classes.
+   ;; loaded-model / tokenizer / generation classes — bound directly via @genmlx/core
+   ;; native classes in llm/backend.cljs (load-upstream-model + Qwen3Tokenizer +
+   ;; chatSessionStart) and llm/vision.cljs (bean genmlx-qt34), the LLM orchestration
+   ;; boundary, not the pure compute membrane. The per-token GFI path reaches the
+   ;; low-level forward, not these high-level classes.
    :llm-orchestration
    #{"Gemma4Model" "HarrierModel" "Lfm2Model" "Qwen3Model" "Qwen35Model" "Qwen35MoeModel"
      "Qwen3Tokenizer"


### PR DESCRIPTION
## Problem (genmlx-qt34)

Under bun 1.3.x, **every `llm/*` test crashed at load** because of two *entangled* native-loading failures, both flowing through `genmlx.llm.backend`:

1. **ESM-import crash** — `@genmlx/core`'s package `main` is a bare Node-API addon (`./index.node`) with no `"import"` export condition, so nbb's ESM `:require` compiled to an `import` of a `.node` file, which bun rejects: *"To load Node-API modules, use require() or process.dlopen instead of import."*
2. **Two-cores SIGTRAP** — `@mlx-node/lm` pulls in upstream `@mlx-node/core`, a **second** MLX-linking addon that cannot coexist with `@genmlx/core` in one process (incompatible `MxArray` NAPI types + separate Metal pools — the single-addon constraint from bean `nldo`).

The bean's premise (`ESM → js/require` the native addons) was wrong on both counts: `js/require("@mlx-node/lm")` can't even resolve it (ESM-only `exports`), and keeping `@mlx-node/lm` keeps the forbidden second core. Fixing the ESM crash alone just exposes the SIGTRAP.

## Fix

Drop `@mlx-node/lm` and ride the **single `@genmlx/core` addon** — finishing the PR #143 genmlx-core migration (`backend.cljs` was the last `src/` holdout), as `world.train` already does.

- **`backend.cljs`**: `js/require @genmlx/core`; `detect-model-type` reads `config.json`; `load-upstream-model` dispatches `model_type` → native class `.load` (`Qwen3Model`/`Qwen35Model`/…); `generate-text` → native `chatSessionStart`. `forward`/`prefill`/`step` unchanged (native classes are method-name compatible: `.forward`/`.forwardWithCache`/`.initCaches`/`.resetCaches`).
- **`vision.cljs`**: `load-vlm` + `classify-cell` via native VL `chatSessionStart`-with-images (no `session.reset` — each call is a fresh turn-1, which also removes the old per-call latency growth).
- **`membrane_coverage_test.cljs`**: refresh 2 stale omission-rationale comments (`@mlx-node/lm` → `@genmlx/core`); partition/count unchanged.
- `@mlx-node/lm` is now fully absent from `src/` (prose comments only).

## Verification (all serial, `bun run --bun nbb`)

Done-means: **`llm_msa_test` 138/138**, **`llm_codegen_test` 91/91**.

Same fix re-greens the rest of the formerly-red set: `program_test` 178/178, `program_golden_test` 15/15, `synthesis_exact` 59/59, `smc_scoring` 41/41, `llm_msa_scoring` / `membrane_guard` / `llm_pure_helpers` 0 failures, `membrane_coverage` 0 failures.

## Caveat

The VLM **generation** path (`vision/classify-cell`) is migrated but **unverified** — the only on-disk VL checkpoint is a guard-refused 35B MoE. Namespace-load + pure GFI layer *are* verified (`llm_pure_helpers_test`). Draft follow-up bean filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)