### PR TITLE
Phase 1 + 2: REPL-synthesis kernel + particle/beam search over edits (genmlx-n74t, genmlx-47zx)

### DIFF
--- a/docs/programmer-as-genmlx-model.md
+++ b/docs/programmer-as-genmlx-model.md
@@ -1,0 +1,325 @@
+# The Programmer as a GenMLX Model — REPL-driven, resource-rational program synthesis
+
+*Design doc behind bean **genmlx-d4q4**. The north star for advanced GenMLX model synthesis:
+model an experienced Clojure programmer who builds probabilistic models REPL-first — propose a
+small form, eval it, read the feedback, revise, compose upward — **as a GenMLX generative
+function**, so that program synthesis becomes *inference over the programmer-GF*. Empirical
+motivation: `docs/cljs-coder-loop-results.md` §6–7 (whole-program best-of-K cliffs for BOTH the
+0.8B and the 35B — it is the one-shot *interface*, not capability).*
+
+---
+
+## 1. The thesis: synthesis = inference over a programmer-GF
+
+If the programmer is a GF, the search, the metareasoner, the LLMs, and the oracle stop being
+separate machinery and become *parts of one generative function*. The deep structure is a
+**fixpoint — a GenMLX model that synthesizes GenMLX models** — with GenMLX inference appearing at
+two levels:
+
+- **Object model** — the thing being built (linreg / hierarchy / GMM / Kalman). Trace = the
+  data-generating latents + observations.
+- **Meta model = the programmer** — a GF whose **latent is "a program"** and whose **observation
+  is "the data is well-explained by that program."** Its trace = the *development trajectory*.
+  Inference over it (targeting high model evidence) **is** program synthesis.
+
+This is the natural consequence of the project's standing principle *an agent is a GF and
+inference is pluggable* (`genmlx.agents`): the programmer is an agent whose environment is the
+**REPL + the GenMLX oracle**; its state is the current partial program; its actions are edits;
+its observations are eval feedback + evidence; its policy is the LLM proposers + the metareasoner.
+
+## 2. The traces — the development trajectory
+
+The programmer-GF's trace is the REPL session itself: an `Unfold`/`Scan` over construction steps,
+each step a few trace sites. Illustrative skeleton (GenMLX `gen`/`trace`, aspirational):
+
+```clojure
+(def programmer
+  (gen [data goal]
+    ;; SYSTEM 2 — the architect sketches a decomposition (rare, big model)
+    (let [plan (trace :plan (planner-llm (describe data goal)))]
+      (loop [prog (empty-model), t 0]
+        (let [act (trace [t :edit] (controller-policy prog plan))]    ; metareason: which edit?
+          (if (= act :stop)                                            ; resource-rational stop
+            prog
+            (let [tier (trace [t :which] (escalate? prog act))         ; :fast 0.8b | :slow big ← System 1/2
+                  form (trace [t :form]  (propose tier act prog        ; the concrete cljs form…
+                                           {:grammar genmlx-instaparse}))  ; …constrained valid
+                  prog' (apply-edit prog form)
+                  chk   (check prog' data)    ; ← SELF-CHECK in-process: parse / schema / eval / evidence
+                  keep? (trace [t :accept] (accept-policy chk))]       ; condition on verified feedback
+              (recur (if keep? prog' prog) (inc t)))))))))
+```
+
+**Trace sites (random choices) = the programmer's decisions:** `:plan`; per step `:edit`
+(add-latent / add-obs / wrap-combinator / refactor / fix / stop), `:which` (fast vs slow),
+`:form` (the code), `:accept` (keep / revise / backtrack). **The observations it conditions on**
+are the `check` results — parse status, eval value/error, schema validity, partial-model
+**evidence**. **The weight/likelihood** of the whole trace is the oracle evidence of the
+synthesized model, so `generate`/SMC over `programmer` given `data` *automatically targets
+high-evidence programs*; the intermediate evidences are the SMC intermediate weights.
+
+**The second meaning of "traces" — self-generated training data.** The GFI trace of a
+*successful* run records `(partial-program, feedback) → edit-chosen` at every step. Run inference
+over the programmer-GF (big model + oracle as teacher), keep the high-evidence trajectories, and
+their traces **are** the `(partial + feedback → next edit)` SFT corpus for the fast proposer. The
+programmer generates its own oracle-filtered training data *by being a GF you can run inference
+over*. GRPO then sharpens the proposer at its `:form` sites with evidence as the verifiable reward
+(the GFI-reward GRPO infra already exists, genmlx-ugkv/2ctu).
+
+## 3. The role of each LLM — distributions at trace sites
+
+Each LLM is a `DynamicGF` plugged in at a site, so the whole GFI applies:
+
+| faculty | model | site(s) | cadence |
+|---|---|---|---|
+| **planner / architect** (decompose, pick structure) | big off-the-shelf (qwen3.5 → Coder-Next) | `:plan`, escalated `:form` | rare (System 2) |
+| **proposer** (next form / local edit) | small fast specialist (0.8b-cljs) | high-frequency `:form` | very high (System 1) |
+| **controller** (which edit / which tier / accept) | tiny model or learned softmax | `:edit` `:which` `:accept` | the metareasoner |
+| **verifier** ("did it work / fit?") | **the GenMLX oracle — never an LLM** | the `check` node + the weight | every step, exact |
+
+Fast/slow thinking is literally the `:which` trace site; the metareasoner is the *learnable
+policy* over it. The search strategies become **GenMLX inference over `programmer`**, not bolted-on
+heuristics: `simulate` = synthesize once; `generate` w/ constraints = "build a model that uses a
+Kalman combinator" (condition `:plan`) or "finish this partial"; **SMC** = a *population of
+programmers* exploring trajectories, resampled by partial evidence (best-of-K becomes a principled
+particle filter over development paths); **regenerate/MCMC** = reconsider an earlier decision given
+later feedback (backtracking *as inference*); the metareasoner's expected-utility lookahead reuses
+the `genmlx.agents` machinery.
+
+## 4. Self-checking — why it is a GF, not just an agent loop
+
+`check` runs *inside the programmer's own body* — four complementary verifiers at four altitudes,
+all in-process, and the fitness one is **exact math, not an LLM-judge**:
+
+| level | checker | answers | substrate |
+|---|---|---|---|
+| **syntax** | instaparse / reader-as-grammar | well-formed GenMLX form? | `genmlx.llm.grammar`/`bytes`/`codegen` |
+| **semantics** | **malli** + GenMLX schema | well-formed *model*? (covers data, types/arities, no delta-hack) | `schema.cljs` + malli |
+| **behavior** | **SCI eval** | does it run / error? | `codegen.eval` (in-process) |
+| **fit** | **the oracle** (`score-model*`) | does it explain the data? (the likelihood) | analytical evidence / IS |
+
+The programmer is a **self-conditioning generative model**: its later choices (`:accept`, the next
+`:edit`) are conditioned on the *verified* results of its earlier choices. It **contains its own
+verifier**, and that verifier is *exact* — which is exactly why this beats a generic LLM agent loop
+(whose "self-critique" is another unreliable generation). It also makes the trace *trustworthy as
+training data*: only verified-good trajectories become SFT corpus.
+
+### instaparse — the *support* of the proposal distribution
+instaparse (with the reader-as-grammar) is the grammar constraint at `:form`, composed via the same
+`dispatch/with-handler` middleware as analytical conditioning. It gives the proposer support **only
+over syntactically-valid GenMLX** — `(trace :kw (dist/NAME args…))` with real distributions and real
+`mx` ops — so it **kills a whole class of the §8 failures at generation time** (malformed parens,
+hallucinated `mx/0`/`mx/infer`) instead of at eval. Two tiers: edamame = "valid cljs," instaparse =
+"valid GenMLX *model* form." In GFI terms instaparse **types the action space**: "propose code"
+becomes "sample from the grammar" — sample-efficient and a clean typed move-set for the metareasoner.
+
+### malli — the *semantic* schema + the programmer's introspection
+Where instaparse is syntax, malli is meaning:
+1. **The semantic gate as schemas.** "Every observed address is a trace site" (the covering check),
+   "dist args have the right arity/type," "the body returns an observation map," "no `delta` hack" —
+   these are malli schemas over the parsed model. malli is the `:schema-ok?` checker.
+2. **The programmer's *mental model* of the partial program.** `schema.cljs` already extracts
+   trace-sites / dist-types / dependency sets; as malli, that is the programmer's introspection —
+   *what's covered, typed, missing, depends on what* — and it **drives the next `:edit`** ("schema
+   says `:y2` is uncovered → add a `:y2` site"). The schema is the programmer's working memory.
+3. **Schema-guided generation + typing the meta-trace.** malli can constrain the proposer
+   (schema → generators / as a predicate), validate data conforms to the model's inferred shape, and
+   even type the programmer-GF's own development trajectory (each step a well-formed move).
+
+## 5. The nbb / SCI substrate — the homoiconic in-process loop (a real pillar)
+
+GenMLX runs on **nbb (SCI — the Small Clojure Interpreter), not compiled cljs**. This is not
+incidental; it is what makes the REPL loop a *function call* instead of a subprocess. The
+load-bearing property is **homoiconic, no-compile, sandboxed, in-process eval of generated GenMLX
+code in the same image as the MLX binding and the oracle**:
+
+- **The REPL loop is in-process and cheap.** `propose form` (the form is *data* — an s-expression)
+  → `SCI eval` → a live `DynamicGF` (a *value*) → `oracle score` — all in one image, no compile/IPC,
+  no marshaling (the eval'd model shares the MxArray graph the oracle reads). This is what makes
+  *hundreds* of per-step evals affordable inside a search.
+- **Interpret-don't-compile actually *beats* JVM Clojure here.** A synthesis loop eval's thousands
+  of throwaway candidate programs. SCI just walks the form — **no per-candidate compile latency and
+  no class-leak**, where JVM `eval` would generate thousands of classes (metaspace/JIT churn). And
+  SCI's interpretation overhead lands on the *cheap* part (building the lazy MLX graph — "graph
+  construction is value manipulation"); the *expensive* work (MLX compute, LLM decode) is native, so
+  the interpreter overhead is essentially free for model execution.
+- **Safe eval of untrusted LLM code.** SCI is *sandboxed* — controlled namespaces/capabilities
+  (`codegen.eval` already does this) — so the agent eval's LLM-generated code thousands of times
+  safely; the eval environment is *itself data* the metareasoner can shape per step (expose only the
+  GenMLX DSL + the learned library). Pair with the existing process-group-kill watchdog
+  (`distill_sandbox.cljs`) for non-terminating candidates.
+- **Live library / abstraction growth — the antidote to the §8 length-cliff.** New combinators /
+  sub-model GFs (and, where new *syntax* helps, macros — `gen` itself is a `.cljc` macro SCI runs)
+  that the agent factors from successful syntheses are **immediately available in the same image, no
+  recompile**. The agent compresses recurring structure into reusable abstractions, shrinking the
+  program length that caused the cliff (DreamCoder-style library learning, but live).
+
+**On "live-reload itself" and macros — don't over-index.** The useful version of self-improvement is
+NOT the agent rewriting its own code; it is (a) **inference** (better trajectories), (b)
+**weight-space learning** at the proposer's sites (SFT/GRPO), and (c) **growing a live toolbox of
+reusable abstractions**. For (c), the *primary* mechanism is **GF / combinator composition** —
+learned sub-models are first-class *values* you `splice`, scoreable under the GFI, no macros needed
+and cleaner. **Macros are secondary**: useful because the object-DSL is already macro-based and for
+growing compact *notation* / sub-DSLs, which SCI lets you do live — reach for them only when you want
+new syntax, not as the core lever.
+
+**GRPO vs nbb — orthogonal, both needed, not substitutes.** Two kinds of "update": *weight-space*
+(SFT/GRPO — slow, amortized, changes the proposer's instincts, learns the **policy**) and
+*inference-time structural* (nbb/SCI — the live eval/check/compose loop + library growth, no
+retraining). **GRPO learns *from* the traces the SCI loop *produces*; SCI *runs* the loop the better
+proposer acts in.** nbb is needed for the loop to exist at all (and to generate the training traces);
+GRPO amortizes the policy. nbb is not replaceable by GRPO. (Constraint to preserve across the
+Thor/CUDA move: keep the SCI-eval-next-to-MLX property on the new runtime.)
+
+**The deepest point.** Code is data (forms); the agent *generates* forms (LLM), *evals* them live
+(SCI) into GFs (values), *scores* them (oracle, exact), *composes* them (GFI `splice`/`edit`), and
+*grows its DSL* (live combinators/macros) — all in one image where "graph construction is value
+manipulation." The programmer, the programs it writes, its toolbox, and the data are **all the same
+kind of thing — values/forms in a live evaluable image.** That homoiconic uniformity is the "extreme
+feature": Lisp's promise (the program is data the program can manipulate and run live), finally
+pointed at probabilistic-program synthesis with an exact verifier.
+
+## 6. Resource-rationality — the metareasoner is where it all meets
+
+The programmer-GF is the single point where the three axes meet: **model** (the object program it
+builds), **inference** (the SMC/MCMC search *and* the exact oracle it checks itself with), and
+**control** (`genmlx.control`: the metareasoner choosing edits, tiers, particle budget, and when to
+stop). Resource-rationality is the policy at the control sites: **one-shot vs build-up** (simple
+models stay one-shot — the K=16 tie shows it works there), **fast↔slow escalation** (`:which`),
+**how many particles** to spend on a step, and **anytime stopping** ("one cycle, more if time"). The
+expensive model is invoked *once or a few times* (the `:plan` site + hard escalations); the exact
+oracle does the discrimination — that is the resource-rational unlock (you never pay an LLM to verify).
+
+## 7. Plan + the decisive early experiments
+
+Phases (full detail in `docs/cljs-coder-loop-results.md` §7):
+- **Phase 0 — done.** Exact oracle verifier; whole-program best-of-K (the particle engine); the
+  cliff diagnosis (both models cliff → it is the interface).
+- **Phase 1 — the REPL loop.** State = partial model; action = edit; eval (SCI) + partial evidence →
+  feedback; revise. Big model as proposer first (de-risk capability). Reuses GFI `edit`/`CompositeEdit`,
+  `codegen.eval`, the oracle.
+- **Phase 2 — search over edits.** Particles + SMC/beam over construction steps; resource-rational
+  allocation; stop on evidence plateau.
+- **Phase 3 — specialize the proposer.** REPL-trace SFT + GRPO → the 0.8b becomes the cheap
+  high-frequency proposer; escalate to the big model only on hard steps.
+- **Phase 4 — the controller (the crown).** Metareasoning, anytime, resource-rational.
+- **Phase 5 — enablers (parallel).** Fix/port the batched decoder (→ Thor/CUDA); deeply integrate the
+  big off-the-shelf model GFI-native (genmlx-9uyg) so the *planner* also composes natively.
+
+**Decisive early experiments (experiment-first, before committing):**
+- **(A) Does partial-model evidence GUIDE the search?** Build the 4 advanced models incrementally by
+  hand, score each partial — does evidence climb informatively as correct sites are added, or is it
+  flat/noisy until complete? **The single load-bearing assumption** of REPL-with-evidence. Cheap,
+  decisive. If it fails, the intermediate signal must be eval-success + structural progress instead.
+- **(B) Minimal REPL loop solves an advanced model** that whole-program best-of-16 got 0/16 on.
+- **(C) The decoder pivot.** Fix EOS-stop + the cross-call leak; re-measure — does the cheap proposer
+  become genuinely cheap? This single fact decides the small model's role.
+
+## 8. Why this is cutting-edge
+
+Two camps that don't meet: LLM program synthesis (strong proposer, *weak* verifier — tests/LLM-judges)
+and probabilistic-program inference (exact methods, *no* LLM). This is **REPL-driven program synthesis
+where the verifier is exact Bayesian model evidence, the search is SMC over construction steps with
+per-partial reward, the proposer is a resource-rationally-allocated mix of a cheap specialist and a
+rarely-invoked expensive planner, and the whole programmer is a GF that checks itself and generates its
+own training data — all in one homoiconic, live-evaluable image.** That combination is ahead of where
+either camp is.
+
+---
+*Related: genmlx-d4q4 (this), genmlx-9uyg (Route B — the GFI-native [K]-particle substrate),
+genmlx.agents (agent = GF), genmlx.control (metareasoning). Data: `~/genmlx-loop-artifacts/particle/`.*
+
+## 9. Experiment (A) RESULT (2026-06-22) — partial-model evidence is a calibrated guide ✅
+
+The load-bearing assumption holds. `scripts/partial_evidence_probe.cljs` builds each advanced
+model as a ladder of hand-written intermediate states (crude→correct + variants), all covering the
+same data, scored EXACTLY by the oracle:
+
+```
+linreg:  shared-mean σ2.5 -17.50 | shared-mean σ1 -23.59 (bad, punished) | linear σ3 -17.45
+         | linear no-intercept σ1 -11.05 | linear+intercept σ1 -11.96
+kalman:  iid -7.01 | AR 0.3 -6.39 | AR 0.9 -5.37        (none < weak < correct — smooth ramp)
+hier:    single mean -24.00 | indep groups -15.79 (+8.2) | hierarchical -21.77
+```
+
+**Verdict: evidence is an informative, well-calibrated MODEL-SELECTION gradient** — not just "a
+gradient." Structure-blind baselines are clearly worst; the structurally-necessary component earns
+a large correct jump; genuinely-bad moves are punished (−23.6); and crucially it implements **Occam**
+— it does NOT blindly reward more structure. The two apparent "anomalies" are the oracle being
+*right*: `no-intercept` ≳ full model (the intercept costs a parameter it barely needs), and
+`independent-groups` ≫ `hierarchical` for well-separated groups (the partial-pooling prior is
+mismatched, so the hierarchical complexity is unwarranted by *this* data — my hand-labeled "ground
+truth" was not evidence-optimal).
+
+**Design consequences (this sharpens §6's controller):**
+- The search target is **the simplest model the data warrants**, not a pre-specified textbook
+  structure. So stepwise synthesis is naturally **"add structure while evidence climbs, stop when it
+  plateaus/drops"** — self-terminating and resource-rational by construction. The controller's
+  **stopping rule (evidence plateau) is doing real work**, not decoration.
+- Evidence is a *selection* signal, so a single-axis greedy climb can stall (linreg `shared-σ2.5 ≈
+  linear-σ3` until the noise also tightens at `linear-σ1`) — structure and parameters must move
+  together. This argues for **search over edits (SMC/particles), not greedy repair**, and matches the
+  realistic REPL move "evidence didn't move → my noise scale is off."
+- The high-evidence basin is reachable with the crude models well below it — a particle search finds
+  it. Data: `~/genmlx-loop-artifacts/particle/partial_evidence.json`.
+
+## 10. Phase 1 — the kernel + experiment (B): the loop solves the cliff ✅
+
+The Phase-1 kernel is built (`src/genmlx/world/synth.cljs`, native-free, 36/36
+`test/genmlx/synth_test.cljs`): the **model spec** (a partial GenMLX program as data —
+ordered latent + observation trace sites with argument *forms*), the form-level **edit
+ops** (`add-latent` / `add-obs` / `set-args` / `set-mean` / `set-noise` /
+`wrap-combinator` — all pure `spec → spec`, the homoiconic build-up of §5, *not* the
+trace-level GFI `CompositeEdit`, which is a different layer), the four-level **check
+node** (§4: `:parses?` reader / `:schema-ok?` schema+no-delta+returns-a-map /
+`:covered?` schema-vs-data / `:evals?`+`:error` SCI / `:evidence`+`:method` the exact
+oracle), and the greedy **driver** (`synthesize`: propose → check every candidate →
+accept the best evidence-improving valid one → stop on plateau). The check node's
+evidence is pinned against an *independent* closed-form Gaussian-Gaussian marginal.
+
+**Experiment (B) — `scripts/synth_repl_probe.cljs` — GREEN, 3/3.** Starting from the
+crudest covering rung of the experiment-A ladder, the loop accepts the **key structural
+edit** (oracle-selected over a distractor and the alternative structure) and
+self-terminates on all three exact-scoreable advanced models that whole-program
+best-of-16 got **0/16** on (the teacher got 1/4 and that one fit at junk −35):
+
+```
+                 crude start → LOOP final   (exp-A struct. rung, σ=1)   path (2 accepted edits, then plateau)
+linreg-coupled   −17.50      → −10.14        (−11.05)                   add slope (no-intercept) +1.94 ; shared-noise +5.42
+kalman-chain     −7.01       → −5.05         (−5.37)                    AR(1)-couple coef 0.9 +1.65 ; proc-noise +0.31
+hier-group-means −24.00      → −12.36        (−15.79)                   independent group means +8.22 ; shared-noise +3.43
+```
+
+The **structural jump** is the result: the crude model *lacks* the slope / the temporal
+coupling / the group split, and the oracle's exact evidence selects it over the
+distractor and (for hier) over the more-complex *hierarchical* alternative
+(independent groups are the higher-evidence structure for these well-separated groups —
+exp-A). This is the load-bearing claim made concrete: **a feedback loop with an exact
+verifier turns a 0/16 whole-program problem into a sequence of locally-checkable edits.**
+
+**Honest framing (what this does and does NOT show):**
+- The proposer here is a **structured move-vocabulary, not an LLM** — deliberately, to
+  *isolate* the loop-vs-cliff claim from generation noise. The driver is
+  proposer-agnostic (an injected `(fn [spec feedback] → candidates)`), so wiring a real
+  LLM proposer is a drop-in; **Phase 3 learns it**. So experiment B proves the loop +
+  oracle, not (yet) that a cheap LLM is the proposer.
+- The monotone evidence climb is **true by construction** (the driver only appends an
+  improving step), so it is *not* itself evidence of success — the discriminating facts
+  are that the **structural** edit was accepted and the loop self-terminated.
+- The final lands slightly **above** the σ=1 reference rung because the loop also tunes
+  a single **shared observation-noise** scale — that is **type-II maximum-marginal-
+  likelihood (empirical Bayes) over one fixed hyperparameter**, not added model
+  structure, so it is *not* directly comparable to the fixed-σ rung. The structural
+  step, not the noise tuning, is the result.
+- **Greedy commits to the first improving *structural* move** (e.g. linreg locks into
+  the no-intercept branch — a greedy local optimum, *not* a global-Occam claim; a
+  full-intercept model may score higher under *joint* structure+noise search). This is
+  the predicted greedy limitation and is exactly **why Phase 2 is SMC/beam over edits** —
+  a population explores both branches. Data:
+  `~/genmlx-loop-artifacts/particle/synth_repl_probe.json`.
+
+The kernel ships **five** form-level edit ops (`add-latent`/`add-obs`/`set-args`/
+`set-mean`/`set-noise`); the named **`wrap-combinator`** move is *deferred* — folding
+repeated sites into a `Map` combinator needs the synthesis SCI sandbox to expose the
+combinators — so the kernel ships `homogeneous-obs?`, the pure predicate that *detects*
+the fold opportunity, rather than a rewrite that would render an un-evaluable form.

--- a/docs/programmer-as-genmlx-model.md
+++ b/docs/programmer-as-genmlx-model.md
@@ -323,3 +323,61 @@ The kernel ships **five** form-level edit ops (`add-latent`/`add-obs`/`set-args`
 repeated sites into a `Map` combinator needs the synthesis SCI sandbox to expose the
 combinators — so the kernel ships `homogeneous-obs?`, the pure predicate that *detects*
 the fold opportunity, rather than a rewrite that would render an un-evaluable form.
+
+## 11. Phase 2 — search over edits: SMC/beam beats greedy ✅
+
+Phase 2 (`src/genmlx/world/search.cljs`, native-free, 19/19 `test/genmlx/search_test.cljs`)
+turns the greedy kernel into a **particle search over construction steps** — the
+best-of-K wrapper moved to the *step* level, where the oracle signal is dense (exp A).
+Instead of one greedy state that commits to the single best edit, it keeps a
+**population** of partial-model particles; each step expands every non-done particle by
+its proposed edits, dedups by rendered program, **adaptively allocates** the beam width
+(wider when the top candidates score within a margin — an ambiguous structural step),
+and selects the next population by **`:beam`** (deterministic top-B) or **`:smc`**
+(resample ∝ softmax of intermediate evidence, exact-scored particles weighted above
+noisy IS ones). It stops when the *whole population* plateaus. All on the Phase-1
+spec / edit ops / four-level `check` / exact oracle; the proposer is still injected.
+
+**`backtrack-refine` — the regenerate-style move.** On plateau, the best particle's
+trajectory is re-opened decision-by-decision: at each step take a *road not taken* (an
+alternative proposed edit) from the spec *before* it and greedy-continue — keeping the
+best result. This lets even a width-1 (greedy) search escape a structural lock-in. It is
+the design's "backtracking = reconsider an earlier decision given later feedback" realized
+as **deterministic backtracking (best-first re-search over the trajectory)** — *not* MCMC
+(no stochastic accept/reject), and *not* the literal materialized programmer-GF +
+`p/regenerate` stochastic move (the §2 fixpoint, deferred). Honest about the layer.
+
+**Result — `scripts/synth_search_probe.cljs`, greedy vs beam through the *same* code
+path (greedy = beam-width 1), same proposers, same budget:**
+
+```
+model     greedy   beam     winner   structure-reached
+linreg    −10.14   −6.90    BEAM     yes      (+3.24 nats — the headline)
+kalman    −5.05    −4.92    beam     yes      (+0.13)
+hier      −12.36   −12.36   tie      yes      (greedy already optimal)
+gmm       −17.62   −17.62   tie      NO       (IS-scoring bottleneck, see below)
+```
+
+**Solves 3/4; beam ≥ greedy on every model; strictly wins on 2.** The headline is
+**linreg**: greedy commits to the no-intercept branch and locks in (−10.14); the beam
+keeps the *full-intercept* branch alive too, and the exact oracle prefers it after noise
+tuning (−6.90) — a clean exact +3-nat win that *directly* fixes the Phase-1 greedy
+limitation (and confirms the full-intercept model is the global optimum, contra the
+Phase-1 lock-in). The width-1 + `backtrack-refine` path reaches the same −6.90,
+recovering the branch a narrow search first missed.
+
+**Honest: GMM is NOT solved — by *either* search, and that is a SCORING bottleneck, not
+a search one.** The 2-component mixture's marginal is estimated by importance sampling
+from the *prior* over 6 discrete assignments (`z0..z5`), which rarely hits the right
+assignment, so `log-mean-exp` is biased **low** and never clears the single-cluster
+baseline. The search *correctly declines* an edit whose estimated evidence is worse — it
+faithfully reflects an unreliable oracle. (The IS estimate is also un-seeded, so GMM is
+noisy run-to-run; the exact models are bit-reproducible.) Unblocking it needs a better
+discrete-latent marginal — **enumerate / Rao-Blackwellize the assignments** (GenMLX has
+both) — which is orthogonal to the search. Tracked as **`genmlx-akvp`**.
+
+**Take:** the search beats greedy wherever the oracle is sound, and where it doesn't the
+bottleneck is cleanly localized to the oracle, not the search. Phase 3 (`genmlx-oexl`)
+swaps the structured proposer for a *learned* one (REPL-trace SFT + GRPO); Phase 4
+(`genmlx-gjih`) is the resource-rational metareasoner over the control sites (beam
+width, particle budget, when to stop — the adaptive allocation here is its seed).

--- a/scripts/synth_repl_probe.cljs
+++ b/scripts/synth_repl_probe.cljs
@@ -1,0 +1,254 @@
+(ns synth-repl-probe
+  "EXPERIMENT (B) (beans genmlx-n74t / genmlx-77vv): does the minimal REPL synthesis
+   LOOP solve an advanced model that whole-program best-of-16 got 0/16 on?
+
+   For each of the three EXACT-scoreable advanced models (linreg-coupled / kalman-chain
+   / hier-group-means) we start the genmlx.world.synth driver from a CRUDE covering
+   model (the crudest rung of the experiment-A ladder) and give it a STRUCTURED move
+   vocabulary — the structural upgrades a programmer would try (add the slope+intercept
+   structure, couple the latent chain, split into per-group means) PLUS a distractor
+   and the alternative structure (full-vs-no-intercept, independent-vs-hierarchical
+   groups) — and let the EXACT oracle SELECT which edit to keep and WHEN to stop. No
+   LLM: this isolates the load-bearing claim that a feedback loop with an exact verifier
+   turns a 0/16 whole-program problem into a sequence of locally checkable edits.
+   (Phase 2 SEARCHES this vocabulary; Phase 3 LEARNS the proposer.)
+
+   We report, per model: the full per-step trajectory (edit, evidence, delta, method),
+   the loop's final evidence vs the crude start and the whole-program best-of-16
+   baseline, and that the oracle's selection is discriminating (it rejects the
+   distractor; for hier it prefers INDEPENDENT over hierarchical groups, the
+   higher-evidence structure for these well-separated groups — experiment A). NB the
+   driver is GREEDY: it commits to the first improving structural move, so e.g. linreg
+   locks into the no-intercept branch — a greedy local optimum, NOT a global-Occam
+   claim; joint structure+noise search (Phase 2 SMC) may prefer a fuller model.
+
+   Run: bun run --bun nbb scripts/synth_repl_probe.cljs"
+  (:require [genmlx.world.synth :as syn]
+            [clojure.string :as str]))
+
+(def os   (js/require "os"))
+(def path (js/require "path"))
+(def fs   (js/require "fs"))
+(defn home [& xs] (apply (.-join path) (.homedir os) xs))
+(def out-dir (home "genmlx-loop-artifacts" "particle"))
+
+(defn fx [x] (when (and x (js/isFinite x)) (.toFixed (js/Number x) 2)))
+
+;; ---------------------------------------------------------------------------
+;; Small spec builders shared by the per-task proposers.
+;; ---------------------------------------------------------------------------
+
+(defn- cur-noise [sp] (last (:args (first (:obs sp)))))   ; current obs noise scale
+(defn- has-latent? [sp sym] (some #(= sym (:sym %)) (:latents sp)))
+(defn- mx-mul [a b] (list 'mx/multiply a b))
+(defn- mx-add [a b] (list 'mx/add a b))
+(defn- mx-scalar [x] (list 'mx/scalar x))
+
+;; A SHARED-noise refinement: set EVERY obs site to the same scale g. One shared
+;; scale is a single hyperparameter (type-II maximum-marginal-likelihood over it), so
+;; the loop picks the best grid value in ONE step — keeping the trajectory focused on
+;; the STRUCTURAL step rather than a long noise-tuning tail, and matching the
+;; shared-sigma rungs of experiment A. The grid is a COARSE, hand-provided vocabulary
+;; (Phase 2 searches it; Phase 3 learns the proposer); the loop stops on the evidence
+;; plateau over whatever grid it is given, so a finer grid would land slightly higher.
+(defn- set-all-noise [sp g] (reduce #(syn/set-noise %1 %2 g) sp (map :addr (:obs sp))))
+(defn- shared-noise-moves [sp grid]
+  (for [g grid :when (not= g (cur-noise sp))]
+    {:edit :set-noise :desc (str "shared obs noise -> " g) :spec' (set-all-noise sp g)}))
+
+;; ===========================================================================
+;; LINREG — x=0..6, y ~ linear (slope~1, intercept~1). Crude start: one shared
+;; mean. Structural move: introduce slope (+ optional intercept) and re-point each
+;; obs at slope*xj(+intercept). Occam test: the no-intercept model out-scores the
+;; full one for these priors (experiment A), so the oracle should PREFER it.
+;; ===========================================================================
+
+(def linreg-obs {:y0 1.1 :y1 2.0 :y2 2.7 :y3 4.2 :y4 4.8 :y5 6.1 :y6 6.9})
+(def linreg-ys  [:y0 :y1 :y2 :y3 :y4 :y5 :y6])
+
+(def linreg-init
+  (syn/spec [(syn/latent 'mu "gaussian" [0 10])]
+            (for [k linreg-ys] (syn/obs k "gaussian" ['mu 2.5]))))
+
+(defn- linreg-build [intercept? noise]
+  (let [mean (fn [j] (if intercept?
+                       (mx-add (mx-mul 'slope (mx-scalar (double j))) 'intercept)
+                       (mx-mul 'slope (mx-scalar (double j)))))]
+    (syn/spec (cond-> [(syn/latent 'slope "gaussian" [0 3])]
+                intercept? (conj (syn/latent 'intercept "gaussian" [0 5])))
+              (map-indexed (fn [j k] (syn/obs k "gaussian" [(mean j) noise])) linreg-ys))))
+
+(defn linreg-propose [sp _fb]
+  (let [n (cur-noise sp)]
+    (if-not (has-latent? sp 'slope)
+      ;; structural step: offer full-linear, no-intercept-linear, and a distractor
+      ;; (tighten the shared-mean's noise WITHOUT fixing the structure).
+      [{:edit :add-linear        :desc "add slope+intercept, linear mean" :spec' (linreg-build true n)}
+       {:edit :add-linear-noint  :desc "add slope only (no intercept)"    :spec' (linreg-build false n)}
+       {:edit :distractor-tighten :desc "tighten shared-mean noise -> 1 (no structure)"  :spec' (set-all-noise sp 1)}]
+      ;; refinement: tune the (now linear) observation noise (shared scale).
+      (shared-noise-moves sp [0.3 0.5 0.7 1 1.5 2.5]))))
+
+;; ===========================================================================
+;; KALMAN — smooth series; AR(1) coupling is the structural step. Crude start: iid
+;; latents. Structural move: couple z_t ~ N(coef*z_{t-1}, 0.5) over a coef grid.
+;; ===========================================================================
+
+(def kalman-obs {:y0 0.4 :y1 0.9 :y2 1.3 :y3 1.1 :y4 0.6})
+
+(def kalman-init
+  (syn/spec (for [t (range 5)] (syn/latent (symbol (str "z" t)) "gaussian" [0 1]))
+            (for [t (range 5)] (syn/obs (keyword (str "y" t)) "gaussian" [(symbol (str "z" t)) 0.7]))))
+
+(defn- kalman-build [coef proc-noise]
+  (syn/spec (cons (syn/latent 'z0 "gaussian" [0 1])
+                  (for [t (range 1 5)]
+                    (syn/latent (symbol (str "z" t)) "gaussian"
+                                [(mx-mul (mx-scalar coef) (symbol (str "z" (dec t)))) proc-noise])))
+            (for [t (range 5)] (syn/obs (keyword (str "y" t)) "gaussian" [(symbol (str "z" t)) 0.7]))))
+
+(defn- coupled? [sp] (seq? (first (:args (second (:latents sp))))))  ; z1 mean is a form
+
+(defn kalman-propose [sp _fb]
+  (if-not (coupled? sp)
+    ;; structural step: offer AR(1) coupling over a coefficient grid (0.3 is a weak,
+    ;; wrong coupling distractor; 0.9 is the data-warranted one).
+    (for [c [0.3 0.6 0.9 1.0]]
+      {:edit :couple :desc (str "AR(1) couple, coef " c) :spec' (kalman-build c 0.5)})
+    ;; refinement: tune the process noise (a single shared scale).
+    (for [pn [0.1 0.2 0.3 0.4 0.5 0.7 1.0]]
+      {:edit :set-proc-noise :desc (str "process noise -> " pn)
+       :spec' (syn/spec (cons (syn/latent 'z0 "gaussian" [0 1])
+                              (for [t (range 1 5)]
+                                (syn/latent (symbol (str "z" t)) "gaussian"
+                                            [(first (:args (nth (:latents sp) t))) pn])))
+                        (:obs sp))})))
+
+;; ===========================================================================
+;; HIERARCHICAL — 3 well-separated groups. Crude start: single shared mean.
+;; Structural move: per-group means (independent) OR partial-pooled (hierarchical).
+;; Occam test: for well-separated groups the INDEPENDENT model out-scores the
+;; hierarchical one (experiment A), so the oracle should prefer it.
+;; ===========================================================================
+
+(def hier-obs {:a0 5.2 :a1 4.8 :a2 5.5 :b0 -1.1 :b1 -0.7 :b2 -1.4 :c0 2.1 :c1 2.6 :c2 1.9})
+(def hier-groups {'mu-a [:a0 :a1 :a2] 'mu-b [:b0 :b1 :b2] 'mu-c [:c0 :c1 :c2]})
+
+(def hier-init
+  (syn/spec [(syn/latent 'mu "gaussian" [0 5])]
+            (for [k (keys hier-obs)] (syn/obs k "gaussian" ['mu 2]))))
+
+(defn- hier-build [pooled? noise]
+  (syn/spec (cond-> (for [g (keys hier-groups)]
+                      (syn/latent g "gaussian" (if pooled? ['grand 2] [0 5])))
+              pooled? (->> (cons (syn/latent 'grand "gaussian" [0 5]))))
+            (for [[g ks] hier-groups, k ks] (syn/obs k "gaussian" [g noise]))))
+
+(defn hier-propose [sp _fb]
+  (if-not (has-latent? sp 'mu-a)
+    [{:edit :indep-groups  :desc "per-group independent means" :spec' (hier-build false 1)}
+     {:edit :hierarchical  :desc "partial-pooled (hierarchical) means" :spec' (hier-build true 1)}]
+    (shared-noise-moves sp [0.3 0.5 0.7 1 1.5 2])))
+
+;; ===========================================================================
+;; Run the loop on each task; report the trajectory + the comparison.
+;; ===========================================================================
+
+;; :ref-rung = the experiment-A rung for the CORRECT structure at fixed noise=1
+;; (no-intercept linear / AR(0.9) / independent groups). It is a REPORTING reference,
+;; NOT the success gate: it lets us see the structural evidence the loop reaches. The
+;; loop typically ends a bit ABOVE it because it also tunes the shared observation
+;; noise (type-II maximum-marginal-likelihood over ONE fixed scale the rung held at 1)
+;; — that is hyperparameter fitting, not added model structure, so it is not directly
+;; comparable to the rung; the STRUCTURAL step is the result.
+;;
+;; :bestof16 is the whole-program baseline from the PRIOR run (NOT recomputed here):
+;; particle_advanced_probe on the SAME data + SAME oracle — the student got 0/16 on
+;; all four advanced models; the teacher got 1/4 and that one fit at ~ -35 (junk).
+;; See ~/genmlx-loop-artifacts/particle/advanced_probe.json. The :obs below are
+;; byte-identical to that probe's :observations, so the comparison is apples-to-apples.
+(def tasks
+  [{:id :linreg-coupled :init linreg-init :obs linreg-obs :propose linreg-propose
+    :ref-rung -11.05 :bestof16 "student 0/16 ; teacher fit -35 (junk)"}
+   {:id :kalman-chain :init kalman-init :obs kalman-obs :propose kalman-propose
+    :ref-rung -5.37 :bestof16 "student 0/16"}
+   {:id :hier-group-means :init hier-init :obs hier-obs :propose hier-propose
+    :ref-rung -15.79 :bestof16 "student 0/16"}])
+
+;; The STRUCTURAL edits — the key structure the crude covering model lacks and that
+;; whole-program best-of-16 produced 0 valid candidates for.
+(def structural-edits #{:add-linear :add-linear-noint :couple :indep-groups :hierarchical})
+(defn- structural-step? [traj] (boolean (some #(structural-edits (:edit %)) traj)))
+
+;; "solved" = the loop ACCEPTED the key structural edit (driven by exact oracle
+;; evidence, over distractors + the structural alternative), IMPROVED on the crude
+;; start, and SELF-TERMINATED on an evidence plateau (not :stuck / :max-steps). We do
+;; NOT count the monotone climb as a criterion: the driver only appends an improving
+;; step, so a monotone trajectory is true BY CONSTRUCTION, not evidence of success.
+(defn- solved? [{:keys [start final trajectory stop-reason]}]
+  (and (structural-step? trajectory)
+       (> final start)
+       (= :plateau stop-reason)))
+
+(defn run-task [{:keys [id init obs propose ref-rung bestof16]}]
+  (println (str "\n================  " (name id) "  ================"))
+  (let [res  (syn/synthesize {:init-spec init :observations obs :propose propose
+                              :max-steps 12 :plateau-eps 0.05 :n-particles 4000})
+        traj (:trajectory res)
+        start (:evidence (first traj))
+        final (:evidence (last traj))
+        row  {:id id :start start :final final :ref-rung ref-rung
+              :stop-reason (:stop-reason res) :steps (:steps res)
+              :trajectory (mapv #(select-keys % [:step :edit :desc :evidence :delta :method]) traj)
+              :final-code (:code res)}]
+    (println (str (.padEnd "step" 6) (.padEnd "edit" 24) (.padEnd "evidence" 11)
+                  (.padEnd "delta" 9) "method"))
+    (doseq [r traj]
+      (println (str (.padEnd (str (:step r)) 6)
+                    (.padEnd (str (name (:edit r))) 24)
+                    (.padEnd (or (fx (:evidence r)) "--") 11)
+                    (.padEnd (or (fx (:delta r)) "--") 9)
+                    (str (some-> (:method r) name)))))
+    (println (str "\n  stop-reason: " (name (:stop-reason res)) " after " (:steps res) " accepted edits"))
+    (println (str "  structural edit accepted: " (structural-step? traj)
+                  " (the structure the crude model + whole-program best-of-16 lacked)"))
+    (println (str "  crude start evidence    : " (fx start)))
+    (println (str "  LOOP final evidence     : " (fx final)
+                  "   (vs exp-A fixed-noise=1 structural rung ~ " ref-rung
+                  "; any excess = shared-noise type-II ML, not added structure)"))
+    (println (str "  whole-program best-of-16: " bestof16))
+    (println (str "  => loop improvement over crude start: " (fx (- final start)) " nats"
+                  "   SOLVED? " (solved? row)))
+    (println (str "  final model:\n   " (:code res)))
+    row))
+
+(println "\n###  EXPERIMENT (B): does the REPL loop solve an advanced model?  ###")
+(let [results (mapv run-task tasks)]
+  (println "\n================  VERDICT  ================")
+  (println (str (.padEnd "model" 20) (.padEnd "start" 9) (.padEnd "final" 9)
+                (.padEnd "struct?" 9) (.padEnd "stop" 9) "solved?"))
+  (doseq [r results]
+    (println (str (.padEnd (name (:id r)) 20)
+                  (.padEnd (str (fx (:start r))) 9)
+                  (.padEnd (str (fx (:final r))) 9)
+                  (.padEnd (str (structural-step? (:trajectory r))) 9)
+                  (.padEnd (name (:stop-reason r)) 9)
+                  (solved? r))))
+  (let [n-solved (count (filter solved? results))]
+    (println (str "\n  => the REPL loop SOLVES " n-solved "/" (count results)
+                  " advanced models: from a crude covering model it ACCEPTS the key"
+                  " structural edit (oracle-selected over distractors + the structural"
+                  " alternative) and self-terminates — where whole-program best-of-16 got 0/16."))
+    (println "\n  HONEST CAVEATS (this isolates the loop, it is not the whole story):")
+    (println "   - the proposer is a STRUCTURED move-vocabulary, NOT an LLM — deliberately, to")
+    (println "     isolate the loop-vs-cliff claim from generation noise (Phase 3 learns the proposer).")
+    (println "   - GREEDY commits to the first improving STRUCTURAL move and cannot reconsider it")
+    (println "     (e.g. linreg locks into no-intercept; a full-intercept model may score higher under")
+    (println "     JOINT structure+noise search) -> exactly why Phase 2 is SMC/beam over edits.")
+    (println "   - the shared-noise refinement is type-II ML over ONE fixed scale (hyperparameter")
+    (println "     fitting, not structure); the STRUCTURAL jump is the result, not the noise tuning.")
+    (when-not (.existsSync fs out-dir) (.mkdirSync fs out-dir #js {:recursive true}))
+    (.writeFileSync fs (home "genmlx-loop-artifacts" "particle" "synth_repl_probe.json")
+                    (js/JSON.stringify (clj->js {:results results :n-solved n-solved
+                                                 :n-tasks (count results)}) nil 2))
+    (println "  wrote particle/synth_repl_probe.json")))

--- a/scripts/synth_search_probe.cljs
+++ b/scripts/synth_search_probe.cljs
@@ -1,0 +1,194 @@
+(ns synth-search-probe
+  "EXPERIMENT (Phase 2, genmlx-47zx): does the PARTICLE/BEAM search over construction
+   steps measurably beat the greedy Phase-1 loop, and solve >=3/4 advanced models
+   robustly?
+
+   We run a GREEDY baseline and a BEAM search through the SAME genmlx.world.search code
+   path (greedy = beam-width 1) with the SAME structured proposer, so the comparison is
+   apples-to-apples — only the population size differs. The 4 advanced models are the
+   ones whole-program best-of-16 got 0/16 on (linreg / kalman / hier exact; gmm IS).
+
+   The decisive case is linreg: greedy commits to the first improving STRUCTURAL move
+   (no-intercept) and locks in; the beam keeps the full-intercept branch alive too and
+   lets the exact oracle pick the global winner. gmm is the NOISY (importance-sampling)
+   regime where a population is more robust than a single greedy IS draw.
+
+   Run: bun run --bun nbb scripts/synth_search_probe.cljs"
+  (:require [genmlx.world.search :as se]
+            [genmlx.world.synth :as syn]))
+
+(def os   (js/require "os"))
+(def path (js/require "path"))
+(def fs   (js/require "fs"))
+(defn home [& xs] (apply (.-join path) (.homedir os) xs))
+(def out-dir (home "genmlx-loop-artifacts" "particle"))
+(defn fx [x] (when (and x (js/isFinite x)) (.toFixed (js/Number x) 2)))
+
+(defn- cur-noise [sp] (last (:args (first (:obs sp)))))
+(defn- has-latent? [sp sym] (some #(= sym (:sym %)) (:latents sp)))
+(defn- mx-mul [a b] (list 'mx/multiply a b))
+(defn- mx-add [a b] (list 'mx/add a b))
+(defn- mx-scalar [x] (list 'mx/scalar x))
+(defn- set-all-noise [sp g] (reduce #(syn/set-noise %1 %2 g) sp (map :addr (:obs sp))))
+(defn- shared-noise-moves [sp grid]
+  (for [g grid :when (not= g (cur-noise sp))]
+    {:edit :set-noise :desc (str "shared obs noise -> " g) :spec' (set-all-noise sp g)}))
+
+;; ---------------------------------------------------------------------------
+;; LINREG — the decisive case: full-intercept vs no-intercept are competing branches.
+;; ---------------------------------------------------------------------------
+(def linreg-obs {:y0 1.1 :y1 2.0 :y2 2.7 :y3 4.2 :y4 4.8 :y5 6.1 :y6 6.9})
+(def linreg-ys  [:y0 :y1 :y2 :y3 :y4 :y5 :y6])
+(def linreg-init
+  (syn/spec [(syn/latent 'mu "gaussian" [0 10])]
+            (for [k linreg-ys] (syn/obs k "gaussian" ['mu 2.5]))))
+(defn- linreg-build [intercept? noise]
+  (let [mean (fn [j] (if intercept?
+                       (mx-add (mx-mul 'slope (mx-scalar (double j))) 'intercept)
+                       (mx-mul 'slope (mx-scalar (double j)))))]
+    (syn/spec (cond-> [(syn/latent 'slope "gaussian" [0 3])]
+                intercept? (conj (syn/latent 'intercept "gaussian" [0 5])))
+              (map-indexed (fn [j k] (syn/obs k "gaussian" [(mean j) noise])) linreg-ys))))
+(defn linreg-propose [sp _fb]
+  (if-not (has-latent? sp 'slope)
+    [{:edit :add-linear :desc "slope+intercept" :spec' (linreg-build true (cur-noise sp))}
+     {:edit :add-linear-noint :desc "slope only" :spec' (linreg-build false (cur-noise sp))}
+     {:edit :distractor :desc "tighten shared-mean noise" :spec' (set-all-noise sp 1)}]
+    (shared-noise-moves sp [0.3 0.5 0.7 1 1.5 2.5])))
+
+;; ---------------------------------------------------------------------------
+;; KALMAN — AR(1) coupling over a coefficient grid, then process noise.
+;; ---------------------------------------------------------------------------
+(def kalman-obs {:y0 0.4 :y1 0.9 :y2 1.3 :y3 1.1 :y4 0.6})
+(def kalman-init
+  (syn/spec (for [t (range 5)] (syn/latent (symbol (str "z" t)) "gaussian" [0 1]))
+            (for [t (range 5)] (syn/obs (keyword (str "y" t)) "gaussian" [(symbol (str "z" t)) 0.7]))))
+(defn- kalman-build [coef pn]
+  (syn/spec (cons (syn/latent 'z0 "gaussian" [0 1])
+                  (for [t (range 1 5)]
+                    (syn/latent (symbol (str "z" t)) "gaussian"
+                                [(mx-mul (mx-scalar coef) (symbol (str "z" (dec t)))) pn])))
+            (for [t (range 5)] (syn/obs (keyword (str "y" t)) "gaussian" [(symbol (str "z" t)) 0.7]))))
+(defn- coupled? [sp] (seq? (first (:args (second (:latents sp))))))
+(defn kalman-propose [sp _fb]
+  (if-not (coupled? sp)
+    (for [c [0.3 0.6 0.9 1.0]] {:edit :couple :desc (str "AR coef " c) :spec' (kalman-build c 0.5)})
+    (for [pn [0.1 0.2 0.3 0.4 0.5 0.7]]
+      {:edit :proc-noise :desc (str "proc noise " pn)
+       :spec' (syn/spec (cons (syn/latent 'z0 "gaussian" [0 1])
+                              (for [t (range 1 5)]
+                                (syn/latent (symbol (str "z" t)) "gaussian"
+                                            [(first (:args (nth (:latents sp) t))) pn])))
+                        (:obs sp))})))
+
+;; ---------------------------------------------------------------------------
+;; HIER — independent vs hierarchical group means, then noise.
+;; ---------------------------------------------------------------------------
+(def hier-obs {:a0 5.2 :a1 4.8 :a2 5.5 :b0 -1.1 :b1 -0.7 :b2 -1.4 :c0 2.1 :c1 2.6 :c2 1.9})
+(def hier-groups {'mu-a [:a0 :a1 :a2] 'mu-b [:b0 :b1 :b2] 'mu-c [:c0 :c1 :c2]})
+(def hier-init
+  (syn/spec [(syn/latent 'mu "gaussian" [0 5])]
+            (for [k (keys hier-obs)] (syn/obs k "gaussian" ['mu 2]))))
+(defn- hier-build [pooled? noise]
+  (syn/spec (cond-> (for [g (keys hier-groups)]
+                      (syn/latent g "gaussian" (if pooled? ['grand 2] [0 5])))
+              pooled? (->> (cons (syn/latent 'grand "gaussian" [0 5]))))
+            (for [[g ks] hier-groups, k ks] (syn/obs k "gaussian" [g noise]))))
+(defn hier-propose [sp _fb]
+  (if-not (has-latent? sp 'mu-a)
+    [{:edit :indep :desc "independent group means" :spec' (hier-build false 1)}
+     {:edit :hierarchical :desc "hierarchical means" :spec' (hier-build true 1)}]
+    (shared-noise-moves sp [0.3 0.5 0.7 1 1.5 2])))
+
+;; ---------------------------------------------------------------------------
+;; GMM — single cluster -> 2-component mixture. IS-scored (the noisy regime).
+;; ---------------------------------------------------------------------------
+(def gmm-obs {:y0 -2.8 :y1 3.1 :y2 -3.3 :y3 2.6 :y4 -2.5 :y5 3.4})
+(def gmm-init
+  (syn/spec [(syn/latent 'mu "gaussian" [0 3])]
+            (for [j (range 6)] (syn/obs (keyword (str "y" j)) "gaussian" ['mu 2]))))
+(defn- gmm-build [noise]
+  (syn/spec (into [(syn/latent 'mu0 "gaussian" [-3 2])
+                   (syn/latent 'mu1 "gaussian" [3 2])
+                   (syn/latent 'p "beta-dist" [1 1])]
+                  (for [j (range 6)] (syn/latent (symbol (str "z" j)) "bernoulli" ['p])))
+            (for [j (range 6)]
+              (syn/obs (keyword (str "y" j)) "gaussian"
+                       [(mx-add (mx-mul (symbol (str "z" j)) 'mu1)
+                                (mx-mul (list 'mx/subtract (mx-scalar 1) (symbol (str "z" j))) 'mu0))
+                        noise]))))
+(defn gmm-propose [sp _fb]
+  (if-not (has-latent? sp 'mu0)
+    [{:edit :add-mixture :desc "2-component mixture" :spec' (gmm-build 1)}]
+    (shared-noise-moves sp [0.7 1 1.5])))
+
+;; ---------------------------------------------------------------------------
+
+(def structural-edits #{:add-linear :add-linear-noint :couple :indep :hierarchical :add-mixture})
+(defn- structural? [traj] (boolean (some #(structural-edits (:edit %)) traj)))
+
+(def tasks
+  [{:id :linreg :init linreg-init :obs linreg-obs :propose linreg-propose :np 0    :exact? true}
+   {:id :kalman :init kalman-init :obs kalman-obs :propose kalman-propose :np 0    :exact? true}
+   {:id :hier   :init hier-init   :obs hier-obs   :propose hier-propose   :np 0    :exact? true}
+   {:id :gmm    :init gmm-init    :obs gmm-obs    :propose gmm-propose     :np 4000 :exact? false}])
+
+(defn- run [{:keys [init obs propose np]} mode]
+  (let [base {:init-spec init :observations obs :propose propose :max-steps 16
+              :plateau-eps 0.05 :n-particles (if (pos? np) np 2000)}
+        res  (case mode
+               :greedy (se/search (merge base {:beam-width 1 :adaptive? false}))
+               :beam   (se/search (merge base {:beam-width 4 :adaptive? true})))]
+    {:evidence (:evidence (:best res))
+     :structural? (structural? (:trajectory (:best res)))
+     :steps (:steps res) :code (syn/render (:spec (:best res)))}))
+
+(defn run-task [t]
+  (println (str "\n================  " (name (:id t)) (when-not (:exact? t) "  (IS-scored)") "  ================"))
+  (let [g (run t :greedy)
+        b (run t :beam)
+        win (cond (> (:evidence b) (+ (:evidence g) 0.1)) :beam
+                  (> (:evidence g) (+ (:evidence b) 0.1)) :greedy
+                  :else :tie)]
+    (println (str "  greedy (width 1): " (fx (:evidence g)) "  struct=" (:structural? g) "  steps=" (:steps g)))
+    (println (str "  beam   (width 4): " (fx (:evidence b)) "  struct=" (:structural? b) "  steps=" (:steps b)))
+    (println (str "  => " (case win :beam "BEAM WINS" :greedy "greedy wins" :tie "tie")
+                  " (beam - greedy = " (fx (- (:evidence b) (:evidence g))) " nats)"))
+    (when-not (:structural? b)
+      (println (str "  NOTE: the structural edit was DECLINED by BOTH — its oracle-estimated evidence did"
+                    "\n  not clear the crude baseline. For " (name (:id t)) " (IS-scored) this is the SCORING"
+                    "\n  bottleneck, not the search: importance sampling from the prior over the discrete"
+                    "\n  assignments is biased low. The search correctly refuses an edit it cannot verify.")))
+    (when (= win :beam) (println (str "  beam final model:\n   " (:code b))))
+    {:id (:id t) :greedy g :beam b :winner win}))
+
+(println "\n###  EXPERIMENT (Phase 2): particle/beam search vs greedy  ###")
+(let [results (mapv run-task tasks)]
+  (println "\n================  VERDICT  ================")
+  (println (str (.padEnd "model" 10) (.padEnd "greedy" 10) (.padEnd "beam" 10)
+                (.padEnd "winner" 10) "structure-reached"))
+  (doseq [r results]
+    (println (str (.padEnd (name (:id r)) 10)
+                  (.padEnd (str (fx (:evidence (:greedy r)))) 10)
+                  (.padEnd (str (fx (:evidence (:beam r)))) 10)
+                  (.padEnd (name (:winner r)) 10)
+                  (str (:structural? (:beam r))))))
+  (let [solved (count (filter #(:structural? (:beam %)) results))
+        beam>= (every? #(>= (:evidence (:beam %)) (- (:evidence (:greedy %)) 0.1)) results)
+        beam-wins (count (filter #(= :beam (:winner %)) results))]
+    (println (str "\n  solves (reaches correct structure): " solved "/" (count results)))
+    (println (str "  beam >= greedy on every model: " beam>= "  (beam strictly wins on " beam-wins ")"))
+    (println "\n  WHY beam beats greedy: it keeps competing structural branches alive where greedy")
+    (println "  commits to the first improving one; the exact oracle then picks the global winner.")
+    (println "  The headline is linreg: greedy locks into no-intercept, beam keeps the full-intercept")
+    (println "  branch and the oracle prefers it after noise tuning (a clean exact +3 nat win).")
+    (println "\n  HONEST: gmm is NOT solved by EITHER — the 2-component mixture's marginal is estimated")
+    (println "  by importance sampling from the prior over 6 discrete assignments, which is biased LOW")
+    (println "  and never clears the single-cluster baseline, so the search correctly declines it. That")
+    (println "  is an ORACLE/scoring limitation (enumerate / Rao-Blackwellize the assignments), NOT a")
+    (println "  search one — orthogonal to Phase 2. The search beats greedy wherever the oracle is sound.")
+    (when-not (.existsSync fs out-dir) (.mkdirSync fs out-dir #js {:recursive true}))
+    (.writeFileSync fs (home "genmlx-loop-artifacts" "particle" "synth_search_probe.json")
+                    (js/JSON.stringify (clj->js {:results results :solved solved
+                                                 :beam-wins beam-wins :n-tasks (count results)}) nil 2))
+    (println "  wrote particle/synth_search_probe.json")))

--- a/src/genmlx/world/search.cljs
+++ b/src/genmlx/world/search.cljs
@@ -1,0 +1,300 @@
+(ns genmlx.world.search
+  "Phase 2 of the north star (milestone genmlx-77vv, bean genmlx-47zx): turn the greedy
+   Phase-1 kernel into a PARTICLE SEARCH over construction steps. The best-of-K wrapper
+   moves to the STEP level, where the oracle signal is dense (experiment A): instead of
+   one greedy state that commits to the single best edit, keep a POPULATION of partial
+   models and resample/beam them by INTERMEDIATE model evidence — SMC over construction
+   steps, not whole programs.
+
+   WHY (the Phase-1 limitation it fixes). Greedy commits to the first improving
+   STRUCTURAL move and cannot reconsider it (Phase-1 linreg locked into the no-intercept
+   branch). A population explores competing branches in parallel; a wider beam keeps both
+   the no-intercept and full-intercept linreg branches alive and lets the exact oracle
+   pick the global winner. It is also the right tool for the NOISY-evidence regime (the
+   IS-scored GMM): a single greedy importance-sampling draw oscillates, a population
+   averages it out.
+
+   Builds entirely on genmlx.world.synth — same model-spec, same edit ops, the same
+   four-level `check` node and exact oracle, the same INJECTED proposer
+   `(fn [spec feedback] -> [candidate ...])`. Native-free; the proposer here is the
+   structured move-vocabulary (native particles); an LLM proposer is a drop-in (Phase 3).
+
+   Sections:
+     1. Particles — a partial-model trajectory as a search state
+     2. Expansion — propose K edits per particle, render + check + keep the improving
+     3. Selection — :beam (deterministic top-B) | :smc (resample by evidence) + dedup
+     4. Adaptive allocation — wider beam on ambiguous (close-evidence) steps
+     5. search — the population loop (stop when the whole population plateaus)
+     6. backtrack-refine — deterministic backtracking (best-first re-search over a trajectory)"
+  (:require [genmlx.world.synth :as syn]))
+
+;; ===========================================================================
+;; 1. Particles — a partial-model trajectory as a search state
+;;
+;; A particle carries its current spec, the check feedback, its evidence (nil until
+;; scored), a :done? flag (set once no proposed edit improves it), and its trajectory
+;; (one row per accepted state — each row keeps its :spec so backtrack can re-open it).
+;; ===========================================================================
+
+(defn- init-particle
+  [spec observations opts]
+  (let [code (syn/render spec)
+        fb   (syn/check code observations opts)]
+    {:spec spec :feedback fb :evidence (:evidence fb) :done? false
+     :trajectory [{:step 0 :edit :init :desc "crude covering model" :code code
+                   :evidence (:evidence fb) :method (:method fb) :delta nil :spec spec}]}))
+
+(defn- deterministic-method?
+  [fb] (contains? #{:exact :kalman} (:method fb)))
+
+(defn- particle-rank
+  "Ascending sort key: deterministically-scored particles first (an exact marginal
+   never loses to a noisy IS estimate), then higher evidence, then — among genuine
+   evidence ties (e.g. two routes to the same program in dedup) — a LIVE particle
+   before a :done? one, then shorter trajectory (Occam tie-break)."
+  [p]
+  [(if (deterministic-method? (:feedback p)) 0 1)
+   (- (or (:evidence p) ##-Inf))
+   (if (:done? p) 1 0)
+   (count (:trajectory p))])
+
+(defn- particle-code [p] (syn/render (:spec p)))
+
+;; ===========================================================================
+;; 2. Expansion — propose K edits per particle, render + check, keep the improving
+;; ===========================================================================
+
+(defn- expand
+  "Expand one particle: render+check up to `expand-k` proposed candidate edits and keep
+   the ones that are valid AND improve the particle's evidence beyond :plateau-eps. If
+   none improves, the particle STAYS (returned once, marked :done?) — so a plateaued
+   particle persists in the beam as a terminal until the whole population is done."
+  [p propose observations {:keys [plateau-eps expand-k] :or {plateau-eps 0.05} :as opts}]
+  (if (:done? p)
+    [p]
+    (let [cands    (let [cs (propose (:spec p) (:feedback p))]
+                     (if expand-k (take expand-k cs) cs))
+          cur-ev   (or (:evidence p) ##-Inf)
+          children (for [c cands
+                         :let [code (syn/render (:spec' c))
+                               fb   (syn/check code observations opts)]
+                         :when (syn/scored? fb)]
+                     {:spec (:spec' c) :feedback fb :evidence (:evidence fb) :done? false
+                      :trajectory (conj (:trajectory p)
+                                        {:step (count (:trajectory p)) :edit (:edit c) :desc (:desc c)
+                                         :code code :evidence (:evidence fb) :method (:method fb)
+                                         :delta (when (:evidence p) (- (:evidence fb) (:evidence p)))
+                                         :spec (:spec' c)})})
+          improving (filter #(> (:evidence %) (+ cur-ev plateau-eps)) children)]
+      (if (seq improving)
+        improving
+        [(assoc p :done? true)]))))
+
+;; ===========================================================================
+;; 3. Selection — :beam (deterministic top-B) | :smc (resample) + dedup
+;; ===========================================================================
+
+(defn- dedup-pool
+  "Collapse particles whose current program renders identically to one (best-ranked)
+   particle — the same partial model is the same search state, however it was reached."
+  [pool]
+  (->> pool
+       (group-by particle-code)
+       vals
+       (mapv #(first (sort-by particle-rank %)))))
+
+(defn- select-beam
+  "Deterministic top-`width` particles by particle-rank."
+  [pool width]
+  (vec (take width (sort-by particle-rank pool))))
+
+;; A tiny pure LCG so :smc resampling (and the stochastic-proposer experiment) is
+;; reproducible without touching js/Math.random (which nbb can't seed in required nses).
+(defn- lcg-next [s] (mod (+ (* 1103515245 s) 12345) 2147483648))
+(defn- uniforms [seed n]
+  (loop [s (lcg-next (+ seed 1)), i 0, acc []]
+    (if (>= i n) acc (recur (lcg-next s) (inc i) (conj acc (/ s 2147483648.0))))))
+
+(defn- softmax [xs temp]
+  (let [t  (max temp 1e-6)
+        m  (apply max xs)
+        es (map #(js/Math.exp (/ (- % m) t)) xs)
+        z  (reduce + es)]
+    (map #(/ % z) es)))
+
+(defn- weighted-pick [items weights u]
+  (loop [is items, ws weights, acc 0.0]
+    (let [acc' (+ acc (first ws))]
+      (if (or (empty? (rest is)) (<= u acc')) (first is) (recur (rest is) (rest ws) acc')))))
+
+(defn- select-smc
+  "Resample `width` UNIQUE particles from the pool with replacement, proportional to
+   softmax(evidence / temperature), then dedup — SMC's stochastic exploration biased to
+   high-evidence branches. Deterministically-scored particles get a small weight bonus
+   so a noisy IS draw cannot crowd out an exact one. Reproducible via `seed`."
+  [pool width seed temperature]
+  (let [pool (dedup-pool pool)]
+    (if (<= (count pool) width)
+      (vec pool)
+      (let [evs  (mapv (fn [p] (+ (or (:evidence p) ##-Inf)
+                                  (if (deterministic-method? (:feedback p)) 1.0 0.0))) pool)]
+        (if (every? #(= ##-Inf %) evs)
+          ;; no particle scored — softmax would be all-NaN; fall back to a deterministic
+          ;; top-width by rank rather than feed NaN weights to weighted-pick.
+          (vec (take width (sort-by particle-rank pool)))
+          (let [ws    (softmax evs temperature)
+                us    (uniforms seed (* 3 width))
+                picks (->> us (map #(weighted-pick pool ws %)) distinct (take width))]
+            (vec (if (seq picks) picks (take width (sort-by particle-rank pool))))))))))
+
+;; ===========================================================================
+;; 4. Adaptive allocation — wider beam on ambiguous (close-evidence) steps
+;; ===========================================================================
+
+(defn- pool-spread
+  "Evidence gap between the best and 2nd-best DISTINCT-program particle in the pool. A
+   small gap = an ambiguous step (competing structures score alike -> widen the beam to
+   keep them); a large gap = one move dominates (narrow). ##Inf when <2 distinct."
+  [pool]
+  (let [evs (->> (dedup-pool pool) (keep :evidence) sort reverse)]
+    (if (>= (count evs) 2) (- (first evs) (second evs)) ##Inf)))
+
+(defn- adapt-width
+  "Resource-rational beam width for this step: spend MORE particles when the top
+   candidates are within :spread-margin (uncertain/structural), fewer when one dominates."
+  [base spread {:keys [min-width max-width spread-margin]
+                :or {min-width 1 max-width 6 spread-margin 1.0}}]
+  (cond
+    (< spread spread-margin) (max base max-width)
+    (> spread (* 3 spread-margin)) (max min-width (min base 2))
+    :else base))
+
+;; ===========================================================================
+;; 5. search — the population loop
+;; ===========================================================================
+
+(declare backtrack-refine)
+
+(defn search
+  "Particle/beam search over construction steps. Maintains a population of partial-model
+   particles; each step expands every non-done particle by its proposed edits, dedups,
+   adaptively allocates the beam width, and selects the next population (:beam top-B or
+   :smc resampling). Stops when the WHOLE population has plateaued (no particle improves)
+   or :max-steps is reached.
+
+   opts:
+     :init-spec     the crude covering model to start from (or :init-specs for many)
+     :observations  {:addr value ...} the data the oracle scores against
+     :propose       (fn [spec feedback] -> [{:edit :desc :spec'} ...])  (injected)
+     :beam-width    base population size B (default 4)
+     :expand-k      max candidate edits considered per particle per step (default all)
+     :strategy      :beam (deterministic top-B, default) | :smc (resample by evidence)
+     :adaptive?     adapt the beam width to the per-step evidence spread (default true)
+     :backtrack?    after the population plateaus, run backtrack-refine on the best
+                    particle to escape a lock-in (default false)
+     :min-width :max-width :spread-margin   adaptive-width bounds + the evidence-spread
+                    threshold below which a step is treated as ambiguous (widen the beam)
+     :max-steps :plateau-eps :n-particles :temperature :seed   (search controls)
+
+   Returns {:best :population :trajectory :steps :stop-reason :diagnostics} where :best
+   is the highest-evidence particle ever seen (method-aware) and :trajectory is its
+   development trace; :diagnostics is one row per step (width, spread, best-evidence)."
+  [{:keys [init-spec init-specs observations propose beam-width expand-k strategy
+           adaptive? backtrack? max-steps plateau-eps n-particles temperature seed
+           min-width max-width spread-margin]
+    :or   {beam-width 4 strategy :beam adaptive? true backtrack? false
+           max-steps 16 plateau-eps 0.05 n-particles 2000 temperature 0.5 seed 1}}]
+  (let [opts  {:plateau-eps plateau-eps :n-particles n-particles :expand-k expand-k}
+        awopts {:min-width (or min-width 1) :max-width (or max-width (* 2 beam-width))
+                :spread-margin (or spread-margin 1.0)}
+        pop0  (mapv #(init-particle % observations opts)
+                    (or init-specs [init-spec]))
+        better (fn [a b] (if (neg? (compare (particle-rank a) (particle-rank b))) a b))]
+    (loop [pop  pop0
+           t    0
+           best (reduce better (first pop0) (rest pop0))
+           diag []]
+      (let [all-done? (every? :done? pop)]
+        (if (or all-done? (>= t max-steps))
+          (let [final-best best
+                refined (when (and backtrack? (syn/scored? (:feedback final-best)))
+                          (backtrack-refine final-best observations propose
+                                            (assoc opts :max-steps max-steps :plateau-eps plateau-eps)))
+                best' (if (:improved? refined) (:result refined) final-best)]
+            {:best best' :population pop :trajectory (:trajectory best')
+             :steps t :stop-reason (if all-done? :plateau :max-steps)
+             :diagnostics diag
+             :backtrack (when refined (dissoc refined :result))})
+          (let [pool    (dedup-pool (vec (mapcat #(expand % propose observations opts) pop)))
+                spread  (pool-spread pool)
+                width   (if adaptive? (adapt-width beam-width spread awopts) beam-width)
+                pop'    (if (= strategy :smc)
+                          (select-smc pool width (+ seed t) temperature)
+                          (select-beam pool width))
+                ;; track the global best over the FULL pre-selection pool, not just the
+                ;; selected pop' — :smc resampling (or a narrow beam) can drop the best
+                ;; particle from the active population, but it must never be lost.
+                best'   (reduce better best pool)
+                row     {:t (inc t) :pool (count pool) :width width
+                         :spread (when (js/isFinite spread) spread)
+                         :best-evidence (:evidence best') :n-done (count (filter :done? pop'))}]
+            (recur pop' (inc t) best' (conj diag row))))))))
+
+;; ===========================================================================
+;; 6. backtrack-refine — deterministic backtracking (best-first re-search) over a trajectory
+;;
+;; The design's "backtracking = reconsider an earlier decision given later feedback"
+;; (genmlx-47zx). OPERATIONAL realization: for each earlier decision point in the best
+;; particle's trajectory, re-open it — take a ROAD NOT TAKEN (an alternative proposed
+;; edit ≠ the one originally accepted) from the spec BEFORE that step, greedy-continue
+;; it, and keep the best-evidence result. This lets even a NARROW search (beam-width 1 =
+;; greedy) escape a structural lock-in (e.g. the Phase-1 linreg no-intercept commitment).
+;; It is DETERMINISTIC best-first re-search, NOT MCMC (no stochastic accept/reject); it
+;; operates on the trajectory directly rather than through a materialized programmer-GF +
+;; GenMLX p/regenerate (the stochastic regenerate move — the §2 fixpoint, deferred).
+;; ===========================================================================
+
+(defn- greedy-from
+  "Greedy continuation from `spec`: beam-width 1, no adaptation/backtrack — the Phase-1
+   driver expressed in the search loop, used as the re-proposal continuation."
+  [spec observations propose opts]
+  (:best (search (merge opts {:init-spec spec :observations observations :propose propose
+                              :beam-width 1 :adaptive? false :backtrack? false}))))
+
+(defn backtrack-refine
+  "Re-open each earlier decision in `particle`'s trajectory: at each step take a road
+   NOT taken (an alternative proposed edit ≠ the one originally accepted) from the spec
+   BEFORE that step, greedy-continue it, and keep the best result (method-aware rank —
+   an exact alternative never loses to a noisy IS one). Taking the alternative — not
+   re-running greedy, which would re-commit to the same locally-best move — is what
+   escapes a step-1 structural lock-in. The returned :result's :trajectory SPLICES the
+   original prefix in front of the re-search continuation (with the re-opened edit
+   relabeled :reopened?), so it reads as the full development path, not a fresh run.
+   Returns {:improved? :result :from :to :reopened-at}; :result is the better particle,
+   or the original when nothing beats it."
+  [particle observations propose opts]
+  (let [traj  (:trajectory particle)
+        alts  (for [t     (range 1 (count traj))
+                    :let  [prefix    (:spec (nth traj (dec t)))
+                           prefix-fb (syn/check (syn/render prefix) observations opts)
+                           taken     (:code (nth traj t))]
+                    c     (propose prefix prefix-fb)
+                    :let  [alt-spec (:spec' c)
+                           alt-code (syn/render alt-spec)]
+                    :when (not= alt-code taken)            ; a road not taken at step t
+                    :let  [res (greedy-from alt-spec observations propose opts)]
+                    :when (syn/scored? (:feedback res))]
+                {:res res :reopened-at t :edit (:edit c) :desc (:desc c)
+                 :prefix-rows (subvec traj 0 t)})
+        best  (first (sort-by (comp particle-rank :res) alts))]
+    (if (and best
+             (> (or (:evidence (:res best)) ##-Inf)
+                (+ (or (:evidence particle) ##-Inf) (or (:plateau-eps opts) 0.05))))
+      (let [res      (:res best)
+            cont     (:trajectory res)                       ; re-search path (cont[0] = its :init)
+            reopened (assoc (first cont) :edit (:edit best) :desc (:desc best) :reopened? true)
+            rows     (into (vec (:prefix-rows best)) (cons reopened (rest cont)))
+            spliced  (vec (map-indexed (fn [i r] (assoc r :step i)) rows))]
+        {:improved? true :result (assoc res :trajectory spliced)
+         :from (:evidence particle) :to (:evidence res) :reopened-at (:reopened-at best)})
+      {:improved? false :result particle})))

--- a/src/genmlx/world/synth.cljs
+++ b/src/genmlx/world/synth.cljs
@@ -1,0 +1,464 @@
+(ns genmlx.world.synth
+  "Phase 1 of the north star (beans genmlx-77vv / genmlx-n74t): the minimal
+   REPL-driven program-synthesis KERNEL — *the programmer as a GenMLX model*.
+
+   THE IDEA (docs/programmer-as-genmlx-model.md). Whole-program one-shot best-of-K
+   CLIFFS to ~0/16 on advanced models (linreg/hier/gmm/kalman) for BOTH a 0.8B AND a
+   35B teacher — it is the one-shot INTERFACE, not capability (each failure is a
+   one-eval-away DSL slip on a structurally-correct model). The lever is the closed
+   FEEDBACK loop a generic code LLM lacks: GenMLX gives (a) exact per-PARTIAL model
+   evidence (a calibrated model-selection gradient — experiment A) and (b) in-process
+   SCI eval (parse/eval/error/value per step). So synthesis becomes: build the model
+   INCREMENTALLY by small edits, CHECK each partial with the exact oracle, and let the
+   oracle SELECT which edit to keep and WHEN to stop (add structure while evidence
+   climbs, stop on plateau — self-terminating, resource-rational).
+
+   THIS NAMESPACE IS NATIVE-FREE. Like its siblings genmlx.world.distill and
+   genmlx.world.train-reward it reuses the same oracle spine — codegen.eval (edamame
+   reader + SCI) and msa-score (Bayesian model evidence) — and never loads the policy
+   LLM. The proposer is INJECTED as a plain `(fn [spec feedback] -> [candidate ...])`,
+   so the driver is identical whether the proposer is the structured move-vocabulary
+   used to isolate the loop (experiment B) or a real LLM wired in by a caller.
+
+   DIVISION OF LABOUR ACROSS THE PHASES (kept honest here):
+     - Phase 1 (this) proves the LOOP: the four-level self-check, the form-level edit
+       ops, and a greedy oracle-driven driver that climbs evidence and self-terminates.
+       The proposer's move VOCABULARY is provided.
+     - Phase 2 SEARCHES that vocabulary (SMC/beam over construction steps).
+     - Phase 3 LEARNS the proposer (REPL-trace SFT + GRPO on the 0.8B).
+     - Phase 4 is the metareasoner (genmlx.control) over the control sites.
+
+   A NOTE ON GFI edit/CompositeEdit. genmlx.edit's edits (Constraint/Selection/
+   ArgsUpdate/Proposal/Composite) rewrite a *trace* of a FIXED model and carry a GFI
+   weight; they are the inference-time analog. Building the MODEL itself changes the
+   program's SOURCE FORM, a different layer — so the construction edits here are
+   form-level (the homoiconic 'code is data' path, design-doc §5), not trace edits.
+
+   Sections:
+     1. Model spec — a partial GenMLX program as data
+     2. Rendering — spec -> a (fn [trace] ...) code string
+     3. Edit operations — pure spec -> spec moves (the typed action space)
+     4. The check node — the four-level self-check (the programmer's senses)
+     5. The greedy REPL driver — propose -> check -> accept / backtrack / stop
+     6. Proposer helpers — generic parameter-refinement moves + combinators"
+  (:require [genmlx.llm.msa-score :as score]
+            [genmlx.codegen.eval :as ce]
+            [genmlx.world.train-reward :as reward]
+            [genmlx.schema :as schema]
+            [clojure.string :as str]))
+
+;; ===========================================================================
+;; 1. Model spec — a partial GenMLX program as data
+;;
+;; A partial model is a VALUE: an ordered list of latent trace sites (rendered as
+;; let-bindings) and an ordered list of observation trace sites (rendered as the
+;; returned map). A SITE is data: an address keyword, a distribution name, and a
+;; vector of argument FORMS (numbers, latent-referencing symbols, or s-expressions
+;; — code is data). A latent additionally carries the :sym other sites reference.
+;;
+;;   latent {:sym 'slope :addr :slope :dist "gaussian" :args [0 3]}
+;;   obs    {:addr :y0    :dist "gaussian"
+;;           :args [(list 'mx/add (list 'mx/multiply 'slope (list 'mx/scalar 0.0))
+;;                        'intercept) 1]}
+;;   spec   {:latents [latent ...] :obs [obs ...]}
+;; ===========================================================================
+
+(defn latent
+  "A latent trace site (a let-binding). `sym` is the binding symbol later sites
+   reference; `addr` its trace address (defaults to (keyword sym)); `dist` the
+   distribution constructor name (string, e.g. \"gaussian\"); `args` a vector of
+   argument forms."
+  ([sym dist args] (latent sym (keyword sym) dist args))
+  ([sym addr dist args] {:sym sym :addr addr :dist dist :args (vec args)}))
+
+(defn obs
+  "An observation trace site (an entry in the returned map). `addr` the observed
+   address; `dist` the distribution name; `args` a vector of argument forms (the
+   first is the mean expression, the last the noise scale, by GenMLX convention)."
+  [addr dist args]
+  {:addr addr :dist dist :args (vec args)})
+
+(defn spec
+  "Assemble a model spec from a seq of latents and a seq of obs sites."
+  [latents obs-sites]
+  {:latents (vec latents) :obs (vec obs-sites)})
+
+(defn site-by-addr
+  "Find the [collection-key index site] of the trace site with `addr`, searching
+   latents then obs, or nil. Used by the edit ops to target a site generically.
+   INVARIANT: latent and obs addresses must be DISJOINT (they share one trace-address
+   namespace, so a collision would render a duplicate address and shadow the obs here).
+   Constructors keep them disjoint by convention (latents :mu/:slope, obs :y*/:a*)."
+  [{:keys [latents obs]} addr]
+  (or (some (fn [[i s]] (when (= addr (:addr s)) [:latents i s]))
+            (map-indexed vector latents))
+      (some (fn [[i s]] (when (= addr (:addr s)) [:obs i s]))
+            (map-indexed vector obs))))
+
+;; ===========================================================================
+;; 2. Rendering — spec -> a (fn [trace] ...) code string
+;;
+;; The rendered string is exactly the shape the oracle expects (and the shape the
+;; advanced-probe reference programs use): (fn [trace] (let [<bindings>] {<obs>})).
+;; Arg forms are emitted with pr-str (a number renders as a literal, a symbol as a
+;; bare name resolving to a let-binding, an s-expression as itself).
+;; ===========================================================================
+
+(defn- render-arg
+  "Render one distribution argument FORM to source text."
+  [a]
+  (pr-str a))
+
+(defn- render-dist
+  "Render a (dist/NAME args...) constructor call from a site's :dist and :args."
+  [{:keys [dist args]}]
+  (str "(dist/" dist
+       (when (seq args) (str " " (str/join " " (map render-arg args))))
+       ")"))
+
+(defn- render-site
+  "Render a (trace :addr (dist/NAME args...)) form for a site."
+  [{:keys [addr] :as site}]
+  (str "(trace " (pr-str addr) " " (render-dist site) ")"))
+
+(defn render
+  "Render a model spec to a complete (fn [trace] (let [...] {...})) code string —
+   the input the check node parses, evals, and scores."
+  [{:keys [latents obs]}]
+  (let [bindings (str/join " " (for [l latents] (str (:sym l) " " (render-site l))))
+        body     (str/join " " (for [o obs] (str (pr-str (:addr o)) " " (render-site o))))]
+    (str "(fn [trace] (let [" bindings "] {" body "}))")))
+
+;; ===========================================================================
+;; 3. Edit operations — pure spec -> spec moves (the typed action space)
+;;
+;; Each op is a pure spec -> spec function: the homoiconic build-up moves the design
+;; doc names. add-latent / add-obs / set-args / set-mean / set-noise are the
+;; load-bearing moves for the advanced models. The named `wrap-combinator` MOVE is
+;; deferred — folding repeated sites into a Map combinator needs the synthesis SCI
+;; sandbox to expose the combinators, and the three exact targets are flat — so this
+;; section ships `homogeneous-obs?`, the pure predicate that DETECTS the fold
+;; opportunity, instead of a rewrite that would render an un-evaluable form.
+;; ===========================================================================
+
+(defn add-latent
+  "Append a latent trace site to the spec (a new let-binding)."
+  [spec lat]
+  (update spec :latents (fnil conj []) lat))
+
+(defn add-obs
+  "Append (or, when `addr` already exists, REPLACE) an observation trace site."
+  [spec ob]
+  (update spec :obs
+          (fn [obs] (let [obs (vec obs)
+                          i   (first (keep-indexed #(when (= (:addr %2) (:addr ob)) %1) obs))]
+                      (if i (assoc obs i ob) (conj obs ob))))))
+
+(defn set-args
+  "Replace the full argument vector of the site at `addr` (latent or obs). The
+   canonical 'set-prior' move on a latent, and the general parameter edit."
+  [spec addr new-args]
+  (if-let [[coll i _] (site-by-addr spec addr)]
+    (assoc-in spec [coll i :args] (vec new-args))
+    spec))
+
+(defn set-mean
+  "Replace the MEAN (first argument) of the site at `addr`, keeping its remaining
+   args. The move that re-points an observation at a latent-dependent mean (e.g.
+   shared-mean -> slope*x+intercept, or pooled -> per-group)."
+  [spec addr mean-form]
+  (if-let [[coll i s] (site-by-addr spec addr)]
+    (assoc-in spec [coll i :args] (assoc (vec (:args s)) 0 mean-form))
+    spec))
+
+(defn set-noise
+  "Replace the NOISE (last argument) of the site at `addr`, keeping its mean. The
+   parameter-refinement move on an observation's scale. Expects a [mean noise] site
+   (>= 2 args); a site with fewer args has no distinct noise slot, so it is left
+   unchanged rather than clobber the mean."
+  [spec addr noise]
+  (if-let [[coll i s] (site-by-addr spec addr)]
+    (let [args (vec (:args s))]
+      (if (< (count args) 2)
+        spec
+        (assoc-in spec [coll i :args] (assoc args (dec (count args)) noise))))
+    spec))
+
+(defn homogeneous-obs?
+  "True iff every observation site shares the same distribution, the same noise (last
+   arg), and the SAME single LATENT symbol as its mean — the precondition for folding
+   them into one Map combinator. A pure QUERY, not a rewrite: the actual fold awaits
+   the synthesis SCI sandbox exposing the combinators (the three advanced targets are
+   heterogeneous + flat, so it is not needed here). Kept honest — it detects the
+   fold opportunity rather than render a combinator form that would not eval."
+  [{:keys [obs latents]}]
+  (let [lat-syms (set (map :sym latents))
+        m0       (first (:args (first obs)))]
+    (boolean (and (seq obs)
+                  (every? #(>= (count (:args %)) 2) obs)
+                  (apply = (map :dist obs))
+                  (apply = (map (comp last :args) obs))
+                  (symbol? m0) (contains? lat-syms m0)
+                  (every? #(= m0 (first (:args %))) obs)))))
+
+;; ===========================================================================
+;; 4. The check node — the four-level self-check (the programmer's senses)
+;;
+;; (partial-program code) -> a feedback map. Four altitudes, each gating the next;
+;; the fitness level is EXACT math, never an LLM-judge:
+;;   syntax    :parses?    edamame reader      — a complete cljs form?
+;;   semantics :schema-ok? GenMLX schema       — a well-formed MODEL? (sites, returns
+;;                                                a map, no delta point-mass hack)
+;;   coverage  :covered?   schema vs data       — every observed addr is a trace site?
+;;   behavior  :evals?/:error  SCI eval         — runs to a DynamicGF / what errored?
+;;   fit       :evidence/:method  the oracle    — Bayesian model evidence of the data
+;; (:delta is relative to a PRIOR accepted state, so it is computed by the driver,
+;; not by a single check.)
+;; ===========================================================================
+
+(defn- uses-delta?
+  "Does the form CALL a `delta` distribution constructor anywhere — a list whose head
+   symbol is `delta` / `dist/delta`? A delta point-mass at an observed site is a
+   degenerate reward-hack (log-evidence ~0 beats any honest noisy fit). Matches only a
+   constructor in HEAD position, so an honest latent/variable merely NAMED `delta` (a
+   common offset/difference name) is NOT rejected — narrower (and more precise) than
+   genmlx.world.distill/form-uses-delta?, which flags any mention of the name."
+  [form]
+  (cond
+    (seq? form)  (or (and (symbol? (first form)) (= "delta" (name (first form))))
+                     (boolean (some uses-delta? form)))
+    (coll? form) (boolean (some uses-delta? form))
+    :else        false))
+
+(defn- result-form
+  "The expression a model body ultimately RETURNS: unwrap let/let*/do wrappers to
+   their tail form (the schema's :return-form is the outer let, whose tail is the
+   observation map)."
+  [form]
+  (if (and (seq? form) (contains? #{'let 'let* 'do} (first form)))
+    (recur (last form))
+    form))
+
+(defn- eval-gf
+  "Eval a model code string to a DynamicGF, CAPTURING any error message (msa-score's
+   eval-model swallows the error to nil). {:gf gf} on success, {:error msg} otherwise."
+  [code]
+  (try
+    (let [f (score/eval-model-fn code)]
+      (if (fn? f)
+        {:gf (score/wrap-model f (score/code->source-form code))}
+        {:error "result is not a (fn [trace] ...) form"}))
+    (catch :default e {:error (.-message e)})))
+
+(defn check
+  "Run the four-level self-check on a candidate partial program against
+   `observations`. Returns a uniform feedback map (every key present, nil where a
+   level was not reached):
+
+     {:code :parses? :schema-ok? :n-sites :returns-map? :uses-delta?
+      :covered? :evals? :error :evidence :method}
+
+   `:evidence` is the exact/IS Bayesian model log-evidence (nil if not scored).
+   opts: {:n-particles n}  importance samples for the non-conjugate IS fallback."
+  ([code observations] (check code observations {}))
+  ([code observations {:keys [n-particles] :or {n-particles 2000}}]
+   (let [code       (str/trim (str code))
+         parses?    (ce/valid-cljs? code)
+         src        (when parses? (score/code->source-form code))
+         sm         (when src (schema/extract-schema src))
+         sites      (:trace-sites sm)
+         site-addrs (set (map :addr sites))
+         returns-map? (boolean (and sm (map? (result-form (:return-form sm)))))
+         delta?     (boolean (when-let [f (ce/parse-form code)] (uses-delta? f)))
+         n-sites    (count sites)
+         schema-ok? (boolean (and src (pos? n-sites) returns-map? (not delta?)))
+         base       {:code code :parses? parses? :schema-ok? schema-ok?
+                     :n-sites n-sites :returns-map? returns-map? :uses-delta? delta?
+                     :covered? false :evals? false :error nil :evidence nil :method nil}]
+     (cond
+       (not parses?)
+       (assoc base :error "does not parse as a complete ClojureScript form")
+
+       (not schema-ok?)
+       (assoc base :error (cond delta?            "uses a delta (point-mass) distribution at a site"
+                                (not returns-map?) "model body does not return an observation map"
+                                (zero? n-sites)    "no trace sites — not a model"
+                                :else              "not a well-formed model form"))
+
+       ;; No data is a misconfiguration, NOT a perfectly-explained model: scoring an
+       ;; empty choicemap returns log p({}) = 0, the best possible evidence, which
+       ;; would dominate any real candidate. Leave it unscored (scored? false).
+       (empty? observations)
+       (assoc base :error "no observations to score against")
+
+       (not (every? site-addrs (keys observations)))
+       (assoc base :error "an observed address is not a trace site (uncovered)")
+
+       :else
+       (let [{:keys [gf error]} (eval-gf code)]
+         (if error
+           (assoc base :covered? true :evals? false :error error)
+           (let [{:keys [log-ml method]} (score/score-model* gf observations {:n-particles n-particles})
+                 ok? (reward/finite? log-ml)]
+             ;; only report :method for a verdict that was VALIDLY scored — do not
+             ;; leak a method label alongside a nil (non-finite) evidence.
+             (assoc base :covered? true :evals? true
+                    :evidence (when ok? log-ml) :method (when ok? method)
+                    :error (when-not ok? "model evidence is non-finite")))))))))
+
+(defn scored?
+  "True iff a check verdict reached a finite model evidence (the only candidates the
+   driver compares / accepts)."
+  [feedback]
+  (and (:evals? feedback) (some? (:evidence feedback))))
+
+;; ===========================================================================
+;; 5. The greedy REPL driver — propose -> check -> accept / backtrack / stop
+;;
+;; A PROPOSER is an injected (fn [spec feedback] -> [candidate ...]) where a
+;; candidate is {:edit <kw> :desc <str> :spec' <spec>} (it is conditioned on the
+;; previous step's feedback, satisfying 'condition each step on verified feedback').
+;; Each step renders + checks every candidate, ACCEPTS the best valid one that
+;; improves evidence beyond :plateau-eps (BACKTRACK = a broken/uncovered candidate is
+;; simply never the max, so the loop steps past it), and STOPS when none improves
+;; (the experiment-A self-terminating rule — 'add while evidence climbs').
+;;
+;; CANDIDATE RANKING is method-aware (mirrors genmlx.world.distill/select-key): an
+;; EXACT/Kalman analytical evidence is reproducible, so it outranks a noisy
+;; importance-sampling estimate that happened to draw high — only then by evidence.
+;; CAVEAT: when the WHOLE search is non-conjugate (every candidate IS-scored), the
+;; greedy accept compares two noisy estimates and can mis-accept / oscillate on a
+;; lucky draw; that regime is Phase-2 SMC territory (a particle population averages
+;; out the noise). The three experiment-B targets are exact, so this does not bite.
+;; ===========================================================================
+
+(defn- score-candidates
+  "Render + check every proposed candidate against the observations."
+  [candidates observations opts]
+  (for [c candidates
+        :let [code (render (:spec' c))
+              fb   (check code observations opts)]]
+    (assoc c :code code :feedback fb :evidence (:evidence fb))))
+
+(defn- deterministic-method?
+  "True iff a verdict's evidence came from a reproducible analytical method (not IS)."
+  [feedback]
+  (contains? #{:exact :kalman} (:method feedback)))
+
+(defn- candidate-rank
+  "Ascending sort key for VALID candidates: deterministically-scored first (an exact
+   marginal never loses to a noisy IS estimate), then higher evidence."
+  [c]
+  [(if (deterministic-method? (:feedback c)) 0 1) (- (:evidence c))])
+
+(defn step
+  "One greedy REPL step from `state` ({:spec :feedback}). Returns
+   {:candidates [...] :best <candidate-or-nil> :improved? bool}: the best VALID
+   candidate (method-aware rank) whose evidence beats the current by more than
+   :plateau-eps, if any."
+  [{:keys [feedback]} candidates observations {:keys [plateau-eps] :or {plateau-eps 0.05} :as opts}]
+  (let [cur-ev (:evidence feedback)
+        scored (score-candidates candidates observations opts)
+        valid  (filter (comp scored? :feedback) scored)
+        best   (first (sort-by candidate-rank valid))]
+    {:candidates scored
+     :best best
+     :improved? (boolean (and best (or (nil? cur-ev)
+                                       (> (:evidence best) (+ cur-ev plateau-eps)))))}))
+
+(defn synthesize
+  "Run the greedy REPL synthesis loop.
+
+   opts:
+     :init-spec     the starting partial model spec (a crude covering model)
+     :observations  {:addr value ...} the data the oracle scores against
+     :propose       (fn [spec feedback] -> [{:edit :desc :spec'} ...])
+     :max-steps     hard cap on accepted edits (default 12)
+     :plateau-eps   min evidence gain to accept an edit / not stop (default 0.05)
+     :n-particles   IS samples for the non-conjugate fallback (default 2000)
+
+   Returns {:spec :code :feedback :trajectory :stop-reason :steps}, where :stop-reason
+   is :plateau (no edit improves a fitted model), :stuck (never reached a scored model)
+   or :max-steps. The trajectory is the development trace: one row per state with the
+   edit taken, the chosen code, its exact evidence, the scoring :method, and the :delta
+   from the prior state — the reportable artifact AND (design-doc §2) the shape of the
+   future SFT corpus."
+  [{:keys [init-spec observations propose max-steps plateau-eps n-particles]
+    :or   {max-steps 12 plateau-eps 0.05 n-particles 2000}}]
+  (let [opts      {:plateau-eps plateau-eps :n-particles n-particles}
+        init-code (render init-spec)
+        init-fb   (check init-code observations opts)]
+    (loop [state {:spec init-spec :feedback init-fb}
+           t     0
+           traj  [{:step 0 :edit :init :desc "crude covering model"
+                   :code init-code :evidence (:evidence init-fb)
+                   :method (:method init-fb) :delta nil :accepted? true
+                   :n-candidates 0}]]
+      (if (>= t max-steps)
+        {:spec (:spec state) :code (render (:spec state)) :feedback (:feedback state)
+         :trajectory traj :stop-reason :max-steps :steps t}
+        (let [cands (vec (propose (:spec state) (:feedback state)))
+              {:keys [best improved?]} (step state cands observations opts)]
+          (if-not improved?
+            ;; :plateau = stopped at a genuinely scored model no edit improves;
+            ;; :stuck = the current state never reached a finite evidence AND no valid
+            ;; candidate did either (a structurally-incomplete init the proposer could
+            ;; not complete) — NOT a fitted plateau, so report it distinctly.
+            {:spec (:spec state) :code (render (:spec state)) :feedback (:feedback state)
+             :trajectory traj :steps t
+             :stop-reason (if (scored? (:feedback state)) :plateau :stuck)}
+            (let [prev-ev (:evidence (:feedback state))
+                  delta   (when (and prev-ev (:evidence best)) (- (:evidence best) prev-ev))]
+              (recur {:spec (:spec' best) :feedback (:feedback best)}
+                     (inc t)
+                     (conj traj {:step (inc t) :edit (:edit best) :desc (:desc best)
+                                 :code (:code best) :evidence (:evidence best)
+                                 :method (:method (:feedback best)) :delta delta
+                                 :accepted? true :n-candidates (count cands)})))))))))
+
+;; ===========================================================================
+;; 6. Proposer helpers — generic parameter-refinement moves + combinators
+;;
+;; These are the structure-NEUTRAL moves any proposer can offer: tune an existing
+;; site's noise / prior over a small grid. A caller composes them with the
+;; (task-shaped, Phase-1-provided) STRUCTURAL moves via `union-proposer`. Phase 2
+;; replaces the provided vocabulary with a search; Phase 3 with a learned LLM.
+;; ===========================================================================
+
+(defn noise-refinements
+  "Candidate edits that set each observation site's noise to each value in `grid` —
+   the parameter-refinement vocabulary. Skips the no-op (current value)."
+  ([spec] (noise-refinements spec [0.3 0.5 0.7 1 1.5 2.5]))
+  ([spec grid]
+   (for [o (:obs spec)
+         g grid
+         :when (not= g (last (:args o)))]
+     {:edit :set-noise :desc (str "set " (:addr o) " noise -> " g)
+      :spec' (set-noise spec (:addr o) g)})))
+
+(defn prior-std-refinements
+  "Candidate edits that set each latent's prior std (its last arg) to each value in
+   `grid` — refines how tightly a latent is regularized."
+  ([spec] (prior-std-refinements spec [1 2 5]))
+  ([spec grid]
+   (for [l (:latents spec)
+         g grid
+         :when (not= g (last (:args l)))]
+     {:edit :set-prior :desc (str "set " (:addr l) " prior-std -> " g)
+      :spec' (set-args spec (:addr l) (assoc (vec (:args l)) (dec (count (:args l))) g))})))
+
+(defn union-proposer
+  "Combine several proposers into one whose candidates are the concatenation of all
+   their candidates (deduped WITHIN a step by rendered code so identical moves are not
+   re-scored). It does not dedup across steps, but that is harmless: a re-offered
+   already-accepted move renders to the current state, so its evidence does not beat
+   the current by :plateau-eps and it is never re-accepted."
+  [& proposers]
+  (fn [spec feedback]
+    (let [cands (mapcat (fn [p] (p spec feedback)) proposers)]
+      (->> cands
+           (reduce (fn [[seen acc] c]
+                     (let [k (render (:spec' c))]
+                       (if (contains? seen k) [seen acc] [(conj seen k) (conj acc c)])))
+                   [#{} []])
+           second))))

--- a/test/genmlx/search_test.cljs
+++ b/test/genmlx/search_test.cljs
@@ -1,0 +1,158 @@
+;; @tier slow
+(ns genmlx.search-test
+  "Acceptance for genmlx.world.search — the Phase-2 particle/beam search over construction
+   steps (genmlx-47zx). Deterministic, native-free: every partial model is a shared-mean
+   Gaussian scored by the EXACT analytical marginal, so the orderings are reproducible and
+   checkable against an INDEPENDENT closed form. The 4-advanced-model + greedy-vs-beam
+   head-to-head lives in scripts/synth_search_probe.cljs; this file pins the search core.
+
+   Run: bun run --bun nbb test/genmlx/search_test.cljs
+
+   PARTS:
+     A — particles + expansion + selection: beam keeps a POPULATION (>1 branch alive),
+         dedups identical programs, ranks deterministic evidence first.
+     B — BEAM BEATS GREEDY on a constructed two-branch trap: greedy locks into the
+         locally-best branch A; beam (width 2) keeps branch B alive and finds the global
+         optimum B2 (exact evidence, verified against the closed form).
+     C — backtrack-refine rescues a NARROW search: greedy (beam-width 1) + backtrack
+         re-opens the step-1 decision, takes the road not taken, and recovers B2.
+     D — :smc resampling reaches the optimum; adaptive width widens on an ambiguous step;
+         the search self-terminates on a whole-population plateau with per-step diagnostics."
+  (:require [genmlx.world.search :as se]
+            [genmlx.world.synth :as syn]))
+
+(def ^:private pass (atom 0))
+(def ^:private fail (atom 0))
+(defn assert-true [label v]
+  (if v (do (swap! pass inc) (println "  PASS" label))
+        (do (swap! fail inc) (println "  FAIL" label))))
+(defn assert-close [label expected actual tol]
+  (let [ok (and (number? actual) (js/isFinite actual) (<= (js/Math.abs (- expected actual)) tol))]
+    (if ok (do (swap! pass inc) (println "  PASS" label (str "(" actual " ~ " expected ")")))
+           (do (swap! fail inc) (println "  FAIL" label (str "(" actual " vs " expected ")"))))))
+
+;; Independent closed-form Gaussian-Gaussian marginal (mu ~ N(m0,s0), y_i ~ N(mu, sn)).
+(defn gaussian-gaussian-marginal [ys m0 s0 sn]
+  (let [n (count ys) s0² (* s0 s0) sn² (* sn sn)
+        ds (map #(- % m0) ys) sd (reduce + ds) sd² (reduce + (map #(* % %) ds))
+        denom (+ sn² (* n s0²))
+        logdet (+ (js/Math.log denom) (* (dec n) (js/Math.log sn²)))
+        quad (* (/ 1.0 sn²) (- sd² (* (/ s0² denom) (* sd sd))))]
+    (- (* -0.5 n (js/Math.log (* 2 js/Math.PI))) (* 0.5 logdet) (* 0.5 quad))))
+
+(def ^:private obs4 {:y0 2.0 :y1 2.3 :y2 1.7 :y3 2.1})
+(def ^:private obs-ys (mapv obs4 [:y0 :y1 :y2 :y3]))
+
+(defn smean
+  "A shared-mean Gaussian spec mu~N(m0,s0), :yj~N(mu,noise), tagged with :branch (an
+   extra key render ignores) so the trap proposer can route on which branch a spec is in."
+  [m0 s0 noise branch]
+  (assoc (syn/spec [(syn/latent 'mu "gaussian" [m0 s0])]
+                   (for [k [:y0 :y1 :y2 :y3]] (syn/obs k "gaussian" ['mu noise])))
+         :branch branch))
+
+(defn ev [spec] (:evidence (syn/check (syn/render spec) obs4)))
+
+;; ---- The two-branch trap (all exact). Evidence rises as sn -> data spread (~0.22):
+;;   E(sn=1.5) < E(sn=1.0) < E(sn=0.7) < E(sn=0.3). So branch A (1.0->0.7) is locally
+;;   better at step 1 (greedy takes it) but branch B (1.5->0.3) is the GLOBAL optimum. ----
+(def crude (smean 2 1 2.5 nil))
+(def A1 (smean 2 1 1.0 :a))
+(def A2 (smean 2 1 0.7 :a))
+(def B1 (smean 2 1 1.5 :b))
+(def B2 (smean 2 1 0.3 :b))
+
+(defn trap-propose [sp _fb]
+  (let [n (last (:args (first (:obs sp)))) br (:branch sp)]
+    (cond
+      (nil? br)                  [{:edit :a1 :desc "branch A start (sn 1.0)" :spec' A1}
+                                  {:edit :b1 :desc "branch B start (sn 1.5)" :spec' B1}]
+      (and (= br :a) (= n 1.0))  [{:edit :a2 :desc "refine A -> 0.7" :spec' A2}]
+      (and (= br :b) (= n 1.5))  [{:edit :b2 :desc "refine B -> 0.3" :spec' B2}]
+      :else                      [])))
+
+(defn part-a []
+  (println "\n== PART A: particles + expansion + selection ==")
+  ;; the trap is real: branch ordering as designed
+  (assert-true "trap ordering E(B1) < E(A1) < E(A2) < E(B2)"
+               (< (ev B1) (ev A1) (ev A2) (ev B2)))
+  ;; beam (width 2) keeps BOTH branches alive after step 1
+  (let [res (se/search {:init-spec crude :observations obs4 :propose trap-propose
+                        :beam-width 2 :adaptive? false :max-steps 6})
+        branches (set (map (comp :branch :spec) (:population res)))]
+    (assert-true "beam population explores >1 branch (both A and B kept alive)"
+                 (= #{:a :b} branches)))
+  ;; selection ranks an EXACT-scored particle ahead of an IS one (method-aware)
+  (let [det {:feedback {:method :exact} :evidence -5.0}
+        is  {:feedback {:method :handler-is} :evidence -4.0}]
+    (assert-true "exact evidence outranks a higher IS estimate"
+                 (= det (first (sort-by @#'se/particle-rank [is det]))))))
+
+(defn part-b []
+  (println "\n== PART B: BEAM BEATS GREEDY on the two-branch trap ==")
+  (let [greedy (se/search {:init-spec crude :observations obs4 :propose trap-propose
+                           :beam-width 1 :adaptive? false :max-steps 6})
+        beam   (se/search {:init-spec crude :observations obs4 :propose trap-propose
+                           :beam-width 2 :adaptive? false :max-steps 6})
+        ge (:evidence (:best greedy)) be (:evidence (:best beam))]
+    (assert-true "greedy (width 1) locks into branch A" (= :a (:branch (:spec (:best greedy)))))
+    (assert-close "greedy final == E(A2) (the local optimum)" (ev A2) ge 1e-2)
+    (assert-true "beam (width 2) finds branch B" (= :b (:branch (:spec (:best beam)))))
+    (assert-close "beam final == E(B2) (the global optimum)" (ev B2) be 1e-2)
+    (assert-true "BEAM STRICTLY BEATS GREEDY (be > ge)" (> be ge))
+    (println (str "  greedy -> " (.toFixed (js/Number ge) 3) " (A) | beam -> "
+                  (.toFixed (js/Number be) 3) " (B)"))))
+
+(defn part-c []
+  (println "\n== PART C: backtrack-refine rescues a narrow (greedy) search ==")
+  (let [greedy (se/search {:init-spec crude :observations obs4 :propose trap-propose
+                           :beam-width 1 :adaptive? false :max-steps 6})
+        bt     (se/backtrack-refine (:best greedy) obs4 trap-propose {:plateau-eps 0.05 :n-particles 2000 :max-steps 6})]
+    (assert-true "backtrack reports an improvement" (:improved? bt))
+    (assert-true "backtrack re-opened the step-1 decision" (= 1 (:reopened-at bt)))
+    (assert-close "backtrack recovers B2 (the global optimum)" (ev B2) (:evidence (:result bt)) 1e-2)
+    ;; the spliced result trajectory reads as the FULL path (original prefix in front)
+    ;; with the re-opened edit flagged, not a fresh run rooted at the alternative.
+    (assert-true "backtrack result trajectory splices the original prefix (starts at :init)"
+                 (= :init (:edit (first (:trajectory (:result bt))))))
+    (assert-true "backtrack result flags the re-opened edit (:reopened?)"
+                 (boolean (some :reopened? (:trajectory (:result bt)))))
+    (assert-true "backtrack result trajectory steps are renumbered 0..n"
+                 (= (range (count (:trajectory (:result bt))))
+                    (map :step (:trajectory (:result bt)))))
+    ;; and search with :backtrack? on beam-width 1 does it end-to-end
+    (let [g+bt (se/search {:init-spec crude :observations obs4 :propose trap-propose
+                           :beam-width 1 :adaptive? false :backtrack? true :max-steps 6})]
+      (assert-close "search beam-width 1 + :backtrack? reaches B2" (ev B2) (:evidence (:best g+bt)) 1e-2)
+      (assert-true "search reports the backtrack improvement" (:improved? (:backtrack g+bt))))))
+
+(defn part-d []
+  (println "\n== PART D: :smc strategy, adaptive width, plateau termination ==")
+  ;; :smc resampling still reaches the global optimum (seeded -> reproducible)
+  (let [smc (se/search {:init-spec crude :observations obs4 :propose trap-propose
+                        :strategy :smc :beam-width 3 :temperature 0.3 :seed 7
+                        :adaptive? false :max-steps 6})]
+    (assert-close "smc reaches the global optimum B2" (ev B2) (:evidence (:best smc)) 1e-2))
+  ;; adaptive width WIDENS on the ambiguous first step (A1 and B1 score close) ...
+  (let [res  (se/search {:init-spec crude :observations obs4 :propose trap-propose
+                         :beam-width 1 :adaptive? true :spread-margin 5.0 :max-width 4 :max-steps 6})
+        d1   (first (:diagnostics res))]
+    (assert-true "adaptive width > base on the ambiguous step-1" (> (:width d1) 1))
+    ;; ... and with the wider beam even base-width-1 now finds the global optimum
+    (assert-close "adaptive search reaches B2" (ev B2) (:evidence (:best res)) 1e-2))
+  ;; self-terminates on plateau (not max-steps) with one diagnostics row per step
+  (let [res (se/search {:init-spec crude :observations obs4 :propose trap-propose
+                        :beam-width 2 :adaptive? false :max-steps 20})]
+    (assert-true "search self-terminates on plateau" (= :plateau (:stop-reason res)))
+    (assert-true "diagnostics has one row per step" (= (:steps res) (count (:diagnostics res))))
+    (assert-true "trajectory of the best particle is recorded" (>= (count (:trajectory (:best res))) 2))))
+
+(defn- summary []
+  (println (str "\n== search (genmlx-47zx): " @pass " passed, " @fail " failed =="))
+  (when (pos? @fail) (set! (.-exitCode js/process) 1)))
+
+(part-a)
+(part-b)
+(part-c)
+(part-d)
+(summary)

--- a/test/genmlx/synth_test.cljs
+++ b/test/genmlx/synth_test.cljs
@@ -1,0 +1,237 @@
+;; @tier slow
+(ns genmlx.synth-test
+  "Acceptance for genmlx.world.synth — the Phase-1 REPL-synthesis KERNEL (genmlx-n74t):
+   the model-spec + form-level edit ops, the four-level self-check, and the greedy
+   oracle-driven driver. Deterministic, NATIVE-FREE (no policy LLM): conjugate partial
+   models score the EXACT analytical marginal, so every assertion is reproducible. The
+   end-to-end loop-solves-an-advanced-model demonstration (experiment B) lives in
+   scripts/synth_repl_probe.cljs; this file pins the pure, unit-testable parts.
+
+   Run: bun run --bun nbb test/genmlx/synth_test.cljs
+
+   PARTS:
+     A — spec + render + edit ops: each move is a pure spec->spec transform whose
+         render is valid ClojureScript with the expected structure.
+     B — the check node: the four levels gate correctly (parse / schema / coverage /
+         eval / fit), with the right :error, and a valid model's :evidence matches an
+         INDEPENDENT closed-form Gaussian-Gaussian marginal (non-circular).
+     C — the greedy driver: climbs exact evidence, rejects distractor + broken
+         candidates (backtrack), self-terminates on plateau, and lands at the
+         grid-optimal model the closed form predicts."
+  (:require [genmlx.world.synth :as s]
+            [genmlx.codegen.eval :as ce]
+            [clojure.string :as str]))
+
+(def ^:private pass (atom 0))
+(def ^:private fail (atom 0))
+
+(defn assert-true [label v]
+  (if v
+    (do (swap! pass inc) (println "  PASS" label))
+    (do (swap! fail inc) (println "  FAIL" label))))
+
+(defn assert-close [label expected actual tol]
+  (let [ok (and (number? actual) (js/isFinite actual) (<= (js/Math.abs (- expected actual)) tol))]
+    (if ok
+      (do (swap! pass inc) (println "  PASS" label (str "(" actual " ~ " expected ")")))
+      (do (swap! fail inc) (println "  FAIL" label (str "(" actual " vs " expected " tol " tol ")"))))))
+
+;; Independent closed-form Gaussian-Gaussian marginal (DERIVED outside GenMLX —
+;; mu ~ N(m0,s0), y_i ~ N(mu, sn) — so the evidence check is not circular).
+(defn gaussian-gaussian-marginal [ys m0 s0 sn]
+  (let [n (count ys) s0² (* s0 s0) sn² (* sn sn)
+        ds (map #(- % m0) ys) sd (reduce + ds) sd² (reduce + (map #(* % %) ds))
+        denom (+ sn² (* n s0²))
+        logdet (+ (js/Math.log denom) (* (dec n) (js/Math.log sn²)))
+        quad (* (/ 1.0 sn²) (- sd² (* (/ s0² denom) (* sd sd))))]
+    (- (* -0.5 n (js/Math.log (* 2 js/Math.PI))) (* 0.5 logdet) (* 0.5 quad))))
+
+(def ^:private obs4 {:y0 2.0 :y1 2.3 :y2 1.7 :y3 2.1})
+(def ^:private obs-ys (mapv obs4 [:y0 :y1 :y2 :y3]))
+
+;; A shared-mean spec helper: mu ~ N(m0, s0), each :yj ~ N(mu, noise).
+(defn shared-mean-spec [m0 s0 noise]
+  (s/spec [(s/latent 'mu "gaussian" [m0 s0])]
+          (for [k [:y0 :y1 :y2 :y3]]
+            (s/obs k "gaussian" ['mu noise]))))
+
+;; ===========================================================================
+;; PART A — spec + render + edit operations
+;; ===========================================================================
+
+(defn part-a []
+  (println "\n== PART A: spec + render + edit ops ==")
+  (let [sp (shared-mean-spec 2 1 0.5)
+        code (s/render sp)]
+    (assert-true "render produces a complete cljs form" (ce/valid-cljs? code))
+    (assert-true "render reads as (fn [trace] ...)" (str/starts-with? code "(fn [trace] (let ["))
+    (assert-true "render emits the latent let-binding"
+                 (str/includes? code "mu (trace :mu (dist/gaussian 2 1))"))
+    (assert-true "render emits an obs trace site in the returned map"
+                 (str/includes? code ":y0 (trace :y0 (dist/gaussian mu 0.5))")))
+
+  ;; add-latent / add-obs
+  (let [sp (-> (s/spec [] [])
+               (s/add-latent (s/latent 'slope "gaussian" [0 3]))
+               (s/add-obs (s/obs :y0 "gaussian" ['slope 1])))]
+    (assert-true "add-latent appends a latent" (= 1 (count (:latents sp))))
+    (assert-true "add-obs appends an obs site" (= 1 (count (:obs sp))))
+    (assert-true "add-latent + add-obs render to valid cljs" (ce/valid-cljs? (s/render sp)))
+    (assert-true "add-obs REPLACES an existing addr (no duplicate)"
+                 (= 1 (count (:obs (s/add-obs sp (s/obs :y0 "gaussian" ['slope 2])))))))
+
+  ;; set-args (set-prior) / set-mean / set-noise
+  (let [sp (shared-mean-spec 2 1 0.5)]
+    (assert-true "set-args replaces a latent's prior"
+                 (str/includes? (s/render (s/set-args sp :mu [0 10]))
+                                "mu (trace :mu (dist/gaussian 0 10))"))
+    (assert-true "set-mean re-points an obs at a latent-dependent mean"
+                 (str/includes? (s/render (s/set-mean sp :y0 (list 'mx/multiply 'mu (list 'mx/scalar 2.0))))
+                                ":y0 (trace :y0 (dist/gaussian (mx/multiply mu (mx/scalar 2)) 0.5))"))
+    (assert-true "set-noise replaces an obs site's last arg"
+                 (str/includes? (s/render (s/set-noise sp :y0 1.5))
+                                ":y0 (trace :y0 (dist/gaussian mu 1.5))"))
+    (assert-true "edit ops leave other sites untouched"
+                 (str/includes? (s/render (s/set-noise sp :y0 1.5))
+                                ":y1 (trace :y1 (dist/gaussian mu 0.5))")))
+
+  ;; homogeneous-obs?: detects the Map-fold opportunity (same dist, same noise, same
+  ;; single latent mean) without rewriting; false for heterogeneous / non-latent means.
+  (let [homo     (s/spec [(s/latent 'mu "gaussian" [0 5])]
+                         (for [k [:y0 :y1 :y2]] (s/obs k "gaussian" ['mu 1])))
+        hetero   (s/spec [(s/latent 'a "gaussian" [0 5]) (s/latent 'b "gaussian" [0 5])]
+                         [(s/obs :y0 "gaussian" ['a 1]) (s/obs :y1 "gaussian" ['b 1])])
+        non-lat  (s/spec [(s/latent 'mu "gaussian" [0 5])]
+                         [(s/obs :y0 "gaussian" [(list 'mx/scalar 0.0) 1])])]
+    (assert-true "homogeneous-obs? true for same dist+noise+single latent mean"
+                 (s/homogeneous-obs? homo))
+    (assert-true "homogeneous-obs? false for distinct per-site latents"
+                 (not (s/homogeneous-obs? hetero)))
+    (assert-true "homogeneous-obs? false when the mean is not a latent symbol"
+                 (not (s/homogeneous-obs? non-lat))))
+
+  ;; set-noise is robust on a no-arg site (pure no-op, never throws).
+  (let [sp (s/spec [] [(s/obs :y0 "gaussian" [])])]
+    (assert-true "set-noise on an empty-args site is a no-op (no throw)"
+                 (= sp (s/set-noise sp :y0 1.0)))))
+
+;; ===========================================================================
+;; PART B — the four-level self-check
+;; ===========================================================================
+
+(defn part-b []
+  (println "\n== PART B: the check node (four levels) ==")
+
+  ;; level 1: syntax
+  (let [fb (s/check "(fn [trace] (let [" obs4)]
+    (assert-true "unparseable -> :parses? false" (false? (:parses? fb)))
+    (assert-true "unparseable -> not evaluated, has an :error"
+                 (and (false? (:evals? fb)) (string? (:error fb)))))
+
+  ;; level 2: semantics — body does not return a map
+  (let [fb (s/check "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 1))] mu))" obs4)]
+    (assert-true "non-map return -> :schema-ok? false" (false? (:schema-ok? fb)))
+    (assert-true "non-map return -> :returns-map? false" (false? (:returns-map? fb))))
+
+  ;; level 2: semantics — a delta DISTRIBUTION CONSTRUCTOR is the point-mass hack
+  (let [fb (s/check (str "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 1))] "
+                         "{:y0 (trace :y0 (dist/delta mu))}))") {:y0 2.0})]
+    (assert-true "(dist/delta ...) -> :uses-delta? true" (true? (:uses-delta? fb)))
+    (assert-true "(dist/delta ...) -> :schema-ok? false (rejected)" (false? (:schema-ok? fb))))
+
+  ;; but an honest latent merely NAMED `delta` (a common offset name) is NOT rejected
+  (let [fb (s/check (str "(fn [trace] (let [delta (trace :delta (dist/gaussian 0 1))] "
+                         "{:y0 (trace :y0 (dist/gaussian delta 1))}))") {:y0 2.0})]
+    (assert-true "a variable named `delta` is NOT a point-mass hack" (false? (:uses-delta? fb)))
+    (assert-true "a variable named `delta` -> :schema-ok? true (accepted + scored)"
+                 (and (:schema-ok? fb) (s/scored? fb))))
+
+  ;; empty observations is a misconfiguration, not a perfectly-explained (evidence-0) model
+  (let [fb (s/check (s/render (shared-mean-spec 2 1 0.5)) {})]
+    (assert-true "empty observations -> not scored (no vacuous evidence 0)"
+                 (and (not (s/scored? fb)) (nil? (:evidence fb))))
+    (assert-true "empty observations -> carries an explanatory :error" (string? (:error fb))))
+
+  ;; level 3: coverage — declares a latent but ignores the data addresses
+  (let [fb (s/check "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 5))] {:result (trace :result (dist/gaussian mu 1))}))" obs4)]
+    (assert-true "uncovered -> :schema-ok? true but :covered? false"
+                 (and (:schema-ok? fb) (false? (:covered? fb))))
+    (assert-true "uncovered -> not scored (no evidence)" (nil? (:evidence fb))))
+
+  ;; level 4: behavior — covered, well-formed, but errors at eval (unknown dist)
+  (let [fb (s/check (str "(fn [trace] {:y0 (trace :y0 (dist/student-t 0 1))})") {:y0 2.0})]
+    (assert-true "eval error -> :covered? true but :evals? false"
+                 (and (:covered? fb) (false? (:evals? fb))))
+    (assert-true "eval error -> captures an :error message" (string? (:error fb))))
+
+  ;; level 5: fit — a valid model scores the EXACT marginal (matches the closed form)
+  (let [m0 2 s0 1 sn 0.5
+        fb (s/check (s/render (shared-mean-spec m0 s0 sn)) obs4)
+        truth (gaussian-gaussian-marginal obs-ys m0 s0 sn)]
+    (assert-true "valid model -> parses/schema-ok/covered/evals all true"
+                 (and (:parses? fb) (:schema-ok? fb) (:covered? fb) (:evals? fb)))
+    (assert-true "valid conjugate model scored by an EXACT method" (= :exact (:method fb)))
+    (assert-close "check evidence == independent closed-form marginal" truth (:evidence fb) 1e-2))
+
+  ;; scored? predicate
+  (assert-true "scored? true for a finite-evidence verdict"
+               (s/scored? (s/check (s/render (shared-mean-spec 2 1 0.5)) obs4)))
+  (assert-true "scored? false for an unparseable verdict"
+               (not (s/scored? (s/check "(fn [trace] (let [" obs4)))))
+
+;; ===========================================================================
+;; PART C — the greedy driver climbs, backtracks, self-terminates
+;; ===========================================================================
+
+(defn part-c []
+  (println "\n== PART C: greedy REPL driver ==")
+  (let [grid       [0.3 0.5 0.7 1 1.5 2.5]
+        init       (shared-mean-spec 2 1 2.5)   ; loose noise: headroom to climb
+        ;; proposer = noise-grid refinements (good) + a clearly-worse distractor
+        ;; (noise 9.0) + a BROKEN candidate (drops :y3 -> uncovered). The oracle must
+        ;; pick only improving valid moves; the distractor/broken never get accepted.
+        broken     (update (shared-mean-spec 2 1 0.5) :obs (comp vec butlast))
+        propose    (fn [sp _fb]
+                     (concat (s/noise-refinements sp grid)
+                             [{:edit :distractor :desc "noise -> 9.0 (worse)" :spec' (s/set-noise sp :y0 9.0)}
+                              {:edit :broken :desc "drop :y3 (uncovered)" :spec' broken}]))
+        res        (s/synthesize {:init-spec init :observations obs4 :propose propose})
+        traj       (:trajectory res)
+        init-ev    (:evidence (first traj))
+        final-ev   (:evidence (last traj))
+        grid-best  (apply max (map #(gaussian-gaussian-marginal obs-ys 2 1 %) grid))]
+    (assert-true "driver self-terminates on plateau" (= :plateau (:stop-reason res)))
+    (assert-true "driver makes >=1 accepted edit" (>= (count traj) 2))
+    (assert-true "final evidence strictly improves on the crude start" (> final-ev init-ev))
+    (assert-true "every accepted step has a positive delta (monotone climb)"
+                 (every? #(or (nil? (:delta %)) (pos? (:delta %))) traj))
+    ;; the per-site noise search STRICTLY CONTAINS the homogeneous-noise grid (setting
+    ;; every site to the same sigma is reachable), so the driver does at least as well
+    ;; as the best shared-sigma model the closed form predicts — here strictly better.
+    (assert-true "driver does at least as well as the best shared-sigma model (closed-form max)"
+                 (>= final-ev (- grid-best 1e-2)))
+    (assert-true "no distractor/broken edit was ever accepted"
+                 (every? #(not (contains? #{:distractor :broken} (:edit %))) traj))
+    (assert-true "final model is valid + covered + scored" (s/scored? (:feedback res)))
+
+    ;; a never-scored init (uncovered) the proposer cannot complete -> :stuck, NOT a
+    ;; spurious :plateau (which would falsely read as a fitted model).
+    (let [stuck-init (s/spec [(s/latent 'mu "gaussian" [0 1])] [(s/obs :result "gaussian" ['mu 1])])
+          stuck (s/synthesize {:init-spec stuck-init :observations obs4 :propose (fn [_ _] [])})]
+      (assert-true "never-scored init + no candidate -> :stop-reason :stuck (not :plateau)"
+                   (= :stuck (:stop-reason stuck))))
+
+    (println (str "  trajectory: "
+                  (str/join " -> " (map (fn [r] (str (name (:edit r)) "@"
+                                                     (.toFixed (js/Number (:evidence r)) 2))) traj))))))
+
+;; ===========================================================================
+
+(defn- summary []
+  (println (str "\n== synth (genmlx-n74t): " @pass " passed, " @fail " failed =="))
+  (when (pos? @fail) (set! (.-exitCode js/process) 1)))
+
+(part-a)
+(part-b)
+(part-c)
+(summary)


### PR DESCRIPTION
> **Updated scope (now Phase 1 + Phase 2).** This PR originally landed the Phase-1 REPL-synthesis kernel; **Phase 2 (the particle/beam search over edits, `genmlx-47zx`) has been folded in** as a second commit. Two commits off `main`; all dependencies are on `main`. Tests run against this branch: `synth_test` **43/43**, `search_test` **22/22**.

## Phase 2 — search over edits: SMC/beam beats greedy (`genmlx-47zx`)

`src/genmlx/world/search.cljs` turns the greedy Phase-1 kernel into a **population search over construction steps** — the best-of-K wrapper moved to the *step* level. It keeps a population of partial-model particles; each step expands every non-done particle by its proposed edits, dedups, **adaptively allocates** the beam width (wider when the top candidates score within a margin — an ambiguous structural step), and selects by **`:beam`** (deterministic top-B) or **`:smc`** (resample ∝ softmax of intermediate evidence, exact-scored particles above noisy IS). It stops when the *whole population* plateaus. `backtrack-refine` re-opens an earlier decision (takes a road not taken + greedy-continues) to rescue even a width-1 search — **deterministic best-first re-search**, *not* literal GFI `p/regenerate` (the §2 fixpoint, deferred).

**Result — greedy vs beam through the *same* code path (greedy = beam-width 1), same proposers/budget:**

| model | greedy | beam | winner |
|---|---|---|---|
| linreg | −10.14 | **−6.90** | **beam (+3.24)** — escapes the no-intercept lock-in to the full-intercept global optimum |
| kalman | −5.05 | −4.92 | beam (+0.13) |
| hier | −12.36 | −12.36 | tie (greedy already optimal) |
| gmm | −17.62 | −17.62 | tie — **not solved by either** |

**Solves 3/4; beam ≥ greedy everywhere; strictly wins on 2.** Honest: **GMM is not solved by either search** — its mixture marginal is estimated by importance sampling from the prior over 6 discrete assignments (biased low), so the structural edit never clears the baseline and the search *correctly declines* it. That's an **oracle/scoring** bottleneck, not a search one (the un-seeded IS also makes GMM non-reproducible). Follow-up `genmlx-akvp` (enumerate / Rao-Blackwellize the assignments). The proposer is still the structured move-vocabulary, not an LLM (Phase 3 learns it).

**Verification:** `search_test.cljs` 22/22 (closed-form-oracle-checked: branch exploration, the beam-beats-greedy trap, backtrack rescue + trajectory splicing, SMC, adaptive width, plateau). A 4-dimension adversarial-review workflow ran; the experiment-honesty reviewer was stopped when it went runaway (re-executing the slow GMM oracle) and self-audited, the other 3 completed → **10 findings, all confirmed, all fixed** (HIGH: global-best was tracked over the selected population only and could be dropped under SMC → now over the full pool; method-aware backtrack selection; backtrack trajectory now splices its prefix; the "MCMC" label corrected to deterministic best-first re-search; SMC NaN guard; unused requires removed).

---

## What

The **Phase-1 REPL-driven program-synthesis kernel** for the north star (milestone `genmlx-77vv`, bean `genmlx-n74t`): synthesis = build a GenMLX probabilistic model by *small, oracle-checked edits*. Native-free — it reuses the existing distill / train-reward oracle spine (`codegen.eval` + `msa-score`) and never loads the policy LLM.

Single commit on top of `main`. The four dependencies (`msa-score`, `codegen.eval`, `train-reward`, `schema`) are already on `main`, so this is independently mergeable.

## Why

Whole-program one-shot best-of-16 **cliffs to 0/16** on advanced models (linreg / kalman / hier) for *both* a 0.8B and a 35B teacher — it is the one-shot **interface**, not capability (each failure is a one-eval-away DSL slip on a structurally-correct model). The lever is the closed feedback loop a generic code LLM lacks: exact per-*partial* model evidence (a calibrated model-selection gradient — experiment A) + in-process SCI eval.

## What's in it

- **`src/genmlx/world/synth.cljs`** — the kernel:
  - model **spec** = a partial GenMLX program as *data* (latent + observation trace sites with argument *forms*)
  - **render** → a `(fn [trace] (let […] {…}))` string the oracle parses / evals / scores
  - five pure form-level **edit ops** `add-latent` / `add-obs` / `set-args` / `set-mean` / `set-noise` (+ `homogeneous-obs?` fold-opportunity detection)
  - the four-level **`check` node** `{:parses? :schema-ok? :covered? :evals? :error :evidence :method}` composing edamame (syntax) / schema (semantics) / SCI (behavior) / the **exact oracle** (`score-model*`, fit)
  - the greedy **`synthesize` driver** — propose → check every candidate → accept the best evidence-improving valid one (method-aware rank, exact > IS) → stop on `:plateau` / `:stuck` / `:max-steps`
- **`test/genmlx/synth_test.cljs`** — 43/43; the check node's evidence is pinned to an **independent closed-form Gaussian-Gaussian marginal** (non-circular).
- **`scripts/synth_repl_probe.cljs`** — experiment B.
- **`docs/programmer-as-genmlx-model.md`** — the design doc (the programmer modeled as a GF) + §10 (this kernel + the experiment-B result + honest caveats).

## Experiment B — the cliff, inverted (3/3)

From a crude covering model, the loop accepts the **key structural edit** (oracle-selected over a distractor + the alternative structure) and self-terminates, on the three exact-scoreable advanced models whole-program best-of-16 got **0/16** on:

| model | crude → final | structural edit |
|---|---|---|
| linreg | −17.50 → −10.14 | add slope |
| kalman | −7.01 → −5.05 | AR(1) couple (coef 0.9) |
| hier | −24.00 → −12.36 | independent group means |

**A feedback loop with an exact verifier turns a 0/16 whole-program problem into a sequence of locally-checkable edits.**

## Honest scope (no overclaims)

- The experiment-B proposer is a **structured move-vocabulary, not an LLM** — deliberately, to isolate the loop-vs-cliff claim from generation noise. The driver is proposer-agnostic, so an LLM is a drop-in; **Phase 3 learns it**.
- The construction edits are **form-level** (the homoiconic "code is data" path); GFI `edit`/`CompositeEdit` operate on *traces*, a different layer.
- The named **`wrap-combinator` move is deferred** (folding needs combinators exposed in the synthesis SCI sandbox) — so the kernel ships `homogeneous-obs?` *detection*, not a lying stub.
- **Greedy** commits to the first improving structural move (e.g. linreg locks into no-intercept — a local optimum, not a global-Occam claim) → exactly why **Phase 2 is SMC/beam over edits**. The shared-noise tuning is type-II ML over one hyperparameter, not added structure.

## Verification

- `test/genmlx/synth_test.cljs` — **43/43** (run against this branch off `main`).
- Reviewed by a **25-agent adversarial-review workflow** (correctness / experiment-honesty / idiomaticity, each finding independently verified): 19 confirmed + 1 refuted; **all 19 fixed** before merge (delta false-reject now matches only a delta *constructor*; empty-obs no longer scores a vacuous 0; method-aware ranking; no `:method` leak on non-finite evidence; never-scored init → `:stuck`; experiment-honesty overclaims removed).

## Next
Phase 2 (`genmlx-47zx`, SMC/beam over edits — the greedy/branch limitation motivates it); Phase 3 (`genmlx-oexl`, learn the proposer via REPL-trace SFT + GRPO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

