### PR TITLE
fix(analytical): refuse branching trees in Kalman-chain detection (genmlx-iraj)

### DIFF
--- a/src/genmlx/affine.cljs
+++ b/src/genmlx/affine.cljs
@@ -360,37 +360,53 @@
           ;; Addresses that appear as priors
           prior-set (set (map :prior-addr nn-pairs))
 
-          ;; Follow chains from each root
+          ;; Follow chains from each root. Returns {:steps [...] :valid? bool}; :valid?
+          ;; is false for a structure that is NOT a linear chain (a branching tree or a
+          ;; cycle), so the comprehension below drops it.
           follow-chain
           (fn [root]
             (loop [current root
-                   steps []]
-              (let [successors (get by-prior current [])
-                    ;; Chain successor: obs that is itself a prior of another pair
-                    chain-next (first (filter #(contains? prior-set (:obs-addr %)) successors))
-                    ;; Observations: non-chain successors
-                    obs (filterv #(not= (:obs-addr %) (:obs-addr chain-next)) successors)
-                    step {:latent current
-                          :observations (mapv :obs-addr obs)
-                          :obs-dep-types (mapv :dependency-type obs)
-                          :transition (when chain-next (:dependency-type chain-next))
-                          :noise-std (when chain-next
-                                       (let [args (:dist-args (:obs-site chain-next))]
-                                         (when (>= (count args) 2) (second args))))
-                          :next-latent (when chain-next (:obs-addr chain-next))}
-                    steps' (conj steps step)]
-                (if chain-next
-                  (recur (:obs-addr chain-next) steps')
-                  steps'))))
+                   steps   []
+                   seen    #{}]
+              (if (contains? seen current)
+                ;; a cycle is not a valid linear chain
+                {:steps steps :valid? false}
+                (let [successors (get by-prior current [])
+                      ;; Chain successors: successors that are THEMSELVES a prior of
+                      ;; another pair (i.e. intermediate latent nodes).
+                      chain-cands (filter #(contains? prior-set (:obs-addr %)) successors)
+                      chain-next  (first chain-cands)
+                      ;; Observations: non-chain successors
+                      obs (filterv #(not= (:obs-addr %) (:obs-addr chain-next)) successors)
+                      step {:latent current
+                            :observations (mapv :obs-addr obs)
+                            :obs-dep-types (mapv :dependency-type obs)
+                            :transition (when chain-next (:dependency-type chain-next))
+                            :noise-std (when chain-next
+                                         (let [args (:dist-args (:obs-site chain-next))]
+                                           (when (>= (count args) 2) (second args))))
+                            :next-latent (when chain-next (:obs-addr chain-next))}
+                      steps' (conj steps step)]
+                  (cond
+                    ;; BRANCHING: a node with >1 latent (chain) successor is a TREE, not a
+                    ;; linear chain (e.g. a centered hierarchy grand -> {g_a,g_b,g_c}).
+                    ;; Refuse it rather than silently following only the first successor —
+                    ;; doing so mishandles the other branches' observations and produces a
+                    ;; wrong, non-deterministic marginal mislabeled :kalman (bug genmlx-iraj).
+                    ;; Refusing lets method-selection fall through to lg-block (which
+                    ;; correctly declines latent-in-latent priors) and then to IS.
+                    (> (count chain-cands) 1) {:steps steps' :valid? false}
+                    chain-next (recur (:obs-addr chain-next) steps' (conj seen current))
+                    :else {:steps steps' :valid? true})))))
 
           ;; Find chain roots: priors that are not obs of any NN pair
           obs-set (set (map :obs-addr nn-pairs))
           chain-roots (set/difference prior-set obs-set)
 
           chains (for [root chain-roots
-                       :let [steps (follow-chain root)]
-                       ;; Must have at least 2 latent nodes to be a chain
-                       :when (>= (count steps) 2)]
+                       :let [{:keys [steps valid?]} (follow-chain root)]
+                       ;; A valid linear chain with at least 2 latent nodes.
+                       :when (and valid? (>= (count steps) 2))]
                    {:steps steps
                     :latent-addrs (mapv :latent steps)
                     :obs-addrs (into [] (mapcat :observations) steps)})]

--- a/test/genmlx/affine_test.cljs
+++ b/test/genmlx/affine_test.cljs
@@ -293,6 +293,42 @@
       (is (= [:z0 :z1] (:latent-addrs (first chains))) "latent-only chain: latents [z0 z1]")
       (is (= [:z2] (:obs-addrs (first chains))) "latent-only chain: z2 is obs"))))
 
+(deftest detect-kalman-chains-branching-tree
+  ;; Regression for genmlx-iraj: a CENTERED hierarchy is a TREE (grand -> {ga,gb,gc}),
+  ;; not a linear chain. detect-kalman-chains must REFUSE it (a branch node has >1 latent
+  ;; successor) rather than silently follow the first successor — the old code returned a
+  ;; bogus 1-chain whose Kalman path produced a non-deterministic, grossly-wrong marginal
+  ;; mislabeled :exact. Refusing lets method-selection fall through to lg-block (which
+  ;; declines latent-in-latent priors) and then to honest IS.
+  (testing "centered hierarchy (a tree) is NOT detected as a Kalman chain"
+    (let [s (schema/extract-schema '([x]
+              (let [grand (trace :grand (dist/gaussian 0 5))
+                    ga (trace :ga (dist/gaussian grand 2))
+                    gb (trace :gb (dist/gaussian grand 2))
+                    gc (trace :gc (dist/gaussian grand 2))]
+                (trace :a0 (dist/gaussian ga 1))
+                (trace :b0 (dist/gaussian gb 1))
+                (trace :c0 (dist/gaussian gc 1))
+                grand)))
+          pairs (conj/detect-conjugate-pairs s)
+          chains (aff/detect-kalman-chains pairs)]
+      (is (= 0 (count chains))
+          "branching tree: refused (no chain), not a bogus 1-chain")))
+  (testing "a genuine linear chain branching point only at OBSERVATIONS is still a chain"
+    ;; sanity: a normal Kalman node has 1 latent successor + many obs successors; that is
+    ;; NOT a branch and must still be detected.
+    (let [s (schema/extract-schema '([x]
+              (let [z0 (trace :z0 (dist/gaussian 0 1))
+                    z1 (trace :z1 (dist/gaussian (mx/multiply 0.9 z0) 0.5))]
+                (trace :y0a (dist/gaussian z0 0.3))
+                (trace :y0b (dist/gaussian z0 0.3))
+                (trace :y1 (dist/gaussian z1 0.3))
+                z1)))
+          pairs (conj/detect-conjugate-pairs s)
+          chains (aff/detect-kalman-chains pairs)]
+      (is (= 1 (count chains)) "multi-obs-per-latent linear chain: still 1 chain")
+      (is (= [:z0 :z1] (:latent-addrs (first chains))) "linear chain: latents [z0 z1]"))))
+
 (deftest detect-kalman-chains-mixed
   (testing "Mixed: chain + independent conjugate pair"
     (let [s (schema/extract-schema '([x]


### PR DESCRIPTION
## What

`affine.cljs` `detect-kalman-chains`/`follow-chain` assumed a **linear** chain — every latent has at most one latent successor — and silently took `(first …)` of the successors. A **centered hierarchy** is a *tree* (`grand → {g_a, g_b, g_c}`), so it followed only the first branch and mishandled the others' observations, emitting a bogus 1-chain whose Kalman path produced a **non-deterministic, grossly-wrong marginal** (observed −57…−4233 across runs on identical data) that `score-model*` mislabeled `:exact`.

This corrupted Bayesian model evidence for **any** latent-in-latent (centered hierarchical) linear-Gaussian model — affecting MSA ranking and the synthesis oracle.

## Fix

`follow-chain` now returns `{:steps :valid?}` and **refuses** a node with >1 latent (chain) successor (a branching tree), plus a cycle guard, instead of silently following the first. Refusing lets method-selection fall through to `lg-block` (which correctly declines latent-in-latent priors) and then to honest IS — a finite, correctly-labeled estimate rather than garbage `:kalman`.

## Verified

- Pooled hierarchy now scores `:hmc −13.9` (finite, sane), **not** `:kalman`; genuine AR(1)/Kalman chains still `:exact`; independent groups still `:exact`.
- Regression test added (`affine_test` `detect-kalman-chains-branching-tree`): a centered hierarchy → 0 chains (refused); a genuine multi-obs-per-latent linear chain → still 1 chain.
- Analytical regression green: affine (106 assertions), kalman, multistep-kalman-ekf, auto-analytical, exact (120), rewrite, analytical-posterior-referee (independent oracle), conjugate-posterior, hmm-forward.

The **bug** (silently-wrong garbage) is fixed here; making hierarchies genuinely `:exact` via joint elimination is a separate **feature** follow-up (genmlx-71wh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)