### PR TITLE
feat(train): cljs-coder SFT harness — oracle-graded held-out LoRA loop (genmlx-o8w9)

### DIFF
--- a/scripts/distill_teacher.py
+++ b/scripts/distill_teacher.py
@@ -1,10 +1,21 @@
 #!/usr/bin/env python3
-"""Teacher generation for the cljs-coder distillation loop (genmlx-j0d6, step 2).
+"""Teacher/student generation for the cljs-coder distillation+SFT loop (genmlx-j0d6 /
+genmlx-o8w9, step 2 and the eval step).
 
-Reads task prompts (exported by `distill_filter.cljs --export-tasks`), runs a teacher
-LLM N times per prompt via mlx-lm, and writes raw_candidates.jsonl for the GenMLX
-oracle-filter (step 3). This is the ONLY step that touches the big model; it is a
-decoupled batch job whose only interface to GenMLX is the candidates file.
+Reads task prompts (exported by `distill_filter.cljs --export-tasks` or
+`sft_prep.cljs --export-{train,eval}-tasks`), runs an LLM N times per prompt via mlx-lm,
+and writes raw_candidates.jsonl for the GenMLX oracle (the distill filter, or sft_eval).
+This is the ONLY step that touches a model; it is a decoupled batch job whose only
+interface to GenMLX is the candidates file.
+
+TWO ROLES, ONE PROMPT RENDERING
+  - TEACHER (corpus build): a strong model over the TRAIN tasks -> raw_candidates.jsonl.
+  - STUDENT (SFT eval): the small student, with or without a LoRA --adapter, over the
+    held-out EVAL tasks -> baseline/sft candidates for sft_eval.cljs.
+  Both go through the SAME build_prompt with enable_thinking=False, so the chat template
+  pre-fills a CLOSED EMPTY <think></think> block and the model emits the code form
+  directly — no populated reasoning block ever appears (and the GenMLX oracle strips any
+  residual <think> defensively). Teacher and student therefore render identically.
 
 ENGINE / MACHINE NOTES
   - mlx-lm is METAL-ONLY (Apple Silicon). On the Jetson Thor (CUDA) use vLLM /
@@ -15,8 +26,12 @@ ENGINE / MACHINE NOTES
     valid/invalid mix to exercise the filter. Swap with --model for the real teacher.
 
 USAGE
+  # teacher (corpus):
   python scripts/distill_teacher.py --tasks <tasks.jsonl> --out <raw_candidates.jsonl> \\
       [--model <dir-or-hf-id>] [--n 8] [--max-tokens 512] [--temp 0.8] [--limit K]
+  # student eval (greedy sample 0 for pass@1, then K sampled for pass@k):
+  python scripts/distill_teacher.py --tasks <eval_tasks.jsonl> --out <cands.jsonl> \\
+      --model <student> [--adapter <lora_path>] --greedy-first --n 5
 """
 
 import argparse
@@ -55,6 +70,12 @@ def main():
     ap.add_argument("--out", required=True, help="raw_candidates.jsonl to write")
     ap.add_argument("--model", default="qwen25-coder-3b-4bit",
                     help="local ~/.cache/models/<name> dir or an HF/mlx-community id")
+    ap.add_argument("--adapter", default=None,
+                    help="optional LoRA adapter dir (mlx-lm adapter_path) — for grading "
+                         "an SFT'd student against its own baseline")
+    ap.add_argument("--greedy-first", action="store_true",
+                    help="make sample_idx 0 GREEDY (temperature 0) so sft_eval can read "
+                         "it as the pass@1 sample; samples 1.. use --temp/--top-p")
     ap.add_argument("--n", type=int, default=8, help="samples per prompt")
     ap.add_argument("--max-tokens", type=int, default=512)
     ap.add_argument("--temp", type=float, default=0.8)
@@ -73,12 +94,15 @@ def main():
         tasks = tasks[: args.limit]
 
     model_path = resolve_model(args.model)
-    print(f"Loading teacher: {model_path}", flush=True)
+    adapter = resolve_model(args.adapter) if args.adapter else None
+    print(f"Loading model: {model_path}"
+          + (f"  (+LoRA adapter {adapter})" if adapter else ""), flush=True)
     t0 = time.time()
-    model, tokenizer = load(model_path)
+    model, tokenizer = load(model_path, adapter_path=adapter)
     print(f"  loaded in {time.time() - t0:.1f}s", flush=True)
 
     sampler = make_sampler(temp=args.temp, top_p=args.top_p)
+    greedy_sampler = make_sampler(temp=0.0)  # argmax — for the pass@1 sample
 
     n_written = 0
     with open(args.out, "w") as out:
@@ -87,8 +111,10 @@ def main():
             print(f"[{ti + 1}/{len(tasks)}] {task['task_id']} "
                   f"({task.get('kind')}) x{args.n}", flush=True)
             for s in range(args.n):
+                use_greedy = args.greedy_first and s == 0
                 text = generate(model, tokenizer, prompt=prompt,
-                                max_tokens=args.max_tokens, sampler=sampler,
+                                max_tokens=args.max_tokens,
+                                sampler=(greedy_sampler if use_greedy else sampler),
                                 verbose=False)
                 out.write(json.dumps({
                     "task_id": task["task_id"],

--- a/scripts/sft_eval.cljs
+++ b/scripts/sft_eval.cljs
@@ -1,0 +1,151 @@
+(ns genmlx.sft-eval
+  "Held-out evaluation runner for the cljs-coder SFT step (genmlx-o8w9). The thin I/O
+   shell that grades a BASELINE student and an SFT'd student on the held-out eval tasks
+   with the EXACT j0d6 oracle, then reports the lift.
+
+   It reuses, unchanged:
+     - the oracle gate ladder    genmlx.world.distill/evaluate-candidate
+     - the timeout/process sandbox genmlx.world.distill-sandbox/collect-verdicts
+       (student code is untrusted — a non-terminating completion is killed and recorded
+        :timeout, exactly as for teacher candidates)
+     - the in-tree tasks          genmlx.world.distill-tasks (the eval tasks live here;
+       they are held out from TRAINING, never from the oracle)
+     - the pure report core       genmlx.world.sft/eval-report (pass@k + cold-start)
+
+   USAGE
+     bun run --bun nbb scripts/sft_eval.cljs \\
+       --baseline <baseline_candidates.jsonl> --sft <sft_candidates.jsonl> \\
+       --out <dir> [--k 4] [--n-particles 50] [--timeout-ms 15000]
+
+   Each candidates file holds the student's completions for the held-out EVAL tasks
+   (produced by scripts/distill_teacher.py pointed at the student model, --greedy-first
+   so sample_idx 0 is the greedy/temperature-0 sample and 1.. are temperature-sampled):
+     {task_id, sample_idx, raw_text}
+
+   Writes <dir>/{eval_report.json}, and prints a baseline-vs-SFT pass@1/pass@k table
+   with a per-kind breakdown and a cold-start flag (baseline pass@k == 0 → unreachable;
+   neither SFT nor GRPO can lift it, so it bounds the achievable ceiling)."
+  (:require [genmlx.world.sft :as sft]
+            [genmlx.world.distill-tasks :as t]
+            [genmlx.world.distill-sandbox :as sb]
+            [clojure.string :as str]
+            [promesa.core :as p]))
+
+(def fs (js/require "fs"))
+(def path-mod (js/require "path"))
+
+(defn- ensure-dir [dir]
+  (when-not (.existsSync fs dir) (.mkdirSync fs dir #js {:recursive true})))
+
+(defn- default-out-dir []
+  (.join path-mod (or (.. js/process -env -TMPDIR) "/tmp") "genmlx-sft"))
+
+(defn- parse-args [argv]
+  (loop [args (seq argv), m {}]
+    (if-let [a (first args)]
+      (if (str/starts-with? a "--")
+        (let [k (keyword (subs a 2)), v (second args)]
+          (if (and v (not (str/starts-with? v "--")))
+            (recur (nnext args) (assoc m k v))
+            (recur (next args) (assoc m k true))))
+        (recur (next args) m))
+      m)))
+
+(defn- pos-int-or [s d]
+  (if (string? s) (let [n (js/parseInt s 10)] (if (or (js/isNaN n) (< n 1)) d n)) d))
+
+(defn- float-or-nil [s]
+  (when (string? s) (let [x (js/parseFloat s)] (when-not (js/isNaN x) x))))
+
+(defn- write-json [path data]
+  (.writeFileSync fs path (js/JSON.stringify (clj->js data) nil 2)))
+
+(defn- fmt [x] (.toFixed (js/Number x) 3))
+
+(defn- grade
+  "Sandbox-grade one candidates file (a student's eval completions). Returns a promise
+   of the verdict vector."
+  [label candidates out-dir eval-opts timeout-ms]
+  (println (str "  grading " label " (" candidates ") ..."))
+  (sb/collect-verdicts candidates
+                       {:out-path   (.join path-mod out-dir (str "_eval_" label ".edn"))
+                        :eval-opts  eval-opts
+                        :timeout-ms timeout-ms :poll-ms 400 :verbose? false}))
+
+(defn- print-table [report]
+  (let [k (:k report)]
+    (println (str "\n== held-out eval: baseline vs SFT (pass@1 greedy / pass@" k ") =="))
+    (println (str (.padEnd "task" 26) (.padEnd "kind" 10)
+                  (.padEnd "base p@1" 10) (.padEnd "sft p@1" 10)
+                  (.padEnd (str "base p@" k) 10) (.padEnd (str "sft p@" k) 10) "cold?"))
+    (println (str "  (base-cold = baseline pass@" k " 0; sft-cold = SFT pass@" k " 0 → GRPO-unreachable)"))
+    (doseq [r (:tasks report)]
+      (println (str (.padEnd (str (:task-id r)) 26) (.padEnd (str (:kind r)) 10)
+                    (.padEnd (fmt (:pass1-greedy (:baseline r))) 10)
+                    (.padEnd (fmt (:pass1-greedy (:sft r))) 10)
+                    (.padEnd (fmt (:passk (:baseline r))) 10)
+                    (.padEnd (fmt (:passk (:sft r))) 10)
+                    (str (when (:cold-start? r) "base-cold ")
+                         (when (:sft-cold? r) "SFT-COLD")))))
+    (let [a (:aggregate report)]
+      (println (str "\n  aggregate pass@1: baseline " (fmt (:baseline-pass1 a))
+                    " -> SFT " (fmt (:sft-pass1 a))
+                    "   (Δ " (fmt (:delta-pass1 a)) ")"))
+      (println (str "  aggregate pass@" k ": baseline " (fmt (:baseline-passk a))
+                    " -> SFT " (fmt (:sft-passk a))
+                    "   (Δ " (fmt (:delta-passk a)) ")"))
+      (println (str "  base-cold (baseline pass@" k " = 0): " (:n-cold-start a) "/" (:n-tasks a)
+                    "  — SFT must generalize from train-task demos to lift these"))
+      (println (str "  SFT-cold  (SFT pass@" k " = 0): " (:n-sft-cold a) "/" (:n-tasks a)
+                    "  — the GRPO step (genmlx-2ctu) has no reward signal here; this bounds the loop's ceiling")))
+    (println "\n  per-kind:")
+    (doseq [[kind m] (:by-kind report)]
+      (println (str "    " (.padEnd (str kind) 10)
+                    "pass@1 " (fmt (:baseline-pass1 m)) "->" (fmt (:sft-pass1 m))
+                    "  pass@" k " " (fmt (:baseline-passk m)) "->" (fmt (:sft-passk m)))))))
+
+(defn- warn-non-eval!
+  "Symmetric to the corpus-side assert-train-disjoint!: warn loudly if any graded
+   candidate references a NON-held-out (train) task — its pass@k is then not a held-out
+   measurement and would inflate the reported lift (genmlx-o8w9 review)."
+  [verdicts]
+  (let [non-eval (distinct (remove sft/eval-task? (map :task-id verdicts)))]
+    (when (seq non-eval)
+      (println (str "  WARNING: graded candidates reference NON-held-out task(s): "
+                    (str/join ", " non-eval)
+                    "\n           these are TRAIN tasks — their pass@k is NOT a held-out"
+                    " measurement (did you point --baseline/--sft at the wrong file? use"
+                    " sft_prep --export-eval-tasks).")))))
+
+(defn- run! [{:keys [baseline sft out k n-particles timeout-ms min-log-ml]}]
+  (let [out-dir (or out (default-out-dir))
+        kk      (pos-int-or k 4)
+        n-part  (pos-int-or n-particles 50)
+        tmo     (pos-int-or timeout-ms 15000)
+        ;; thread the SAME model-evidence floor the corpus was filtered with, so eval
+        ;; grading and corpus validation use the identical oracle gate (genmlx-o8w9 review).
+        min-ml  (float-or-nil min-log-ml)
+        eopts   (cond-> {:n-particles n-part} min-ml (assoc :min-log-ml min-ml))]
+    (ensure-dir out-dir)
+    (when min-ml (println (str "  applying model-evidence floor --min-log-ml " min-ml
+                               " (must match the corpus build)")))
+    (p/let [b-verdicts (grade "baseline" baseline out-dir eopts tmo)
+            s-verdicts (grade "sft" sft out-dir eopts tmo)]
+      (warn-non-eval! (concat b-verdicts s-verdicts))
+      (let [report (assoc (sft/eval-report b-verdicts s-verdicts kk t/tasks-by-id)
+                          :min-log-ml min-ml :n-particles n-part)]
+        (write-json (.join path-mod out-dir "eval_report.json") report)
+        (print-table report)
+        (println (str "\nWrote " (.join path-mod out-dir "eval_report.json")))))))
+
+;; ---------------------------------------------------------------------------
+
+(let [opts (parse-args (vec (drop 2 (.-argv js/process))))]
+  (if (and (:baseline opts) (:sft opts))
+    (-> (p/resolved nil)
+        (p/then (fn [_] (run! opts)))
+        (p/catch (fn [e] (println "ERROR:" (.-message e))
+                   (set! (.-exitCode js/process) 1))))
+    (do (println "usage:")
+        (println "  --baseline <baseline_candidates.jsonl> --sft <sft_candidates.jsonl> --out <dir> [--k 4] [--n-particles 50] [--timeout-ms 15000] [--min-log-ml F]")
+        (set! (.-exitCode js/process) 1))))

--- a/scripts/sft_lora.yaml
+++ b/scripts/sft_lora.yaml
@@ -1,0 +1,13 @@
+# LoRA adapter hyperparameters for the cljs-coder SFT step (genmlx-o8w9).
+# Consumed via:  python -m mlx_lm lora -c scripts/sft_lora.yaml ...
+#
+# rank 16 / scale 20 mirrors the proven cljs FIM run (lora_config_v2.yaml). On the
+# qwen3.5-0.8b-bf16 student a 32GB Mac mini trains this comfortably; the ceiling-raiser
+# qwen3.5-4b-bf16 also fits at this rank under LoRA (not full FT). A small dropout guards
+# against overfitting the small distilled corpus (the distilled set is high-value but
+# tiny until genmlx-7473 scales it). Everything else (num-layers, iters, batch, lr,
+# max-seq-length, --mask-prompt) is passed as a flag by scripts/sft_train.sh.
+lora_parameters:
+  rank: 16
+  scale: 20.0
+  dropout: 0.05

--- a/scripts/sft_prep.cljs
+++ b/scripts/sft_prep.cljs
@@ -1,0 +1,170 @@
+(ns genmlx.sft-prep
+  "Data-prep runner for the cljs-coder SFT step (genmlx-o8w9). The thin I/O shell around
+   the pure core (genmlx.world.sft) — twin of scripts/distill_filter.cljs.
+
+   THREE MODES
+
+     1. Export the TRAIN tasks for the teacher (the split happens BEFORE generation, so
+        the corpus is built only over train tasks and the eval tasks stay truly held-out):
+          bun run --bun nbb scripts/sft_prep.cljs --export-train-tasks <tasks.jsonl>
+
+     2. Export the held-out EVAL tasks for student generation at eval time:
+          bun run --bun nbb scripts/sft_prep.cljs --export-eval-tasks <eval_tasks.jsonl>
+
+        Both exports write the TEACHER-FACING projection only ({task_id, kind,
+        system_prompt, prompt}) — the held-out oracle signal never leaves the tree.
+
+     3. Build an mlx-lm LoRA data dir from a distilled corpus:
+          bun run --bun nbb scripts/sft_prep.cljs \\
+            --corpus <distill_sft.jsonl> --out <dir> \\
+            [--pairs <training_pairs.jsonl>] [--blend N] [--valid-frac 0.15]
+        --corpus      the oracle-validated rows from distill_filter (step 3 output)
+        --pairs       optional volume corpus (already {messages} chat rows) to blend in
+        --blend N     how many volume rows to append behind the distilled rows (default 0)
+        --valid-frac  fraction of the train rows held out as the mlx-lm validation set
+                      (loss monitoring / early-stopping — NOT the held-out pass@1 eval;
+                      default 0.15)
+        Writes <dir>/{train.jsonl, valid.jsonl}, rows = {\"messages\":[...]}. ASSERTS that
+        no held-out eval-task row entered training (aborts with a non-zero exit on leak),
+        and logs row/task counts.
+
+   Outputs default to an EXTERNAL scratch dir ($TMPDIR/genmlx-sft) so nothing lands in
+   the repo."
+  (:require [genmlx.world.sft :as sft]
+            [genmlx.world.distill-tasks :as t]
+            [clojure.string :as str]))
+
+(def fs (js/require "fs"))
+(def path-mod (js/require "path"))
+
+(defn- ensure-dir [dir]
+  (when-not (.existsSync fs dir)
+    (.mkdirSync fs dir #js {:recursive true})))
+
+(defn- default-out-dir []
+  (let [tmp (or (.. js/process -env -TMPDIR) "/tmp")]
+    (.join path-mod tmp "genmlx-sft")))
+
+(defn- parse-args [argv]
+  (loop [args (seq argv), m {}]
+    (if-let [a (first args)]
+      (if (str/starts-with? a "--")
+        (let [k (keyword (subs a 2))
+              v (second args)]
+          (if (and v (not (str/starts-with? v "--")))
+            (recur (nnext args) (assoc m k v))
+            (recur (next args) (assoc m k true))))
+        (recur (next args) m))
+      m)))
+
+(defn- read-jsonl
+  "Read a JSONL file into a vector of keywordized maps; a malformed line is skipped
+   and counted. Returns {:rows [...] :skipped n}."
+  [path]
+  (let [lines  (remove str/blank? (str/split-lines (.readFileSync fs path "utf8")))
+        parsed (map (fn [l] (try (js->clj (js/JSON.parse l) :keywordize-keys true)
+                                 (catch :default _ ::bad)))
+                    lines)]
+    {:rows    (vec (remove #(= ::bad %) parsed))
+     :skipped (count (filter #(= ::bad %) parsed))}))
+
+(defn- write-jsonl [path rows]
+  (.writeFileSync fs path (str (str/join "\n" (map #(js/JSON.stringify (clj->js %)) rows))
+                               (when (seq rows) "\n"))))
+
+(defn- pos-int-or [s d]
+  (if (string? s)
+    (let [n (js/parseInt s 10)] (if (or (js/isNaN n) (neg? n)) d n))
+    d))
+
+(defn- frac-or [s d]
+  (if (string? s)
+    (let [x (js/parseFloat s)] (if (js/isNaN x) d x))
+    d))
+
+;; ---------------------------------------------------------------------------
+;; Mode 1/2 — export teacher-facing task prompts for one side of the split.
+;; ---------------------------------------------------------------------------
+
+(defn- export-side! [path which tasks]
+  (ensure-dir (.dirname path-mod path))
+  (write-jsonl path (map t/task->prompt-record tasks))
+  (println (str "Exported " (count tasks) " " (name which) " task prompts -> " path))
+  (println (str "  ids: " (str/join ", " (map :id tasks))))
+  (println "  (held-out oracle signal NOT included — no test leakage)"))
+
+;; ---------------------------------------------------------------------------
+;; Mode 3 — build the mlx-lm LoRA data dir.
+;; ---------------------------------------------------------------------------
+
+(defn- build-data-dir! [{:keys [corpus out pairs blend valid-frac]}]
+  (let [out-dir (or out (default-out-dir))
+        n-blend (pos-int-or blend 0)
+        vfrac   (frac-or valid-frac 0.15)
+        {:keys [rows skipped]} (read-jsonl corpus)
+        ;; 1. partition by task: drop any held-out eval-task row, report it.
+        {:keys [train-rows dropped-eval eval-task-ids-present train-task-ids]}
+        (sft/partition-corpus rows)
+        ;; 2. HARD leakage guard — abort if any eval row survived into training.
+        _ (sft/assert-train-disjoint! train-rows)
+        ;; 3. strip provenance -> bare {messages}; optionally blend volume rows.
+        distilled (mapv sft/row->messages train-rows)
+        vol       (when (and pairs (pos? n-blend)) (:rows (read-jsonl pairs)))
+        blended   (sft/blend distilled (vec vol) n-blend)
+        ;; 4. carve a validation slice for mlx-lm loss monitoring.
+        {:keys [train valid]} (sft/valid-split blended vfrac)]
+    (ensure-dir out-dir)
+    (write-jsonl (.join path-mod out-dir "train.jsonl") train)
+    (write-jsonl (.join path-mod out-dir "valid.jsonl") valid)
+    (println (str "Read " (count rows) " distilled rows from " corpus
+                  (when (pos? skipped) (str " (" skipped " malformed skipped)"))))
+    (when (seq dropped-eval)
+      (println (str "  DROPPED " (count dropped-eval) " held-out eval-task row(s): "
+                    (str/join ", " eval-task-ids-present) " (never trained on)")))
+    (when (and pairs (pos? n-blend))
+      (println (str "  Blended " (min n-blend (count vol)) " volume rows from " pairs)))
+    (println (str "  train tasks present: " (str/join ", " train-task-ids)))
+    (println (str "\nWrote mlx-lm data dir -> " out-dir))
+    (println (str "  train.jsonl: " (count train) " rows"))
+    (println (str "  valid.jsonl: " (count valid) " rows"))
+    (println (str "  (" (count distilled) " distilled + "
+                  (max 0 (- (count blended) (count distilled))) " volume = "
+                  (count blended) " total, split " vfrac " to valid)"))
+    ;; Honesty: partition-corpus + assert-train-disjoint! guarantee the DISTILLED rows are
+    ;; disjoint from the held-out eval tasks. Blended volume rows carry no :task-id, so the
+    ;; task-id guard cannot see them — say so rather than print an unconditional ✓ (genmlx-o8w9 review).
+    (if (and pairs (pos? n-blend))
+      (println (str "\n  LEAKAGE GUARD: distilled rows are disjoint from held-out eval tasks ["
+                    (str/join ", " (sort sft/eval-task-ids)) "] ✓"
+                    "\n  NOTE: " (min n-blend (count vol)) " blended volume rows are NOT task-id-screened"
+                    " (general-cljs corpus, no :task-id) — assumed task-neutral."))
+      (println (str "\n  LEAKAGE GUARD: held-out eval tasks ["
+                    (str/join ", " (sort sft/eval-task-ids)) "] are absent from training ✓")))))
+
+;; ---------------------------------------------------------------------------
+
+(let [opts (parse-args (vec (drop 2 (.-argv js/process))))
+      {:keys [train eval]} (sft/split-tasks t/tasks)]
+  (cond
+    (:export-train-tasks opts)
+    (export-side! (if (string? (:export-train-tasks opts)) (:export-train-tasks opts)
+                      (.join path-mod (default-out-dir) "train_tasks.jsonl"))
+                  :train train)
+
+    (:export-eval-tasks opts)
+    (export-side! (if (string? (:export-eval-tasks opts)) (:export-eval-tasks opts)
+                      (.join path-mod (default-out-dir) "eval_tasks.jsonl"))
+                  :eval eval)
+
+    (:corpus opts)
+    (try (build-data-dir! opts)
+         (catch :default e
+           (println "ERROR:" (.-message e))
+           (set! (.-exitCode js/process) 1)))
+
+    :else
+    (do (println "usage:")
+        (println "  --export-train-tasks <tasks.jsonl>")
+        (println "  --export-eval-tasks <eval_tasks.jsonl>")
+        (println "  --corpus <distill_sft.jsonl> --out <dir> [--pairs <pairs.jsonl>] [--blend N] [--valid-frac 0.15]")
+        (set! (.-exitCode js/process) 1))))

--- a/scripts/sft_train.sh
+++ b/scripts/sft_train.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# LoRA SFT for the cljs-coder student (genmlx-o8w9, loop step 3/5).
+#
+# Trains a LoRA adapter on the qwen3.5 student over the oracle-validated, instruct/chat
+# corpus prepared by scripts/sft_prep.cljs, then fuses it into a standalone model the
+# GRPO step (genmlx-2ctu) and the GenMLX owned-forward (@genmlx/core) can reload.
+#
+# This is INSTRUCT SFT, not FIM: --mask-prompt trains the loss on the assistant turn only.
+# The prior cljs fine-tunes failed STRUCTURALLY (qwen2 arch + FIM objective) — this path fixes both.
+#
+# <think> CONSISTENCY (genmlx-o8w9 review): mlx-lm renders SFT training rows with the chat
+# template DEFAULT (it exposes no enable_thinking knob), while distill_teacher.py GENERATES with
+# enable_thinking=False (a CLOSED EMPTY <think></think>). For qwen3.5-0.8b the template default IS
+# closed-think, so train render == inference render and the student learns to emit code directly.
+# For qwen3.5-4b the template default is OPEN-think, so the two diverge. The CHECK_THINK preflight
+# below ABORTS on any such mismatch, so a student can never silently train in the wrong <think>
+# context. (Fix for a mismatched model: pre-render a {text} corpus or override its template default.)
+#
+# 32GB-SAFE CONFIG (defaults below; override via env):
+#   STUDENT      qwen3.5-0.8b-mlx-bf16  (the loop workhorse; = what GRPO loads)
+#                qwen3.5-4b-mlx-bf16    (the ceiling-raiser; also fits 32GB under LoRA)
+#   rank/scale   scripts/sft_lora.yaml  (rank 16, scale 20, dropout 0.05)
+#   NUM_LAYERS   8   (last N of 24; -1 = all. 8 is a small-corpus default; raise with scale)
+#   ITERS        200 (smoke. A meaningful run after genmlx-7473 scales the corpus: ~600-1500)
+#   BATCH        1   (tiny corpus; raise to 2-4 once the corpus is larger)
+#   LR           1e-5
+#   MAXSEQ       2048 (system+user+assistant fit easily; completions are short forms)
+#
+# USAGE
+#   # 1. build the data dir first:
+#   bun run --bun nbb scripts/sft_prep.cljs --corpus <distill_sft.jsonl> --out $TMPDIR/genmlx-sft
+#   # 2. train + fuse:
+#   bash scripts/sft_train.sh
+#   # override anything:
+#   STUDENT=qwen3.5-4b-mlx-bf16 ITERS=800 NUM_LAYERS=-1 bash scripts/sft_train.sh
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+MODELS="$HOME/.cache/models"
+TMP="${TMPDIR:-/tmp}"
+
+STUDENT="${STUDENT:-qwen3.5-0.8b-mlx-bf16}"
+DATA="${DATA:-$TMP/genmlx-sft}"
+ADAPTER="${ADAPTER:-$MODELS/${STUDENT}-cljs-sft-lora}"
+FUSED="${FUSED:-$MODELS/${STUDENT}-cljs-sft-fused}"
+NUM_LAYERS="${NUM_LAYERS:-8}"
+ITERS="${ITERS:-200}"
+BATCH="${BATCH:-1}"
+LR="${LR:-1e-5}"
+MAXSEQ="${MAXSEQ:-2048}"
+FUSE="${FUSE:-1}"
+LOG="${LOG:-$DATA/train.log}"
+
+MODEL="$MODELS/$STUDENT"
+[ -d "$MODEL" ] || { echo "ERROR: student model not found: $MODEL" >&2; exit 1; }
+[ -f "$DATA/train.jsonl" ] || { echo "ERROR: $DATA/train.jsonl missing — run sft_prep.cljs first" >&2; exit 1; }
+[ -f "$DATA/valid.jsonl" ] || { echo "ERROR: $DATA/valid.jsonl missing — run sft_prep.cljs first" >&2; exit 1; }
+
+echo "Student:  $MODEL"
+echo "Data:     $DATA ($(wc -l < "$DATA/train.jsonl" | tr -d ' ') train, $(wc -l < "$DATA/valid.jsonl" | tr -d ' ') valid)"
+echo "Adapter:  $ADAPTER"
+echo "Config:   rank=16 (sft_lora.yaml), layers=$NUM_LAYERS, iters=$ITERS, batch=$BATCH, lr=$LR, maxseq=$MAXSEQ, mask-prompt"
+echo "Log:      $LOG"
+echo ""
+
+# <think> train/inference consistency preflight (genmlx-o8w9). mlx-lm trains with the chat
+# template DEFAULT; distill_teacher.py infers with enable_thinking=False. If they disagree
+# for this model, abort rather than train a student in a different <think> context than it
+# will see at inference. Disable with CHECK_THINK=0 (e.g. once a {text} corpus is pre-rendered).
+if [ "${CHECK_THINK:-1}" = "1" ]; then
+  echo "Preflight: chat-template default vs enable_thinking=False ..."
+  if ! python3 - "$MODEL" <<'PYCHK'
+import sys
+from transformers import AutoTokenizer
+tok = AutoTokenizer.from_pretrained(sys.argv[1])
+user = [{"role": "user", "content": "x"}]
+# A = mlx-lm's prompt-mask boundary render: default template, add_generation_prompt=True
+# (this is the context the model is CONDITIONED on during --mask-prompt training).
+A = tok.apply_chat_template(user, add_generation_prompt=True, tokenize=False)
+# B = distill_teacher.py inference render: enable_thinking=False, add_generation_prompt=True.
+try:
+    B = tok.apply_chat_template(user, add_generation_prompt=True, tokenize=False, enable_thinking=False)
+except TypeError:
+    B = A  # template ignores the flag -> A IS the no-think render
+if A == B:
+    print("  OK: training mask-boundary render == enable_thinking=False inference render")
+    sys.exit(0)
+print("  MISMATCH: this model's DEFAULT generation-prompt differs from enable_thinking=False.")
+print("    train boundary:", repr(A[-30:]))
+print("    inference     :", repr(B[-30:]))
+print("    mlx-lm --mask-prompt conditions training on the DEFAULT prompt; distill_teacher.py")
+print("    infers with enable_thinking=False, so the student trains in a different <think> context")
+print("    (e.g. qwen3.5-4b's default leaves <think> OPEN; it would learn to emit the closing")
+print("    </think> that inference already supplies). Use a student whose default matches")
+print("    (qwen3.5-0.8b), pre-render a {text} corpus with the closed-think prefix baked in, or")
+print("    override this model's chat_template default.")
+sys.exit(1)
+PYCHK
+  then
+    echo "ABORTING: train/inference <think> render mismatch for $STUDENT (set CHECK_THINK=0 to override)"
+    exit 9
+  fi
+fi
+
+mkdir -p "$ADAPTER" "$(dirname "$LOG")"
+
+python3 -m mlx_lm lora \
+  -c "$DIR/sft_lora.yaml" \
+  --model "$MODEL" \
+  --data "$DATA" \
+  --train \
+  --fine-tune-type lora \
+  --mask-prompt \
+  --num-layers "$NUM_LAYERS" \
+  --batch-size "$BATCH" \
+  --iters "$ITERS" \
+  --learning-rate "$LR" \
+  --max-seq-length "$MAXSEQ" \
+  --steps-per-report 20 \
+  --steps-per-eval 50 \
+  --val-batches -1 \
+  --save-every 100 \
+  --adapter-path "$ADAPTER" 2>&1 | tee "$LOG"
+
+echo ""
+echo "LoRA adapter written -> $ADAPTER"
+
+if [ "$FUSE" = "1" ]; then
+  echo "Fusing adapter into a standalone model -> $FUSED"
+  python3 -m mlx_lm fuse \
+    --model "$MODEL" \
+    --adapter-path "$ADAPTER" \
+    --save-path "$FUSED"
+  # mlx_lm.fuse may shard large models; merge shards so the GenMLX owned-forward loader
+  # (@genmlx/core) sees a single model.safetensors. No-op for a single-shard small model.
+  if ls "$FUSED"/model-*.safetensors >/dev/null 2>&1; then
+    echo "  merging safetensors shards -> model.safetensors"
+    python3 -c "
+import mlx.core as mx, os, glob
+p='$FUSED'
+shards=sorted(glob.glob(os.path.join(p,'model-*.safetensors')))
+t={}
+for s in shards: t.update(mx.load(s))
+mx.save_safetensors(os.path.join(p,'model.safetensors'), t)
+print('  merged', len(shards), 'shards')
+"
+  fi
+  echo "Fused student -> $FUSED  (reloadable by GenMLX / the GRPO step)"
+fi
+
+echo ""
+echo "DONE. Next: grade baseline vs SFT on the held-out eval tasks:"
+echo "  bun run --bun nbb scripts/sft_prep.cljs --export-eval-tasks $DATA/eval_tasks.jsonl"
+echo "  python3 scripts/distill_teacher.py --model $STUDENT               --tasks $DATA/eval_tasks.jsonl --out $DATA/eval_baseline.jsonl --greedy-first --n 5"
+echo "  python3 scripts/distill_teacher.py --model $STUDENT --adapter $ADAPTER --tasks $DATA/eval_tasks.jsonl --out $DATA/eval_sft.jsonl      --greedy-first --n 5"
+echo "  bun run --bun nbb scripts/sft_eval.cljs --baseline $DATA/eval_baseline.jsonl --sft $DATA/eval_sft.jsonl --out $DATA --k 4"

--- a/src/genmlx/world/sft.cljs
+++ b/src/genmlx/world/sft.cljs
@@ -1,0 +1,259 @@
+(ns genmlx.world.sft
+  "Pure core for the cljs-coder SFT step (genmlx-o8w9) — loop step 3 of 5
+   (corpus → **SFT** → GRPO → iterate).
+
+   THE OFFLINE-PREP + EVAL TWIN of `genmlx.world.distill`. Where distill BUILDS the
+   oracle-validated SFT corpus from a teacher's candidates, this namespace (a) SPLITS
+   that corpus into a training set and a leakage-guarded held-out eval set, (b) shapes
+   the training rows for mlx-lm LoRA, and (c) scores the SFT'd student on the held-out
+   tasks with the EXACT SAME oracle (`genmlx.world.distill/evaluate-candidate`, via the
+   `distill-sandbox` timeout worker). Corpus-validation and eval-grading therefore use
+   ONE oracle — they can never silently disagree about what a 'good' completion is, the
+   same invariant distill enforces between the filter and the GRPO reward.
+
+   This file is PURE: data shaping + pass@k arithmetic only. No model loading, no file
+   or process I/O (mlx-lm trains/generates; the thin shells scripts/sft_prep.cljs and
+   scripts/sft_eval.cljs do the I/O and call the sandbox grader). That is why the whole
+   leakage guarantee, the corpus split, and the pass@k math are unit-testable here with
+   synthetic rows — no GPU, no LLM.
+
+   Sections:
+     1. The canonical TRAIN / EVAL task split (held-out, leakage-guarded)
+     2. Corpus prep — distill_sft rows → mlx-lm {messages} train/valid rows
+     3. pass@k arithmetic (Chen et al. 2021 unbiased estimator)
+     4. Eval reporting — baseline-vs-SFT table + cold-start guard"
+  (:require [clojure.string :as str]))
+
+;; ===========================================================================
+;; 1. The canonical TRAIN / EVAL task split
+;; ===========================================================================
+
+(def eval-task-ids
+  "The held-out EVAL task ids — ONE per oracle family, chosen so pass@1 covers BOTH
+   oracle paths (model-evidence for :program, behavioral for :function) while leaving
+   enough same-family train signal:
+
+     gaussian-mean-negshift  :program  — train sees gaussian-mean-near2 + beta-bernoulli
+                                          + gamma-poisson (conjugate-program transfer)
+     traffic-light           :function — train sees counter-machine + toggle-switch
+                                          (state-machine transfer)
+     palindrome?             :function — train sees factorial/fizzbuzz/gcd/sum-evens
+                                          (pure-function/test-case transfer)
+
+   These tasks' completions MUST NEVER enter the training corpus — the rrps test-split
+   leakage lesson (a validation-on-train win evaporated on a disjoint test split). The
+   split is at the TASK level, before generation: the teacher generates the corpus over
+   TRAIN tasks only, and the student is graded on EVAL tasks it was never trained on."
+  #{"gaussian-mean-negshift"
+    "traffic-light"
+    "palindrome?"})
+
+(defn eval-task?
+  "True iff a seed task (or anything with an :id) is in the held-out eval set."
+  [task-or-id]
+  (contains? eval-task-ids (if (map? task-or-id) (:id task-or-id) task-or-id)))
+
+(defn train-task?
+  "True iff a seed task is NOT held out (its completions may train the student)."
+  [task-or-id]
+  (not (eval-task? task-or-id)))
+
+(defn split-tasks
+  "Partition a seed task seq into {:train [...] :eval [...]} by `eval-ids`
+   (default `eval-task-ids`). Input order is preserved within each side."
+  ([tasks] (split-tasks tasks eval-task-ids))
+  ([tasks eval-ids]
+   (let [in-eval? #(contains? eval-ids (:id %))]
+     {:train (vec (remove in-eval? tasks))
+      :eval  (vec (filter in-eval? tasks))})))
+
+;; ===========================================================================
+;; 2. Corpus prep — distill_sft rows → mlx-lm chat rows
+;; ===========================================================================
+
+(defn row->messages
+  "Strip a distill_sft row {:task-id :kind :rank-key :messages [...]} to the bare
+   mlx-lm chat record {:messages [...]} — the trainer must see ONLY the conversation,
+   never the provenance keys (which could otherwise be mistaken for input features)."
+  [row]
+  {:messages (:messages row)})
+
+(defn assert-train-disjoint!
+  "Defensive post-condition: throw if any row belongs to a held-out EVAL task. The actual
+   leakage prevention is done by partition-corpus (which DROPS eval-task rows by construction);
+   this re-checks that the training set partition-corpus produced is genuinely clean, and also
+   serves as a real load-bearing guard when applied to RAW (un-partitioned) corpus rows. Returns
+   `rows` unchanged on success so it can wrap a pipeline."
+  ([rows] (assert-train-disjoint! rows eval-task-ids))
+  ([rows eval-ids]
+   (let [leaked (filter #(contains? eval-ids (:task-id %)) rows)]
+     (when (seq leaked)
+       (throw (ex-info (str "LEAKAGE: " (count leaked)
+                            " corpus row(s) belong to held-out eval task(s) "
+                            (str/join ", " (distinct (map :task-id leaked))))
+                       {:eval-ids eval-ids
+                        :leaked-task-ids (vec (distinct (map :task-id leaked)))})))
+     rows)))
+
+(defn partition-corpus
+  "Split distill_sft `rows` into the training set, DROPPING (never silently keeping)
+   any held-out eval-task rows. Disjointness is enforced here by construction and the
+   dropped set is reported, not folded in. Returns:
+     {:train-rows           [...]   ; rows whose :task-id is a TRAIN task
+      :dropped-eval         [...]   ; rows that belonged to a held-out eval task
+      :train-task-ids       #{...}  ; distinct train task ids actually present
+      :eval-task-ids-present #{...}} ; held-out ids that appeared (should be empty if
+                                       the teacher only generated over train tasks)"
+  ([rows] (partition-corpus rows eval-task-ids))
+  ([rows eval-ids]
+   (let [{train true dropped false} (group-by #(train-task? (:task-id %)) rows)]
+     {:train-rows            (vec train)
+      :dropped-eval          (vec dropped)
+      :train-task-ids        (into (sorted-set) (map :task-id) train)
+      :eval-task-ids-present (into (sorted-set) (map :task-id) dropped)})))
+
+(defn valid-split
+  "Deterministically carve a validation slice out of `rows` for mlx-lm early-stopping /
+   loss monitoring. Every `stride`-th row (stride derived from `frac`) goes to valid,
+   the rest to train. Validation draws from TRAIN tasks — it monitors training loss and
+   is NOT the held-out pass@1 eval (a different, task-disjoint set). Guarantees a
+   non-empty train AND valid whenever `rows` has ≥2 rows (mlx-lm requires both)."
+  [rows frac]
+  (let [n (count rows)]
+    (if (< n 2)
+      {:train (vec rows) :valid (vec rows)} ; degenerate: reuse the row(s) so both files exist
+      (let [stride (max 2 (js/Math.round (/ 1.0 (max frac 1e-9))))
+            tagged (map-indexed vector rows)
+            v?     (fn [[i _]] (zero? (mod (inc i) stride)))
+            valid  (mapv second (filter v? tagged))
+            train  (mapv second (remove v? tagged))]
+        {:train (if (seq train) train (vec (butlast rows)))
+         :valid (if (seq valid) valid [(last rows)])}))))
+
+(defn blend
+  "Interleave volume rows into the high-value distilled rows for LoRA volume. The
+   distilled `head` rows lead (highest signal); up to `n` `volume` rows fill behind
+   them. Deterministic (takes the first `n` volume rows — the caller pre-shuffles if a
+   random draw is wanted). Both inputs are already {:messages ...} records."
+  [head volume n]
+  (vec (concat head (take (max 0 n) volume))))
+
+;; ===========================================================================
+;; 3. pass@k arithmetic — Chen et al. (2021) unbiased estimator
+;; ===========================================================================
+
+(defn pass-at-k
+  "Unbiased pass@k estimate (Chen et al. 2021, the HumanEval estimator): given `n`
+   i.i.d. samples of which `c` are correct, the probability that `k` uniformly-drawn
+   samples contain ≥1 correct is
+
+       1 − C(n−c, k) / C(n, k)  =  1 − ∏_{i=n−c+1}^{n} (1 − k/i)
+
+   The product form is numerically stable (no big binomials). Edge cases: 0.0 when
+   c=0 (no correct sample can be drawn) or n≤0; 1.0 when n−c < k (every draw must hit a
+   correct one). `k` is clamped to ≤ n by the (n−c<k ⇒ 1.0) branch."
+  [n c k]
+  (cond
+    (<= n 0)     0.0
+    (<= c 0)     0.0
+    (< (- n c) k) 1.0
+    :else        (- 1.0 (reduce * (for [i (range (inc (- n c)) (inc n))]
+                                    (- 1.0 (/ k i)))))))
+
+(defn passk-of
+  "Pass-rates for ONE task's sample verdicts. `verdicts` are that task's graded samples
+   (each carrying :kept? and :sample-idx). By the generation convention sample-idx 0 is
+   the GREEDY (temperature-0) sample and 1.. are temperature-sampled. Returns:
+     {:n :c                  ; total / kept count over the SAMPLED (idx≥1) verdicts
+      :pass1-greedy         ; 1.0/0.0 — did the greedy (idx 0) sample pass?
+      :passk}               ; unbiased pass@k over the sampled verdicts at `k`
+   When there is no idx-0 verdict (greedy not generated), :pass1-greedy falls back to
+   pass-at-k over the sampled set at k=1."
+  [verdicts k]
+  (let [greedy   (first (filter #(= 0 (:sample-idx %)) verdicts))
+        sampled  (filter #(pos? (or (:sample-idx %) 0)) verdicts)
+        n        (count sampled)
+        c        (count (filter :kept? sampled))
+        kk       (min k (max 1 n))]
+    {:n n
+     :c c
+     :pass1-greedy (cond
+                      greedy        (if (:kept? greedy) 1.0 0.0)
+                      (pos? n)      (pass-at-k n c 1)
+                      :else         0.0)
+     :passk (pass-at-k n c kk)}))
+
+;; ===========================================================================
+;; 4. Eval reporting — baseline-vs-SFT table + cold-start guard
+;; ===========================================================================
+
+(defn- by-task [verdicts] (group-by :task-id verdicts))
+
+(defn- mean [xs] (if (seq xs) (/ (reduce + xs) (count xs)) 0.0))
+
+(defn eval-report
+  "Build the baseline-vs-SFT comparison from graded eval verdicts. `baseline` and `sft`
+   are verdict seqs over the SAME held-out eval tasks (each verdict {:task-id :kind
+   :sample-idx :kept? ...}). `tasks-by-id` maps task-id → seed task (for :kind / order).
+   Returns:
+     {:k k
+      :tasks [{:task-id :kind
+               :baseline {:n :c :pass1-greedy :passk}
+               :sft      {...}
+               :delta-pass1 :delta-passk
+               :cold-start?      ; baseline pass@k 0 AND greedy fails → the base policy never
+                                 ;   reaches a correct solution at all. SFT may still lift it by
+                                 ;   generalizing from train-task demos; a reward-only method could not.
+               :sft-cold?}]      ; SFT pass@k 0 AND greedy fails → even after SFT it is unreachable,
+                                 ;   so the downstream GRPO step (genmlx-2ctu) has no reward signal to
+                                 ;   sharpen — THIS is what bounds the loop's achievable ceiling.
+      :aggregate {:baseline-pass1 :sft-pass1 :delta-pass1
+                  :baseline-passk :sft-passk :delta-passk
+                  :n-cold-start :n-sft-cold :n-tasks}
+      :by-kind {<kind> {:baseline-pass1 :sft-pass1 :delta-pass1 ...}}}"
+  [baseline sft k tasks-by-id]
+  (let [b-by   (by-task baseline)
+        s-by   (by-task sft)
+        ;; Preserve first-appearance order from the verdicts. The candidates are generated
+        ;; in task-export order and collect-verdicts returns them sorted by row index, so
+        ;; first-appearance IS the canonical task order. Do NOT sort by (vals tasks-by-id):
+        ;; a >8-key CLJS map iterates in hash order, not insertion order (genmlx-o8w9 review).
+        ids    (distinct (concat (map :task-id baseline) (map :task-id sft)))
+        rows   (for [id ids
+                     :let [bk (passk-of (get b-by id) k)
+                           sk (passk-of (get s-by id) k)
+                           kind (name (:kind (get tasks-by-id id) :unknown))]]
+                 {:task-id      id
+                  :kind         kind
+                  :baseline     bk
+                  :sft          sk
+                  :delta-pass1 (- (:pass1-greedy sk) (:pass1-greedy bk))
+                  :delta-passk (- (:passk sk) (:passk bk))
+                  ;; "cold" = genuinely unreachable: NEITHER the temperature samples (passk)
+                  ;; NOR the greedy sample reach a correct solution. A greedy-only success is
+                  ;; reachable (just not by the sampled set), so it is NOT cold (genmlx-o8w9 review).
+                  :cold-start?  (and (zero? (:passk bk)) (zero? (:pass1-greedy bk)))
+                  :sft-cold?    (and (zero? (:passk sk)) (zero? (:pass1-greedy sk)))})
+        agg-fn (fn [sel rs] (mean (map sel rs)))]
+    {:k k
+     :tasks (vec rows)
+     :aggregate
+     {:n-tasks         (count rows)
+      :baseline-pass1 (agg-fn (comp :pass1-greedy :baseline) rows)
+      :sft-pass1      (agg-fn (comp :pass1-greedy :sft) rows)
+      :delta-pass1    (agg-fn :delta-pass1 rows)
+      :baseline-passk (agg-fn (comp :passk :baseline) rows)
+      :sft-passk      (agg-fn (comp :passk :sft) rows)
+      :delta-passk    (agg-fn :delta-passk rows)
+      :n-cold-start    (count (filter :cold-start? rows))
+      :n-sft-cold      (count (filter :sft-cold? rows))}
+     :by-kind
+     (into {}
+           (for [[kind rs] (group-by :kind rows)]
+             [kind {:n-tasks         (count rs)
+                    :baseline-pass1 (agg-fn (comp :pass1-greedy :baseline) rs)
+                    :sft-pass1      (agg-fn (comp :pass1-greedy :sft) rs)
+                    :delta-pass1    (agg-fn :delta-pass1 rs)
+                    :baseline-passk (agg-fn (comp :passk :baseline) rs)
+                    :sft-passk      (agg-fn (comp :passk :sft) rs)
+                    :delta-passk    (agg-fn :delta-passk rs)}]))}))

--- a/test/genmlx/sft_test.cljs
+++ b/test/genmlx/sft_test.cljs
@@ -1,0 +1,176 @@
+(ns genmlx.sft-test
+  "Tests for the pure SFT core (genmlx.world.sft, genmlx-o8w9): the leakage-guarded
+   train/eval task split, mlx-lm corpus shaping, the Chen-et-al. pass@k estimator, and
+   the baseline-vs-SFT report. Pure data + arithmetic — no GPU, no LLM, no I/O.
+
+   Run: bun run --bun nbb test/genmlx/sft_test.cljs"
+  (:require [genmlx.world.sft :as sft]
+            [genmlx.world.distill-tasks :as t]
+            [clojure.set]
+            [clojure.string :as str]))
+
+(def ^:private fails (atom 0))
+(def ^:private passes (atom 0))
+
+(defn assert-true [desc x]
+  (if x (do (swap! passes inc) (println (str "  ok   " desc)))
+        (do (swap! fails inc) (println (str "  FAIL " desc)))))
+
+(defn assert-eq [desc expected actual]
+  (assert-true (str desc " (expected " (pr-str expected) ", got " (pr-str actual) ")")
+               (= expected actual)))
+
+(defn assert-close [desc expected actual tol]
+  (assert-true (str desc " (expected " expected ", got " actual ")")
+               (< (js/Math.abs (- expected actual)) tol)))
+
+(defn assert-throws [desc thunk]
+  (assert-true desc (try (thunk) false (catch :default _ true))))
+
+;; ===========================================================================
+(println "\n== 1. train/eval task split ==")
+
+(let [{:keys [train eval]} (sft/split-tasks t/tasks)]
+  (assert-eq "12 seed tasks total" 12 (count t/tasks))
+  (assert-eq "3 held-out eval tasks" 3 (count eval))
+  (assert-eq "9 train tasks" 9 (count train))
+  (assert-true "train/eval are disjoint by id"
+               (empty? (clojure.set/intersection
+                         (set (map :id train)) (set (map :id eval)))))
+  (assert-true "eval set is exactly the canonical ids"
+               (= sft/eval-task-ids (set (map :id eval))))
+  (assert-true "eval covers BOTH oracle kinds (program + function)"
+               (= #{:program :function} (set (map :kind eval))))
+  (assert-true "each eval task has same-family train siblings"
+               (every? (fn [et]
+                         (some #(= (:kind et) (:kind %)) train))
+                       eval)))
+
+(assert-true "eval-task? true for a held-out id"  (sft/eval-task? "palindrome?"))
+(assert-true "eval-task? false for a train id"     (not (sft/eval-task? "factorial")))
+(assert-true "train-task? is the complement"       (sft/train-task? "factorial"))
+(assert-true "eval-task? accepts a task map"        (sft/eval-task? {:id "traffic-light"}))
+
+;; ===========================================================================
+(println "\n== 2. corpus prep / leakage guard ==")
+
+(def ^:private sample-rows
+  [{:task-id "factorial" :kind "function" :rank-key 1.0
+    :messages [{:role "user" :content "fac"} {:role "assistant" :content "(fn [n] 1)"}]}
+   {:task-id "gcd" :kind "function" :rank-key 1.0
+    :messages [{:role "user" :content "gcd"} {:role "assistant" :content "(fn [a b] a)"}]}
+   {:task-id "gaussian-mean-near2" :kind "program" :rank-key -8.0
+    :messages [{:role "user" :content "g"} {:role "assistant" :content "(fn [trace] {})"}]}])
+
+(let [m (sft/row->messages (first sample-rows))]
+  (assert-eq "row->messages keeps only :messages" [:messages] (keys m))
+  (assert-true "row->messages preserves the conversation"
+               (= (:messages (first sample-rows)) (:messages m))))
+
+(assert-true "assert-train-disjoint! passes a clean (train-only) corpus"
+             (= sample-rows (sft/assert-train-disjoint! sample-rows)))
+
+(assert-throws "assert-train-disjoint! throws when an eval-task row leaks in"
+               #(sft/assert-train-disjoint!
+                  (conj sample-rows
+                        {:task-id "palindrome?" :kind "function" :rank-key 1.0
+                         :messages [{:role "assistant" :content "(fn [s] true)"}]})))
+
+(let [leaky (conj sample-rows
+                  {:task-id "traffic-light" :kind "function" :rank-key 1.0
+                   :messages [{:role "assistant" :content "x"}]})
+      {:keys [train-rows dropped-eval eval-task-ids-present]} (sft/partition-corpus leaky)]
+  (assert-eq "partition-corpus keeps the 3 train rows" 3 (count train-rows))
+  (assert-eq "partition-corpus drops the 1 eval row" 1 (count dropped-eval))
+  (assert-eq "partition-corpus reports which eval id leaked"
+             #{"traffic-light"} (set eval-task-ids-present))
+  (assert-true "the partitioned train-rows survive the disjointness assertion"
+               (= train-rows (sft/assert-train-disjoint! train-rows))))
+
+;; ===========================================================================
+(println "\n== 3. valid-split / blend ==")
+
+(let [rows (mapv (fn [i] {:messages [{:role "assistant" :content (str i)}]}) (range 10))
+      {:keys [train valid]} (sft/valid-split rows 0.2)]
+  (assert-true "valid-split: train non-empty" (seq train))
+  (assert-true "valid-split: valid non-empty" (seq valid))
+  (assert-eq "valid-split: no rows lost" 10 (+ (count train) (count valid)))
+  (assert-true "valid-split: train and valid are disjoint"
+               (empty? (clojure.set/intersection (set train) (set valid)))))
+
+(let [{:keys [train valid]} (sft/valid-split [{:messages [:only]}] 0.2)]
+  (assert-true "valid-split degenerate (1 row): both files non-empty"
+               (and (seq train) (seq valid))))
+
+(let [head [{:messages [:d0]} {:messages [:d1]}]
+      vol  (mapv (fn [i] {:messages [(keyword (str "v" i))]}) (range 100))
+      out  (sft/blend head vol 5)]
+  (assert-eq "blend: head leads, n volume appended" 7 (count out))
+  (assert-eq "blend: distilled rows come first" head (vec (take 2 out)))
+  (assert-eq "blend: takes the first n volume rows" {:messages [:v0]} (nth out 2)))
+
+;; ===========================================================================
+(println "\n== 4. pass@k estimator (Chen et al. 2021) ==")
+
+(assert-close "pass@k: c=0 -> 0"            0.0 (sft/pass-at-k 5 0 1) 1e-9)
+(assert-close "pass@k: all correct -> 1"    1.0 (sft/pass-at-k 5 5 1) 1e-9)
+(assert-close "pass@1, n=5 c=1 -> 1/5"      0.2 (sft/pass-at-k 5 1 1) 1e-9)
+(assert-close "pass@1, n=5 c=2 -> 2/5"      0.4 (sft/pass-at-k 5 2 1) 1e-9)
+(assert-close "pass@2, n=5 c=1 -> 0.4"      0.4 (sft/pass-at-k 5 1 2) 1e-9)
+(assert-close "pass@2, n=5 c=2 -> 0.7"      0.7 (sft/pass-at-k 5 2 2) 1e-9)
+(assert-close "pass@k: n-c<k -> 1 (k=5,c=1)" 1.0 (sft/pass-at-k 5 1 5) 1e-9)
+(assert-close "pass@1, n=200 c=100 -> 0.5"  0.5 (sft/pass-at-k 200 100 1) 1e-9)
+
+(let [mk (fn [idx kept?] {:task-id "x" :kind :function :sample-idx idx :kept? kept?})
+      verdicts [(mk 0 false) (mk 1 true) (mk 2 false) (mk 3 true) (mk 4 false)]
+      r (sft/passk-of verdicts 4)]
+  (assert-eq "passk-of: n = sampled count (idx>=1)" 4 (:n r))
+  (assert-eq "passk-of: c = kept among sampled" 2 (:c r))
+  (assert-close "passk-of: greedy (idx 0) failed -> pass@1-greedy 0" 0.0 (:pass1-greedy r) 1e-9)
+  (assert-close "passk-of: pass@4 with c=2/4 -> 1.0" 1.0 (:passk r) 1e-9))
+
+(let [mk (fn [idx kept?] {:task-id "x" :kind :function :sample-idx idx :kept? kept?})
+      verdicts [(mk 0 true) (mk 1 false) (mk 2 false)]
+      r (sft/passk-of verdicts 2)]
+  (assert-close "passk-of: greedy passed -> pass@1-greedy 1" 1.0 (:pass1-greedy r) 1e-9)
+  (assert-close "passk-of: pass@2 with c=0/2 -> 0" 0.0 (:passk r) 1e-9))
+
+;; ===========================================================================
+(println "\n== 5. eval-report / cold-start guard ==")
+
+(let [mk (fn [tid kind idx kept?] {:task-id tid :kind kind :sample-idx idx :kept? kept?})
+      tasks-by-id {"palindrome?" {:id "palindrome?" :kind :function}
+                   "gaussian-mean-negshift" {:id "gaussian-mean-negshift" :kind :program}}
+      ;; palindrome?: baseline 0 kept of 3 (cold for greedy, but 0 sampled kept -> cold-start),
+      ;;              sft 2 kept of 3 + greedy kept  -> a lift
+      baseline (concat [(mk "palindrome?" :function 0 false)
+                        (mk "palindrome?" :function 1 false)
+                        (mk "palindrome?" :function 2 false)]
+                       [(mk "gaussian-mean-negshift" :program 0 true)
+                        (mk "gaussian-mean-negshift" :program 1 true)
+                        (mk "gaussian-mean-negshift" :program 2 false)])
+      sft-v    (concat [(mk "palindrome?" :function 0 true)
+                        (mk "palindrome?" :function 1 true)
+                        (mk "palindrome?" :function 2 false)]
+                       [(mk "gaussian-mean-negshift" :program 0 true)
+                        (mk "gaussian-mean-negshift" :program 1 true)
+                        (mk "gaussian-mean-negshift" :program 2 true)])
+      report (sft/eval-report baseline sft-v 2 tasks-by-id)
+      pal    (first (filter #(= "palindrome?" (:task-id %)) (:tasks report)))]
+  (assert-eq "eval-report: 2 eval tasks" 2 (:n-tasks (:aggregate report)))
+  (assert-true "eval-report: palindrome? flagged base-cold (baseline pass@k 0)"
+               (:cold-start? pal))
+  (assert-true "eval-report: palindrome? NOT sft-cold (SFT lifted it off zero)"
+               (not (:sft-cold? pal)))
+  (assert-eq "eval-report: 1 base-cold task" 1 (:n-cold-start (:aggregate report)))
+  (assert-eq "eval-report: 0 sft-cold tasks (SFT reaches both)" 0 (:n-sft-cold (:aggregate report)))
+  (assert-true "eval-report: SFT pass@1 >= baseline pass@1 in aggregate"
+               (>= (:sft-pass1 (:aggregate report)) (:baseline-pass1 (:aggregate report))))
+  (assert-true "eval-report: SFT shows a non-negative pass@k delta"
+               (>= (:delta-passk (:aggregate report)) 0.0))
+  (assert-true "eval-report: per-kind breakdown has program + function"
+               (= #{"program" "function"} (set (keys (:by-kind report))))))
+
+;; ===========================================================================
+(println (str "\n== SUMMARY: " @passes " passed, " @fails " failed =="))
+(when (pos? @fails) (set! (.-exitCode js/process) 1))


### PR DESCRIPTION
## What

Loop step 3/5 of the cljs-coder distillation loop (corpus → **SFT** → GRPO → iterate, `genmlx-o8w9`). SFT the small cljs student on the j0d6 oracle-validated corpus via **mlx-lm LoRA** (instruct/chat, **not** FIM), then measure the lift with a **leakage-guarded, oracle-graded held-out** pass@1/pass@k.

The harness reuses the **exact j0d6 oracle** (`distill/evaluate-candidate` via the `distill-sandbox` timeout worker) for grading, so corpus-validation and eval-grading can never silently disagree about what a "good" completion is.

## Files

- **`src/genmlx/world/sft.cljs`** — pure core: canonical train/eval task split (held-out, leakage-guarded), `distill_sft` → mlx-lm `{messages}` shaping, Chen-2021 unbiased pass@k, baseline-vs-SFT report with `base-cold`/`sft-cold` guards.
- **`scripts/sft_prep.cljs`** — export train/eval task prompts; build the mlx-lm data dir (partition by task, drop+report held-out rows, optional volume blend, valid split).
- **`scripts/sft_eval.cljs`** — grade baseline vs SFT on held-out tasks via the j0d6 oracle; `--min-log-ml` threaded to match the corpus filter; symmetric non-eval-task guard.
- **`scripts/sft_train.sh`** + **`scripts/sft_lora.yaml`** — 32GB-safe LoRA config + fuse; a `<think>` train/inference **preflight**.
- **`scripts/distill_teacher.py`** — `+--adapter +--greedy-first`: one generation path serves teacher and student, both `enable_thinking=False` (no populated `<think>` block).
- **`test/genmlx/sft_test.cljs`** — 49/49 (split/leakage, corpus shaping, pass@k, report).

## The `<think>` preflight

mlx-lm renders SFT training rows with the chat-template **default**, while `distill_teacher.py` generates with `enable_thinking=False`. For `qwen3.5-0.8b` the default is closed-`<think>` → train render == inference render (consistent). For `qwen3.5-4b` the default leaves `<think>` **open**, so the student would train to emit the closing `</think>` that inference already supplies. `sft_train.sh` aborts on this mismatch (overridable via `CHECK_THINK=0`).

## Review

6-dimension adversarial review (leakage, oracle-reuse, pass@k math, `<think>`, mlx-lm compat, CLJS correctness) → **8 findings confirmed and fixed**, 1 false positive dropped.

## Verified end-to-end (32GB Mac mini M4)

- LoRA trains on the owned `qwen3_5` hybrid arch (0.479% trainable).
- **Teacher bake-off** (9 train tasks): qwen3.5-4b = generalist (9/9, both kinds); qwen3-0.6b-cljs = program-specialist (beats 4b on model-evidence, fails functions); union corpus = best-per-task.
- **SFT smoke = honest negative** (overfit at 12-task scale — the harness *caught* the regression via the held-out eval, rather than reporting a fake win).

## Scope / not in this PR

Harness is buildable + smoke-verified now. A **meaningful lift is gated on corpus scale** (`genmlx-7473`); then GRPO sharpening (`genmlx-2ctu`). The overfit is a task-*diversity* problem, so a stronger teacher alone won't fix it until the task set grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
