### PR TITLE
feat(train): KL-to-base penalty for world.train GRPO (genmlx-65d5, Phase 1.5)

### DIFF
--- a/docs/phase1.5-kl-to-base-spec.md
+++ b/docs/phase1.5-kl-to-base-spec.md
@@ -1,0 +1,164 @@
+# Phase 1.5 — KL-to-base penalty through GRPO autograd (genmlx-65d5)
+
+> **Status:** SPEC — awaiting approval. No code until approved (milestone protocol).
+> **Bean:** `genmlx-65d5` (child of `genmlx-nv1t`). Builds on Phase 1 (`genmlx-ugkv`),
+> which trains KL-free because the native autograd path rejects `klCoef > 0`.
+> **Date:** 2026-06-21. Every file:line below verified against source.
+
+## Done-means (from the bean)
+
+1. `klCoef > 0` trains **without error** under autograd.
+2. A KL term **measurably regularizes** the policy toward the base policy.
+3. The `world.train` kl-coef test **flips from "rejected" to "applied."**
+
+## Current state (verified)
+
+- **The KL math already exists and is correct.** `grpo::loss::grpo_loss`
+  (`grpo/loss.rs:120`, last arg `ref_per_token_logps: Option<&MxArray>`) implements
+  the k3 estimator when `beta > 0` (`loss.rs:248-267`):
+  `KL(ref‖new) = exp(ref−new) − (ref−new) − 1`, log-ratio clamped to `[-88,88]`,
+  scaled by `beta`, added to the per-token loss. Shape of `ref_per_token_logps` is
+  `[B,T]` — identical to `per_token_logps`.
+- **The autograd path refuses `beta > 0`.** `compute_loss_and_gradients_autograd`
+  (`grpo/autograd.rs:64`) early-returns an error at `autograd.rs:76-81`, and both
+  loss closures call `grpo_loss(..., None /* no reference model */)`
+  (`autograd.rs:328-329` standard, `autograd.rs:521` chunked). So the **only** thing
+  missing is producing `ref_per_token_logps` and passing it in.
+- **No reference/frozen-base model exists today.** `engine.rs` has no
+  reference/ref-logprob/frozen-param machinery (`grpo/engine.rs`, 2027 lines).
+- **Training orchestration is per-model.** `compute_loss_and_gradients_autograd` is
+  called only from `models/{qwen3,qwen3_5,qwen3_5_moe}/model.rs`
+  (`train_step_grpo_sync`, e.g. `models/qwen3/model.rs:5092` → call at `:5163`).
+  `old_logprobs` = `ts.cached_completion_logprobs` — the logprobs cached **at
+  generation time** (`models/qwen3/model.rs:4781,5117`), i.e. the **old policy**
+  (the policy that produced the rollout), **not** the reference.
+- **`beta` is wired from config at two engine sites** (`engine.rs:1188`, `:1777`),
+  both building `GRPOLossConfig { beta: self.config.kl_coef.unwrap_or(0.0), .. }`,
+  both flowing into `train_step_grpo_sync` → autograd. One fix covers both.
+- **Param updates are functional.** `OptimizerImpl::apply_gradient(&mut self,
+  param: &MxArray, grad: &MxArray) -> Result<MxArray>` (`optimizers/mod.rs:26`)
+  **returns a new array**; the model replaces the layer weight with it. Weights are
+  **replaced, not buffer-mutated** ⇒ an Arc-clone snapshot of the initial params is a
+  valid frozen reference (no deep copy).
+- **CLJS surface.** `world/train.cljs:106` documents the honest contract
+  ("klCoef > 0 ERRORs under autograd"); `world/train.cljs:116-117` maps
+  `:kl-coef`/`:beta` → `klCoef`. The test `world_train_test.cljs:174-181` asserts
+  `kl-coef>0` ⇒ `:rejected`.
+
+## Design
+
+### Reference = frozen snapshot of the initial policy params
+
+Standard GRPO/TRL: `π_ref` is the model **before** RL. GRPO starts from the
+base/SFT checkpoint, so the **initial params ARE the reference** — no separate
+checkpoint, no extra config.
+
+- New field on each model's `TrainingState`:
+  `reference_params: Option<HashMap<String, MxArray>>`.
+- **Populated lazily on the first train step where `beta > 0`** — an **Arc-clone**
+  of `get_parameters_sync()` (cheap; keeps the initial buffers resident). When
+  `beta == 0` (the default) it is never populated ⇒ **zero cost when KL is off**.
+- Lifecycle: persists across steps; dropped on `reset()`/dispose (alongside the
+  existing training-state teardown). Survives in-place optimizer updates because
+  updates replace weights, not the snapshot's buffers.
+- **Memory:** `+1× params` (frozen reference, e.g. ~1.6 GB for 0.8B bf16), paid
+  **only when `klCoef > 0`**.
+
+### Reference logprobs (per step, no-grad)
+
+Computed inside `compute_loss_and_gradients_autograd` when `beta > 0`:
+
+1. Reuse the already-built `input_ids` (padded prompt+completion), `prompt_len`,
+   `padded_completions`, `completion_masks`.
+2. Forward through **reference_params** (reuse `functional::forward_functional_dispatch`
+   / `functional::chunked_lm_head_selective_logprobs` — the same dispatch the loss
+   closure uses) → completion logits → `efficient_selective_log_softmax` over
+   `padded_completions` ⇒ `ref_per_token_logps` `[B,T]`.
+3. `clip(Some(-20.0), Some(0.0))` (mirror the policy/old-logprob clamping at
+   `autograd.rs:319,179`).
+4. Computed **once, OUTSIDE `value_and_grad`** ⇒ a constant w.r.t. the trainable
+   params (no gradient flows; `value_and_grad` differentiates only the `params`
+   vector). `eval()` to materialize + detach before the closure captures it.
+5. Pass `Some(&ref_per_token_logps)` into `grpo_loss` (standard closure
+   `autograd.rs:322`; chunked closure `autograd.rs:514` — slice the ref array per
+   chunk exactly like `padded_old_logprobs`).
+
+The reference forward is **no-grad** (no backward graph) ⇒ much cheaper than the
+policy forward; it honors `forward_chunk_size` / `lm_head_chunk_size` for the same
+peak-memory bounds.
+
+### Signature & call-site changes
+
+- `compute_loss_and_gradients_autograd` gains
+  `reference_params: Option<&HashMap<String, MxArray>>`; the chunked helper gains the
+  precomputed `ref_per_token_logps: Option<&MxArray>` to slice per chunk.
+- **Remove** the `beta > 0` rejection (`autograd.rs:76-81`). Replace with: if
+  `beta > 0` and `reference_params` is `None`, return a clear error (defensive — the
+  model layer guarantees it is set).
+- `train_step_grpo_sync` (×3 models): when `loss_config.beta > 0`, ensure
+  `ts.reference_params` is populated (snapshot on first use) and pass
+  `Some(&ts.reference_params)`; otherwise pass `None`.
+
+### CLJS + test
+
+- `world/train.cljs`: update the `:106` contract note — `klCoef > 0` is now
+  **applied** (true KL-to-base), no longer an error. No API change (`:kl-coef`/
+  `:beta` mapping at `:116-117` stays).
+- `world_train_test.cljs:174-181`: flip from asserting `:rejected` to asserting
+  `klCoef > 0` **trains** (`gradients_applied = true`, no rejection) — done-means #3.
+
+## Invariants & edge cases
+
+- **`beta == 0` (default): byte-for-byte unchanged** — no snapshot, no ref forward,
+  `grpo_loss(..., None)` as today. Perf/memory neutral.
+- **No gradient into the reference** — ref logprobs are inputs (constants) like
+  `old_logprobs`; assert via the autograd test that the ref forward params receive
+  no gradient.
+- **Shapes** — `ref_per_token_logps` is `[B,T]`, matches `per_token_logps`; padded
+  over completions, masked by `completion_masks`.
+- **`valid_indices` filtering** — the reference forward runs on the **same filtered
+  completions** as the policy (build after filtering, consistent with `old_logprobs`
+  at `models/qwen3/model.rs:5142-5161`).
+- **Numerics** — ref logprobs clamped `[-20,0]`; k3 KL clamps log-ratio `[-88,88]`
+  (already in `loss.rs:260`). NaN handling inherits the existing clip-replaces-NaN
+  behavior.
+- **Determinism** — ref logprobs are a logprob extraction (no sampling) ⇒
+  deterministic given the completions.
+- **Chunked autograd path** — `ref_per_token_logps` sliced per chunk (`start..end`)
+  exactly like `padded_old_logprobs` (`autograd.rs:416`).
+- **All three models** — mechanism is identical; MoE's reference forward routes
+  through the MoE functional dispatch (heavier, but no-grad).
+
+## Test plan
+
+1. **Rust unit (`grpo/loss.rs`)** — `test_kl_coefficient_scaling` (`loss.rs:827`)
+   already covers the KL term in isolation. Add an **autograd** test: `beta > 0`
+   runs end-to-end with a frozen reference, ref logprobs threaded, and the KL term
+   shifts loss/gradients vs `beta = 0`.
+2. **KL-effect (done-means #2)** — train N steps at `kl-coef = 0` vs a large
+   `kl-coef`; assert the large-KL run stays closer to the base policy (measured
+   KL(ref‖policy) or mean param drift `‖θ−θ₀‖` is **smaller**, monotone in `beta`).
+3. **`world_train_test.cljs`** — flip `:174-181` to assert `klCoef > 0` trains
+   (`gradients_applied = true`).
+4. **Regression** — `beta = 0` GRPO path unchanged (existing world.train /
+   world_train_reward suites).
+5. **Native rebuild gate** — after `cd mlx-node && yarn build:native`, run the
+   membrane contract guards (`exact_test`, `gradient_fd_test`, `score_gradient_test`,
+   `clip_contract_test`, `membrane_coverage_test`) per CLAUDE.md, since the native
+   addon was rebuilt.
+
+## Upstream PR
+
+Self-contained mlx-node change (GRPO autograd gains reference-model KL — the TRL
+parity feature). Clean PR to the mlx-node fork.
+
+## Decisions (LOCKED 2026-06-21)
+
+1. **Reference source** — ✅ **initial-params snapshot** (Arc-clone of the model at
+   training start; standard GRPO, zero extra config, exact "KL-to-base").
+2. **Model scope** — ✅ **all three** (qwen3 + qwen3_5 + qwen3_5_moe; consistent,
+   cleanest upstream PR). MoE reference forward verified lightly (heavier + the MoE
+   is guard-refused elsewhere).
+3. **Freeze mechanism** — ✅ Arc-clone snapshot (evidence: `apply_gradient` returns
+   a new array ⇒ replace-not-mutate). Deep copy only if a future in-place optimizer
+   is added.

--- a/src/genmlx/world/train.cljs
+++ b/src/genmlx/world/train.cljs
@@ -103,10 +103,14 @@
    chunk-size knobs cap peak memory for large-vocab models (the native docs
    recommend :lm-head-chunk-size 2 and :forward-chunk-size 4 for group-size >= 4).
 
-   `:beta`/`:kl-coef` -> klCoef. Setting it > 0 makes `train-step!` ERROR under autograd
-   (reference-model KL is not yet supported natively); leave it 0 (default) for KL-free
-   training. There is no `:seed` — the engine owns its MLX sampler RNG (training RNG ≠
-   GenMLX inference RNG; no native config field exists to seed it)."
+   `:beta`/`:kl-coef` -> klCoef. Setting it > 0 applies a true KL-to-base penalty
+   through the autograd path (genmlx-65d5): on the first KL-enabled step the native
+   engine snapshots the frozen base policy, then each step adds the k3 KL term
+   `KL(ref‖policy)` (β-scaled) regularizing toward that base. KL(ref‖policy) and its
+   gradient are 0 at step 1 (policy == ref by construction); the effect grows as the
+   policy diverges. Leave it 0 (default) for KL-free training. There is no `:seed` —
+   the engine owns its MLX sampler RNG (training RNG ≠ GenMLX inference RNG; no native
+   config field exists to seed it)."
   [config]
   (clj->js
     (merge

--- a/test/genmlx/world_train_test.cljs
+++ b/test/genmlx/world_train_test.cljs
@@ -171,14 +171,47 @@
                                (= 4 @re-calls))
           _       (assert-true "multi-prompt demux: prompt-major pairing (group 0 -> prompt 0, group 1 -> prompt 1)"
                                (= ["alpha" "alpha" "beta" "beta"] @re-pairs))
-          ;; --- KL under autograd is rejected (the honest contract: klCoef>0 errors) ---
+          ;; --- Phase 1.5 (genmlx-65d5): KL-to-base penalty under autograd ---
+          ;; (1) klCoef>0 now TRAINS (the rejection is gone): a true KL-to-base
+          ;; penalty is wired through the autograd path, so a step applies gradients
+          ;; without error instead of rejecting.
+          rfn      (fn [_ c] (double (count (distinct (seq c)))))
           klres   (train/with-trainer model {:group-size 2 :kl-coef 0.1 :max-completion-length 12}
                     (fn [t]
-                      (-> (train/train-step! t ["Hi there"] (fn [_ c] (double (count (distinct (seq c))))))
-                          (p/then (fn [_] :no-throw))
-                          (p/catch (fn [_] :rejected)))))
-          _       (assert-true "kl-coef>0 makes train-step! reject under autograd (reference-model KL unsupported)"
-                               (= :rejected klres))
+                      (-> (train/train-step! t ["Hi there"] rfn)
+                          (p/then (fn [m] (:gradients-applied? m)))
+                          (p/catch (fn [_] :threw)))))
+          _       (assert-true "kl-coef>0 trains under autograd (reference-model KL now wired, not rejected)"
+                               (true? klres))
+          ;; (2) KL MEASURABLY regularizes toward the base policy. Load two FRESH
+          ;; models from the SAME random checkpoint (identical initial weights) and
+          ;; run K steps each — one KL-free, one with a strong KL-to-base. The
+          ;; strong-KL run must stay CLOSER to base (smaller forward-logits drift from
+          ;; the shared initial logits). KL(ref||policy) and its gradient are 0 at
+          ;; step 1 (policy==ref by construction), so the effect needs multiple steps.
+          ;; run-steps returns the LAST train-step metrics (so we can confirm the KL
+          ;; run actually trained — a NaN-skipped step would falsely show ~0 drift).
+          run-steps (fn [t n]
+                      (reduce (fn [acc _] (p/then acc (fn [_] (train/train-step! t ["Hi there"] rfn))))
+                              (p/resolved nil) (range n)))
+          drift   (fn [kl]
+                    (p/let [m     (.load (.-Qwen35Model gcore) dir)
+                            base  (mx/->clj (.forward m in))
+                            last  (train/with-trainer m
+                                    {:group-size 4 :kl-coef kl :learning-rate 0.03 :max-completion-length 12}
+                                    (fn [t] (run-steps t 4)))
+                            after (mx/->clj (.forward m in))]
+                      {:drift (l1 base after) :applied? (boolean (:gradients-applied? last))}))
+          rf      (drift 0.0)
+          rk      (drift 20.0)
+          _       (println "    drift kl=0:" (:drift rf) " | drift kl=20:" (:drift rk)
+                           " | kl-run last-step trained?" (:applied? rk))
+          _       (assert-true "KL-free run actually moved from base (sanity)"
+                               (> (:drift rf) 0.0))
+          _       (assert-true "strong-KL run trained (gradients applied, not NaN-skipped)"
+                               (:applied? rk))
+          _       (assert-true "KL regularizes toward base: strong-KL drift < KL-free drift"
+                               (< (:drift rk) (:drift rf)))
           _       (clean-dir!)]
     (summary))))
 


### PR DESCRIPTION
## Summary

Phase 1.5 (`genmlx-65d5`): wires a true **KL-to-base penalty** into `world.train` GRPO. Phase 1 trained KL-free because the native autograd path rejected `klCoef > 0`. This bumps the `mlx-node` submodule to the reference-model-KL support and flips the contract from "rejected" to "applied."

## Two-repo change

- **`mlx-node` submodule** → **robert-johansson/mlx-node#5** (commit `225ea37`): reference logprobs wired through the GRPO autograd path (frozen base-policy snapshot + no-grad reference forward → the k3 KL term in `grpo_loss`). `beta==0` is byte-for-byte unchanged.
- **This repo**: submodule pointer bump `10eeb77 → 225ea37`, plus:
  - `world/train.cljs` — contract note: `klCoef > 0` now applies a KL-to-base penalty.
  - `world_train_test.cljs` — flipped the kl-coef assertion (rejected → trains) + a KL-effect drift test.
  - `docs/phase1.5-kl-to-base-spec.md` — the spec.

## Verification

`world_train_test.cljs` **34/34**:
- β=0 Phase-0 regression unchanged.
- `klCoef>0` trains under autograd (no rejection).
- KL regularizes toward base: drift **kl=0 = 86821** vs **kl=20 = 56073** (~35% less), KL run confirmed trained (not NaN-skipped).

Membrane contract guards green after the native rebuild (`exact` 120/120, `gradient_fd`/`score_gradient`/`clip_contract`/`membrane_coverage` 0-fail).

## ⚠️ Merge ordering (submodule)

Merge **robert-johansson/mlx-node#5 first**, ideally with a **merge/rebase (not squash)** so commit `225ea37` stays reachable on `mlx-node` `main` — this PR's submodule pointer references it. If #5 is squash-merged, the pointer here must be re-pointed to the squashed commit before merging this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)