### PR TITLE
feat(train): offline oracle-filter cljs distillation pipeline (genmlx-j0d6)

### DIFF
--- a/scripts/distill_check.cljs
+++ b/scripts/distill_check.cljs
@@ -1,0 +1,57 @@
+(ns genmlx.distill-check
+  "Sandbox WORKER for the distillation filter (genmlx-8d15).
+
+   A RESUMABLE leaf process: evaluates candidates from `--start` to the end of the
+   candidates file, appending one EDN verdict line per row (flushed) to `--out`. Its
+   point is to be DISPOSABLE — if a candidate is non-terminating (a sync infinite loop
+   that single-threaded JS cannot preempt) or crashes the process natively, the PARENT
+   watchdog (genmlx.world.distill-sandbox) kills this worker and respawns it past the
+   bad row. Because verdicts are appended incrementally, the rows completed before the
+   kill are never lost, and `--start` resumes exactly where the parent says.
+
+   Usage (invoked by the parent, not by hand):
+     bun run --bun nbb scripts/distill_check.cljs \\
+       --candidates <raw_candidates.jsonl> --out <verdicts.edn> --start <i> \\
+       [--n-particles N] [--min-log-ml F]"
+  (:require [genmlx.world.distill :as d]
+            [genmlx.world.distill-tasks :as t]
+            [clojure.string :as str]))
+
+(def fs (js/require "fs"))
+
+(defn- parse-args [argv]
+  (loop [args (seq argv), m {}]
+    (if-let [a (first args)]
+      (if (str/starts-with? a "--")
+        (let [v (second args)]
+          (if (and v (not (str/starts-with? v "--")))
+            (recur (nnext args) (assoc m (keyword (subs a 2)) v))
+            (recur (next args) (assoc m (keyword (subs a 2)) true))))
+        (recur (next args) m))
+      m)))
+
+(defn- read-candidates [path]
+  (->> (str/split-lines (.readFileSync fs path "utf8"))
+       (remove str/blank?)
+       (keep (fn [l] (try (js->clj (js/JSON.parse l) :keywordize-keys true)
+                          (catch :default _ nil))))
+       vec))
+
+(let [opts   (parse-args (vec (drop 2 (.-argv js/process))))
+      cf     (:candidates opts)
+      out    (:out opts)
+      start  (js/parseInt (or (:start opts) "0") 10)
+      n-part (js/parseInt (or (:n-particles opts) "50") 10)
+      min-ml (let [m (and (string? (:min-log-ml opts)) (js/parseFloat (:min-log-ml opts)))]
+               (when (and m (not (js/isNaN m))) m))
+      eopts  (cond-> {:n-particles n-part} min-ml (assoc :min-log-ml min-ml))
+      rows   (read-candidates cf)]
+  (doseq [i (range start (count rows))]
+    (let [{:keys [task-id sample-idx raw-text]} (d/candidate->fields (nth rows i))
+          task    (get t/tasks-by-id task-id)
+          verdict (if task
+                    (assoc (d/evaluate-candidate (merge task eopts) raw-text sample-idx) :index i)
+                    {:index i :unknown-task? true :task-id task-id :sample-idx sample-idx})]
+      ;; appendFileSync is synchronous + flushed, so the parent watchdog sees each
+      ;; completed row immediately and never loses work when it kills this worker.
+      (.appendFileSync fs out (str (pr-str verdict) "\n")))))

--- a/scripts/distill_filter.cljs
+++ b/scripts/distill_filter.cljs
@@ -1,0 +1,187 @@
+(ns genmlx.distill-filter
+  "Runner for the cljs-coder distillation oracle-filter (genmlx-j0d6).
+
+   The thin I/O shell around the pure core (genmlx.world.distill): reads the teacher's
+   raw candidates, runs the oracle gate ladder against the in-tree seed tasks, and
+   writes an oracle-validated SFT corpus + a stats report. No teacher LLM is loaded
+   here — candidates arrive over a file.
+
+   TWO MODES
+
+     1. Export tasks for the teacher (step 1->2 handoff):
+          bun run --bun nbb scripts/distill_filter.cljs --export-tasks <tasks.jsonl>
+        Writes one {task_id, kind, system_prompt, prompt} line per seed task. The
+        held-out oracle signal (observations / transitions / test-cases) is NOT
+        exported — it can never leak into a teacher prompt.
+
+     2. Filter the teacher's candidates (steps 3-4):
+          bun run --bun nbb scripts/distill_filter.cljs \\
+            --candidates <raw_candidates.jsonl> --out <dir> \\
+            [--top-k 1] [--n-particles 50] [--min-log-ml <float>]
+        --top-k     best candidates kept per prompt (default 1 — one best exemplar)
+        --min-log-ml optional absolute model-evidence floor for :program candidates
+        raw_candidates.jsonl lines: {task_id, sample_idx, raw_text} (aliases accepted:
+        completion / text for raw_text). Writes into <dir>:
+          distill_sft.jsonl  — Qwen3 chat rows (the corpus)
+          verdicts.jsonl     — every candidate's verdict (the audit trail)
+          stats.json         — parse/eval/test-pass rates, mean log-ML, per-prompt yield
+
+   Outputs default to an EXTERNAL scratch dir ($TMPDIR/genmlx-distill) so nothing
+   lands in the repo (the repo intentionally has no catch-all gitignore)."
+  (:require [genmlx.world.distill :as d]
+            [genmlx.world.distill-tasks :as t]
+            [clojure.string :as str]))
+
+(def fs (js/require "fs"))
+(def path-mod (js/require "path"))
+
+(defn- ensure-dir [dir]
+  (when-not (.existsSync fs dir)
+    (.mkdirSync fs dir #js {:recursive true})))
+
+(defn- default-out-dir []
+  (let [tmp (or (.. js/process -env -TMPDIR) "/tmp")]
+    (.join path-mod tmp "genmlx-distill")))
+
+;; ---------------------------------------------------------------------------
+;; Tiny CLI arg parsing: --key value pairs + bare --flags.
+;; ---------------------------------------------------------------------------
+
+(defn- parse-args [argv]
+  (loop [args (seq argv), m {}]
+    (if-let [a (first args)]
+      (if (str/starts-with? a "--")
+        (let [k (keyword (subs a 2))
+              v (second args)]
+          (if (and v (not (str/starts-with? v "--")))
+            (recur (nnext args) (assoc m k v))
+            (recur (next args) (assoc m k true))))
+        (recur (next args) m))
+      m)))
+
+;; ---------------------------------------------------------------------------
+;; JSONL read/write.
+;; ---------------------------------------------------------------------------
+
+(defn- read-jsonl
+  "Read a JSONL file into {:rows [...] :skipped n}. A malformed/truncated line is
+   skipped and counted — one bad line never aborts the whole filter run."
+  [path]
+  (let [lines  (remove str/blank? (str/split-lines (.readFileSync fs path "utf8")))
+        parsed (map (fn [l] (try (js->clj (js/JSON.parse l) :keywordize-keys true)
+                                 (catch :default _ ::bad)))
+                    lines)]
+    {:rows    (vec (remove #(= ::bad %) parsed))
+     :skipped (count (filter #(= ::bad %) parsed))}))
+
+(defn- pos-int-or-nil
+  "Parse s as a positive integer, or nil (a bare flag arrives as boolean true ->
+   nil, so the caller can reject it instead of silently using a garbage value)."
+  [s]
+  (let [n (js/parseInt (str s) 10)]
+    (when-not (or (js/isNaN n) (< n 1)) n)))
+
+(defn- write-jsonl [path rows]
+  (.writeFileSync fs path (str (str/join "\n" (map #(js/JSON.stringify (clj->js %)) rows))
+                               (when (seq rows) "\n"))))
+
+(defn- write-json [path data]
+  (.writeFileSync fs path (js/JSON.stringify (clj->js data) nil 2)))
+
+;; ---------------------------------------------------------------------------
+;; Mode 1 — export teacher-facing task prompts.
+;; ---------------------------------------------------------------------------
+
+(defn- export-tasks! [path]
+  (ensure-dir (.dirname path-mod path))
+  (write-jsonl path (map t/task->prompt-record t/tasks))
+  (println (str "Exported " (count t/tasks) " task prompts -> " path))
+  (println "  (held-out oracle signal NOT included — no test leakage)"))
+
+;; ---------------------------------------------------------------------------
+;; Mode 2 — filter candidates into an SFT corpus.
+;; ---------------------------------------------------------------------------
+
+(defn- candidate->fields
+  "Normalize a candidate row: task id, sample index, and raw text (accepting a few
+   field-name aliases the teacher side might use)."
+  [c]
+  {:task-id    (or (:task_id c) (:task-id c) (:id c))
+   :sample-idx (or (:sample_idx c) (:sample-idx c) 0)
+   :raw-text   (or (:raw_text c) (:completion c) (:text c) "")})
+
+(defn- filter! [{:keys [candidates out top-k n-particles min-log-ml]}]
+  (let [out-dir   (or out (default-out-dir))
+        top-k     (pos-int-or-nil (or top-k 1))
+        n-part    (pos-int-or-nil (or n-particles 50))
+        min-ml    (let [m (and (string? min-log-ml) (js/parseFloat min-log-ml))]
+                    (when (and m (not (js/isNaN m))) m))]
+    (cond
+      (or (nil? top-k) (nil? n-part))
+      (do (println "ERROR: --top-k and --n-particles must be positive integers")
+          (set! (.-exitCode js/process) 1))
+
+      :else
+      (let [{:keys [rows skipped]} (read-jsonl candidates)
+            _        (println (str "Read " (count rows) " candidates from " candidates
+                                   (when (pos? skipped)
+                                     (str " (" skipped " malformed lines skipped)"))))
+            ;; attach scoring opts to each task at evaluate time via assoc
+            eval-opts (cond-> {:n-particles n-part} min-ml (assoc :min-log-ml min-ml))
+            verbose? (.. js/process -env -DISTILL_VERBOSE)
+            prog-log (.join path-mod out-dir "progress.log")
+            _        (when verbose? (ensure-dir out-dir) (.writeFileSync fs prog-log ""))
+            note     (fn [s] (when verbose? (println s) (.appendFileSync fs prog-log (str s "\n"))))
+            verdicts (vec (for [c rows
+                                :let [{:keys [task-id sample-idx raw-text]} (candidate->fields c)
+                                      task (get t/tasks-by-id task-id)]
+                                :when task]
+                            (do (note (str "scoring " task-id " #" sample-idx))
+                                (let [v (d/evaluate-candidate (merge task eval-opts) raw-text sample-idx)]
+                                  (note (str "  -> " (:reason v)
+                                             (when (:log-ml v) (str " log-ml=" (:log-ml v)))))
+                                  v))))
+            unknown  (- (count rows) (count verdicts))
+            selected (d/rank-and-select verdicts top-k)
+            records  (d/build-sft-records t/tasks-by-id selected)
+            stats    (assoc (d/verdicts->stats t/tasks verdicts selected)
+                            :top-k top-k :n-particles n-part :min-log-ml min-ml
+                            :malformed-lines-skipped skipped
+                            :candidates-with-unknown-task unknown)]
+        (ensure-dir out-dir)
+        (write-jsonl (.join path-mod out-dir "distill_sft.jsonl") records)
+        (write-jsonl (.join path-mod out-dir "verdicts.jsonl") verdicts)
+        (write-json  (.join path-mod out-dir "stats.json") stats)
+        (println "\n== distillation stats ==")
+        (doseq [k [:n-candidates :n-tasks :n-tasks-attempted :n-kept :n-selected
+                   :parse-rate :eval-rate :program-pass-rate :function-pass-rate
+                   :mean-log-ml :yield-per-prompt :task-space-coverage
+                   :n-prompts-covered :n-selected-noisy-is :drop-reasons]]
+          (println (str "  " (name k) ": " (get stats k))))
+        (when (pos? (:n-selected-noisy-is stats))
+          (println (str "  WARNING: " (:n-selected-noisy-is stats)
+                        " selected program(s) ranked by non-reproducible importance sampling")))
+        (when (pos? unknown)
+          (println (str "  WARNING: " unknown " candidates referenced an unknown task_id (skipped)")))
+        (println (str "\nWrote:\n  " (.join path-mod out-dir "distill_sft.jsonl")
+                      "  (" (count records) " SFT rows)\n  "
+                      (.join path-mod out-dir "verdicts.jsonl") "\n  "
+                      (.join path-mod out-dir "stats.json")))))))
+
+;; ---------------------------------------------------------------------------
+
+(let [opts (parse-args (vec (drop 2 (.-argv js/process))))]
+  (cond
+    (:export-tasks opts)
+    (export-tasks! (if (string? (:export-tasks opts))
+                     (:export-tasks opts)
+                     (.join path-mod (default-out-dir) "tasks.jsonl")))
+
+    (:candidates opts)
+    (filter! opts)
+
+    :else
+    (do (println "usage:")
+        (println "  --export-tasks <tasks.jsonl>")
+        (println "  --candidates <raw_candidates.jsonl> [--out <dir>] [--top-k 1] [--n-particles 50] [--min-log-ml <float>]")
+        (set! (.-exitCode js/process) 1))))

--- a/scripts/distill_filter.cljs
+++ b/scripts/distill_filter.cljs
@@ -17,9 +17,14 @@
      2. Filter the teacher's candidates (steps 3-4):
           bun run --bun nbb scripts/distill_filter.cljs \\
             --candidates <raw_candidates.jsonl> --out <dir> \\
-            [--top-k 1] [--n-particles 50] [--min-log-ml <float>]
-        --top-k     best candidates kept per prompt (default 1 — one best exemplar)
+            [--top-k 1] [--n-particles 50] [--min-log-ml <float>] \\
+            [--timeout-ms 15000] [--no-sandbox]
+        --top-k      best candidates kept per prompt (default 1 — one best exemplar)
         --min-log-ml optional absolute model-evidence floor for :program candidates
+        --timeout-ms per-candidate evaluation budget; a non-terminating teacher
+                     candidate is killed and recorded :timeout (default 15000)
+        --no-sandbox evaluate in-process (faster, but a non-terminating candidate
+                     hangs the whole run — use only on trusted input)
         raw_candidates.jsonl lines: {task_id, sample_idx, raw_text} (aliases accepted:
         completion / text for raw_text). Writes into <dir>:
           distill_sft.jsonl  — Qwen3 chat rows (the corpus)
@@ -30,7 +35,9 @@
    lands in the repo (the repo intentionally has no catch-all gitignore)."
   (:require [genmlx.world.distill :as d]
             [genmlx.world.distill-tasks :as t]
-            [clojure.string :as str]))
+            [genmlx.world.distill-sandbox :as sb]
+            [clojure.string :as str]
+            [promesa.core :as p]))
 
 (def fs (js/require "fs"))
 (def path-mod (js/require "path"))
@@ -102,71 +109,81 @@
 ;; Mode 2 — filter candidates into an SFT corpus.
 ;; ---------------------------------------------------------------------------
 
-(defn- candidate->fields
-  "Normalize a candidate row: task id, sample index, and raw text (accepting a few
-   field-name aliases the teacher side might use)."
-  [c]
-  {:task-id    (or (:task_id c) (:task-id c) (:id c))
-   :sample-idx (or (:sample_idx c) (:sample-idx c) 0)
-   :raw-text   (or (:raw_text c) (:completion c) (:text c) "")})
+;; In-process scoring (the --no-sandbox path): fast, but a non-terminating candidate
+;; hangs the whole run. The default path isolates each candidate in a worker process.
+(defn- score-in-process [rows eval-opts note]
+  (vec (for [c rows
+             :let [{:keys [task-id sample-idx raw-text]} (d/candidate->fields c)
+                   task (get t/tasks-by-id task-id)]
+             :when task]
+         (do (note (str "scoring " task-id " #" sample-idx))
+             (let [v (d/evaluate-candidate (merge task eval-opts) raw-text sample-idx)]
+               (note (str "  -> " (:reason v) (when (:log-ml v) (str " log-ml=" (:log-ml v)))))
+               v)))))
 
-(defn- filter! [{:keys [candidates out top-k n-particles min-log-ml]}]
+(defn- filter! [{:keys [candidates out top-k n-particles min-log-ml timeout-ms no-sandbox]}]
   (let [out-dir   (or out (default-out-dir))
         top-k     (pos-int-or-nil (or top-k 1))
         n-part    (pos-int-or-nil (or n-particles 50))
+        tmo       (pos-int-or-nil (or timeout-ms 15000))
         min-ml    (let [m (and (string? min-log-ml) (js/parseFloat min-log-ml))]
                     (when (and m (not (js/isNaN m))) m))]
     (cond
-      (or (nil? top-k) (nil? n-part))
-      (do (println "ERROR: --top-k and --n-particles must be positive integers")
+      (or (nil? top-k) (nil? n-part) (nil? tmo))
+      (do (println "ERROR: --top-k, --n-particles and --timeout-ms must be positive integers")
           (set! (.-exitCode js/process) 1))
 
       :else
       (let [{:keys [rows skipped]} (read-jsonl candidates)
+            _        (ensure-dir out-dir)
             _        (println (str "Read " (count rows) " candidates from " candidates
                                    (when (pos? skipped)
-                                     (str " (" skipped " malformed lines skipped)"))))
-            ;; attach scoring opts to each task at evaluate time via assoc
+                                     (str " (" skipped " malformed lines skipped)"))
+                                   (if no-sandbox "  [in-process]"
+                                       (str "  [sandboxed, timeout " tmo "ms]"))))
+            ;; attach scoring opts to each task at evaluate time via assoc/merge
             eval-opts (cond-> {:n-particles n-part} min-ml (assoc :min-log-ml min-ml))
             verbose? (.. js/process -env -DISTILL_VERBOSE)
             prog-log (.join path-mod out-dir "progress.log")
-            _        (when verbose? (ensure-dir out-dir) (.writeFileSync fs prog-log ""))
+            _        (when verbose? (.writeFileSync fs prog-log ""))
             note     (fn [s] (when verbose? (println s) (.appendFileSync fs prog-log (str s "\n"))))
-            verdicts (vec (for [c rows
-                                :let [{:keys [task-id sample-idx raw-text]} (candidate->fields c)
-                                      task (get t/tasks-by-id task-id)]
-                                :when task]
-                            (do (note (str "scoring " task-id " #" sample-idx))
-                                (let [v (d/evaluate-candidate (merge task eval-opts) raw-text sample-idx)]
-                                  (note (str "  -> " (:reason v)
-                                             (when (:log-ml v) (str " log-ml=" (:log-ml v)))))
-                                  v))))
-            unknown  (- (count rows) (count verdicts))
-            selected (d/rank-and-select verdicts top-k)
-            records  (d/build-sft-records t/tasks-by-id selected)
-            stats    (assoc (d/verdicts->stats t/tasks verdicts selected)
-                            :top-k top-k :n-particles n-part :min-log-ml min-ml
-                            :malformed-lines-skipped skipped
-                            :candidates-with-unknown-task unknown)]
-        (ensure-dir out-dir)
-        (write-jsonl (.join path-mod out-dir "distill_sft.jsonl") records)
-        (write-jsonl (.join path-mod out-dir "verdicts.jsonl") verdicts)
-        (write-json  (.join path-mod out-dir "stats.json") stats)
-        (println "\n== distillation stats ==")
-        (doseq [k [:n-candidates :n-tasks :n-tasks-attempted :n-kept :n-selected
-                   :parse-rate :eval-rate :program-pass-rate :function-pass-rate
-                   :mean-log-ml :yield-per-prompt :task-space-coverage
-                   :n-prompts-covered :n-selected-noisy-is :drop-reasons]]
-          (println (str "  " (name k) ": " (get stats k))))
-        (when (pos? (:n-selected-noisy-is stats))
-          (println (str "  WARNING: " (:n-selected-noisy-is stats)
-                        " selected program(s) ranked by non-reproducible importance sampling")))
-        (when (pos? unknown)
-          (println (str "  WARNING: " unknown " candidates referenced an unknown task_id (skipped)")))
-        (println (str "\nWrote:\n  " (.join path-mod out-dir "distill_sft.jsonl")
-                      "  (" (count records) " SFT rows)\n  "
-                      (.join path-mod out-dir "verdicts.jsonl") "\n  "
-                      (.join path-mod out-dir "stats.json")))))))
+            unknown  (count (remove #(get t/tasks-by-id (:task-id (d/candidate->fields %))) rows))]
+        (p/let [verdicts (if no-sandbox
+                           (p/resolved (score-in-process rows eval-opts note))
+                           (sb/collect-verdicts candidates
+                                                {:out-path   (.join path-mod out-dir "_sandbox_verdicts.edn")
+                                                 :eval-opts  eval-opts :timeout-ms tmo
+                                                 :poll-ms    400 :verbose? verbose?}))]
+          (let [n-timeout (count (filter #(contains? #{:timeout :crashed} (:reason %)) verdicts))
+                selected (d/rank-and-select verdicts top-k)
+                records  (d/build-sft-records t/tasks-by-id selected)
+                stats    (assoc (d/verdicts->stats t/tasks verdicts selected)
+                                :top-k top-k :n-particles n-part :min-log-ml min-ml
+                                :sandboxed? (not no-sandbox) :timeout-ms tmo
+                                :n-timed-out n-timeout
+                                :malformed-lines-skipped skipped
+                                :candidates-with-unknown-task unknown)]
+            (write-jsonl (.join path-mod out-dir "distill_sft.jsonl") records)
+            (write-jsonl (.join path-mod out-dir "verdicts.jsonl") verdicts)
+            (write-json  (.join path-mod out-dir "stats.json") stats)
+            (println "\n== distillation stats ==")
+            (doseq [k [:n-candidates :n-tasks :n-tasks-attempted :n-kept :n-selected
+                       :parse-rate :eval-rate :program-pass-rate :function-pass-rate
+                       :mean-log-ml :yield-per-prompt :task-space-coverage
+                       :n-prompts-covered :n-selected-noisy-is :n-timed-out :drop-reasons]]
+              (println (str "  " (name k) ": " (get stats k))))
+            (when (pos? n-timeout)
+              (println (str "  NOTE: " n-timeout
+                            " candidate(s) were non-terminating/crashing and recorded :timeout/:crashed")))
+            (when (pos? (:n-selected-noisy-is stats))
+              (println (str "  WARNING: " (:n-selected-noisy-is stats)
+                            " selected program(s) ranked by non-reproducible importance sampling")))
+            (when (pos? unknown)
+              (println (str "  WARNING: " unknown " candidates referenced an unknown task_id (skipped)")))
+            (println (str "\nWrote:\n  " (.join path-mod out-dir "distill_sft.jsonl")
+                          "  (" (count records) " SFT rows)\n  "
+                          (.join path-mod out-dir "verdicts.jsonl") "\n  "
+                          (.join path-mod out-dir "stats.json")))))))))
 
 ;; ---------------------------------------------------------------------------
 
@@ -178,10 +195,13 @@
                      (.join path-mod (default-out-dir) "tasks.jsonl")))
 
     (:candidates opts)
-    (filter! opts)
+    (-> (p/resolved nil)
+        (p/then (fn [_] (filter! opts)))
+        (p/catch (fn [e] (println "ERROR:" (.-message e))
+                   (set! (.-exitCode js/process) 1))))
 
     :else
     (do (println "usage:")
         (println "  --export-tasks <tasks.jsonl>")
-        (println "  --candidates <raw_candidates.jsonl> [--out <dir>] [--top-k 1] [--n-particles 50] [--min-log-ml <float>]")
+        (println "  --candidates <raw_candidates.jsonl> [--out <dir>] [--top-k 1] [--n-particles 50] [--min-log-ml <float>] [--timeout-ms 15000] [--no-sandbox]")
         (set! (.-exitCode js/process) 1))))

--- a/scripts/distill_teacher.py
+++ b/scripts/distill_teacher.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Teacher generation for the cljs-coder distillation loop (genmlx-j0d6, step 2).
+
+Reads task prompts (exported by `distill_filter.cljs --export-tasks`), runs a teacher
+LLM N times per prompt via mlx-lm, and writes raw_candidates.jsonl for the GenMLX
+oracle-filter (step 3). This is the ONLY step that touches the big model; it is a
+decoupled batch job whose only interface to GenMLX is the candidates file.
+
+ENGINE / MACHINE NOTES
+  - mlx-lm is METAL-ONLY (Apple Silicon). On the Jetson Thor (CUDA) use vLLM /
+    transformers instead — the candidates file is engine-agnostic.
+  - The PRODUCTION teacher is Qwen3-Coder-Next-4bit (~45GB) — it needs a 96GB Mac;
+    it will NOT load on a 32GB box. For a LOCAL smoke on a 32GB Mac mini, the default
+    here is a small coder model (qwen25-coder-3b-4bit, ~2GB) that produces a realistic
+    valid/invalid mix to exercise the filter. Swap with --model for the real teacher.
+
+USAGE
+  python scripts/distill_teacher.py --tasks <tasks.jsonl> --out <raw_candidates.jsonl> \\
+      [--model <dir-or-hf-id>] [--n 8] [--max-tokens 512] [--temp 0.8] [--limit K]
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+
+def resolve_model(spec: str) -> str:
+    """A local ~/.cache/models/<name> dir if it exists, else the spec verbatim
+    (an HF id / mlx-community name mlx-lm will download)."""
+    local = os.path.expanduser(os.path.join("~/.cache/models", spec))
+    return local if os.path.isdir(local) else spec
+
+
+def build_prompt(tokenizer, system_prompt, user_prompt):
+    """Render a chat prompt; Qwen3 reasoning is disabled when supported so the model
+    emits the code form directly. Falls back to a plain template if needed."""
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": user_prompt})
+    try:
+        return tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=False,
+            enable_thinking=False)
+    except TypeError:
+        return tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=False)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tasks", required=True, help="tasks.jsonl from --export-tasks")
+    ap.add_argument("--out", required=True, help="raw_candidates.jsonl to write")
+    ap.add_argument("--model", default="qwen25-coder-3b-4bit",
+                    help="local ~/.cache/models/<name> dir or an HF/mlx-community id")
+    ap.add_argument("--n", type=int, default=8, help="samples per prompt")
+    ap.add_argument("--max-tokens", type=int, default=512)
+    ap.add_argument("--temp", type=float, default=0.8)
+    ap.add_argument("--top-p", type=float, default=0.95)
+    ap.add_argument("--limit", type=int, default=0,
+                    help="only the first K tasks (0 = all) — for a quick smoke")
+    args = ap.parse_args()
+
+    # Import here so --help works without mlx installed.
+    from mlx_lm import load, generate
+    from mlx_lm.sample_utils import make_sampler
+
+    with open(args.tasks) as f:
+        tasks = [json.loads(line) for line in f if line.strip()]
+    if args.limit > 0:
+        tasks = tasks[: args.limit]
+
+    model_path = resolve_model(args.model)
+    print(f"Loading teacher: {model_path}", flush=True)
+    t0 = time.time()
+    model, tokenizer = load(model_path)
+    print(f"  loaded in {time.time() - t0:.1f}s", flush=True)
+
+    sampler = make_sampler(temp=args.temp, top_p=args.top_p)
+
+    n_written = 0
+    with open(args.out, "w") as out:
+        for ti, task in enumerate(tasks):
+            prompt = build_prompt(tokenizer, task.get("system_prompt"), task["prompt"])
+            print(f"[{ti + 1}/{len(tasks)}] {task['task_id']} "
+                  f"({task.get('kind')}) x{args.n}", flush=True)
+            for s in range(args.n):
+                text = generate(model, tokenizer, prompt=prompt,
+                                max_tokens=args.max_tokens, sampler=sampler,
+                                verbose=False)
+                out.write(json.dumps({
+                    "task_id": task["task_id"],
+                    "kind": task.get("kind"),
+                    "sample_idx": s,
+                    "raw_text": text,
+                }) + "\n")
+                out.flush()
+                n_written += 1
+
+    print(f"\nWrote {n_written} candidates -> {args.out}", flush=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/genmlx/world/distill.cljs
+++ b/src/genmlx/world/distill.cljs
@@ -51,7 +51,27 @@
    :low-evidence "model evidence below the configured :min-log-ml floor"
    :test-fail    "failed at least one held-out test"
    :no-oracle    "task carries no held-out oracle (no :transitions and no :test-cases) — misconfigured"
+   :timeout      "evaluation exceeded the per-candidate timeout (non-terminating untrusted code)"
+   :crashed      "evaluation crashed the worker process (native abort)"
    :unknown-kind "task :kind is neither :program nor :function"})
+
+(defn timeout-verdict
+  "The verdict a sandboxed evaluation gets when the worker had to be killed: a
+   non-terminating (`:timeout`) or process-crashing (`:crashed`) candidate. Never
+   kept; carries the provenance the in-process path would. The runner's process
+   isolation produces these — evaluate-candidate itself never returns them."
+  [task sample-idx reason]
+  {:task-id (:id task) :sample-idx sample-idx :kind (:kind task)
+   :code "" :parse? false :kept? false :reason reason})
+
+(defn candidate->fields
+  "Normalize a raw candidate row (from raw_candidates.jsonl, keywordized) to
+   {:task-id :sample-idx :raw-text}, accepting the field-name aliases the teacher
+   side might use (task_id/task-id/id; sample_idx/sample-idx; raw_text/completion/text)."
+  [c]
+  {:task-id    (or (:task_id c) (:task-id c) (:id c))
+   :sample-idx (or (:sample_idx c) (:sample-idx c) 0)
+   :raw-text   (or (:raw_text c) (:completion c) (:text c) "")})
 
 (defn- safe-div
   "n/d as a float, or 0.0 when d is 0 — for rate stats over possibly-empty sets."

--- a/src/genmlx/world/distill.cljs
+++ b/src/genmlx/world/distill.cljs
@@ -1,0 +1,344 @@
+(ns genmlx.world.distill
+  "Offline oracle-filter for teacher->student ClojureScript distillation (genmlx-j0d6).
+
+   THE OFFLINE TWIN of `genmlx.world.train-reward`. Where train-reward turns ONE
+   completion into a scalar GRPO reward online (the *wake phase* signal), this
+   namespace BATCH-FILTERS a strong teacher's many candidate completions into an
+   oracle-VALIDATED SFT corpus — using the SAME native-free oracle: `codegen.eval`
+   (edamame reader + SCI) and `msa-score` (Bayesian model evidence). No new native
+   code; the policy/teacher LLM is never loaded here — candidates arrive over a file
+   (`raw_candidates.jsonl`) from the teacher's offline batch (step 2 of the recipe).
+
+   Because the filter and the reward share the exact extraction (`extract-program`,
+   `strip-think`) and the exact integrity guard (`covered-observations?`), the
+   distilled corpus and the GRPO reward can never silently disagree about what a
+   'good' completion is.
+
+   THE GATE LADDER (steps 3-4 of the j0d6 recipe):
+
+     candidate ──extract──► code ──parse?──► eval?──► {behavioral gate}──► rank
+       :program  ─► coverage guard ─► score-model log-evidence   (rank by evidence)
+       :function ─► verify-transition-fn  OR  held-out test-cases (rank by accuracy)
+
+   Keep the top-k valid+highest-ranked completions per prompt; emit Qwen3 chat-format
+   SFT records + a stats report. Per-prompt YIELD (fraction of prompts that produced
+   >=1 kept candidate) measures the teacher's coverage of the task space.
+
+   Sections:
+     1. Drop reasons + small helpers
+     2. evaluate-candidate  (the per-completion gate ladder, both kinds)
+     3. rank-and-select     (top-k per prompt)
+     4. verdicts->stats     (corpus-quality report)
+     5. build-sft-records   (kept candidates -> Qwen3 chat JSONL rows)"
+  (:require [genmlx.world.train-reward :as reward]
+            [genmlx.llm.msa-score :as score]
+            [genmlx.codegen.eval :as ce]
+            [clojure.string :as str]))
+
+;; ===========================================================================
+;; 1. Drop reasons + helpers
+;; ===========================================================================
+
+(def drop-reasons
+  "Human-readable explanation per terminal :reason a verdict can carry."
+  {:kept         "passed all gates"
+   :empty        "no code extracted from the completion"
+   :unparseable  "extracted text is not a complete, valid ClojureScript form"
+   :eval-error   "evaluated to an error / not a model (or function)"
+   :uncovered    "program ignores an observed address (the reward-integrity guard)"
+   :degenerate   "program uses a point-mass (delta) at an observed site — a degenerate reward-hack fit"
+   :nonfinite-ml "model evidence was non-finite (-Inf / NaN)"
+   :low-evidence "model evidence below the configured :min-log-ml floor"
+   :test-fail    "failed at least one held-out test"
+   :no-oracle    "task carries no held-out oracle (no :transitions and no :test-cases) — misconfigured"
+   :unknown-kind "task :kind is neither :program nor :function"})
+
+(defn- safe-div
+  "n/d as a float, or 0.0 when d is 0 — for rate stats over possibly-empty sets."
+  [n d]
+  (if (zero? d) 0.0 (/ n d)))
+
+(defn- mean
+  "Arithmetic mean of a non-empty seq of numbers, or nil if empty."
+  [xs]
+  (when (seq xs) (/ (reduce + xs) (count xs))))
+
+(defn- structure-of
+  "Idiomaticity score of a code string (ce/score-structure over its parsed form),
+   or nil when the code does not parse to a form."
+  [code]
+  (when-let [f (ce/parse-form code)]
+    (ce/score-structure f)))
+
+(defn- form-uses-delta?
+  "Does the parsed form reference a `delta` distribution anywhere? A delta (point
+   mass) at an OBSERVED site is a degenerate reward-hack: it asserts the observation
+   is deterministic, scoring log-evidence ~0 (it beats any honest noisy model). We
+   reject any program that mentions delta — none of the seed tasks legitimately need
+   one. (coll? is false for strings in CLJS, so the walk never recurses into chars.)"
+  [form]
+  (cond
+    (symbol? form) (= "delta" (name form))
+    (coll? form)   (boolean (some form-uses-delta? form))
+    :else          false))
+
+(defn- degenerate-program?
+  "True iff the program's source uses a point-mass delta (see form-uses-delta?)."
+  [code]
+  (boolean (when-let [f (ce/parse-form code)] (form-uses-delta? f))))
+
+;; ===========================================================================
+;; 2. evaluate-candidate — the per-completion gate ladder
+;; ===========================================================================
+
+(defn- gate-program
+  "Gate a :program completion via the MSA / model-evidence oracle. Mirrors
+   train-reward/model-evidence-reward's ladder exactly (same extract, same coverage
+   guard, same scorer) but RETURNS A VERDICT instead of a floored scalar — a corpus
+   filter wants to know *why* a candidate was dropped, and to RANK survivors by
+   evidence rather than collapse failures to a floor."
+  [{:keys [observations n-particles require-coverage? min-log-ml]
+    :or   {n-particles 50 require-coverage? true}}
+   completion]
+  (let [code (reward/extract-program completion)]
+    (cond
+      (str/blank? code)
+      {:code code :parse? false :kept? false :reason :empty}
+
+      (not (ce/valid-cljs? code))
+      {:code code :parse? false :kept? false :reason :unparseable}
+
+      :else
+      (let [gf (score/eval-model code)]
+        (cond
+          (nil? gf)
+          {:code code :parse? true :eval? false :kept? false :reason :eval-error}
+
+          (and require-coverage? (not (reward/covered-observations? gf observations)))
+          {:code code :parse? true :eval? true :covered? false
+           :kept? false :reason :uncovered}
+
+          (degenerate-program? code)
+          {:code code :parse? true :eval? true :covered? true
+           :kept? false :reason :degenerate}
+
+          :else
+          (let [{:keys [log-ml method]}
+                (score/score-model* gf observations {:n-particles n-particles})]
+            (cond
+              (not (reward/finite? log-ml))
+              {:code code :parse? true :eval? true :covered? true
+               :log-ml log-ml :method method :kept? false :reason :nonfinite-ml}
+
+              (and min-log-ml (< log-ml min-log-ml))
+              {:code code :parse? true :eval? true :covered? true
+               :log-ml log-ml :method method :kept? false :reason :low-evidence}
+
+              :else
+              {:code code :parse? true :eval? true :covered? true
+               :log-ml log-ml :method method :structure (structure-of code)
+               :rank-key log-ml :kept? true :reason :kept})))))))
+
+(defn- run-test-cases
+  "Apply f to each test-case's :args and compare to :expected, returning the same
+   {:accuracy :total :correct :failures} shape as ce/verify-transition-fn so the
+   two behavioral gates fold into one code path."
+  [f test-cases]
+  (let [total   (count test-cases)
+        results (map-indexed
+                  (fn [i {:keys [args expected]}]
+                    (try
+                      (let [actual (apply f args)]
+                        (if (= expected actual)
+                          {:correct true}
+                          {:correct false :index i :args args
+                           :expected expected :actual actual}))
+                      (catch :default e
+                        {:correct false :index i :args args
+                         :expected expected :actual (str "ERROR: " (.-message e))})))
+                  test-cases)
+        correct (count (filter :correct results))]
+    {:accuracy (if (zero? total) 1.0 (/ correct total))
+     :total    total
+     :correct  correct
+     :failures (vec (remove :correct results))}))
+
+(defn- gate-function
+  "Gate a :function completion behaviorally. The task carries EITHER :transitions
+   (scored by ce/verify-transition-fn, the state x action -> state oracle) XOR
+   :test-cases ([{:args [..] :expected v}], scored by applying the fn). The held-out
+   tests are NEVER shown in the prompt, so passing them is real generalization.
+   Kept iff accuracy >= :pass-threshold (default 1.0 — only fully-correct exemplars
+   belong in an SFT corpus)."
+  [{:keys [transitions test-cases pass-threshold]
+    :or   {pass-threshold 1.0}}
+   completion]
+  ;; Keep the original form (named defn / named fn) — unlike extract-program, do NOT
+  ;; canonicalize defn -> anonymous fn, which would break self-recursive solutions
+  ;; (factorial, gcd) that call themselves by name.
+  (let [code (ce/extract-code (reward/strip-think completion))]
+    (cond
+      ;; A :function task with NO held-out oracle would otherwise keep EVERY fn that
+      ;; evals (accuracy defaults to 1.0 over zero checks) — silent corpus poisoning.
+      ;; Treat it as a task misconfiguration, never a pass.
+      (not (or (seq transitions) (seq test-cases)))
+      {:code code :parse? false :kept? false :reason :no-oracle}
+
+      (str/blank? code)
+      {:code code :parse? false :kept? false :reason :empty}
+
+      (not (ce/valid-cljs? code))
+      {:code code :parse? false :kept? false :reason :unparseable}
+
+      :else
+      (let [{:keys [accuracy total correct error]}
+            (if transitions
+              (ce/verify-transition-fn code transitions)
+              (let [{f :fn err :error} (ce/eval-fn code)]
+                (if err {:accuracy 0.0 :error err} (run-test-cases f test-cases))))]
+        (cond
+          error
+          {:code code :parse? true :eval? false :kept? false :reason :eval-error}
+
+          (< accuracy pass-threshold)
+          {:code code :parse? true :eval? true :accuracy accuracy
+           :total total :correct correct :kept? false :reason :test-fail}
+
+          :else
+          {:code code :parse? true :eval? true :accuracy accuracy
+           :total total :correct correct :structure (structure-of code)
+           :rank-key accuracy :kept? true :reason :kept})))))
+
+(defn evaluate-candidate
+  "Run the full oracle gate ladder on ONE raw teacher completion against its task.
+
+   `task`       — a seed task map (see genmlx.world.distill-tasks): {:id :kind ...}
+                  plus :observations (for :program) or :transitions/:test-cases
+                  (for :function).
+   `completion` — the raw teacher output string (may carry <think>, fences, prose).
+   `sample-idx` — which of the N teacher samples this is (for provenance).
+
+   Returns a verdict map that ALWAYS has :task-id :sample-idx :kind :kept? :reason,
+   plus :code (the gated string) and path-specific fields (:log-ml/:method for
+   :program, :accuracy for :function, :structure for survivors). Never throws — an
+   unexpected error is caught and reported as an :eval-error verdict."
+  [task completion sample-idx]
+  (let [base {:task-id (:id task) :sample-idx sample-idx :kind (:kind task)}]
+    (merge base
+           (try
+             (case (:kind task)
+               :program  (gate-program task completion)
+               :function (gate-function task completion)
+               {:code "" :parse? false :kept? false :reason :unknown-kind})
+             (catch :default e
+               {:code "" :parse? false :kept? false
+                :reason :eval-error :error (.-message e)})))))
+
+;; ===========================================================================
+;; 3. rank-and-select — top-k survivors per prompt
+;; ===========================================================================
+
+(defn- deterministic-score?
+  "True iff a verdict's :rank-key is reproducible: any :function verdict (accuracy is
+   exact) or a :program scored by an EXACT analytical method. A non-conjugate program
+   scored by importance sampling (:handler-is/:smc/:hmc/:vi) is non-reproducible and
+   must never out-rank a deterministically-scored peer."
+  [v]
+  (or (= :function (:kind v))
+      (contains? #{:exact :kalman} (:method v))))
+
+(defn- select-key
+  "Sort key for ranking KEPT verdicts within a task (ascending vector of comparables):
+   deterministically-scored candidates first (an exact marginal / a function accuracy
+   never loses to a noisy IS estimate), then higher :rank-key (evidence/accuracy),
+   then — for :function only, where idiomaticity is meaningful — higher structure
+   score, then shorter code (Occam tie-break)."
+  [v]
+  [(if (deterministic-score? v) 0 1)
+   (- (:rank-key v))
+   (if (= :function (:kind v)) (- (or (:structure v) 0)) 0)
+   (count (:code v))])
+
+(defn rank-and-select
+  "Group KEPT verdicts by :task-id and keep the top-`top-k` per task, ranked by
+   model evidence / test accuracy (idiomaticity & brevity break ties). Returns the
+   flat seq of selected verdicts across all tasks (input order of tasks preserved)."
+  [verdicts top-k]
+  (->> verdicts
+       (filter :kept?)
+       (group-by :task-id)
+       vals
+       (mapcat (fn [vs] (take top-k (sort-by select-key vs))))))
+
+;; ===========================================================================
+;; 4. verdicts->stats — corpus-quality report
+;; ===========================================================================
+
+(defn verdicts->stats
+  "Aggregate per-candidate verdicts (and the selected subset) into a corpus-quality
+   report: parse / eval / test-pass rates, mean model evidence over kept programs,
+   per-prompt yield (coverage of the task space), and a drop-reason histogram.
+
+   `tasks` — the seed tasks that were filtered (for n-tasks / yield denominators).
+   `verdicts` — every candidate's verdict. `selected` — the kept top-k subset."
+  [tasks verdicts selected]
+  (let [n         (count verdicts)
+        n-tasks   (count tasks)
+        prog?     #(= :program (:kind %))
+        fn?       #(= :function (:kind %))
+        progs     (filter prog? verdicts)
+        fns       (filter fn? verdicts)
+        kept      (filter :kept? verdicts)
+        kept-prog (filter :kept? progs)
+        attempted (count (distinct (map :task-id verdicts)))
+        with-kept (count (distinct (map :task-id kept)))]
+    {:n-candidates      n
+     :n-tasks           n-tasks
+     :n-tasks-attempted attempted
+     :n-kept            (count kept)
+     :n-selected        (count selected)
+     :parse-rate        (safe-div (count (filter :parse? verdicts)) n)
+     :eval-rate         (safe-div (count (filter :eval? verdicts)) n)
+     :program-pass-rate (safe-div (count kept-prog) (count progs))
+     :function-pass-rate (safe-div (count (filter :kept? fns)) (count fns))
+     :mean-log-ml       (mean (keep :log-ml kept-prog))
+     ;; yield = fraction of ATTEMPTED prompts that produced >=1 kept candidate
+     ;; (the teacher's hit-rate over the prompts it was actually given).
+     :yield-per-prompt  (safe-div with-kept attempted)
+     ;; coverage = fraction of the FULL seed task space that got >=1 kept candidate.
+     :task-space-coverage (safe-div with-kept n-tasks)
+     :n-prompts-covered with-kept
+     ;; how many SELECTED programs were scored by non-reproducible importance sampling
+     ;; (a non-conjugate model): >0 means that prompt's pick is not deterministic.
+     :n-selected-noisy-is (count (filter #(and (= :program (:kind %))
+                                               (not (contains? #{:exact :kalman} (:method %))))
+                                         selected))
+     :drop-reasons      (into (sorted-map) (frequencies (map :reason verdicts)))}))
+
+;; ===========================================================================
+;; 5. build-sft-records — kept candidates -> Qwen3 chat JSONL rows
+;; ===========================================================================
+
+(defn task->messages
+  "Build a Qwen3 instruct/chat message vector for an SFT pair: the task's optional
+   system turn, its user prompt, then the validated completion as the assistant
+   turn. Roles are STRINGS (\"system\"/\"user\"/\"assistant\") for JSONL fidelity."
+  [task code]
+  (cond-> []
+    (:system-prompt task) (conj {:role "system" :content (:system-prompt task)})
+    true                  (conj {:role "user" :content (:prompt task)})
+    true                  (conj {:role "assistant" :content code})))
+
+(defn build-sft-records
+  "Turn selected verdicts into SFT corpus rows. `tasks-by-id` maps :task-id -> task
+   (so the prompt/system turns come from the canonical in-tree task, never from a
+   file that could leak hidden tests). Each row carries provenance (:task-id :kind
+   :rank-key) alongside the :messages the trainer consumes."
+  [tasks-by-id selected]
+  (for [v selected
+        :let [task (get tasks-by-id (:task-id v))]
+        :when task]
+    {:task-id  (:task-id v)
+     :kind     (name (:kind v))
+     :rank-key (:rank-key v)
+     :messages (task->messages task (:code v))}))

--- a/src/genmlx/world/distill_sandbox.cljs
+++ b/src/genmlx/world/distill_sandbox.cljs
@@ -1,0 +1,159 @@
+(ns genmlx.world.distill-sandbox
+  "Process-isolation layer for the distillation filter (genmlx-8d15).
+
+   WHY. The filter evaluates UNTRUSTED teacher code (SCI eval + apply, and model
+   scoring). Such code can NON-TERMINATE — the real qwen3.5-4b smoke emitted a
+   factorial `(reduce * (iterate identity n))` (an infinite lazy seq) and a swapped-arg
+   gcd `recur` — or crash the process natively. Single-threaded JS cannot preempt a
+   synchronous infinite loop, so the Step-3-spec'd 'sandbox + timeout' MUST live in a
+   separate process.
+
+   HOW. A single RESUMABLE worker child (scripts/distill_check.cljs) evaluates rows
+   from `--start` to the end, appending one EDN verdict line per row (flushed). The
+   parent here WATCHDOGS it asynchronously (promesa; the event loop must stay free so
+   the worker's exit fires and its writes flush) by polling the verdict file's line
+   count:
+     - progress (line count grows)  -> reset the stall timer;
+     - stalled past `timeout-ms`     -> the row at the current line count is looping:
+                                        kill the worker's PROCESS GROUP, record a
+                                        :timeout verdict for it, respawn from the next row;
+     - worker exits non-zero/signal  -> it crashed on the current row: record :crashed,
+                                        respawn from the next row;
+     - worker exits 0                -> all rows done.
+
+   Two subprocess-lifecycle subtleties this handles (learned the hard way):
+     * `bun run --bun nbb` spawns a wrapper whose nbb/node GRANDCHILD runs the loop, so
+       we spawn `detached` and kill the whole PROCESS GROUP (`process.kill (- pid)`) —
+       killing just the wrapper would orphan a CPU-spinning grandchild.
+     * the watchdog is ASYNC (never blocks the event loop), so the worker's 'exit'
+       event is actually delivered and clean completion is detected.
+
+   The expensive GenMLX + native load is paid ONCE in the common case (and once more
+   per killed candidate). evaluate-candidate stays PURE in genmlx.world.distill;
+   isolation lives only here. collect-verdicts returns a PROMISE of the verdict vector
+   (reassembled by row :index, deduped, sentinels dropped)."
+  (:require [genmlx.world.distill :as d]
+            [genmlx.world.distill-tasks :as t]
+            [clojure.string :as str]
+            [cljs.reader :as reader]
+            [promesa.core :as p]))
+
+(def ^:private fs (js/require "fs"))
+(def ^:private cp (js/require "child_process"))
+
+(defn- count-lines [path]
+  (if (.existsSync fs path)
+    (->> (str/split-lines (.readFileSync fs path "utf8")) (remove str/blank?) count)
+    0))
+
+(defn read-candidates
+  "Read raw_candidates.jsonl into a vector of keywordized maps (malformed lines
+   skipped). The parent and worker read it identically, so row indices agree."
+  [path]
+  (->> (str/split-lines (.readFileSync fs path "utf8"))
+       (remove str/blank?)
+       (keep (fn [l] (try (js->clj (js/JSON.parse l) :keywordize-keys true)
+                          (catch :default _ nil))))
+       vec))
+
+(defn- spawn-worker [candidates-file out-path start eval-opts]
+  (let [args (cond-> ["run" "--bun" "nbb" "scripts/distill_check.cljs"
+                      "--candidates" candidates-file "--out" out-path "--start" (str start)
+                      "--n-particles" (str (:n-particles eval-opts 50))]
+               (:min-log-ml eval-opts) (conj "--min-log-ml" (str (:min-log-ml eval-opts))))]
+    ;; detached -> the worker leads its own process group, so we can kill the whole
+    ;; tree (wrapper + nbb/node grandchild). stdout ignored (wrapper is noisy; verdicts
+    ;; go to the file); stderr inherited so a worker error surfaces on our stderr.
+    (.spawn cp "bun" (clj->js args)
+            #js {:stdio #js ["ignore" "ignore" "inherit"] :detached true})))
+
+(defn- kill-group! [worker]
+  (try (js/process.kill (- (.-pid worker)) "SIGKILL")
+       (catch :default _ (try (.kill worker "SIGKILL") (catch :default _ nil)))))
+
+(defn- watch-worker
+  "Async watchdog over one worker. Resolves to
+   {:status :done} | {:status :stall :index k} | {:status :crash :index k}.
+   k = the current line count = the next-unwritten row = the one that stalled/crashed."
+  [worker out-path timeout-ms poll-ms]
+  (p/create
+    (fn [resolve _reject]
+      (let [last-lines (volatile! (count-lines out-path))
+            last-prog  (volatile! (js/Date.now))
+            iv         (volatile! nil)
+            settled?   (volatile! false)
+            finish     (fn [m] (when-not @settled?
+                                 (vreset! settled? true)
+                                 (when @iv (js/clearInterval @iv))
+                                 (resolve m)))]
+        (.on worker "exit"
+             (fn [code signal]
+               (if (and (= 0 code) (nil? signal))
+                 (finish {:status :done})
+                 (finish {:status :crash :index (count-lines out-path)}))))
+        (vreset! iv
+          (js/setInterval
+            (fn []
+              (when-not @settled?
+                (let [lines (count-lines out-path)]
+                  (if (> lines @last-lines)
+                    (do (vreset! last-lines lines) (vreset! last-prog (js/Date.now)))
+                    (when (> (- (js/Date.now) @last-prog) timeout-ms)
+                      (kill-group! worker)
+                      (finish {:status :stall :index lines}))))))
+            poll-ms))))))
+
+(defn- assemble
+  "Read the accumulated verdict lines, dedupe by :index (prefer a real verdict over a
+   :timeout/:crashed/unknown sentinel if a race wrote both), drop unknown-task rows,
+   strip :index, and return verdicts ordered by row index."
+  [out-path]
+  (let [sentinel? #(or (:unknown-task? %) (contains? #{:timeout :crashed} (:reason %)))]
+    (->> (str/split-lines (.readFileSync fs out-path "utf8"))
+         (remove str/blank?)
+         (map reader/read-string)
+         (group-by :index)
+         vals
+         (map (fn [vs] (or (first (remove sentinel? vs)) (first vs))))
+         (remove :unknown-task?)
+         (sort-by :index)
+         (mapv #(dissoc % :index)))))
+
+(defn collect-verdicts
+  "Evaluate every candidate in `candidates-file` under process isolation. Returns a
+   PROMISE of the verdict vector (sorted by row index). A non-terminating row gets a
+   :timeout verdict, a process-crashing row gets :crashed, and the batch ALWAYS
+   completes.
+
+   opts:
+     :out-path    scratch EDN file accumulating verdict lines (required)
+     :eval-opts   {:n-particles :min-log-ml} forwarded to evaluate-candidate
+     :timeout-ms  per-candidate stall budget before the worker group is killed
+                  (default 15000; must exceed the worker's cold-start ~2-4s)
+     :poll-ms     watchdog poll interval (default 400)
+     :verbose?    print per-worker / per-kill progress"
+  [candidates-file {:keys [out-path eval-opts timeout-ms poll-ms verbose?]
+                    :or   {timeout-ms 15000 poll-ms 400}}]
+  (let [rows (read-candidates candidates-file)
+        n    (count rows)]
+    (.writeFileSync fs out-path "")
+    (letfn [(step [start]
+              (if (>= start n)
+                (p/resolved (assemble out-path))
+                (do (when verbose? (println (str "  [sandbox] worker resuming at row " start "/" n)))
+                    (-> (watch-worker (spawn-worker candidates-file out-path start eval-opts)
+                                      out-path timeout-ms poll-ms)
+                        (p/then (fn [{:keys [status index]}]
+                                  (if (= :done status)
+                                    (assemble out-path)
+                                    (let [reason (if (= :stall status) :timeout :crashed)
+                                          {:keys [task-id sample-idx]} (d/candidate->fields (nth rows index))
+                                          task   (or (get t/tasks-by-id task-id) {:id task-id :kind nil})]
+                                      (when verbose?
+                                        (println (str "  [sandbox] row " index " (" task-id " #" sample-idx
+                                                      ") -> " reason "; resuming")))
+                                      (.appendFileSync fs out-path
+                                                       (str (pr-str (assoc (d/timeout-verdict task sample-idx reason)
+                                                                           :index index)) "\n"))
+                                      (step (inc index))))))))))]
+      (step 0))))

--- a/src/genmlx/world/distill_tasks.cljs
+++ b/src/genmlx/world/distill_tasks.cljs
@@ -1,0 +1,222 @@
+(ns genmlx.world.distill-tasks
+  "The seed task set for the cljs-coder distillation loop (genmlx-j0d6).
+
+   The CANONICAL, in-tree source of distillation tasks. Each task carries the
+   teacher-facing fields (:id :kind :system-prompt :prompt) AND the held-out oracle
+   signal (:observations for :program; :transitions or :test-cases for :function).
+   The held-out signal lives HERE, never in the exported teacher prompts, so a
+   completion that passes the oracle is real generalization — the teacher never saw
+   the tests it is graded on.
+
+   Two kinds, two oracle paths (see genmlx.world.distill):
+     :program  — a GenMLX probabilistic program scored by Bayesian model evidence
+                 (log p(observations | program)). The four here are conjugate, so the
+                 evidence is the EXACT analytical marginal (deterministic).
+     :function — an ordinary ClojureScript function checked behaviorally, either as a
+                 :transitions state-machine (state x action -> state) or by :test-cases
+                 ([{:args [..] :expected v}]).
+
+   Start tiny (12 tasks); the loop grows this set as the teacher's coverage is
+   measured (yield-per-prompt) and weak spots are found."
+  (:require [clojure.string :as str]))
+
+;; ===========================================================================
+;; System prompts
+;; ===========================================================================
+
+(def program-system-prompt
+  (str "You are a ClojureScript code generator for the GenMLX probabilistic "
+       "programming system. Reply with ONLY a single (fn [trace] ...) form — no "
+       "prose, no markdown, no comments. A random choice is written "
+       "(trace :name (dist/DISTRIBUTION args...)). You may use the distributions "
+       "dist/gaussian, dist/uniform, dist/bernoulli, dist/beta, dist/gamma, "
+       "dist/exponential, dist/poisson and the math ops mx/add, mx/subtract, "
+       "mx/multiply, mx/divide, mx/scalar, mx/exp, mx/log, mx/sqrt, mx/abs. "
+       "Begin your reply with the characters (fn [trace]."))
+
+(def function-system-prompt
+  (str "You are a ClojureScript code generator. Reply with ONLY a single "
+       "ClojureScript function — no prose, no markdown, no comments. Begin your "
+       "reply with ( ."))
+
+;; ===========================================================================
+;; Program tasks — conjugate models, EXACT analytical model evidence
+;; ===========================================================================
+
+(defn- gaussian-mean-prompt
+  "A shared-mean Gaussian program prompt: gives a complete template over the real
+   observation addresses (so a faithful completion clears the coverage guard) with
+   deliberately loose priors, and asks the teacher to ADAPT the three numbers."
+  [obs]
+  (let [pairs (sort-by (comp name key) obs)
+        data  (str/join ", " (map (fn [[k v]] (str (name k) "=" v)) pairs))
+        body  (str/join " " (map (fn [[k _]] (str k " (trace " k
+                                                 " (dist/gaussian mu 1))")) pairs))]
+    (str "Write a GenMLX probabilistic model that explains this data: " data ".\n"
+         "It has one shared latent mean :mu and one Gaussian observation site per\n"
+         "data point. Start from this example and ADAPT the three numbers (the prior\n"
+         "mean, the prior std, and the observation noise) so the data is well\n"
+         "explained — a higher marginal likelihood is better:\n\n"
+         "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 10))] {" body "}))\n\n"
+         "Output ONLY your completed (fn [trace] ...) form, nothing else.")))
+
+(def program-tasks
+  [{:id "gaussian-mean-near2"
+    :kind :program
+    :system-prompt program-system-prompt
+    :prompt (gaussian-mean-prompt {:y0 2.0 :y1 2.3 :y2 1.7 :y3 2.1})
+    :observations {:y0 2.0 :y1 2.3 :y2 1.7 :y3 2.1}}
+
+   {:id "gaussian-mean-negshift"
+    :kind :program
+    :system-prompt program-system-prompt
+    :prompt (gaussian-mean-prompt {:y0 -3.1 :y1 -2.7 :y2 -3.4 :y3 -2.9})
+    :observations {:y0 -3.1 :y1 -2.7 :y2 -3.4 :y3 -2.9}}
+
+   {:id "beta-bernoulli-coin"
+    :kind :program
+    :system-prompt program-system-prompt
+    :prompt (str "Write a GenMLX model for a possibly-biased coin observed flipping\n"
+                 "1 1 1 0 1 0 (six flips, sites :f0..:f5, 1 = heads). One latent bias\n"
+                 ":p with a Beta prior; each flip is Bernoulli(p). Start from this and\n"
+                 "ADAPT the two Beta-prior numbers so the data is well explained:\n\n"
+                 "(fn [trace] (let [p (trace :p (dist/beta 1 1))]"
+                 " {:f0 (trace :f0 (dist/bernoulli p))"
+                 " :f1 (trace :f1 (dist/bernoulli p))"
+                 " :f2 (trace :f2 (dist/bernoulli p))"
+                 " :f3 (trace :f3 (dist/bernoulli p))"
+                 " :f4 (trace :f4 (dist/bernoulli p))"
+                 " :f5 (trace :f5 (dist/bernoulli p))}))\n\n"
+                 "Output ONLY your completed (fn [trace] ...) form, nothing else.")
+    :observations {:f0 1.0 :f1 1.0 :f2 1.0 :f3 0.0 :f4 1.0 :f5 0.0}}
+
+   {:id "gamma-poisson-counts"
+    :kind :program
+    :system-prompt program-system-prompt
+    :prompt (str "Write a GenMLX model for count data 3 5 4 6 2 (sites :c0..:c4). One\n"
+                 "latent rate :rate with a Gamma prior; each count is Poisson(rate).\n"
+                 "Start from this and ADAPT the two Gamma-prior numbers so the data is\n"
+                 "well explained:\n\n"
+                 "(fn [trace] (let [rate (trace :rate (dist/gamma 1 1))]"
+                 " {:c0 (trace :c0 (dist/poisson rate))"
+                 " :c1 (trace :c1 (dist/poisson rate))"
+                 " :c2 (trace :c2 (dist/poisson rate))"
+                 " :c3 (trace :c3 (dist/poisson rate))"
+                 " :c4 (trace :c4 (dist/poisson rate))}))\n\n"
+                 "Output ONLY your completed (fn [trace] ...) form, nothing else.")
+    :observations {:c0 3.0 :c1 5.0 :c2 4.0 :c3 6.0 :c4 2.0}}])
+
+;; ===========================================================================
+;; Function tasks — state-machine transitions (held-out)
+;; ===========================================================================
+
+(def transition-tasks
+  [{:id "counter-machine"
+    :kind :function
+    :system-prompt function-system-prompt
+    :prompt (str "Write a ClojureScript function (fn [state action] ...) for a "
+                 "counter.\nThe state is a map {:count n}. Actions: :inc adds 1 to "
+                 ":count, :dec\nsubtracts 1, :reset sets :count to 0. Return the new "
+                 "state map.\nExample: (f {:count 5} :inc) => {:count 6}.")
+    :transitions [{:state {:count 0}  :action :inc   :expected {:count 1}}
+                  {:state {:count 3}  :action :dec   :expected {:count 2}}
+                  {:state {:count 7}  :action :reset :expected {:count 0}}
+                  {:state {:count -2} :action :inc   :expected {:count -1}}]}
+
+   {:id "traffic-light"
+    :kind :function
+    :system-prompt function-system-prompt
+    :prompt (str "Write a ClojureScript function (fn [state action] ...) for a "
+                 "traffic light.\nThe state is {:light color} where color is :red, "
+                 ":green, or :yellow.\nThe only action is :tick, which advances the "
+                 "light: :red -> :green ->\n:yellow -> :red. Return the new state. "
+                 "Example: (f {:light :red} :tick) => {:light :green}.")
+    :transitions [{:state {:light :red}    :action :tick :expected {:light :green}}
+                  {:state {:light :green}  :action :tick :expected {:light :yellow}}
+                  {:state {:light :yellow} :action :tick :expected {:light :red}}]}
+
+   {:id "toggle-switch"
+    :kind :function
+    :system-prompt function-system-prompt
+    :prompt (str "Write a ClojureScript function (fn [state action] ...) for a toggle "
+                 "switch.\nThe state is {:on bool}. The action :flip inverts :on; any "
+                 "other action\nleaves the state unchanged. Return the new state. "
+                 "Example:\n(f {:on false} :flip) => {:on true}.")
+    :transitions [{:state {:on false} :action :flip :expected {:on true}}
+                  {:state {:on true}  :action :flip :expected {:on false}}
+                  {:state {:on true}  :action :noop :expected {:on true}}]}])
+
+;; ===========================================================================
+;; Function tasks — pure functions checked by held-out test-cases
+;; ===========================================================================
+
+(def test-case-tasks
+  [{:id "factorial"
+    :kind :function
+    :system-prompt function-system-prompt
+    :prompt (str "Write a ClojureScript function (fn [n] ...) that returns n! "
+                 "(n factorial)\nfor a non-negative integer n. (f 0) => 1, "
+                 "(f 4) => 24.")
+    :test-cases [{:args [0] :expected 1} {:args [1] :expected 1}
+                 {:args [5] :expected 120} {:args [6] :expected 720}]}
+
+   {:id "fizzbuzz"
+    :kind :function
+    :system-prompt function-system-prompt
+    :prompt (str "Write a ClojureScript function (fn [n] ...) that returns \"Fizz\" "
+                 "if n is\ndivisible by 3, \"Buzz\" if divisible by 5, \"FizzBuzz\" "
+                 "if divisible by\nboth, otherwise the number as a string. "
+                 "(f 3) => \"Fizz\", (f 7) => \"7\".")
+    :test-cases [{:args [3] :expected "Fizz"} {:args [5] :expected "Buzz"}
+                 {:args [15] :expected "FizzBuzz"} {:args [7] :expected "7"}
+                 {:args [9] :expected "Fizz"}]}
+
+   {:id "gcd"
+    :kind :function
+    :system-prompt function-system-prompt
+    :prompt (str "Write a ClojureScript function (fn [a b] ...) returning the greatest "
+                 "common\ndivisor of two positive integers a and b. (f 12 8) => 4.")
+    :test-cases [{:args [12 8] :expected 4} {:args [54 24] :expected 6}
+                 {:args [7 1] :expected 1} {:args [100 75] :expected 25}]}
+
+   {:id "palindrome?"
+    :kind :function
+    :system-prompt function-system-prompt
+    :prompt (str "Write a ClojureScript function (fn [s] ...) returning true if the "
+                 "string s\nreads the same forwards and backwards, else false. "
+                 "(f \"racecar\") => true,\n(f \"hello\") => false.")
+    :test-cases [{:args ["racecar"] :expected true} {:args ["hello"] :expected false}
+                 {:args [""] :expected true} {:args ["abba"] :expected true}
+                 {:args ["abc"] :expected false}]}
+
+   {:id "sum-evens"
+    :kind :function
+    :system-prompt function-system-prompt
+    :prompt (str "Write a ClojureScript function (fn [coll] ...) returning the sum of "
+                 "the even\nnumbers in the collection coll. (f [1 2 3 4]) => 6.")
+    :test-cases [{:args [[1 2 3 4]] :expected 6} {:args [[]] :expected 0}
+                 {:args [[2 4 6]] :expected 12} {:args [[1 3 5]] :expected 0}
+                 {:args [[10 -2 3]] :expected 8}]}])
+
+;; ===========================================================================
+;; The assembled seed set
+;; ===========================================================================
+
+(def tasks
+  "The full seed task set (12): 4 conjugate programs + 3 state machines + 5 functions."
+  (vec (concat program-tasks transition-tasks test-case-tasks)))
+
+(def tasks-by-id
+  "Map of :id -> task, for joining verdicts/candidates back to their prompts."
+  (into {} (map (juxt :id identity)) tasks))
+
+(defn task->prompt-record
+  "The TEACHER-FACING projection of a task: only the fields the teacher needs to
+   generate (id, kind, system + user prompt). The held-out oracle signal
+   (:observations / :transitions / :test-cases) is intentionally dropped so it can
+   never leak into a teacher prompt. Snake-cased keys for the Python/JSONL side."
+  [task]
+  {:task_id       (:id task)
+   :kind          (name (:kind task))
+   :system_prompt (:system-prompt task)
+   :prompt        (:prompt task)})

--- a/src/genmlx/world/train_reward.cljs
+++ b/src/genmlx/world/train_reward.cljs
@@ -88,9 +88,11 @@
 ;; isolate the FIRST function form and pr-str it back to a clean code string.
 ;; ===========================================================================
 
-(defn- strip-think
+(defn strip-think
   "Drop everything up to and including the final `</think>` (Qwen reasoning),
-   whose contents are full of parens that would fool a first-paren extractor."
+   whose contents are full of parens that would fool a first-paren extractor.
+   Public so the offline distillation filter (genmlx.world.distill) shares the
+   exact same completion-cleaning as the online reward."
   [s]
   (let [s (str s)]
     (if-let [idx (str/last-index-of s "</think>")]

--- a/test/genmlx/distill_sandbox_test.cljs
+++ b/test/genmlx/distill_sandbox_test.cljs
@@ -1,0 +1,65 @@
+;; @tier slow
+(ns genmlx.distill-sandbox-test
+  "Acceptance for genmlx.world.distill-sandbox — the process-isolation layer that makes
+   the distillation filter robust to NON-TERMINATING / crashing untrusted teacher code
+   (genmlx-8d15). It spawns REAL worker subprocesses (scripts/distill_check.cljs), so it
+   is slow; run:
+     bun run --bun nbb test/genmlx/distill_sandbox_test.cljs
+
+   The canonical case: a batch of 3 counter-machine candidates where row 1 is an
+   infinite loop `(fn [state action] (loop [] (recur)))`. The sandbox must process
+   row 0, KILL the worker stuck on row 1 (recording :timeout), resume, and process
+   row 2 — the whole batch completes and the corpus is never poisoned by the hanger."
+  (:require [genmlx.world.distill-sandbox :as sb]
+            [clojure.string :as str]
+            [promesa.core :as p]))
+
+(def fs   (js/require "fs"))
+(def os   (js/require "os"))
+(def path (js/require "path"))
+
+(def ^:private pass (atom 0))
+(def ^:private fail (atom 0))
+(defn assert-true [label v]
+  (if v (do (swap! pass inc) (println "  PASS" label))
+        (do (swap! fail inc) (println "  FAIL" label))))
+
+(def tmp-dir (.join path (.tmpdir os) "genmlx-distill-sandbox-test"))
+(when-not (.existsSync fs tmp-dir) (.mkdirSync fs tmp-dir #js {:recursive true}))
+
+(def candidates
+  [{:task_id "counter-machine" :sample_idx 0
+    :raw_text "(fn [state action] (case action :inc (update state :count inc) :dec (update state :count dec) :reset (assoc state :count 0) state))"}
+   {:task_id "counter-machine" :sample_idx 1
+    :raw_text "(fn [state action] (loop [] (recur)))"}              ;; NON-TERMINATING
+   {:task_id "counter-machine" :sample_idx 2
+    :raw_text "(fn [state action] (update state :count inc))"}])    ;; wrong, but TERMINATES
+
+(def cand-file (.join path tmp-dir "cands.jsonl"))
+(.writeFileSync fs cand-file (str/join "\n" (map #(js/JSON.stringify (clj->js %)) candidates)))
+
+(defn by-sample [verdicts s] (first (filter #(= s (:sample-idx %)) verdicts)))
+
+(println "\n== sandbox over 3 candidates (row 1 is an infinite loop) ==")
+(-> (sb/collect-verdicts cand-file
+                         {:out-path   (.join path tmp-dir "verdicts.edn")
+                          :eval-opts  {:n-particles 10}
+                          :timeout-ms 8000 :poll-ms 300 :verbose? true})
+    (p/then
+      (fn [verdicts]
+        (let [v0 (by-sample verdicts 0)
+              v1 (by-sample verdicts 1)
+              v2 (by-sample verdicts 2)]
+          (assert-true "batch COMPLETED with a verdict for all 3 rows (no hang)" (= 3 (count verdicts)))
+          (assert-true "row 0 (correct counter) is kept" (:kept? v0))
+          (assert-true "row 1 (non-terminating) -> :timeout, not kept"
+                       (and (some? v1) (= :timeout (:reason v1)) (not (:kept? v1))))
+          (assert-true "row 1 timeout verdict keeps its provenance (task-id + sample-idx)"
+                       (and (= "counter-machine" (:task-id v1)) (= 1 (:sample-idx v1))))
+          (assert-true "row 2 (after the hang) still processed -> :test-fail, not kept"
+                       (and (some? v2) (= :test-fail (:reason v2)) (not (:kept? v2)))))))
+    (p/catch (fn [e] (swap! fail inc) (println "  FAIL (uncaught)" (.-message e))))
+    (p/finally
+      (fn [_ _]
+        (println (str "\n== distill-sandbox (genmlx-8d15): " @pass " passed, " @fail " failed =="))
+        (when (pos? @fail) (set! (.-exitCode js/process) 1)))))

--- a/test/genmlx/distill_test.cljs
+++ b/test/genmlx/distill_test.cljs
@@ -1,0 +1,301 @@
+;; @tier slow
+(ns genmlx.distill-test
+  "Acceptance for genmlx.world.distill — the OFFLINE oracle-filter (the batch twin of
+   genmlx.world.train-reward) that turns teacher completions into an SFT corpus (genmlx-j0d6).
+
+   Deterministic, no teacher LLM (conjugate programs score the EXACT analytical
+   marginal; functions are checked behaviorally). Run:
+     bun run --bun nbb test/genmlx/distill_test.cljs
+
+   PARTS:
+     A — the gate ladder discriminates: valid+correct kept, garbage / non-function /
+         data-ignoring / wrong dropped with the right :reason; program evidence ranks
+         a good fit above a bad fit and matches an INDEPENDENT closed-form oracle.
+     B — rank-and-select keeps the top-k per prompt by evidence/accuracy.
+     C — verdicts->stats computes the corpus-quality rates; build-sft-records emits
+         well-formed Qwen3 chat rows whose assistant turn is the validated code.
+     D — every one of the 12 seed tasks is SOLVABLE (a reference solution is kept) and
+         DISCRIMINATING (a trivial wrong/empty answer is dropped) — the tasks are real."
+  (:require [genmlx.world.distill :as d]
+            [genmlx.world.distill-tasks :as t]
+            [genmlx.world.train-reward :as tr]
+            [genmlx.llm.msa-score :as msa]
+            [clojure.string :as str]))
+
+(def ^:private pass (atom 0))
+(def ^:private fail (atom 0))
+
+(defn assert-true [label v]
+  (if v
+    (do (swap! pass inc) (println "  PASS" label))
+    (do (swap! fail inc) (println "  FAIL" label))))
+
+(defn assert-close [label expected actual tol]
+  (let [ok (and (number? actual) (js/isFinite actual) (<= (js/Math.abs (- expected actual)) tol))]
+    (if ok
+      (do (swap! pass inc) (println "  PASS" label (str "(" actual " ~ " expected ")")))
+      (do (swap! fail inc) (println "  FAIL" label (str "(" actual " vs " expected " tol " tol ")"))))))
+
+;; Independent closed-form gaussian-gaussian marginal (copied from the reward test —
+;; DERIVED outside GenMLX, so the program-evidence check is not circular).
+(defn gaussian-gaussian-marginal [ys m0 s0 sn]
+  (let [n (count ys) s0² (* s0 s0) sn² (* sn sn)
+        ds (map #(- % m0) ys) sd (reduce + ds) sd² (reduce + (map #(* % %) ds))
+        denom (+ sn² (* n s0²))
+        logdet (+ (js/Math.log denom) (* (dec n) (js/Math.log sn²)))
+        quad (* (/ 1.0 sn²) (- sd² (* (/ s0² denom) (* sd sd))))]
+    (- (* -0.5 n (js/Math.log (* 2 js/Math.PI))) (* 0.5 logdet) (* 0.5 quad))))
+
+;; ===========================================================================
+;; PART A — the gate ladder discriminates
+;; ===========================================================================
+
+(def ^:private gm-task (t/tasks-by-id "gaussian-mean-near2"))
+(def ^:private gm-obs (:observations gm-task))
+;; a well-fit shared-mean model (prior near the data, tight noise), wrapped in the
+;; noise an extractor must peel (think block + fence + trailing prose).
+(def ^:private good-model
+  "(fn [trace] (let [mu (trace :mu (dist/gaussian 2 1))] {:y0 (trace :y0 (dist/gaussian mu 0.5)) :y1 (trace :y1 (dist/gaussian mu 0.5)) :y2 (trace :y2 (dist/gaussian mu 0.5)) :y3 (trace :y3 (dist/gaussian mu 0.5))}))")
+(def ^:private good-completion
+  (str "<think> the data sits near 2 ( a stray paren</think>\n```clojure\n" good-model "\n```\nDone."))
+;; a covered-but-badly-fit model (prior mean 50, data near 2): finite, kept, low evidence.
+(def ^:private bad-model
+  "(fn [trace] (let [mu (trace :mu (dist/gaussian 50 1))] {:y0 (trace :y0 (dist/gaussian mu 0.5)) :y1 (trace :y1 (dist/gaussian mu 0.5)) :y2 (trace :y2 (dist/gaussian mu 0.5)) :y3 (trace :y3 (dist/gaussian mu 0.5))}))")
+;; declares a latent but IGNORES the data (traces none of :y0..:y3).
+(def ^:private ignoring-model "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 5))] {:result mu}))")
+
+(defn part-a []
+  (println "\n== PART A: gate ladder discrimination ==")
+
+  ;; ---- program path ----
+  (let [v (d/evaluate-candidate gm-task good-completion 0)]
+    (assert-true "good program: kept" (:kept? v))
+    (assert-true "good program: reason :kept" (= :kept (:reason v)))
+    (assert-true "good program: parsed + evaluated + covered"
+                 (and (:parse? v) (:eval? v) (:covered? v)))
+    (assert-true "good program: finite model evidence as :log-ml (= :rank-key)"
+                 (and (js/isFinite (:log-ml v)) (= (:log-ml v) (:rank-key v))))
+    (assert-true "good program: extracted code is the (fn ...) form (noise peeled)"
+                 (and (str/starts-with? (:code v) "(fn") (str/includes? (:code v) ":y3")))
+    ;; independent oracle: gaussian-gaussian marginal with m0=2 s0=1 sn=0.5
+    (let [oracle (gaussian-gaussian-marginal (map gm-obs [:y0 :y1 :y2 :y3]) 2.0 1.0 0.5)]
+      (println "    program evidence =" (:log-ml v) " method=" (:method v) " oracle=" oracle)
+      (assert-close "good program evidence ~ independent closed-form marginal"
+                    oracle (:log-ml v) 1.0)))
+
+  (let [vbad (d/evaluate-candidate gm-task bad-model 0)
+        vgood (d/evaluate-candidate gm-task good-model 0)]
+    (assert-true "bad-fit program is still kept (covered + finite)" (:kept? vbad))
+    (assert-true "good-fit program out-ranks bad-fit (higher model evidence)"
+                 (> (:rank-key vgood) (:rank-key vbad))))
+
+  (let [v (d/evaluate-candidate gm-task ignoring-model 0)]
+    (assert-true "data-ignoring program dropped (coverage guard)"
+                 (and (not (:kept? v)) (= :uncovered (:reason v)))))
+  (assert-true "garbage program dropped as :unparseable"
+               (= :unparseable (:reason (d/evaluate-candidate gm-task "this is not (((" 0))))
+  (assert-true "empty completion dropped as :empty"
+               (= :empty (:reason (d/evaluate-candidate gm-task "" 0))))
+  (assert-true "a non-model (parses + evaluates, but not a fn) dropped as :eval-error"
+               (= :eval-error (:reason (d/evaluate-candidate gm-task "(+ 1 2)" 0))))
+
+  ;; ---- function path: transitions ----
+  (let [task (t/tasks-by-id "counter-machine")
+        correct "(fn [state action] (case action :inc (update state :count inc) :dec (update state :count dec) :reset (assoc state :count 0) state))"
+        wrong   "(fn [state action] state)"
+        vgood (d/evaluate-candidate task correct 0)
+        vbad  (d/evaluate-candidate task wrong 0)]
+    (assert-true "correct transition fn: kept, accuracy 1.0"
+                 (and (:kept? vgood) (= 1.0 (:accuracy vgood)) (= 1.0 (:rank-key vgood))))
+    (assert-true "wrong transition fn: dropped :test-fail, accuracy < 1"
+                 (and (not (:kept? vbad)) (= :test-fail (:reason vbad)) (< (:accuracy vbad) 1.0)))
+    (assert-true "un-evaluable transition fn: dropped :eval-error"
+                 (= :eval-error (:reason (d/evaluate-candidate task "(fn [state action] (boom!))" 0)))))
+
+  ;; ---- function path: test-cases, incl. a NAMED self-recursive solution ----
+  (let [task (t/tasks-by-id "factorial")
+        recursive "(defn factorial [n] (if (<= n 1) 1 (* n (factorial (dec n)))))"
+        wrong     "(fn [n] (* n n))"
+        vrec (d/evaluate-candidate task recursive 0)]
+    (assert-true "named self-recursive factorial: kept (the defn name is preserved, not anonymized)"
+                 (:kept? vrec))
+    (assert-true "wrong factorial: dropped :test-fail"
+                 (= :test-fail (:reason (d/evaluate-candidate task wrong 0))))))
+
+;; ===========================================================================
+;; PART B — rank-and-select
+;; ===========================================================================
+
+(defn part-b []
+  (println "\n== PART B: rank-and-select top-k per prompt ==")
+  ;; three candidates for one task: good, bad-fit, and garbage; top-1 = good.
+  (let [verdicts [(d/evaluate-candidate gm-task good-model 0)
+                  (d/evaluate-candidate gm-task bad-model 1)
+                  (d/evaluate-candidate gm-task "nonsense" 2)]
+        top1 (d/rank-and-select verdicts 1)
+        top2 (d/rank-and-select verdicts 2)]
+    (assert-true "top-1 selects exactly one survivor" (= 1 (count top1)))
+    (assert-true "top-1 is the higher-evidence (good-fit) candidate"
+                 (= 0 (:sample-idx (first top1))))
+    (assert-true "top-2 keeps both valid survivors (garbage excluded)"
+                 (and (= 2 (count top2)) (every? :kept? top2))))
+  ;; selection is grouped per task: two tasks, top-1 each -> 2 selected.
+  (let [ct (t/tasks-by-id "counter-machine")
+        verdicts [(d/evaluate-candidate gm-task good-model 0)
+                  (d/evaluate-candidate ct "(fn [state action] (case action :inc (update state :count inc) :dec (update state :count dec) :reset (assoc state :count 0) state))" 0)]
+        sel (d/rank-and-select verdicts 1)]
+    (assert-true "top-1-per-task across 2 tasks -> 2 selected"
+                 (= 2 (count (distinct (map :task-id sel)))))))
+
+;; ===========================================================================
+;; PART C — stats + SFT records
+;; ===========================================================================
+
+(defn part-c []
+  (println "\n== PART C: stats + SFT records ==")
+  (let [tasks [{:id "p1" :kind :program} {:id "p2" :kind :program}
+               {:id "f1" :kind :function}]
+        verdicts [{:task-id "p1" :kind :program :parse? true :eval? true :kept? true :reason :kept :log-ml -5.0}
+                  {:task-id "p1" :kind :program :parse? true :eval? true :kept? true :reason :kept :log-ml -7.0}
+                  {:task-id "p2" :kind :program :parse? true :eval? true :kept? false :reason :uncovered}
+                  {:task-id "f1" :kind :function :parse? true :eval? true :kept? true :reason :kept}
+                  {:task-id "f1" :kind :function :parse? false :kept? false :reason :unparseable}]
+        selected (filter :kept? verdicts)
+        s (d/verdicts->stats tasks verdicts selected)]
+    (assert-true "n-candidates counted" (= 5 (:n-candidates s)))
+    (assert-true "n-tasks counted" (= 3 (:n-tasks s)))
+    (assert-close "parse-rate = 4/5" 0.8 (:parse-rate s) 1e-9)
+    (assert-close "eval-rate = 4/5" 0.8 (:eval-rate s) 1e-9)
+    (assert-close "program-pass-rate = 2/3 (kept programs / program candidates)"
+                  (/ 2 3) (:program-pass-rate s) 1e-9)
+    (assert-close "function-pass-rate = 1/2" 0.5 (:function-pass-rate s) 1e-9)
+    (assert-close "mean-log-ml over kept programs = -6.0" -6.0 (:mean-log-ml s) 1e-9)
+    (assert-close "yield-per-prompt = 2/3 prompts produced >=1 kept" (/ 2 3) (:yield-per-prompt s) 1e-9)
+    (assert-true "drop-reasons histogram present (3 kept: p1x2 + f1)"
+                 (= 3 (get (:drop-reasons s) :kept))))
+
+  ;; build-sft-records: chat shape + assistant turn = the validated code.
+  (let [v (d/evaluate-candidate gm-task good-model 0)
+        recs (d/build-sft-records t/tasks-by-id [v])
+        r (first recs)
+        msgs (:messages r)]
+    (assert-true "one SFT record per selected verdict" (= 1 (count recs)))
+    (assert-true "record carries provenance (task-id + kind)"
+                 (and (= "gaussian-mean-near2" (:task-id r)) (= "program" (:kind r))))
+    (assert-true "messages are [system user assistant] with string roles"
+                 (= ["system" "user" "assistant"] (mapv :role msgs)))
+    (assert-true "user turn is the task prompt"
+                 (= (:prompt gm-task) (:content (nth msgs 1))))
+    (assert-true "assistant turn is the ORACLE-VALIDATED code (not the raw completion)"
+                 (= (:code v) (:content (nth msgs 2))))))
+
+;; ===========================================================================
+;; PART D — every seed task is solvable + discriminating
+;; ===========================================================================
+
+(def ^:private reference-solutions
+  {"gaussian-mean-near2"  "(fn [trace] (let [mu (trace :mu (dist/gaussian 2 1))] {:y0 (trace :y0 (dist/gaussian mu 0.5)) :y1 (trace :y1 (dist/gaussian mu 0.5)) :y2 (trace :y2 (dist/gaussian mu 0.5)) :y3 (trace :y3 (dist/gaussian mu 0.5))}))"
+   "gaussian-mean-negshift" "(fn [trace] (let [mu (trace :mu (dist/gaussian -3 1))] {:y0 (trace :y0 (dist/gaussian mu 0.5)) :y1 (trace :y1 (dist/gaussian mu 0.5)) :y2 (trace :y2 (dist/gaussian mu 0.5)) :y3 (trace :y3 (dist/gaussian mu 0.5))}))"
+   "beta-bernoulli-coin"  "(fn [trace] (let [p (trace :p (dist/beta 4 2))] {:f0 (trace :f0 (dist/bernoulli p)) :f1 (trace :f1 (dist/bernoulli p)) :f2 (trace :f2 (dist/bernoulli p)) :f3 (trace :f3 (dist/bernoulli p)) :f4 (trace :f4 (dist/bernoulli p)) :f5 (trace :f5 (dist/bernoulli p))}))"
+   "gamma-poisson-counts" "(fn [trace] (let [rate (trace :rate (dist/gamma 4 1))] {:c0 (trace :c0 (dist/poisson rate)) :c1 (trace :c1 (dist/poisson rate)) :c2 (trace :c2 (dist/poisson rate)) :c3 (trace :c3 (dist/poisson rate)) :c4 (trace :c4 (dist/poisson rate))}))"
+   "counter-machine"      "(fn [state action] (case action :inc (update state :count inc) :dec (update state :count dec) :reset (assoc state :count 0) state))"
+   "traffic-light"        "(fn [state action] (assoc state :light (case (:light state) :red :green :green :yellow :yellow :red)))"
+   "toggle-switch"        "(fn [state action] (if (= action :flip) (update state :on not) state))"
+   "factorial"            "(defn factorial [n] (if (<= n 1) 1 (* n (factorial (dec n)))))"
+   "fizzbuzz"             "(fn [n] (cond (zero? (mod n 15)) \"FizzBuzz\" (zero? (mod n 3)) \"Fizz\" (zero? (mod n 5)) \"Buzz\" :else (str n)))"
+   "gcd"                  "(fn [a b] (if (zero? b) a (recur b (mod a b))))"
+   "palindrome?"          "(fn [s] (= s (apply str (reverse s))))"
+   "sum-evens"            "(fn [coll] (reduce + (filter even? coll)))"})
+
+;; a trivially-wrong answer per task (covered/parseable where needed, but incorrect),
+;; to prove each task's hidden oracle actually DISCRIMINATES (rejects a plausible dud).
+(def ^:private wrong-answers
+  {"counter-machine" "(fn [state action] state)"
+   "traffic-light"   "(fn [state action] state)"
+   "toggle-switch"   "(fn [state action] (assoc state :on true))"
+   "factorial"       "(fn [n] n)"
+   "fizzbuzz"        "(fn [n] (str n))"
+   "gcd"             "(fn [a b] 1)"
+   "palindrome?"     "(fn [s] true)"
+   "sum-evens"       "(fn [coll] (reduce + coll))"})
+
+(defn part-d []
+  (println "\n== PART D: every seed task is solvable + discriminating ==")
+  (assert-true "seed set has 12 tasks" (= 12 (count t/tasks)))
+  (assert-true "task->prompt-record drops the held-out oracle signal (no test leakage)"
+               (let [r (t/task->prompt-record (t/tasks-by-id "factorial"))]
+                 (and (contains? r :prompt) (not (contains? r :test-cases))
+                      (not (contains? r :transitions)) (not (contains? r :observations)))))
+  (doseq [task t/tasks
+          :let [id (:id task)
+                v (d/evaluate-candidate task (reference-solutions id) 0)]]
+    (assert-true (str "[" id "] reference solution is KEPT (task is solvable)") (:kept? v)))
+  (doseq [[id ans] wrong-answers
+          :let [v (d/evaluate-candidate (t/tasks-by-id id) ans 0)]]
+    (assert-true (str "[" id "] a wrong answer is DROPPED (oracle discriminates)")
+                 (not (:kept? v)))))
+
+;; ===========================================================================
+;; PART E — corpus-poisoning guards (from the adversarial review)
+;; ===========================================================================
+
+;; a delta point-mass model: covers every observed address but asserts the data is
+;; deterministic (log-evidence ~0, would out-rank any honest noisy model) — a hack.
+(def ^:private delta-hack
+  "(fn [trace] {:y0 (trace :y0 (dist/delta 2.0)) :y1 (trace :y1 (dist/delta 2.3)) :y2 (trace :y2 (dist/delta 1.7)) :y3 (trace :y3 (dist/delta 2.1))})")
+
+(defn part-e []
+  (println "\n== PART E: corpus-poisoning guards ==")
+
+  ;; ---- :no-oracle — a :function task with no held-out tests keeps NOTHING ----
+  (let [bad-task {:id "no-oracle" :kind :function :prompt "p"}
+        v (d/evaluate-candidate bad-task "(fn [state action] state)" 0)]
+    (assert-true "a :function task with neither transitions nor test-cases keeps no candidate"
+                 (and (not (:kept? v)) (= :no-oracle (:reason v))))
+    (assert-true "empty :test-cases [] is also treated as no-oracle (not a vacuous pass)"
+                 (= :no-oracle (:reason (d/evaluate-candidate
+                                          {:id "e" :kind :function :test-cases []} "(fn [n] n)" 0)))))
+
+  ;; ---- :degenerate — a delta point-mass program is rejected ----
+  (let [v (d/evaluate-candidate gm-task delta-hack 0)]
+    (assert-true "delta point-mass program rejected (covered, but degenerate)"
+                 (and (not (:kept? v)) (= :degenerate (:reason v)))))
+
+  ;; ---- :low-evidence — the optional absolute floor drops a covered-but-awful fit ----
+  (let [vgood (d/evaluate-candidate (assoc gm-task :min-log-ml -10.0) good-model 0)
+        vbad  (d/evaluate-candidate (assoc gm-task :min-log-ml -10.0) bad-model 0)]
+    (assert-true "min-log-ml floor keeps a good fit (evidence above floor)" (:kept? vgood))
+    (assert-true "min-log-ml floor drops a covered-but-awful fit as :low-evidence"
+                 (and (not (:kept? vbad)) (= :low-evidence (:reason vbad)))))
+
+  ;; ---- exact-over-IS ranking tier: a deterministic exact marginal must win the
+  ;;      top-k slot over a higher-but-noisy importance-sampling estimate ----
+  (let [verdicts [{:task-id "p" :kind :program :kept? true :method :handler-is :rank-key -3.0 :code "noisy"}
+                  {:task-id "p" :kind :program :kept? true :method :exact :rank-key -5.0 :code "exact"}]
+        top1 (d/rank-and-select verdicts 1)]
+    (assert-true "kept program records its scoring :method (= :exact for a conjugate model)"
+                 (= :exact (:method (d/evaluate-candidate gm-task good-model 0))))
+    (assert-true "top-1 prefers the EXACT-scored program over a higher-but-noisy-IS one"
+                 (= :exact (:method (first top1)))))
+
+  ;; ---- stats expose task-space coverage alongside the per-prompt hit-rate ----
+  (let [tasks [{:id "p1" :kind :program} {:id "p2" :kind :program} {:id "f1" :kind :function}]
+        verdicts [{:task-id "p1" :kind :program :kept? true :reason :kept :log-ml -5.0 :method :exact}
+                  {:task-id "f1" :kind :function :kept? true :reason :kept}]
+        s (d/verdicts->stats tasks verdicts (filter :kept? verdicts))]
+    (assert-close "task-space-coverage = 2/3 of the full seed set" (/ 2 3) (:task-space-coverage s) 1e-9)
+    (assert-true "n-selected-noisy-is is 0 when no IS-scored program was selected"
+                 (= 0 (:n-selected-noisy-is s)))))
+
+;; ===========================================================================
+
+(defn- summary []
+  (println (str "\n== distill (genmlx-j0d6): " @pass " passed, " @fail " failed =="))
+  (when (pos? @fail) (set! (.-exitCode js/process) 1)))
+
+(part-a)
+(part-b)
+(part-c)
+(part-d)
+(part-e)
+(summary)


### PR DESCRIPTION
## genmlx-j0d6 — offline oracle-filter cljs distillation pipeline

The **batch twin of `world.train-reward`**: turns a teacher LLM's candidate ClojureScript completions into an **oracle-validated SFT corpus**, reusing the *same* native-free oracle (`codegen.eval` + `msa-score` + the reward's extract/coverage guards) so the distilled corpus and the GRPO reward can never drift.

### Pipeline
- **Step 1 — seed tasks** (`distill_tasks.cljs`, 12 tasks). `--export-tasks` projects only the teacher-facing prompt; the held-out oracle (`:observations` / `:transitions` / `:test-cases`) is never exported (no test leakage).
- **Step 2 — teacher** (`distill_teacher.py`, mlx_lm). Offline batch, `--model` swappable, writes `raw_candidates.jsonl`.
- **Steps 3-4 — filter** (`distill.cljs` + `distill_filter.cljs`). Gate ladder → top-k per prompt → `distill_sft.jsonl` + `stats.json` + `verdicts.jsonl` (outputs external; no repo pollution).

Gate ladder:
- `:program` → extract → parse → eval(model) → coverage guard → Bayesian **model evidence** (rank by evidence)
- `:function` → extract → parse → eval-fn → `verify-transition-fn` **or** held-out test-cases (rank by accuracy)

### Verification
- **Unit `test/genmlx/distill_test.cljs`: 66/66** — exact marginal matches an *independent* closed-form gaussian-gaussian oracle to 7 digits; all 12 seed tasks proven solvable + discriminating; corpus-poisoning guards.
- **Real end-to-end on `qwen3.5-4b`** (a 32GB-safe instruct teacher; the production Qwen3-Coder-Next runs off-box): 70 candidates → **45 kept → 23 SFT rows**, `task-space-coverage 1.0`, `mean-log-ml -8.17`, `n-selected-noisy-is 0`. Kept completions eyeballed: valid + idiomatic (priors adapted — `beta(10,5)`/`gamma(5,1)`; named recursive `factorial`/`gcd`; `palindrome?` handles `""`).

### Review
A 29-agent adversarial review (oracle-correctness / corpus-hacking / idiomaticity / robustness), each finding skeptic-verified → 18 confirmed → **7 fixes applied**: `:no-oracle` guard, `:degenerate` delta-point-mass guard, exact-over-IS ranking tier + `:method` recording, malformed-JSONL resilience, numeric-arg validation, `top-k 1` default + optional `--min-log-ml` floor, `task-space-coverage` stat.

### Known follow-ups (beans under milestone genmlx-8587)
- **HIGH — execution-timeout sandbox**: untrusted `:function` candidates can non-terminate (the real teacher emitted `(reduce * (iterate identity n))` and a swapped-arg `gcd` `recur`); single-threaded JS can't preempt a sync loop, so this needs child-process isolation. Interim: drop hangers + OS `timeout` + a flushed progress log.
- seeded reproducible IS scoring, relative-margin corpus floor, expanded held-out test density, fn+prose recovery.

### Test
```
bun run --bun nbb test/genmlx/distill_test.cljs   # 66/66
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
