### PR TITLE
feat(synth): north-star REPL-synthesis foundation — Phases 1–3 (the programmer as a GenMLX model)

### DIFF
--- a/docs/HANDOFF-particle-engine.md
+++ b/docs/HANDOFF-particle-engine.md
@@ -1,0 +1,264 @@
+# HANDOFF — GenMLX-native particle engine (Route A + Route B) — autonomous run
+
+**Audience: a fresh Claude Code session after a machine reboot, with NO memory of the prior
+conversation.** Everything you need is here, in beans, in git, and in `~/genmlx-loop-artifacts/`.
+`/tmp` was wiped by the reboot — do NOT look for anything under `/tmp/genmlx-loop`.
+
+Bean: **genmlx-qsoa** (high priority, parent milestone genmlx-8587). Related: genmlx-2ctu (GRPO),
+genmlx-7473 (generator, done), genmlx-8587 (milestone). Prior results: `docs/cljs-coder-loop-results.md`.
+
+---
+
+## 0. YOUR MISSION (run autonomously, ~several hours OK)
+
+Build the **mlx-node-native batched particle engine** and ship a **demo** where the local
+**0.8B GenMLX-cljs specialist generates a probabilistic program by sampling K particles in one
+batched GPU pass and selecting the best by the GenMLX oracle (Bayesian model evidence)** — and
+show it is **(a) better-fitting and (b) faster than a single shot from the 35B teacher**
+(Qwen3.6-35B-A3B). Attempt **Route A** (reliable, de-risked) first, then **Route B** (the
+GFI-native version, a stretch). Be ruthlessly honest in the final report: if a CLEAN benchmark
+shows we do NOT beat the teacher on programs, say so plainly (see §11 go/no-go).
+
+Scope the demo to **probabilistic-program / model synthesis** (GenMLX's actual domain). That is
+where the 0.8B+particles+oracle beats the teacher. Do NOT scope it to general cljs functions —
+there the 35B teacher wins on raw capability and best-of-K cannot close the gap (evidence below).
+
+---
+
+## 1. GOAL, SUCCESS CRITERIA, FALLBACK
+
+**Demo "win" = both of these, measured cleanly, on probabilistic-program tasks:**
+1. **Better fit:** the best-of-K-selected program's model evidence (log p(data|program)) ≥ the
+   teacher's single-shot program's evidence (higher = better). Tonight's non-clean number:
+   **0.8B best-of-16 = −4.10 vs teacher single = −4.83** (mean over the 11 held-out program tasks).
+2. **Faster:** wall-clock to generate+score K batched particles (model preloaded) < wall-clock
+   for one teacher completion. Tonight's per-use numbers: 0.8B ~1.08 s/completion (~53 tok/s)
+   vs teacher ~9–10 s/completion (~6–11 tok/s); native batched decode of 16 seqs took 13.5 s
+   INCLUDING engine construction + prefill (not a clean number — you must measure cleanly).
+
+**Fallback (when to recommend relying on qwen-3.6 instead):** only if, after a clean Route-A
+benchmark, the 0.8B best-of-K does NOT beat the teacher on programs in BOTH fit and speed. The
+prior (non-clean) evidence says we DO win, so the expected outcome is "ship the particle engine,"
+not "fall back." General-cljs coding is a different story (we lose there) — but that is not this demo.
+
+---
+
+## 2. HONEST FEASIBILITY (assessed 2026-06-22, before the reboot)
+
+- **Route A (native `generateBatch` → oracle best-of-K → benchmark): HIGH feasibility.** The
+  native batched decoder was probed standalone and is STABLE (16 seqs, 13.5 s, no wedge). Clear,
+  well-scoped. This is the reliable deliverable and very likely lands autonomously.
+- **Route B (batch-dim the owned cljs forward + masked-EOS LLM-GF so `vsimulate` runs K
+  particles): STRETCH / risky.** It is deep surgery on the value-level forward (esp. the qwen3.5
+  hybrid GatedDeltaNet cache) and must match the golden oracle bit-for-bit. Attempt it, gate it
+  on correctness, and FALL BACK to Route A for the demo if it can't be made correct reliably.
+- **"Better than teacher": TRUE on probabilistic programs, FALSE on general functions.** Build
+  the demo on programs.
+
+---
+
+## 3. CURRENT STATE (all committed to git on branch `feat/cljs-task-gen-7473`)
+
+Commits (newest first): `010d99a` GRPO wedge doc · `7d80513` GRPO script + results doc ·
+`e5dc40d` pipeline fixes (sandbox --gen, sft_eval arity) · `52d5a3c` the 183-task generator.
+(If on `main` after a merge, `git log --oneline | grep cljs-coder` to find them.)
+
+Built & shipped this loop:
+- **183-task generator** `src/genmlx/world/distill_gen.cljs` (+ `distill_gen_extra.cljs`): 44
+  conjugate programs (all exact-scored) + 139 functions; 143 train / 40 eval split. Test
+  `test/genmlx/distill_gen_test.cljs` 18/18.
+- **Distill→SFT pipeline:** teacher (Qwen3.6-35B-A3B) → 512-row oracle-validated corpus → LoRA
+  SFT of qwen3.5-0.8b → **two fused models** (see §4). Held-out lift (oracle-graded, leakage-free):
+  function pass@1 0.172→0.345 (SFT-300) / 0.276 (SFT-600); function pass@4 0.103→0.310/0.414.
+- **GRPO** `scripts/grpo_sharpen.cljs`: mechanism validated but the native TRAINING step
+  **wedged** (~3.5 h stall in `generateBatchForTraining`/weight-update — NOT the decode). Bean
+  genmlx-2ctu.
+- Results writeup: `docs/cljs-coder-loop-results.md`.
+
+---
+
+## 4. WHERE EVERYTHING IS (post-reboot)
+
+**Models** (`~/.cache/models/`, survive reboot):
+- `qwen3.5-0.8b-cljs-sft600` — **the particle/demo model** (best pass@4 0.575, most headroom).
+- `qwen3.5-0.8b-cljs-sft300` — best greedy pass@1 0.525.
+- `qwen3.5-0.8b-mlx-bf16` — the base 0.8B (what the GRPO/native path loads via `Qwen35Model.load`).
+- `Qwen3.6-35B-A3B-4bit` — the teacher (the baseline to beat). 19 GB; peaks ~20 GB on this 32 GB box.
+
+**Preserved artifacts** (`~/genmlx-loop-artifacts/`, copied out of /tmp before reboot):
+- `corpus/distill_sft.jsonl` (512 SFT rows), `corpus/stats.json`, `corpus/verdicts.jsonl`
+- `gen_tasks.edn` (183 tasks; single-line EDN — regenerate with `gen_tasks.cljs --write-edn` if needed)
+- `train_prompts.jsonl` (143), `eval_prompts.jsonl` (40), `reference_candidates.jsonl` (143)
+- `teacher_candidates.jsonl` (858 — EXPENSIVE to regenerate; ~40 min of 35B)
+- `eval/baseline.jsonl`, `eval/sft_300.jsonl`, `eval/sft_600.jsonl` (n=5), `eval/teacher_eval.jsonl`
+  (40 greedy), `eval/sft600_k16.jsonl` (640 = K=16 particles), `eval/cmp{300,600}/eval_report.json`
+- `adapter/` (LoRA checkpoints 100–700), `sft-data/` (train/valid)
+- `compare.cljs`, `demo.cljs` (best-of-K scorer), `probe.cljs` (the stable-decode probe) — reference impls
+
+**Out-of-tree nbb runner** (to run a scratch script against the repo): from the repo root,
+`ln -sfn $(pwd)/node_modules <dir>/node_modules` then
+`bunx nbb@1.4.208 -cp "src:test:examples:test.check:malli/src:instaparse/src" <dir>/script.cljs`.
+
+---
+
+## 5. VERIFIED ARCHITECTURE STATE (workflow w182a5x7r, 3 cross-checked readers; do NOT re-derive)
+
+Batched `vsimulate` of K LLM particles in one native pass is **NOT wired** as an inference path.
+Three layers:
+
+- **Layer 1 — pure-cljs vectorized sampling: DONE.** Categorical batched sampler `dist.cljs:586`
+  (Gumbel-max `[n,k]→[N]`); per-particle `[N,K]` log-prob via take-along-axis `dist.cljs:558`
+  (exactly the LLM case — each particle a different history); dist-agnostic batched handler
+  `handler.cljs:241+`; `vsimulate`/`vgenerate` `[N]` axis `dynamic.cljs:1342`.
+- **Layer 2 — the LLM-GF body: BLOCKS batching.** `make-llm-gf` `llm/core.cljs:60-65` calls
+  `(mx/item tok)` per token for the EOS check + host control flow (`loop/recur`, EOS `if`) on the
+  scalar. Docstring `core.cljs:43-45`: "Not compatible with vsimulate/vgenerate." Needs a
+  `[K]`-shaped rewrite with a per-particle **active-mask** instead of `mx/item`.
+- **Layer 3 — native forward + KV cache: batch-1 on the GFI path.** native `forward` `[1,seq,vocab]`
+  / `forwardWithCache` `[1,1,vocab]` (`index.d.ts:1558-1567`); `ids->input` `[1 N]`
+  `backend.cljs:299-311`; `forward-step` single scalar token `backend.cljs:391-406`; owned cljs
+  forward `qwen35_forward.cljs:271` `[1 T hidden]`, recurrent/conv cache `[1 Hv Dv Dk]`
+  `qwen35_forward.cljs:187`; `CljsForwardModel` cache atom `{:cache :offset}` no batch dim
+  `backend.cljs:94`. (qwen3 vanilla forward `qwen3_forward.cljs` is `[seq]`/`[seq hidden]`.)
+- **BUT a true native batched decoder EXISTS:** `generateBatch(prompts, groupSize, config) →
+  BatchGenerationResult` ("sequential prefill + batched decode", `index.d.ts:2095`, `:411-425`),
+  reachable via the GRPO engine (`world/train.cljs:395` `train/generate-batch`). **Probed
+  standalone = STABLE.** Tonight's wedge is the *training* step (`generateBatchForTraining` +
+  autograd), NOT the decode.
+
+The oracle (use, do not rebuild): `genmlx.llm.msa-score/score-model*` → `{:log-ml :method}`
+(exact analytical marginal for conjugate programs, IS otherwise); `genmlx.world.distill/evaluate-candidate`
+(full gate ladder); `genmlx.codegen.eval/valid-cljs?` + `eval-fn` (edamame reader + SCI — this
+is "use SCI to test valid cljs", and it works); `genmlx.world.train-reward/extract-program`
+(isolates the FIRST form, dropping the native engine's no-EOS `\n!\n!` filler — IMPORTANT, the
+native decode does not stop at EOS, so always isolate the first form before scoring).
+
+Conditioning substrates (all compose via `dispatch/with-handler` middleware): token-DFA
+`genmlx.llm.grammar`, byte-DFA `genmlx.llm.bytes`, reader-as-grammar `genmlx.llm.codegen`,
+Instaparse grammar (`genmlx.llm.msa` knowledge mode; instaparse is on the nbb classpath).
+
+---
+
+## 6. ROUTE A — build plan (reliable, de-risked)
+
+Goal: a standalone **best-of-K inference primitive** (NOT via training) + oracle selection + a
+clean benchmark + the demo.
+
+1. **Best-of-K generation primitive.** Add `genmlx.llm.particles` (or extend `llm/backend`):
+   `(best-of-k-generate model-dir prompts {:k K :max-tokens N ...}) → {prompt → [k completions]}`.
+   Implementation: reuse `genmlx.world.train` — `(.load (.-Qwen35Model gcore) model-dir)` then
+   `with-trainer` with `{:group-size K :enable-thinking false :max-completion-length N
+   :lm-head-chunk-size 2 :forward-chunk-size 4 :temperature 0.9}` and `train/generate-batch`
+   (the STABLE native batched decode). Construct the engine ONCE, generate for all demo prompts,
+   dispose via `with-trainer`. (This is exactly what `~/genmlx-loop-artifacts/probe.cljs` did and
+   it returned cleanly.) Use the model `qwen3.5-0.8b-cljs-sft600`.
+2. **Oracle scoring + selection.** For each completion: `reward/extract-program` (drop the
+   no-EOS filler) → `score/score-model* gf observations` → evidence. Select argmax-evidence per
+   task = best-of-K-by-evidence. (For function tasks, `distill/evaluate-candidate` + any-pass.)
+3. **Clean benchmark** (model PRELOADED, identical max-tokens):
+   - batched K-particle gen+score wall-clock (the primitive)
+   - vs teacher single-shot wall-clock (load `Qwen3.6-35B-A3B-4bit`, 1 completion/task)
+   - vs (optional) sequential K (for the batching speedup factor)
+   - quality: best-of-K evidence vs teacher evidence on the 11 held-out PROGRAM tasks
+     (`eval_prompts.jsonl`, kind=program), using `~/genmlx-loop-artifacts/` data where useful.
+4. **The demo script** `scripts/particle_demo.cljs`: given a data-explanation task, print the
+   teacher's single program + its evidence + time, then the 0.8B best-of-K program + its evidence
+   + time, and the verdict (better fit, faster). Make it pretty.
+
+Risk: Route A uses the GRPO engine purely for its batched decode. The probe proved the *decode*
+is stable; do NOT call `train-step!`/`generateBatchForTraining` (that is what wedged). If the
+engine construction itself is heavy, construct once and batch many prompts.
+
+---
+
+## 7. ROUTE B — build plan (GFI-native, stretch)
+
+Goal: a `[K]`-particle LLM-GF that `vsimulate` runs in one native pass — fully in the GFI, so it
+composes with grammar/SCI/instaparse conditioning and SMC.
+
+1. **Batch-dim the owned cljs forward** (`src/genmlx/llm/qwen3_forward.cljs`,
+   `qwen35_forward.cljs`): make the leading dim a variable `B`/`K` instead of literal 1.
+   - qwen3 (vanilla attn): `[B,T,hidden]`, KV cache `[B,heads,T,dim]`.
+   - qwen3.5 hybrid (GatedDeltaNet): the recurrent state `[B,Hv,Dv,Dk]` + conv window
+     `[B,K-1,conv-dim]` — batch the leading dim. **This is the delicate part.**
+   - Update `CljsForwardModel` cache to carry a batch dim; `ids->input` to `[B,T]`.
+2. **Rewrite `make-llm-gf`** (`llm/core.cljs`): drop `(mx/item tok)`; keep tokens `[K]`-shaped;
+   use a per-particle **active-mask** (`[K]` bool) to stop appending after each particle's EOS;
+   no host scalar control flow. Generate to a fixed max or until the mask is all-false.
+3. **GOLDEN-ORACLE GATE (mandatory):** a `[K]`-batched forward MUST equal single-stream outputs.
+   Test: (a) K identical prompts → all K logits == the single-stream logits; (b) K different
+   prompts → each == its own single-stream run. Reuse the f6ov golden-oracle test infra. Do NOT
+   proceed to vsimulate until this passes.
+4. **`vsimulate` the LLM-GF at `[K]`** → K token streams in one pass → oracle-score → select.
+   Then demonstrate **in-generation conditioning** (grammar/reader) composed on top.
+
+If the hybrid-cache batching can't be made correct reliably in this run, STOP Route B, document
+exactly where it broke, and ship the Route-A demo. Route B correctness > Route B completeness.
+
+---
+
+## 8. THE DEMO (what to actually show)
+
+A reproducible head-to-head on probabilistic-program synthesis:
+- Pick 3–6 held-out PROGRAM tasks (e.g. from `eval_prompts.jsonl` kind=program: gaussian-mean /
+  beta-bernoulli / gamma-poisson instances) and/or a fresh data-explanation task.
+- For each: teacher single shot (program + evidence + time) vs 0.8B best-of-K (batched particles
+  + evidence-selection: program + evidence + time).
+- Headline table: **evidence (fit) and wall-clock, 0.8B-best-of-K vs teacher.** Plus show the
+  selected 0.8B program is well-formed, adapted, idiomatic GenMLX cljs.
+- State the honest scope: this wins on program/model synthesis (GenMLX's domain); general cljs is
+  the teacher's.
+
+---
+
+## 9. REPRODUCTION (if an artifact is missing/stale)
+
+```bash
+cd ~/code/genmlx
+# task set + prompts (fast, no GPU):
+bun run --bun nbb scripts/gen_tasks.cljs --validate          # 183/183 grounded, 44/44 programs exact
+bun run --bun nbb scripts/gen_tasks.cljs --export-eval  /tmp/eval_prompts.jsonl
+bun run --bun nbb scripts/gen_tasks.cljs --export-train /tmp/train_prompts.jsonl
+bun run --bun nbb scripts/gen_tasks.cljs --write-edn    /tmp/gen_tasks.edn
+# corpus (EXPENSIVE, ~1h GPU; only if you must re-derive — else use ~/genmlx-loop-artifacts/corpus):
+python3 scripts/distill_teacher.py --model Qwen3.6-35B-A3B-4bit --tasks /tmp/train_prompts.jsonl --out /tmp/teacher.jsonl --n 6
+cat /tmp/teacher.jsonl scripts/... ; bun run --bun nbb scripts/distill_filter.cljs --gen --candidates ... --out ... --top-k 4
+# eval grading uses the oracle sandbox:
+bun run --bun nbb scripts/sft_eval.cljs --gen --baseline <b.jsonl> --sft <s.jsonl> --out <dir> --k 4
+```
+
+---
+
+## 10. GOTCHAS (load-bearing)
+
+- **Metal wedge is real.** The native GRPO *training* step wedged ~3.5 h tonight (uninterruptible-ish;
+  reboot clears it). For long native jobs: run in the background, watch a flushed progress file, and
+  set a hard timeout. NEVER run two GPU/Metal jobs concurrently. The batched *decode* (Route A) is
+  stable; the *training* path is the suspect.
+- **mlx-node-native ≠ Python mlx-lm.** "Native" = cljs/nbb → `@genmlx/core` (the Rust/NAPI addon) →
+  Metal, one process, shared `MxArray` graph with the oracle. Python `mlx-lm` is a foreign process
+  (file interface only) — it was scaffolding for the teacher (35B MoE has a deferred native SIGTRAP)
+  and SFT (LoRA). The demo must be **mlx-node-native** (Route A's `generate-batch` is).
+- **The native decode does not stop at EOS** — completions are `(form)` + `\n!\n!…` filler. ALWAYS
+  isolate the first complete form (`reward/extract-program`, or `ce/parse-form` + `pr-str` to
+  preserve names) before scoring. mlx-lm stops at EOS; the native engine does not.
+- **Programs use a lenient "covering-model" gate** — the meaningful program metric is EVIDENCE
+  (log-ML), not pass/fail. Rank/compare by evidence.
+- 32 GB box: don't co-resident the 35B teacher (~20 GB) with training. Run benchmark phases
+  sequentially: teacher pass, then student pass.
+- Run tests with `bun run --bun nbb test/...` (never node-nbb). Verify `distill_gen_test` 18/18,
+  `sft_test` 49/49, `distill_sandbox_test` 5/5 after any change to those modules.
+
+---
+
+## 11. GO / NO-GO (be honest in the final report)
+
+After the clean Route-A benchmark on PROGRAM tasks:
+- **If 0.8B best-of-K beats the teacher on BOTH fit (evidence) and speed → SHIP the particle
+  engine; this is the win.** (Expected, per tonight's −4.10 vs −4.83 and ~9× cheaper/use.)
+- **If it does NOT** (teacher's evidence ≥ ours, or batched particles are not faster) → say so
+  plainly, and recommend planning around the qwen-3.6 teacher for this use case. Do not spin a loss
+  as a win. Capture the numbers either way in `docs/cljs-coder-loop-results.md` and on genmlx-qsoa.
+
+Suggested order: Route A primitive → clean benchmark → go/no-go call → demo script → (if green and
+time remains) Route B forward-batching with the golden-oracle gate → update results doc + beans.

--- a/docs/HANDOFF-particle-engine.md
+++ b/docs/HANDOFF-particle-engine.md
@@ -209,6 +209,16 @@ A reproducible head-to-head on probabilistic-program synthesis:
 - State the honest scope: this wins on program/model synthesis (GenMLX's domain); general cljs is
   the teacher's.
 
+**ALSO probe ADVANCED models (required — user ask).** Beyond the simple single-latent conjugate
+programs, hand-craft 2–4 harder, oracle-scoreable GenMLX models and run the SAME best-of-K-vs-teacher
+comparison: e.g. linear regression (coupled slope+intercept+noise — L3 joint linear-Gaussian
+eliminator scores it exactly), a hierarchical/group-means model, a small mixture (GMM), and/or a
+Kalman/HMM chain (L3.5). The 0.8B was SFT'd ONLY on simple single-latent programs, so expect
+whole-program best-of-K to DEGRADE or fail on these — that is the POINT: measure where the
+whole-program approach breaks as model complexity rises. Report the hit-rate curve vs complexity.
+This is the empirical signal for whether advanced models need a stepwise/FIM strategy (§12), and
+whether the teacher (or a FIM coder) is needed there. Be honest about the breakdown point.
+
 ---
 
 ## 9. REPRODUCTION (if an artifact is missing/stale)
@@ -260,5 +270,42 @@ After the clean Route-A benchmark on PROGRAM tasks:
   plainly, and recommend planning around the qwen-3.6 teacher for this use case. Do not spin a loss
   as a win. Capture the numbers either way in `docs/cljs-coder-loop-results.md` and on genmlx-qsoa.
 
-Suggested order: Route A primitive → clean benchmark → go/no-go call → demo script → (if green and
-time remains) Route B forward-batching with the golden-oracle gate → update results doc + beans.
+Suggested order: Route A primitive → clean benchmark → go/no-go call → demo script (incl. the
+ADVANCED-model probe in §8) → (if green and time remains) Route B forward-batching with the
+golden-oracle gate → update results doc + beans → write up §12 findings.
+
+---
+
+## 12. ADVANCED MODELS & the FIM / stepwise question (research direction — do NOT need to fully build this run)
+
+User's framing (2026-06-22): simple programs are demo'd whole-program; **advanced GenMLX models
+(hierarchical, coupled regression, mixtures, Kalman/HMM, combinator-structured) likely need a
+STEPWISE construction strategy, and FIM (fill-in-the-middle) may be a good mechanism — possibly
+requiring a FIM-capable qwen *coder* model.** This run's job is to PROBE and DOCUMENT, not to build
+the full stepwise engine.
+
+Why stepwise (the real lever): whole-program best-of-K hit-rate COLLAPSES as models grow (search
+space explodes; a small model rarely emits a long correct program). Stepwise construction with
+PER-STEP oracle scoring rescues it — model evidence on a PARTIAL model is still a real number, so
+it gives intermediate reward to prune the search (SMC over construction steps, not whole programs).
+GenMLX uniquely supplies that intermediate reward + the composition machinery (GFI update/regenerate/
+edit/CompositeEdit; combinators Map/Unfold/Scan for repeated structure).
+
+FIM's role + the resolved tension: FIM is a natural per-step mechanism — fix the interface
+(prefix `(fn [trace] (let [` + suffix `] {observations}))`), fill the body (middle) — and it
+composes with particles+oracle (K fills per hole → score → keep best). We DROPPED FIM earlier
+(prior cljs fine-tunes failed), BUT that was FIM-for-WHOLE-generation on qwen2 (non-owned-forward).
+KEY: the inference particle+oracle loop does NOT need owned-forward/differentiability (that was only
+for GRPO weight updates) — so a FIM-capable qwen CODER can be used as a PURE PROPOSAL, scored by the
+GenMLX oracle, sidestepping exactly what broke before. Trade-off: FIM-coder capability vs the cheap
+local 0.8B. (Caveat: qwen2.5-coder is FIM-capable but qwen2 arch; check whether a qwen3-family /
+Qwen3-Coder model offers FIM tokens. FIM tokens: `<|fim_prefix|> <|fim_suffix|> <|fim_middle|>`.)
+
+Nuance: stepwise is the STRATEGY; FIM is ONE mechanism. Alternatives to validate empirically:
+(a) instruct-driven stepwise ("here is the partial model, add the next latent" — no FIM tokens),
+(b) grammar/SMC-guided structured generation fully inside the GFI (reader-as-grammar / instaparse +
+incremental oracle scoring — no FIM model at all, composes natively). Pick by experiment.
+
+Deliverable for THIS run re advanced models: the §8 advanced-model probe (the hit-rate-vs-complexity
+curve) + a written note in `docs/cljs-coder-loop-results.md` on where whole-program breaks and which
+stepwise mechanism looks most promising. Captured as a DRAFT bean for the full stepwise/FIM engine.

--- a/docs/HANDOFF-particle-engine.md
+++ b/docs/HANDOFF-particle-engine.md
@@ -276,7 +276,14 @@ golden-oracle gate → update results doc + beans → write up §12 findings.
 
 ---
 
-## 12. ADVANCED MODELS & the FIM / stepwise question (research direction — do NOT need to fully build this run)
+## 12. ADVANCED MODELS — STEPWISE construction (FIM is one mechanism to explore later)
+
+**User-confirmed stance (2026-06-22): STEPWISE construction is the long-term strategy/goal for
+advanced GenMLX model synthesis. FIM is a possible mechanism WITHIN stepwise — worth exploring
+later — but NOT necessarily the path. Do not over-index on FIM; the primary frame is stepwise +
+per-step oracle scoring, with the mechanism chosen empirically.**
+
+(Research direction — this run PROBES and DOCUMENTS; it does NOT need to fully build the engine.)
 
 User's framing (2026-06-22): simple programs are demo'd whole-program; **advanced GenMLX models
 (hierarchical, coupled regression, mixtures, Kalman/HMM, combinator-structured) likely need a

--- a/docs/cljs-coder-loop-results.md
+++ b/docs/cljs-coder-loop-results.md
@@ -1,0 +1,109 @@
+# GenMLX cljs-coder loop — run results (2026-06-22)
+
+A small, GenMLX-native ClojureScript code generator: a fine-tuned **qwen3.5-0.8b**
+specialized on the GenMLX/cljs program-synthesis distribution (probabilistic models +
+small functions), built by **teacher distillation → oracle filter → SFT**, graded on a
+leakage-free held-out split by the **same grounded oracle** that built the corpus.
+
+This is the milestone `genmlx-8587` loop (task-gen `genmlx-7473` → SFT `genmlx-o8w9` →
+GRPO `genmlx-2ctu`). Honest scope: a **specialist** at GenMLX/cljs program synthesis, not a
+general coder — a 0.8b is near the floor on general code synthesis (the literature), but on
+this narrow, well-tested distribution it rivals far larger models.
+
+## The pipeline (all reproducible from the repo)
+
+```
+distill-gen (183 grounded tasks)
+  → gen_tasks.cljs --export-train          143 teacher prompts
+  → distill_teacher.py (Qwen3.6-35B-A3B)   858 candidates (6/task)
+  + reference seeds (143)                  1001 candidates
+  → distill_filter.cljs --gen --top-k 4    512 oracle-validated SFT rows
+  → sft_prep.cljs --gen                     439 train / 73 valid (0 eval leakage)
+  → sft_train.sh (LoRA, 8 layers, 700 it)   qwen3.5-0.8b adapter + fused model
+  → distill_teacher.py (student) + sft_eval.cljs --gen   held-out pass@1/pass@k
+```
+
+### 1. Task / curriculum generator (`genmlx.world.distill-gen`, genmlx-7473)
+
+**183 grounded tasks** (15× the 12-task seed set), each carrying a REFERENCE solution
+validated against the same native-free oracle that grades the student:
+
+- **44 conjugate programs** (gaussian-mean, beta-bernoulli, gamma-poisson) — ALL score the
+  EXACT analytical marginal (reproducible, no importance-sampling noise).
+- **139 functions** — state machines + a broad standard-function catalog (a 5-agent workflow
+  authored 86 oracle-safe specs into `distill-gen-extra`).
+- Grounding is **non-circular**: program reward is GenMLX's Bayesian model evidence
+  (independent of the reference's form); function ground truth is hand-written (never derived
+  by running the reference). `distill_gen_test` (18/18) admits every reference and checks the
+  oracle discriminates.
+- Family-balanced, leakage-safe split: **143 train / 40 eval** (every eval family has train
+  siblings → real same-distribution generalization, never a leaked instance).
+
+### 2. Teacher distillation + oracle filter (genmlx-j0d6 path, scaled)
+
+- Teacher **Qwen3.6-35B-A3B-4bit** (on-box, the measured 93%-yield teacher), 6 samples ×
+  143 train tasks = 858 candidates; + 143 reference seeds = 1001.
+- `distill_filter --gen --top-k 4`: **784 kept**, **512 selected SFT rows**, **yield 1.0**
+  (every train task covered — no cold-start in training), mean-log-ml −5.57, all programs
+  exact-scored (0 noisy-IS), 1 non-terminator caught by the timeout sandbox.
+- 22× the prior 23-row corpus — this is what fixed the o8w9 overfit.
+
+### 3. SFT (mlx-lm LoRA on qwen3.5-0.8b-mlx-bf16)
+
+- 8 layers, rank 16, batch 2, lr 1e-5, 700 iters, val-batches capped (32GB-safe).
+- Val loss **1.114 → ~0.1–0.2 band, never diverged** (vs the o8w9 smoke that blew up to 2.01
+  at 12-task scale). Checkpoints at every 100; best-val saved at iter 300 / 600.
+
+### 4. Held-out eval (oracle-graded, leakage-free, 40 tasks, pass@k via Chen 2021)
+
+| model | aggregate pass@1 | aggregate pass@4 | **function pass@1** | **function pass@4** |
+|---|---|---|---|---|
+| baseline 0.8b | 0.400 | 0.350 | 0.172 | 0.103 |
+| **SFT-300** | **0.525** | 0.500 | **0.345** (2.0×) | 0.310 (3.0×) |
+| **SFT-600** | 0.475 | **0.575** | 0.276 | **0.414** (4.0×) |
+
+Programs tie at 1.0 (the prompt scaffolds the API + the no-floor "kept" criterion is lenient);
+the discriminating signal is the **no-scaffold function synthesis**, where SFT **doubles
+pass@1 and triples-to-quadruples pass@4**. Clean generalization (baseline 0→SFT 1 on abs-val,
+max-of-list, dedupe-list, count-uppercase, sign-str, unit conversions, …); 2 minor regressions
+(mean-of-list, between?); the hard tail (nth-prime, integer-sqrt, …) stays cold for both — a
+0.8b ceiling, not a pipeline failure.
+
+### Model artifacts
+
+- `~/.cache/models/qwen3.5-0.8b-cljs-sft300` — best **greedy pass@1** (0.525); ship for
+  single-shot use.
+- `~/.cache/models/qwen3.5-0.8b-cljs-sft600` — best **pass@4** (0.575), most GRPO headroom
+  (pass@4 − pass@1 = +0.14 on functions); the GRPO base.
+
+Both are standard MLX safetensors in the qwen3_5 (owned-forward) family — GenMLX loads them
+identically to the base 0.8b.
+
+## 5. GRPO sharpening (genmlx-2ctu)
+
+`scripts/grpo_sharpen.cljs` runs GRPO over `genmlx.world.train` (the native GRPO engine
+membrane): load the fused SFT model as the policy, generate group-size completions per
+TRAIN-task prompt, score each with the SAME grounded oracle (model-evidence for :program,
+behavioral accuracy for :function), and apply the group-relative AdamW update — sharpening
+pass@1 toward the SFT pass@k ceiling (RLVR; Yue 2025). Held-out eval tasks are never in the
+band (leakage).
+
+**Mechanism validated end-to-end:**
+- The fused SFT-600 model loads in GenMLX's native owned forward (`Qwen35Model.load`) and the
+  GRPO step mutates its weights (`gradients-applied? true`, finite rewards, no NaN/Inf).
+- Band curation matters: a random band gave 2/6 learnable groups (always-pass programs +
+  too-hard functions have no reward variance); **medium-difficulty train functions give 8/8
+  learnable groups, valid-rate ~0.5** — the variance sweet spot.
+- A real generation quirk and its fix: the native engine does not stop at EOS (mlx-lm does),
+  so completions are `(valid form)` + `\n!\n!…` filler. Evaluating the whole string errored
+  every reward to the floor; isolating the first complete form (preserving named recursion)
+  fixes it — the reward then correctly scores the code (e.g. a generated dot-product scores
+  1.0). The group-relative baseline cancels the common-mode filler, so the learning signal is
+  the code-quality differential.
+
+The held-out lift of the GRPO'd model is measured by re-running the SAME mlx-lm + oracle eval
+(mlx-lm respects EOS, so the filler does not affect the deployed model). Whether GRPO is
+shipped over SFT-600 is decided by that objective re-eval — RLVR gains are modest by nature.
+
+<!-- final GRPO held-out numbers appended after the run -->
+

--- a/docs/cljs-coder-loop-results.md
+++ b/docs/cljs-coder-loop-results.md
@@ -105,5 +105,15 @@ The held-out lift of the GRPO'd model is measured by re-running the SAME mlx-lm 
 (mlx-lm respects EOS, so the filler does not affect the deployed model). Whether GRPO is
 shipped over SFT-600 is decided by that objective re-eval — RLVR gains are modest by nature.
 
-<!-- final GRPO held-out numbers appended after the run -->
+**Run outcome (2026-06-22): the native GRPO engine WEDGED.** A real run (SFT-600 base, 15
+steps, band 8) loaded the model and completed 2 steps cleanly (step 0 reward-mean −9.68,
+valid-rate 0.50, 8/8 learnable; step 1 −11.77) — then the native `generateBatchForTraining`
+**stalled mid-step-2 and made no progress for ~3.5h** (the Metal-stall risk documented in the
+project memory; `Context leak detected, CoreAnalytics returned false`). Killed; no sharpened
+model was produced. The GRPO MECHANISM is validated (load + reward bridge + gradient step all
+work, with a clean 8/8-learnable signal), but a sustained multi-step run is not reliable on
+this 32GB box overnight. Re-running needs: a smaller band + fewer steps + lower max-completion
+length, per-step generation timeouts/checkpointing in the native engine, and ideally a fresh
+process (a reboot clears any residual Metal wedge). The SFT model (above) is the shipped
+deliverable; GRPO would, at best, modestly sharpen its pass@1 toward the pass@4 ceiling.
 

--- a/docs/programmer-as-genmlx-model.md
+++ b/docs/programmer-as-genmlx-model.md
@@ -1,0 +1,325 @@
+# The Programmer as a GenMLX Model — REPL-driven, resource-rational program synthesis
+
+*Design doc behind bean **genmlx-d4q4**. The north star for advanced GenMLX model synthesis:
+model an experienced Clojure programmer who builds probabilistic models REPL-first — propose a
+small form, eval it, read the feedback, revise, compose upward — **as a GenMLX generative
+function**, so that program synthesis becomes *inference over the programmer-GF*. Empirical
+motivation: `docs/cljs-coder-loop-results.md` §6–7 (whole-program best-of-K cliffs for BOTH the
+0.8B and the 35B — it is the one-shot *interface*, not capability).*
+
+---
+
+## 1. The thesis: synthesis = inference over a programmer-GF
+
+If the programmer is a GF, the search, the metareasoner, the LLMs, and the oracle stop being
+separate machinery and become *parts of one generative function*. The deep structure is a
+**fixpoint — a GenMLX model that synthesizes GenMLX models** — with GenMLX inference appearing at
+two levels:
+
+- **Object model** — the thing being built (linreg / hierarchy / GMM / Kalman). Trace = the
+  data-generating latents + observations.
+- **Meta model = the programmer** — a GF whose **latent is "a program"** and whose **observation
+  is "the data is well-explained by that program."** Its trace = the *development trajectory*.
+  Inference over it (targeting high model evidence) **is** program synthesis.
+
+This is the natural consequence of the project's standing principle *an agent is a GF and
+inference is pluggable* (`genmlx.agents`): the programmer is an agent whose environment is the
+**REPL + the GenMLX oracle**; its state is the current partial program; its actions are edits;
+its observations are eval feedback + evidence; its policy is the LLM proposers + the metareasoner.
+
+## 2. The traces — the development trajectory
+
+The programmer-GF's trace is the REPL session itself: an `Unfold`/`Scan` over construction steps,
+each step a few trace sites. Illustrative skeleton (GenMLX `gen`/`trace`, aspirational):
+
+```clojure
+(def programmer
+  (gen [data goal]
+    ;; SYSTEM 2 — the architect sketches a decomposition (rare, big model)
+    (let [plan (trace :plan (planner-llm (describe data goal)))]
+      (loop [prog (empty-model), t 0]
+        (let [act (trace [t :edit] (controller-policy prog plan))]    ; metareason: which edit?
+          (if (= act :stop)                                            ; resource-rational stop
+            prog
+            (let [tier (trace [t :which] (escalate? prog act))         ; :fast 0.8b | :slow big ← System 1/2
+                  form (trace [t :form]  (propose tier act prog        ; the concrete cljs form…
+                                           {:grammar genmlx-instaparse}))  ; …constrained valid
+                  prog' (apply-edit prog form)
+                  chk   (check prog' data)    ; ← SELF-CHECK in-process: parse / schema / eval / evidence
+                  keep? (trace [t :accept] (accept-policy chk))]       ; condition on verified feedback
+              (recur (if keep? prog' prog) (inc t)))))))))
+```
+
+**Trace sites (random choices) = the programmer's decisions:** `:plan`; per step `:edit`
+(add-latent / add-obs / wrap-combinator / refactor / fix / stop), `:which` (fast vs slow),
+`:form` (the code), `:accept` (keep / revise / backtrack). **The observations it conditions on**
+are the `check` results — parse status, eval value/error, schema validity, partial-model
+**evidence**. **The weight/likelihood** of the whole trace is the oracle evidence of the
+synthesized model, so `generate`/SMC over `programmer` given `data` *automatically targets
+high-evidence programs*; the intermediate evidences are the SMC intermediate weights.
+
+**The second meaning of "traces" — self-generated training data.** The GFI trace of a
+*successful* run records `(partial-program, feedback) → edit-chosen` at every step. Run inference
+over the programmer-GF (big model + oracle as teacher), keep the high-evidence trajectories, and
+their traces **are** the `(partial + feedback → next edit)` SFT corpus for the fast proposer. The
+programmer generates its own oracle-filtered training data *by being a GF you can run inference
+over*. GRPO then sharpens the proposer at its `:form` sites with evidence as the verifiable reward
+(the GFI-reward GRPO infra already exists, genmlx-ugkv/2ctu).
+
+## 3. The role of each LLM — distributions at trace sites
+
+Each LLM is a `DynamicGF` plugged in at a site, so the whole GFI applies:
+
+| faculty | model | site(s) | cadence |
+|---|---|---|---|
+| **planner / architect** (decompose, pick structure) | big off-the-shelf (qwen3.5 → Coder-Next) | `:plan`, escalated `:form` | rare (System 2) |
+| **proposer** (next form / local edit) | small fast specialist (0.8b-cljs) | high-frequency `:form` | very high (System 1) |
+| **controller** (which edit / which tier / accept) | tiny model or learned softmax | `:edit` `:which` `:accept` | the metareasoner |
+| **verifier** ("did it work / fit?") | **the GenMLX oracle — never an LLM** | the `check` node + the weight | every step, exact |
+
+Fast/slow thinking is literally the `:which` trace site; the metareasoner is the *learnable
+policy* over it. The search strategies become **GenMLX inference over `programmer`**, not bolted-on
+heuristics: `simulate` = synthesize once; `generate` w/ constraints = "build a model that uses a
+Kalman combinator" (condition `:plan`) or "finish this partial"; **SMC** = a *population of
+programmers* exploring trajectories, resampled by partial evidence (best-of-K becomes a principled
+particle filter over development paths); **regenerate/MCMC** = reconsider an earlier decision given
+later feedback (backtracking *as inference*); the metareasoner's expected-utility lookahead reuses
+the `genmlx.agents` machinery.
+
+## 4. Self-checking — why it is a GF, not just an agent loop
+
+`check` runs *inside the programmer's own body* — four complementary verifiers at four altitudes,
+all in-process, and the fitness one is **exact math, not an LLM-judge**:
+
+| level | checker | answers | substrate |
+|---|---|---|---|
+| **syntax** | instaparse / reader-as-grammar | well-formed GenMLX form? | `genmlx.llm.grammar`/`bytes`/`codegen` |
+| **semantics** | **malli** + GenMLX schema | well-formed *model*? (covers data, types/arities, no delta-hack) | `schema.cljs` + malli |
+| **behavior** | **SCI eval** | does it run / error? | `codegen.eval` (in-process) |
+| **fit** | **the oracle** (`score-model*`) | does it explain the data? (the likelihood) | analytical evidence / IS |
+
+The programmer is a **self-conditioning generative model**: its later choices (`:accept`, the next
+`:edit`) are conditioned on the *verified* results of its earlier choices. It **contains its own
+verifier**, and that verifier is *exact* — which is exactly why this beats a generic LLM agent loop
+(whose "self-critique" is another unreliable generation). It also makes the trace *trustworthy as
+training data*: only verified-good trajectories become SFT corpus.
+
+### instaparse — the *support* of the proposal distribution
+instaparse (with the reader-as-grammar) is the grammar constraint at `:form`, composed via the same
+`dispatch/with-handler` middleware as analytical conditioning. It gives the proposer support **only
+over syntactically-valid GenMLX** — `(trace :kw (dist/NAME args…))` with real distributions and real
+`mx` ops — so it **kills a whole class of the §8 failures at generation time** (malformed parens,
+hallucinated `mx/0`/`mx/infer`) instead of at eval. Two tiers: edamame = "valid cljs," instaparse =
+"valid GenMLX *model* form." In GFI terms instaparse **types the action space**: "propose code"
+becomes "sample from the grammar" — sample-efficient and a clean typed move-set for the metareasoner.
+
+### malli — the *semantic* schema + the programmer's introspection
+Where instaparse is syntax, malli is meaning:
+1. **The semantic gate as schemas.** "Every observed address is a trace site" (the covering check),
+   "dist args have the right arity/type," "the body returns an observation map," "no `delta` hack" —
+   these are malli schemas over the parsed model. malli is the `:schema-ok?` checker.
+2. **The programmer's *mental model* of the partial program.** `schema.cljs` already extracts
+   trace-sites / dist-types / dependency sets; as malli, that is the programmer's introspection —
+   *what's covered, typed, missing, depends on what* — and it **drives the next `:edit`** ("schema
+   says `:y2` is uncovered → add a `:y2` site"). The schema is the programmer's working memory.
+3. **Schema-guided generation + typing the meta-trace.** malli can constrain the proposer
+   (schema → generators / as a predicate), validate data conforms to the model's inferred shape, and
+   even type the programmer-GF's own development trajectory (each step a well-formed move).
+
+## 5. The nbb / SCI substrate — the homoiconic in-process loop (a real pillar)
+
+GenMLX runs on **nbb (SCI — the Small Clojure Interpreter), not compiled cljs**. This is not
+incidental; it is what makes the REPL loop a *function call* instead of a subprocess. The
+load-bearing property is **homoiconic, no-compile, sandboxed, in-process eval of generated GenMLX
+code in the same image as the MLX binding and the oracle**:
+
+- **The REPL loop is in-process and cheap.** `propose form` (the form is *data* — an s-expression)
+  → `SCI eval` → a live `DynamicGF` (a *value*) → `oracle score` — all in one image, no compile/IPC,
+  no marshaling (the eval'd model shares the MxArray graph the oracle reads). This is what makes
+  *hundreds* of per-step evals affordable inside a search.
+- **Interpret-don't-compile actually *beats* JVM Clojure here.** A synthesis loop eval's thousands
+  of throwaway candidate programs. SCI just walks the form — **no per-candidate compile latency and
+  no class-leak**, where JVM `eval` would generate thousands of classes (metaspace/JIT churn). And
+  SCI's interpretation overhead lands on the *cheap* part (building the lazy MLX graph — "graph
+  construction is value manipulation"); the *expensive* work (MLX compute, LLM decode) is native, so
+  the interpreter overhead is essentially free for model execution.
+- **Safe eval of untrusted LLM code.** SCI is *sandboxed* — controlled namespaces/capabilities
+  (`codegen.eval` already does this) — so the agent eval's LLM-generated code thousands of times
+  safely; the eval environment is *itself data* the metareasoner can shape per step (expose only the
+  GenMLX DSL + the learned library). Pair with the existing process-group-kill watchdog
+  (`distill_sandbox.cljs`) for non-terminating candidates.
+- **Live library / abstraction growth — the antidote to the §8 length-cliff.** New combinators /
+  sub-model GFs (and, where new *syntax* helps, macros — `gen` itself is a `.cljc` macro SCI runs)
+  that the agent factors from successful syntheses are **immediately available in the same image, no
+  recompile**. The agent compresses recurring structure into reusable abstractions, shrinking the
+  program length that caused the cliff (DreamCoder-style library learning, but live).
+
+**On "live-reload itself" and macros — don't over-index.** The useful version of self-improvement is
+NOT the agent rewriting its own code; it is (a) **inference** (better trajectories), (b)
+**weight-space learning** at the proposer's sites (SFT/GRPO), and (c) **growing a live toolbox of
+reusable abstractions**. For (c), the *primary* mechanism is **GF / combinator composition** —
+learned sub-models are first-class *values* you `splice`, scoreable under the GFI, no macros needed
+and cleaner. **Macros are secondary**: useful because the object-DSL is already macro-based and for
+growing compact *notation* / sub-DSLs, which SCI lets you do live — reach for them only when you want
+new syntax, not as the core lever.
+
+**GRPO vs nbb — orthogonal, both needed, not substitutes.** Two kinds of "update": *weight-space*
+(SFT/GRPO — slow, amortized, changes the proposer's instincts, learns the **policy**) and
+*inference-time structural* (nbb/SCI — the live eval/check/compose loop + library growth, no
+retraining). **GRPO learns *from* the traces the SCI loop *produces*; SCI *runs* the loop the better
+proposer acts in.** nbb is needed for the loop to exist at all (and to generate the training traces);
+GRPO amortizes the policy. nbb is not replaceable by GRPO. (Constraint to preserve across the
+Thor/CUDA move: keep the SCI-eval-next-to-MLX property on the new runtime.)
+
+**The deepest point.** Code is data (forms); the agent *generates* forms (LLM), *evals* them live
+(SCI) into GFs (values), *scores* them (oracle, exact), *composes* them (GFI `splice`/`edit`), and
+*grows its DSL* (live combinators/macros) — all in one image where "graph construction is value
+manipulation." The programmer, the programs it writes, its toolbox, and the data are **all the same
+kind of thing — values/forms in a live evaluable image.** That homoiconic uniformity is the "extreme
+feature": Lisp's promise (the program is data the program can manipulate and run live), finally
+pointed at probabilistic-program synthesis with an exact verifier.
+
+## 6. Resource-rationality — the metareasoner is where it all meets
+
+The programmer-GF is the single point where the three axes meet: **model** (the object program it
+builds), **inference** (the SMC/MCMC search *and* the exact oracle it checks itself with), and
+**control** (`genmlx.control`: the metareasoner choosing edits, tiers, particle budget, and when to
+stop). Resource-rationality is the policy at the control sites: **one-shot vs build-up** (simple
+models stay one-shot — the K=16 tie shows it works there), **fast↔slow escalation** (`:which`),
+**how many particles** to spend on a step, and **anytime stopping** ("one cycle, more if time"). The
+expensive model is invoked *once or a few times* (the `:plan` site + hard escalations); the exact
+oracle does the discrimination — that is the resource-rational unlock (you never pay an LLM to verify).
+
+## 7. Plan + the decisive early experiments
+
+Phases (full detail in `docs/cljs-coder-loop-results.md` §7):
+- **Phase 0 — done.** Exact oracle verifier; whole-program best-of-K (the particle engine); the
+  cliff diagnosis (both models cliff → it is the interface).
+- **Phase 1 — the REPL loop.** State = partial model; action = edit; eval (SCI) + partial evidence →
+  feedback; revise. Big model as proposer first (de-risk capability). Reuses GFI `edit`/`CompositeEdit`,
+  `codegen.eval`, the oracle.
+- **Phase 2 — search over edits.** Particles + SMC/beam over construction steps; resource-rational
+  allocation; stop on evidence plateau.
+- **Phase 3 — specialize the proposer.** REPL-trace SFT + GRPO → the 0.8b becomes the cheap
+  high-frequency proposer; escalate to the big model only on hard steps.
+- **Phase 4 — the controller (the crown).** Metareasoning, anytime, resource-rational.
+- **Phase 5 — enablers (parallel).** Fix/port the batched decoder (→ Thor/CUDA); deeply integrate the
+  big off-the-shelf model GFI-native (genmlx-9uyg) so the *planner* also composes natively.
+
+**Decisive early experiments (experiment-first, before committing):**
+- **(A) Does partial-model evidence GUIDE the search?** Build the 4 advanced models incrementally by
+  hand, score each partial — does evidence climb informatively as correct sites are added, or is it
+  flat/noisy until complete? **The single load-bearing assumption** of REPL-with-evidence. Cheap,
+  decisive. If it fails, the intermediate signal must be eval-success + structural progress instead.
+- **(B) Minimal REPL loop solves an advanced model** that whole-program best-of-16 got 0/16 on.
+- **(C) The decoder pivot.** Fix EOS-stop + the cross-call leak; re-measure — does the cheap proposer
+  become genuinely cheap? This single fact decides the small model's role.
+
+## 8. Why this is cutting-edge
+
+Two camps that don't meet: LLM program synthesis (strong proposer, *weak* verifier — tests/LLM-judges)
+and probabilistic-program inference (exact methods, *no* LLM). This is **REPL-driven program synthesis
+where the verifier is exact Bayesian model evidence, the search is SMC over construction steps with
+per-partial reward, the proposer is a resource-rationally-allocated mix of a cheap specialist and a
+rarely-invoked expensive planner, and the whole programmer is a GF that checks itself and generates its
+own training data — all in one homoiconic, live-evaluable image.** That combination is ahead of where
+either camp is.
+
+---
+*Related: genmlx-d4q4 (this), genmlx-9uyg (Route B — the GFI-native [K]-particle substrate),
+genmlx.agents (agent = GF), genmlx.control (metareasoning). Data: `~/genmlx-loop-artifacts/particle/`.*
+
+## 9. Experiment (A) RESULT (2026-06-22) — partial-model evidence is a calibrated guide ✅
+
+The load-bearing assumption holds. `scripts/partial_evidence_probe.cljs` builds each advanced
+model as a ladder of hand-written intermediate states (crude→correct + variants), all covering the
+same data, scored EXACTLY by the oracle:
+
+```
+linreg:  shared-mean σ2.5 -17.50 | shared-mean σ1 -23.59 (bad, punished) | linear σ3 -17.45
+         | linear no-intercept σ1 -11.05 | linear+intercept σ1 -11.96
+kalman:  iid -7.01 | AR 0.3 -6.39 | AR 0.9 -5.37        (none < weak < correct — smooth ramp)
+hier:    single mean -24.00 | indep groups -15.79 (+8.2) | hierarchical -21.77
+```
+
+**Verdict: evidence is an informative, well-calibrated MODEL-SELECTION gradient** — not just "a
+gradient." Structure-blind baselines are clearly worst; the structurally-necessary component earns
+a large correct jump; genuinely-bad moves are punished (−23.6); and crucially it implements **Occam**
+— it does NOT blindly reward more structure. The two apparent "anomalies" are the oracle being
+*right*: `no-intercept` ≳ full model (the intercept costs a parameter it barely needs), and
+`independent-groups` ≫ `hierarchical` for well-separated groups (the partial-pooling prior is
+mismatched, so the hierarchical complexity is unwarranted by *this* data — my hand-labeled "ground
+truth" was not evidence-optimal).
+
+**Design consequences (this sharpens §6's controller):**
+- The search target is **the simplest model the data warrants**, not a pre-specified textbook
+  structure. So stepwise synthesis is naturally **"add structure while evidence climbs, stop when it
+  plateaus/drops"** — self-terminating and resource-rational by construction. The controller's
+  **stopping rule (evidence plateau) is doing real work**, not decoration.
+- Evidence is a *selection* signal, so a single-axis greedy climb can stall (linreg `shared-σ2.5 ≈
+  linear-σ3` until the noise also tightens at `linear-σ1`) — structure and parameters must move
+  together. This argues for **search over edits (SMC/particles), not greedy repair**, and matches the
+  realistic REPL move "evidence didn't move → my noise scale is off."
+- The high-evidence basin is reachable with the crude models well below it — a particle search finds
+  it. Data: `~/genmlx-loop-artifacts/particle/partial_evidence.json`.
+
+## 10. Phase 1 — the kernel + experiment (B): the loop solves the cliff ✅
+
+The Phase-1 kernel is built (`src/genmlx/world/synth.cljs`, native-free, 36/36
+`test/genmlx/synth_test.cljs`): the **model spec** (a partial GenMLX program as data —
+ordered latent + observation trace sites with argument *forms*), the form-level **edit
+ops** (`add-latent` / `add-obs` / `set-args` / `set-mean` / `set-noise` /
+`wrap-combinator` — all pure `spec → spec`, the homoiconic build-up of §5, *not* the
+trace-level GFI `CompositeEdit`, which is a different layer), the four-level **check
+node** (§4: `:parses?` reader / `:schema-ok?` schema+no-delta+returns-a-map /
+`:covered?` schema-vs-data / `:evals?`+`:error` SCI / `:evidence`+`:method` the exact
+oracle), and the greedy **driver** (`synthesize`: propose → check every candidate →
+accept the best evidence-improving valid one → stop on plateau). The check node's
+evidence is pinned against an *independent* closed-form Gaussian-Gaussian marginal.
+
+**Experiment (B) — `scripts/synth_repl_probe.cljs` — GREEN, 3/3.** Starting from the
+crudest covering rung of the experiment-A ladder, the loop accepts the **key structural
+edit** (oracle-selected over a distractor and the alternative structure) and
+self-terminates on all three exact-scoreable advanced models that whole-program
+best-of-16 got **0/16** on (the teacher got 1/4 and that one fit at junk −35):
+
+```
+                 crude start → LOOP final   (exp-A struct. rung, σ=1)   path (2 accepted edits, then plateau)
+linreg-coupled   −17.50      → −10.14        (−11.05)                   add slope (no-intercept) +1.94 ; shared-noise +5.42
+kalman-chain     −7.01       → −5.05         (−5.37)                    AR(1)-couple coef 0.9 +1.65 ; proc-noise +0.31
+hier-group-means −24.00      → −12.36        (−15.79)                   independent group means +8.22 ; shared-noise +3.43
+```
+
+The **structural jump** is the result: the crude model *lacks* the slope / the temporal
+coupling / the group split, and the oracle's exact evidence selects it over the
+distractor and (for hier) over the more-complex *hierarchical* alternative
+(independent groups are the higher-evidence structure for these well-separated groups —
+exp-A). This is the load-bearing claim made concrete: **a feedback loop with an exact
+verifier turns a 0/16 whole-program problem into a sequence of locally-checkable edits.**
+
+**Honest framing (what this does and does NOT show):**
+- The proposer here is a **structured move-vocabulary, not an LLM** — deliberately, to
+  *isolate* the loop-vs-cliff claim from generation noise. The driver is
+  proposer-agnostic (an injected `(fn [spec feedback] → candidates)`), so wiring a real
+  LLM proposer is a drop-in; **Phase 3 learns it**. So experiment B proves the loop +
+  oracle, not (yet) that a cheap LLM is the proposer.
+- The monotone evidence climb is **true by construction** (the driver only appends an
+  improving step), so it is *not* itself evidence of success — the discriminating facts
+  are that the **structural** edit was accepted and the loop self-terminated.
+- The final lands slightly **above** the σ=1 reference rung because the loop also tunes
+  a single **shared observation-noise** scale — that is **type-II maximum-marginal-
+  likelihood (empirical Bayes) over one fixed hyperparameter**, not added model
+  structure, so it is *not* directly comparable to the fixed-σ rung. The structural
+  step, not the noise tuning, is the result.
+- **Greedy commits to the first improving *structural* move** (e.g. linreg locks into
+  the no-intercept branch — a greedy local optimum, *not* a global-Occam claim; a
+  full-intercept model may score higher under *joint* structure+noise search). This is
+  the predicted greedy limitation and is exactly **why Phase 2 is SMC/beam over edits** —
+  a population explores both branches. Data:
+  `~/genmlx-loop-artifacts/particle/synth_repl_probe.json`.
+
+The kernel ships **five** form-level edit ops (`add-latent`/`add-obs`/`set-args`/
+`set-mean`/`set-noise`); the named **`wrap-combinator`** move is *deferred* — folding
+repeated sites into a `Map` combinator needs the synthesis SCI sandbox to expose the
+combinators — so the kernel ships `homogeneous-obs?`, the pure predicate that *detects*
+the fold opportunity, rather than a rewrite that would render an un-evaluable form.

--- a/docs/programmer-as-genmlx-model.md
+++ b/docs/programmer-as-genmlx-model.md
@@ -302,7 +302,8 @@ verifier turns a 0/16 whole-program problem into a sequence of locally-checkable
   *isolate* the loop-vs-cliff claim from generation noise. The driver is
   proposer-agnostic (an injected `(fn [spec feedback] → candidates)`), so wiring a real
   LLM proposer is a drop-in; **Phase 3 learns it**. So experiment B proves the loop +
-  oracle, not (yet) that a cheap LLM is the proposer.
+  oracle, not (yet) that a cheap LLM is the proposer. **§12 now closes that gap — it puts a
+  real LLM (both tiers) in this exact loop.**
 - The monotone evidence climb is **true by construction** (the driver only appends an
   improving step), so it is *not* itself evidence of success — the discriminating facts
   are that the **structural** edit was accepted and the loop self-terminated.
@@ -381,3 +382,208 @@ bottleneck is cleanly localized to the oracle, not the search. Phase 3 (`genmlx-
 swaps the structured proposer for a *learned* one (REPL-trace SFT + GRPO); Phase 4
 (`genmlx-gjih`) is the resource-rational metareasoner over the control sites (beam
 width, particle budget, when to stop — the adaptive allocation here is its seed).
+
+## 12. A REAL LLM in the loop — the load-bearing thesis test (`genmlx-0yv7`)
+
+Sections 10–11 proved the *scaffold* with a hand-coded structured move-vocabulary. They
+did **not** prove the *thesis*, because they never put a real LLM in the loop —
+feedback-conditioning was plumbed but never exercised against a real generator. This
+section closes that gap: a real policy LLM is the proposer, conditioned each step on the
+verifier's feedback, run via `scripts/synth_llm_probe.cljs` against the three
+exact-scoreable advanced models (`linreg` / `kalman` / `hier`) — plus a deliberately
+*harder*, multi-piece model (`vslope`, below) — and the same exact oracle.
+
+**Architecture (native-free, out-of-process).** The synthesis loop never loads a model.
+A resident `scripts/llm_server.py` mlx-lm worker holds the policy LLM in memory;
+`genmlx.world.llm-proposer/call-server` reaches it over HTTP with a synchronous `curl`
+(the driver is synchronous; an LLM call is a genuine I/O boundary). The proposer is a
+drop-in for the already-injected `(fn [spec feedback] → candidates)` slot — so the Phase-1
+driver and the Phase-2 search run **unchanged**; only the proposer differs from the
+structured control. The check node sees the LLM's *literal* code (`synth`/`search` prefer
+a candidate's raw `:code`), so a real DSL slip reaches the verifier exactly as written.
+
+**The mechanism that putting a real LLM in the loop forced us to build: REPL revision.**
+The decisive empirical finding is that a strong instruct model (Qwen3.6-35B-A3B) produces
+the *correct model structure* (e.g. `slope·x + intercept` for `linreg`) but with a
+*one-eval-away DSL slip* — most often a noise **scale given a `(dist/gaussian ..)` prior**
+(which can go negative → non-finite evidence), or a **hallucinated distribution**
+(`dist/positiveskew`). With *no* feedback (one-shot best-of-K) every candidate carried the
+slip, so **0/K scored** — the cliff, reproduced with a real model under a good DSL prompt.
+And a naïve loop that only conditions on the *accepted* model's status **stalls**: when a
+slip blocks *every* candidate, the model is never told *why*. So the proposer
+(`make-proposer`) is a **mini-REPL**: it proposes K candidates, **checks its own output
+against the verifier**, and on a slip **re-prompts the model with that specific error**
+(the most-progressed failure's verdict — a non-positive scale, a missing distribution, an
+uncovered address) up to `:revise` times. This is the north-star inner loop — *propose →
+eval → read the error → revise* — and it is exactly what a one-shot interface denies the
+model. The driver's outer loop still owns **fit** (accept only when exact evidence climbs);
+the proposer's inner loop owns **self-correction**. The structured proposer never slipped,
+so this was invisible until a real LLM exposed it — which is precisely why the step-up
+mattered.
+
+**Exactly-scoreable models, not just valid ones.** The exact oracle is the north star's
+edge, so the DSL prompt also guides the model to write models the oracle can score
+*exactly*: a Gaussian observation with a **fixed positive noise** and its **mean written
+inline** in the `(dist/gaussian ..)` is conjugate → `:exact`; a *latent* σ or a
+*let-factored* mean falls back to noisy importance sampling / HMC and looks worse than it
+is. This is legitimate domain guidance (it aligns the generator with the exact eliminator;
+the structured probe used fixed σ for the same reason) and is given identically to both
+arms. Making the eliminator itself handle latent-σ / let-factored means is the orthogonal
+oracle-reach work (`genmlx-w47t` / `genmlx-aw46`).
+
+### What we ran
+
+Three arms per task, **same model, same DSL prompt, same exact oracle** — the only
+difference is the feedback loop: (1) **one-shot best-of-K** (K full programs, no feedback —
+the control); (2) **greedy loop** (`synth/synthesize` + the LLM proposer); (3) **beam loop**
+(`search/search`, population). Two tiers — the resource-rational fast/slow pair the Phase-4
+metareasoner allocates between: **fast** = `qwen3.5-0.8b-cljs-sft600` (1.4 GB), **slow** =
+`Qwen3.6-35B-A3B-4bit` (19 GB, 3 B-active MoE). "Solved" = reached evidence above a bar set
+≈ halfway from the structureless crude baseline to the data-warranted optimum (so passing
+it requires the *structure*, which the crude model cannot reach). Artifacts: the **fast
+tier** is the complete JSON `~/genmlx-loop-artifacts/particle/synth_llm_probe_fast.json`;
+the **slow-tier** numbers below are read from the run logs (`/tmp/probe_linreg3.log`,
+`/tmp/probe_kh.log`) — those runs were stopped after their decisive arms to free the 19 GB
+model for the fast tier, before the end-of-run artifact write, so there is no slow-tier
+JSON (the only on-disk slow artifact is a *stale* pre-fix run that should be ignored).
+
+### Results — the slow tier (Qwen3.6-35B-A3B, ~10 s/sample)
+
+```
+model    bar     one-shot best-of-K       greedy loop (+revision)   verdict
+linreg   −12.2   −7.51  (6/8 valid)  ✓    −8.31  (1 step)      ✓    both SOLVE  — a tie on the bar
+kalman   −6.0    −6.37  (2/6 valid)  ✗    −5.79  (1 step)      ✓    LOOP SOLVES, one-shot does not
+```
+(K=8 for linreg, K=6 for kalman — the valid-count denominators show it.)
+
+Two clean, opposite outcomes that together tell the honest story. On **linreg** (one
+structural idea — a line) the strong model + the DSL prompt produces 6/8 valid candidates
+and one-shot best-of-8 nails it at −7.51; the loop **ties on the solve-bar** at −8.31
+(though one-shot is ~0.8 nats higher in raw evidence — the "tie" is on solving, not on the
+number). On **kalman** (the harder temporal structure — an AR(1) latent chain) the slip
+rate is higher (only 2/6 one-shot candidates valid) and **one-shot best-of-6 falls short of
+the structure bar (−6.37)**, while the **loop, conditioned on the verifier's feedback,
+climbs past it (−5.79)** in a single accepted step. So where one-shot is *good enough* the loop ties; where
+one-shot *isn't* — exactly the regime the north star targets — the loop wins. (The 0/16
+cliff itself was reproduced earlier in this session with the *weaker* whole-program prompt:
+0/8 valid one-shot; the DSL prompt + the loop is what dissolves it.) The kalman margin is
+**modest** and is really a noise-scale *refinement* + *reliability* win (one-shot's
+best-of-K lottery left the structural model's σ un-tuned at −6.37; the loop tuned it to
+−5.79) rather than a pure structure win — and a fast-tier sample even found a *simpler*
+model at −3.28, the exact oracle correctly preferring the **simplest adequate** model
+(experiment A's Occam) over the 35B's more elaborate AR coupling.
+
+### Results — the fast tier (`qwen3.5-0.8b-cljs-sft600`, ~4 s/sample)
+
+(The 0.8B is only ~2.4× cheaper per sample than the 35B here, not ~10×: its frequent
+**degenerate runs hit the token cap** instead of stopping at EOS, eroding the cheap model's
+speed advantage — another reason the cheap tier needs Phase-3 specialization.)
+
+```
+model    bar     one-shot best-of-8        greedy loop (2 seeds)     beam loop (2 seeds)
+linreg   −12.2   −110.2 (1/8 valid)   ✗    −17.92, −17.92      ✗     −17.92, −17.92      ✗
+kalman   −6.0    −3.28  (2/8 valid)   ✓    −7.27,  −10.15      ✗     −7.27,  −10.15      ✗
+hier     −18.0   −138.6 (1/8 valid)   ✗    −23.77, −23.77      ✗     −23.77, −23.77      ✗
+```
+
+The cheap student **fails the advanced models in *both* arms** — one-shot best-of-8 mostly
+emits malformed or structureless candidates (1/8 valid on linreg/hier, scoring junk), and
+the loop **stalls at the crude baseline** (−17.92 on linreg, greedy *and* beam, both seeds).
+Worse, on kalman the **loop is *below* one-shot** (−7.27/−10.15 vs −3.28): a single lucky
+one-shot sample found a good simple model, but the weak model's *incremental* edits in the
+loop are poor, and a poor proposer makes the population (beam) no better than greedy
+(identical −7.27/−10.15) — a population only helps if at least one of its members is good.
+Revision recovers its *format* slips (coverage, syntax) but cannot supply the *structure
+inference* it lacks: SFT'd on whole-program cljs (not REPL traces), it does not propose the
+slope / coupling / group-split the crude model is missing. This is the honest two-tier
+result — the cheap proposer is **not yet capable** of driving the loop on these models — and
+it is exactly what **Phase 3 (`genmlx-oexl`) exists to fix**: specialize the 0.8B on the
+REPL-trace corpus (the very trajectories the slow-tier runs here produce), so it learns the
+*propose-eval-revise policy*, not whole programs. Until then the metareasoner escalates to
+the big model for structure (the fast/slow `:which` decision).
+
+### A harder benchmark — does the loop's edge grow with structural complexity?
+
+The three models above are *single-idea* (one line / one chain / one group-split), and a
+strong model + the DSL prompt one-shots the easy ones — so they under-test the loop. The
+`vslope` model is deliberately *multi-piece*: **3 groups, each a distinct line in `x`** —
+the data-warranted model needs **6 latents** (a slope *and* an intercept per group), **3
+linear means**, and a tuned noise, all in one program (exactly scoreable, linear-Gaussian,
+calibrated crude ≈ −30 / gold ≈ −17, bar −23.5). The hypothesis: with more pieces, each a
+chance to slip, one-shot best-of-K's joint success rate drops while the loop's revision +
+per-step selection recover the slips — so the loop's margin over one-shot should *widen*.
+
+**Result — and the diagnosis it forced (35B):**
+
+```
+vslope    bar     one-shot best-of-8       loop (greedy / beam)      verdict
+−23.5             −25.25  (4/8 valid)  ✗    −14.61  (both solve) ✓    LOOP WINS by ~10.6 nats
+```
+(greedy reaches −14.61 in 2 steps, beam in 4 — both converge to the σ-grid optimum.)
+
+The first cut **inverted the hypothesis and was the more useful for it.** One-shot best-of-8
+fell short (−25.25); the greedy loop *also* fell short (−26.08) and even slightly *below*
+one-shot — it had **built the full 6-latent structure** (−26.08 is, to the decimal, the
+calibrated full model at σ=1) but then **plateaued without tuning the noise scale**. The
+LLM proposes structure and neglects the nuisance σ — the exact move the *structured*
+proposer (§§10–11) supplied via a σ-grid. Adding that one move back — **union the LLM
+proposer (hard structural moves) with a cheap deterministic shared-σ grid (the
+hyperparameter), the oracle selecting per step** — flips it cleanly: the loop builds the
+structure (step 1, −26) then the oracle tunes σ to the data's true scale (step 2, **−14.61**,
+past even the σ=0.2 gold), while one-shot, which cannot refine, stays at −25.25. **A ~10.6-nat
+win on the model one-shot can't crack** — and a sharp statement of *where* the loop's value
+lives: the LLM for structure, the exact oracle for refinement, and one-shot has neither
+loop. This is the resource-rational split made concrete (cheap grid for the scalar
+hyperparameter, expensive model only for structure).
+
+### Honest verdict — does a real LLM in the loop beat one-shot best-of-K?
+
+**The thesis scaffold holds with a real generator, and the answer is resource-rational, not
+unconditional.**
+
+1. **Validated.** The loop — a *real* LLM proposer + the exact oracle + REPL revision —
+   builds the advanced models that whole-program best-of-16 got 0/16 on (linreg −8.31,
+   kalman −5.79, both above the structure bar). The feedback loop is no longer a scaffold
+   demonstrated only with a hand-coded vocabulary; it works end-to-end with a real model.
+   (Honest attribution: the 0/16 cliff used a *weaker* whole-program prompt, so it is the
+   **DSL prompt + the loop together** that dissolve it — not the loop alone; with the DSL
+   prompt, one-shot already clears the easier models, see below.)
+2. **The load-bearing addition was forced by the real LLM: revision.** A strong model emits
+   correct structure with one-eval-away slips; with no feedback every candidate carries one
+   (0/K valid), and a fit-only loop stalls because it never sees *why*. Re-prompting with the
+   verifier's specific error is what closes the loop. This was invisible with the structured
+   proposer — discovering it is the concrete payoff of *actually putting an LLM in the loop*.
+3. **Beats one-shot, and the margin grows with structural complexity.** On *easy* structure
+   with a *strong* model and a good DSL prompt, one-shot best-of-K already succeeds and the
+   loop **ties** it (linreg). On *harder* structure one-shot's slip rate rises and the loop
+   **wins**: kalman −5.79 vs −6.37, and — decisively — the multi-piece **`vslope`** model
+   (6 latents + 3 lines + a tuned scale) where one-shot tops out at −25.25 (can't assemble
+   *and* tune in one program) while the loop reaches **−14.61, a ~10.6-nat win**. The loop's
+   value is the *composition* one-shot lacks: **LLM for hard structure + exact oracle for
+   refinement**, applied step by step. On the *weak* tier the loop is necessary but not
+   sufficient — the 0.8B needs Phase-3 specialization. So the loop's value is **conditional
+   on the regime** (the resource-rational claim itself): spend one shot when it suffices,
+   spend the loop — and escalate the model — when it does not.
+4. **Honest limitations.** (a) The loop must carry *both* kinds of move: the harder `vslope`
+   model exposed that an LLM proposes structure but neglects the nuisance noise scale, so the
+   loop needs a cheap σ-refinement move (a grid) alongside the LLM's structural edits — with
+   only the LLM it built the structure but stalled at σ=1 (−26); the win required adding the
+   grid back. (b) The DSL
+   prompt is tuned to produce *exactly-scoreable* models (fixed σ, inline means), aligning
+   the generator with the exact eliminator; broadening the eliminator to score latent-σ /
+   let-factored models (`genmlx-w47t` / `genmlx-aw46`) would let the model write more natural
+   code and is the binding oracle-reach constraint. (c) Phase-2 beam-vs-greedy in the
+   *stochastic* regime is only weakly exercised here: the strong tier solves greedily in one
+   step (no room for the population to help) and the weak tier fails both — so the clean
+   beam-beats-greedy evidence remains the structured probe's (§11, linreg +3.24 nats). The
+   structured-proposer results (§§10–11) stand as the deterministic **control**.
+
+**Bottom line:** putting a real LLM in the loop confirms the north star's core bet — the
+closed feedback loop with an exact verifier turns one-shot-fragile model-building into
+locally-checkable, self-correcting construction — and the win is **largest exactly where it
+should be**: on the hardest, multi-piece model the loop beats one-shot by ~10.6 nats
+(−14.6 vs −25.3), because it *composes* what one-shot cannot — LLM-proposed structure with
+oracle-driven refinement, step by step. It also sharpens honestly: the win is
+regime-dependent (one shot suffices on easy models), the loop must carry both structural and
+hyperparameter moves, the cheap proposer needs Phase 3, and the exact oracle's reach is the
+next lever. This is the validated ground Phase 3 (`genmlx-oexl`) now builds on.

--- a/docs/programmer-as-genmlx-model.md
+++ b/docs/programmer-as-genmlx-model.md
@@ -323,3 +323,61 @@ The kernel ships **five** form-level edit ops (`add-latent`/`add-obs`/`set-args`
 repeated sites into a `Map` combinator needs the synthesis SCI sandbox to expose the
 combinators — so the kernel ships `homogeneous-obs?`, the pure predicate that *detects*
 the fold opportunity, rather than a rewrite that would render an un-evaluable form.
+
+## 11. Phase 2 — search over edits: SMC/beam beats greedy ✅
+
+Phase 2 (`src/genmlx/world/search.cljs`, native-free, 19/19 `test/genmlx/search_test.cljs`)
+turns the greedy kernel into a **particle search over construction steps** — the
+best-of-K wrapper moved to the *step* level, where the oracle signal is dense (exp A).
+Instead of one greedy state that commits to the single best edit, it keeps a
+**population** of partial-model particles; each step expands every non-done particle by
+its proposed edits, dedups by rendered program, **adaptively allocates** the beam width
+(wider when the top candidates score within a margin — an ambiguous structural step),
+and selects the next population by **`:beam`** (deterministic top-B) or **`:smc`**
+(resample ∝ softmax of intermediate evidence, exact-scored particles weighted above
+noisy IS ones). It stops when the *whole population* plateaus. All on the Phase-1
+spec / edit ops / four-level `check` / exact oracle; the proposer is still injected.
+
+**`backtrack-refine` — the regenerate-style move.** On plateau, the best particle's
+trajectory is re-opened decision-by-decision: at each step take a *road not taken* (an
+alternative proposed edit) from the spec *before* it and greedy-continue — keeping the
+best result. This lets even a width-1 (greedy) search escape a structural lock-in. It is
+the design's "backtracking = reconsider an earlier decision given later feedback" realized
+as **deterministic backtracking (best-first re-search over the trajectory)** — *not* MCMC
+(no stochastic accept/reject), and *not* the literal materialized programmer-GF +
+`p/regenerate` stochastic move (the §2 fixpoint, deferred). Honest about the layer.
+
+**Result — `scripts/synth_search_probe.cljs`, greedy vs beam through the *same* code
+path (greedy = beam-width 1), same proposers, same budget:**
+
+```
+model     greedy   beam     winner   structure-reached
+linreg    −10.14   −6.90    BEAM     yes      (+3.24 nats — the headline)
+kalman    −5.05    −4.92    beam     yes      (+0.13)
+hier      −12.36   −12.36   tie      yes      (greedy already optimal)
+gmm       −17.62   −17.62   tie      NO       (IS-scoring bottleneck, see below)
+```
+
+**Solves 3/4; beam ≥ greedy on every model; strictly wins on 2.** The headline is
+**linreg**: greedy commits to the no-intercept branch and locks in (−10.14); the beam
+keeps the *full-intercept* branch alive too, and the exact oracle prefers it after noise
+tuning (−6.90) — a clean exact +3-nat win that *directly* fixes the Phase-1 greedy
+limitation (and confirms the full-intercept model is the global optimum, contra the
+Phase-1 lock-in). The width-1 + `backtrack-refine` path reaches the same −6.90,
+recovering the branch a narrow search first missed.
+
+**Honest: GMM is NOT solved — by *either* search, and that is a SCORING bottleneck, not
+a search one.** The 2-component mixture's marginal is estimated by importance sampling
+from the *prior* over 6 discrete assignments (`z0..z5`), which rarely hits the right
+assignment, so `log-mean-exp` is biased **low** and never clears the single-cluster
+baseline. The search *correctly declines* an edit whose estimated evidence is worse — it
+faithfully reflects an unreliable oracle. (The IS estimate is also un-seeded, so GMM is
+noisy run-to-run; the exact models are bit-reproducible.) Unblocking it needs a better
+discrete-latent marginal — **enumerate / Rao-Blackwellize the assignments** (GenMLX has
+both) — which is orthogonal to the search. Tracked as **`genmlx-akvp`**.
+
+**Take:** the search beats greedy wherever the oracle is sound, and where it doesn't the
+bottleneck is cleanly localized to the oracle, not the search. Phase 3 (`genmlx-oexl`)
+swaps the structured proposer for a *learned* one (REPL-trace SFT + GRPO); Phase 4
+(`genmlx-gjih`) is the resource-rational metareasoner over the control sites (beam
+width, particle budget, when to stop — the adaptive allocation here is its seed).

--- a/scripts/curriculum_probe.cljs
+++ b/scripts/curriculum_probe.cljs
@@ -1,0 +1,113 @@
+(ns curriculum-probe
+  "RUN + inspect the REPL-synthesis CURRICULUM (genmlx.world.curriculum, bean genmlx-ilna).
+
+   Generates a graded, oracle-grounded, leakage-safe curriculum of structured-model
+   tasks, writes it as a JSON artifact (out-of-tree), and proves end-to-end that it is
+   consumable by BOTH downstream consumers:
+     - the run loop  (scripts/synth_llm_probe.cljs)  via cur/->probe-task
+     - the harvester (genmlx.world.repl-corpus)       via a no-LLM family-proposer loop
+
+   It reports the COMPLEXITY SPREAD (the resource-rational training signal: gap/n-latents
+   by complexity band) and the two eval cohorts (within-family same-distribution vs the
+   held-out family compositional/OOD).
+
+   Run: bun run --bun nbb scripts/curriculum_probe.cljs
+   Env: INSTANCES (per family, default 25), ROUND (default 0)."
+  (:require [genmlx.world.curriculum :as cur]
+            [genmlx.world.synth :as syn]
+            [genmlx.world.repl-corpus :as rc]
+            [clojure.string :as str]))
+
+(def os   (js/require "os"))
+(def path (js/require "path"))
+(def fs   (js/require "fs"))
+(defn home [& xs] (apply (.-join path) (.homedir os) xs))
+(def out-dir (home "genmlx-loop-artifacts" "curriculum"))
+(defn- env [k d] (or (aget (.-env js/process) k) d))
+(defn- envi [k d] (let [v (env k nil)] (if v (js/parseInt v 10) d)))
+(defn fx [x] (if (and x (js/isFinite x)) (.toFixed (js/Number x) 2) (str x)))
+
+(def instances (envi "INSTANCES" 25))
+(def round     (envi "ROUND" 0))
+
+(println (str "\n=== curriculum RUN  (round " round ", " instances " instances/family) ===\n"))
+(def C (cur/generate-curriculum {:round round :instances-per-family instances}))
+(def tasks (:tasks C))
+
+;; ---------------------------------------------------------------------------
+;; Report.
+;; ---------------------------------------------------------------------------
+(let [s (:summary C)]
+  (println "SUMMARY")
+  (println "  tasks:" (:n-tasks s) " train:" (:n-train s) " eval:" (:n-eval s)
+           " (within-family:" (:eval-within s) " held-out-family:" (:eval-family s) ")")
+  (println "  held-out families:" (:held-out-families s) "  total drops:" (:total-drops s)))
+
+(println "\nBY FAMILY")
+(doseq [[fam {:keys [n drops complexity]}] (:by-family C)]
+  (println (str "  " (name fam)) "  c=" complexity "  n=" n "  drops=" drops))
+
+(println "\nBY COMPLEXITY  (the resource-rational spread)")
+(doseq [[c {:keys [n mean-gap mean-struct-gap mean-n-latents]}] (:by-complexity C)]
+  (println (str "  complexity " c ":  n=" n
+                "  mean-gap=" (fx mean-gap) " nats"
+                "  mean-struct-gap=" (fx mean-struct-gap)
+                "  mean-n-latents=" (fx mean-n-latents))))
+(let [bc (:by-complexity C) cs (sort (keys bc))]
+  (println "  -> n-latents monotone:" (apply <= (map #(:mean-n-latents (bc %)) cs))
+           " | hardest gap > easiest gap:"
+           (> (:mean-gap (bc (last cs))) (:mean-gap (bc (first cs))))))
+
+(println "\nEXAMPLE TASKS (one per family)")
+(doseq [fam (map :family cur/family-defs)
+        :let [t (first (filter #(= fam (:family %)) tasks))]
+        :when t]
+  (println (str "  [" (name fam) "] " (:id t) "  exact?=" (:exact? t)
+                "  crude=" (fx (:crude t)) " gold=" (fx (:gold t))
+                " bar=" (fx (:solve-bar t)) " gap=" (fx (:gap t))))
+  (println (str "      desc: " (:task-desc t))))
+
+;; ---------------------------------------------------------------------------
+;; End-to-end harvest proof (no LLM): run one task/family through the family-proposer
+;; loop, harvest with repl-corpus using the curriculum's eval-ids, show leakage-safety.
+;; ---------------------------------------------------------------------------
+(println "\nEND-TO-END HARVEST (no LLM; family-proposer loop -> repl-corpus)")
+(defn harvest-run [t]
+  (let [obs (:observations t)
+        res (syn/synthesize {:init-spec (cur/crude-spec obs) :observations obs
+                             :propose (cur/family-proposer t) :max-steps 8})]
+    {:task t :trajectory (:trajectory res)
+     :steps (:steps res) :final (get-in res [:feedback :evidence])
+     :solved? (>= (get-in res [:feedback :evidence] -1e9) (:solve-bar t))}))
+
+(def sample-runs
+  (vec (for [fam (map :family cur/family-defs)
+             :let [t (first (filter #(= fam (:family %)) tasks))] :when t]
+         (harvest-run t))))
+(doseq [r sample-runs]
+  (println (str "  [" (name (:family (:task r))) "] steps=" (:steps r)
+                " final=" (fx (:final r)) " bar=" (fx (:solve-bar (:task r)))
+                " solved=" (:solved? r))))
+(println "  loop solves" (count (filter :solved? sample-runs)) "/" (count sample-runs)
+         "sampled tasks via the no-LLM structured proposer")
+
+(let [corpus (rc/build-corpus sample-runs {:eval-ids (:eval-task-ids C)})]
+  (println "\nHARVEST CORPUS")
+  (println "  rows:" (:n-rows corpus) " train-rows:" (count (:train-rows corpus))
+           " dropped-eval-rows:" (count (:dropped-eval corpus)))
+  (println "  train task ids:" (:train-task-ids corpus))
+  (println "  leakage-safe:" (not-any? #(contains? (:eval-task-ids C) (:task-id %))
+                                       (:train-rows corpus))))
+
+;; ---------------------------------------------------------------------------
+;; Write the JSON artifact (out-of-tree).
+;; ---------------------------------------------------------------------------
+(.mkdirSync fs out-dir #js {:recursive true})
+(def artifact (.join path out-dir (str "curriculum-r" round ".json")))
+(.writeFileSync fs artifact
+  (.stringify js/JSON (clj->js {:summary (:summary C)
+                                :by-family (:by-family C)
+                                :by-complexity (:by-complexity C)
+                                :eval-task-ids (vec (:eval-task-ids C))
+                                :tasks tasks}) nil 2))
+(println (str "\nwrote " (count tasks) " tasks -> " artifact))

--- a/scripts/distill_check.cljs
+++ b/scripts/distill_check.cljs
@@ -15,6 +15,7 @@
        [--n-particles N] [--min-log-ml F]"
   (:require [genmlx.world.distill :as d]
             [genmlx.world.distill-tasks :as t]
+            [genmlx.world.distill-gen :as g]
             [clojure.string :as str]))
 
 (def fs (js/require "fs"))
@@ -45,10 +46,14 @@
       min-ml (let [m (and (string? (:min-log-ml opts)) (js/parseFloat (:min-log-ml opts)))]
                (when (and m (not (js/isNaN m))) m))
       eopts  (cond-> {:n-particles n-part} min-ml (assoc :min-log-ml min-ml))
+      ;; --gen routes against the scaled generated task set (genmlx.world.distill-gen);
+      ;; otherwise the 12 in-tree seeds. Must match the parent filter's task source, else
+      ;; every candidate whose id is not a seed is dropped as :unknown-task.
+      tasks-by-id (if (:gen opts) g/tasks-by-id t/tasks-by-id)
       rows   (read-candidates cf)]
   (doseq [i (range start (count rows))]
     (let [{:keys [task-id sample-idx raw-text]} (d/candidate->fields (nth rows i))
-          task    (get t/tasks-by-id task-id)
+          task    (get tasks-by-id task-id)
           verdict (if task
                     (assoc (d/evaluate-candidate (merge task eopts) raw-text sample-idx) :index i)
                     {:index i :unknown-task? true :task-id task-id :sample-idx sample-idx})]

--- a/scripts/distill_filter.cljs
+++ b/scripts/distill_filter.cljs
@@ -35,6 +35,7 @@
    lands in the repo (the repo intentionally has no catch-all gitignore)."
   (:require [genmlx.world.distill :as d]
             [genmlx.world.distill-tasks :as t]
+            [genmlx.world.distill-gen :as g]
             [genmlx.world.distill-sandbox :as sb]
             [clojure.string :as str]
             [promesa.core :as p]))
@@ -49,6 +50,15 @@
 (defn- default-out-dir []
   (let [tmp (or (.. js/process -env -TMPDIR) "/tmp")]
     (.join path-mod tmp "genmlx-distill")))
+
+(defn- task-source
+  "Pick the task source: the scaled generated set (genmlx.world.distill-gen, --gen) or
+   the 12 in-tree seeds (genmlx.world.distill-tasks). Both expose the same shape — the
+   pure core (rank-and-select / build-sft-records / verdicts->stats) is task-agnostic."
+  [gen?]
+  (if gen?
+    {:tasks g/all-tasks :tasks-by-id g/tasks-by-id :label "distill-gen (scaled)"}
+    {:tasks t/tasks :tasks-by-id t/tasks-by-id :label "distill-tasks (seed)"}))
 
 ;; ---------------------------------------------------------------------------
 ;; Tiny CLI arg parsing: --key value pairs + bare --flags.
@@ -99,11 +109,12 @@
 ;; Mode 1 — export teacher-facing task prompts.
 ;; ---------------------------------------------------------------------------
 
-(defn- export-tasks! [path]
+(defn- export-tasks! [path gen?]
   (ensure-dir (.dirname path-mod path))
-  (write-jsonl path (map t/task->prompt-record t/tasks))
-  (println (str "Exported " (count t/tasks) " task prompts -> " path))
-  (println "  (held-out oracle signal NOT included — no test leakage)"))
+  (let [tasks (if gen? g/train-tasks t/tasks)]
+    (write-jsonl path (map (if gen? g/task->prompt-record t/task->prompt-record) tasks))
+    (println (str "Exported " (count tasks) (if gen? " TRAIN" "") " task prompts -> " path))
+    (println "  (held-out oracle signal NOT included — no test leakage)")))
 
 ;; ---------------------------------------------------------------------------
 ;; Mode 2 — filter candidates into an SFT corpus.
@@ -111,18 +122,19 @@
 
 ;; In-process scoring (the --no-sandbox path): fast, but a non-terminating candidate
 ;; hangs the whole run. The default path isolates each candidate in a worker process.
-(defn- score-in-process [rows eval-opts note]
+(defn- score-in-process [rows eval-opts note tasks-by-id]
   (vec (for [c rows
              :let [{:keys [task-id sample-idx raw-text]} (d/candidate->fields c)
-                   task (get t/tasks-by-id task-id)]
+                   task (get tasks-by-id task-id)]
              :when task]
          (do (note (str "scoring " task-id " #" sample-idx))
              (let [v (d/evaluate-candidate (merge task eval-opts) raw-text sample-idx)]
                (note (str "  -> " (:reason v) (when (:log-ml v) (str " log-ml=" (:log-ml v)))))
                v)))))
 
-(defn- filter! [{:keys [candidates out top-k n-particles min-log-ml timeout-ms no-sandbox]}]
-  (let [out-dir   (or out (default-out-dir))
+(defn- filter! [{:keys [candidates out top-k n-particles min-log-ml timeout-ms no-sandbox gen]}]
+  (let [{:keys [tasks tasks-by-id label]} (task-source gen)
+        out-dir   (or out (default-out-dir))
         top-k     (pos-int-or-nil (or top-k 1))
         n-part    (pos-int-or-nil (or n-particles 50))
         tmo       (pos-int-or-nil (or timeout-ms 15000))
@@ -137,6 +149,7 @@
       (let [{:keys [rows skipped]} (read-jsonl candidates)
             _        (ensure-dir out-dir)
             _        (println (str "Read " (count rows) " candidates from " candidates
+                                   "  [tasks: " label "]"
                                    (when (pos? skipped)
                                      (str " (" skipped " malformed lines skipped)"))
                                    (if no-sandbox "  [in-process]"
@@ -147,17 +160,17 @@
             prog-log (.join path-mod out-dir "progress.log")
             _        (when verbose? (.writeFileSync fs prog-log ""))
             note     (fn [s] (when verbose? (println s) (.appendFileSync fs prog-log (str s "\n"))))
-            unknown  (count (remove #(get t/tasks-by-id (:task-id (d/candidate->fields %))) rows))]
+            unknown  (count (remove #(get tasks-by-id (:task-id (d/candidate->fields %))) rows))]
         (p/let [verdicts (if no-sandbox
-                           (p/resolved (score-in-process rows eval-opts note))
+                           (p/resolved (score-in-process rows eval-opts note tasks-by-id))
                            (sb/collect-verdicts candidates
                                                 {:out-path   (.join path-mod out-dir "_sandbox_verdicts.edn")
                                                  :eval-opts  eval-opts :timeout-ms tmo
                                                  :poll-ms    400 :verbose? verbose?}))]
           (let [n-timeout (count (filter #(contains? #{:timeout :crashed} (:reason %)) verdicts))
                 selected (d/rank-and-select verdicts top-k)
-                records  (d/build-sft-records t/tasks-by-id selected)
-                stats    (assoc (d/verdicts->stats t/tasks verdicts selected)
+                records  (d/build-sft-records tasks-by-id selected)
+                stats    (assoc (d/verdicts->stats tasks verdicts selected)
                                 :top-k top-k :n-particles n-part :min-log-ml min-ml
                                 :sandboxed? (not no-sandbox) :timeout-ms tmo
                                 :n-timed-out n-timeout
@@ -192,7 +205,8 @@
     (:export-tasks opts)
     (export-tasks! (if (string? (:export-tasks opts))
                      (:export-tasks opts)
-                     (.join path-mod (default-out-dir) "tasks.jsonl")))
+                     (.join path-mod (default-out-dir) "tasks.jsonl"))
+                   (:gen opts))
 
     (:candidates opts)
     (-> (p/resolved nil)

--- a/scripts/distill_filter.cljs
+++ b/scripts/distill_filter.cljs
@@ -166,7 +166,7 @@
                            (sb/collect-verdicts candidates
                                                 {:out-path   (.join path-mod out-dir "_sandbox_verdicts.edn")
                                                  :eval-opts  eval-opts :timeout-ms tmo
-                                                 :poll-ms    400 :verbose? verbose?}))]
+                                                 :poll-ms    400 :verbose? verbose? :gen? gen}))]
           (let [n-timeout (count (filter #(contains? #{:timeout :crashed} (:reason %)) verdicts))
                 selected (d/rank-and-select verdicts top-k)
                 records  (d/build-sft-records tasks-by-id selected)

--- a/scripts/gen_tasks.cljs
+++ b/scripts/gen_tasks.cljs
@@ -1,0 +1,135 @@
+(ns genmlx.gen-tasks
+  "Runner for the scaled task/curriculum generator (genmlx-7473), twin of
+   scripts/distill_filter.cljs but over genmlx.world.distill-gen instead of the 12 seeds.
+
+   MODES
+
+     --validate
+        Run EVERY generated task's :reference through the SAME oracle that grades the
+        student (genmlx.world.distill/evaluate-candidate). Reports per-task kept?/reason/
+        method and FAILS (non-zero exit) if any reference is not admitted — the grounding
+        guarantee: a task whose own reference cannot pass its oracle is broken and must not
+        ship. Use this before every teacher run.
+
+     --export-train <prompts.jsonl>   teacher-facing prompts for the TRAIN tasks
+     --export-eval  <prompts.jsonl>   teacher-facing prompts for the held-out EVAL tasks
+        (both drop the oracle signal AND the reference — no leakage)
+
+     --export-refs  <candidates.jsonl>
+        One reference-solution candidate row per TRAIN task (sample_idx -1) — seed rows for
+        the SFT corpus (oracle-validated, cold-start insurance). Eval tasks are excluded.
+
+     --write-edn <gen_tasks.edn>      the full task set (with oracle signal + references)
+
+   Default (no mode): print the generated-set summary.
+
+   Outputs default under $TMPDIR/genmlx-gen."
+  (:require [genmlx.world.distill-gen :as g]
+            [genmlx.world.distill :as d]
+            [clojure.string :as str]))
+
+(def fs (js/require "fs"))
+(def path-mod (js/require "path"))
+
+(defn- ensure-dir [dir]
+  (when-not (.existsSync fs dir) (.mkdirSync fs dir #js {:recursive true})))
+
+(defn- default-out-dir []
+  (.join path-mod (or (.. js/process -env -TMPDIR) "/tmp") "genmlx-gen"))
+
+(defn- parse-args [argv]
+  (loop [args (seq argv), m {}]
+    (if-let [a (first args)]
+      (if (str/starts-with? a "--")
+        (let [k (keyword (subs a 2)), v (second args)]
+          (if (and v (not (str/starts-with? v "--")))
+            (recur (nnext args) (assoc m k v))
+            (recur (next args) (assoc m k true))))
+        (recur (next args) m))
+      m)))
+
+(defn- write-jsonl [path rows]
+  (ensure-dir (.dirname path-mod path))
+  (.writeFileSync fs path (str (str/join "\n" (map #(js/JSON.stringify (clj->js %)) rows))
+                               (when (seq rows) "\n"))))
+
+(defn- write-text [path s]
+  (ensure-dir (.dirname path-mod path))
+  (.writeFileSync fs path s))
+
+(defn- pos-int-or [s d]
+  (if (string? s) (let [n (js/parseInt s 10)] (if (or (js/isNaN n) (< n 1)) d n)) d))
+
+;; ---------------------------------------------------------------------------
+
+(defn- validate! [{:keys [n-particles]}]
+  (let [n-part (pos-int-or n-particles 50)
+        verdicts (mapv (fn [t]
+                         (let [v (d/evaluate-candidate (assoc t :n-particles n-part)
+                                                       (:reference t) -1)]
+                           (assoc v :family (:family t) :split (:split t))))
+                       g/all-tasks)
+        failed   (remove :kept? verdicts)
+        progs    (filter #(= :program (:kind %)) verdicts)
+        is-progs (filter #(and (= :program (:kind %))
+                               (not (contains? #{:exact :kalman} (:method %)))) progs)]
+    (println (str "Validating " (count g/all-tasks) " references through the oracle "
+                  "(n-particles " n-part ") ...\n"))
+    (doseq [v verdicts]
+      (println (str "  " (if (:kept? v) "ok  " "FAIL")
+                    " " (.padEnd (str (:task-id v)) 22)
+                    " " (.padEnd (str (name (:kind v))) 9)
+                    " " (.padEnd (str (:reason v)) 14)
+                    (when (:method v) (str "method=" (name (:method v)) " "))
+                    (when (:log-ml v) (str "log-ml=" (.toFixed (js/Number (:log-ml v)) 2))))))
+    (println (str "\n== validation =="))
+    (println (str "  kept: " (count (filter :kept? verdicts)) "/" (count verdicts)))
+    (println (str "  programs scored by EXACT marginal: " (- (count progs) (count is-progs))
+                  "/" (count progs)
+                  (when (seq is-progs) (str "  (IS-scored: " (str/join ", " (map :task-id is-progs)) ")"))))
+    (when (seq failed)
+      (println (str "\n  FAILED references (" (count failed) "):"))
+      (doseq [v failed]
+        (println (str "    " (:task-id v) " -> " (:reason v)
+                      (when (:error v) (str " : " (:error v)))))))
+    (if (seq failed)
+      (do (println "\nGROUNDING FAILURE: some references are not admitted by their own oracle.")
+          (set! (.-exitCode js/process) 1))
+      (println "\nAll references admitted — task set is grounded. ✓"))))
+
+(defn- export-prompts! [path tasks which]
+  (write-jsonl path (map g/task->prompt-record tasks))
+  (println (str "Exported " (count tasks) " " which " task prompts -> " path))
+  (println "  (oracle signal + reference NOT included — no leakage)"))
+
+(defn- export-refs! [path]
+  (let [rows (map g/reference-record g/train-tasks)]
+    (write-jsonl path rows)
+    (println (str "Exported " (count rows) " reference candidate rows (train only) -> " path))))
+
+(defn- write-edn! [path]
+  (write-text path (with-out-str (pr g/all-tasks)))
+  (println (str "Wrote full task set (" (count g/all-tasks) " tasks) -> " path)))
+
+(defn- print-summary []
+  (println "Generated task set summary:")
+  (doseq [[k v] g/summary] (println (str "  " (name k) ": " (pr-str v))))
+  (println "\nModes: --validate | --export-train <f> | --export-eval <f> | --export-refs <f> | --write-edn <f>"))
+
+;; ---------------------------------------------------------------------------
+
+(let [opts (parse-args (vec (drop 2 (.-argv js/process))))
+      od   (default-out-dir)]
+  (cond
+    (:validate opts) (validate! opts)
+    (:export-train opts) (export-prompts! (if (string? (:export-train opts)) (:export-train opts)
+                                              (.join path-mod od "train_prompts.jsonl"))
+                                          g/train-tasks "train")
+    (:export-eval opts) (export-prompts! (if (string? (:export-eval opts)) (:export-eval opts)
+                                             (.join path-mod od "eval_prompts.jsonl"))
+                                         g/eval-tasks "eval")
+    (:export-refs opts) (export-refs! (if (string? (:export-refs opts)) (:export-refs opts)
+                                          (.join path-mod od "reference_candidates.jsonl")))
+    (:write-edn opts) (write-edn! (if (string? (:write-edn opts)) (:write-edn opts)
+                                      (.join path-mod od "gen_tasks.edn")))
+    :else (print-summary)))

--- a/scripts/grpo_sharpen.cljs
+++ b/scripts/grpo_sharpen.cljs
@@ -1,0 +1,203 @@
+(ns genmlx.grpo-sharpen
+  "GRPO sharpening of the SFT'd cljs-coder student (genmlx-2ctu, loop step 4/5).
+
+   Sharpens an SFT'd qwen3.5-0.8b toward its own pass@k ceiling: RLVR (Yue 2025) lifts
+   pass@1 without raising pass@k beyond the SFT base, so this runs AFTER SFT on a band of
+   TRAIN tasks where the student SOMETIMES succeeds (the only band with reward variance —
+   an all-pass or all-fail group has 0 advantage and teaches nothing). The reward is a
+   GROUNDED GFI quantity (the SAME oracle the corpus + held-out eval use): Bayesian model
+   evidence for :program, behavioral accuracy for :function. Held-out eval tasks are NEVER
+   in the band (leakage), so the lift is measured on tasks the student never trained on.
+
+   Reuses, unchanged: genmlx.world.train (the native GRPO engine membrane), the
+   train_reward floor/extraction, and the distill-gen task set.
+
+   ENV
+     STEPS         number of GRPO steps (default 4 = smoke)
+     BAND_SIZE     train tasks per step (default 8; group-size completions each)
+     GROUP_SIZE    completions per prompt (default 6)
+     MAXLEN        max completion length (default 128 — fn forms are short)
+     LR            learning rate (default 2e-6, the Phase-1-stable value)
+     KL            kl-coef to base (default 0.0; >0 = KL-to-base via genmlx-65d5)
+     MODEL         student model dir name under ~/.cache/models (default the SFT-600 fuse)
+     SAVE_TO       if set, saveModel the sharpened weights to ~/.cache/models/<SAVE_TO>"
+  (:require [genmlx.world.train :as train]
+            [genmlx.world.train-reward :as reward]
+            [genmlx.world.distill-gen :as g]
+            [genmlx.llm.msa-score :as score]
+            [genmlx.codegen.eval :as ce]
+            [clojure.string :as str]
+            [promesa.core :as p]))
+
+(def os   (js/require "os"))
+(def path (js/require "path"))
+(def fs   (js/require "fs"))
+(def gcore (js/require "@genmlx/core"))
+
+(defn- env [k d] (or (aget (.-env js/process) k) d))
+(defn- envi [k d] (let [v (aget (.-env js/process) k)] (if v (js/parseInt v 10) d)))
+(defn- envf [k d] (let [v (aget (.-env js/process) k)] (if v (js/parseFloat v) d)))
+
+(def train-floor -20.0)
+
+;; ---------------------------------------------------------------------------
+;; The band — TRAIN tasks only (never held-out eval). A diverse spread across the
+;; function families (where the held-out learnable tasks live) plus a couple of
+;; programs for a stable always-some-signal anchor.
+;; ---------------------------------------------------------------------------
+
+(defn- pick-band
+  "MEDIUM-difficulty train FUNCTIONS — the reward-variance sweet spot. Easy functions the
+   SFT student always solves (no variance) and hard ones it never solves (all floored) teach
+   nothing; medium ones are the band where it SOMETIMES succeeds, the only band GRPO learns
+   from. Programs are excluded (the scaffold makes them near-always covering = low variance).
+   Deterministic even stride across the family spread."
+  [n]
+  (let [med (filterv #(and (= :function (:kind %)) (= :medium (:difficulty %))) g/train-tasks)
+        stride (max 1 (quot (count med) (max 1 n)))]
+    (vec (take n (take-nth stride med)))))
+
+;; ---------------------------------------------------------------------------
+;; The reward dispatcher — identify the task from the prompt, apply its oracle.
+;; ---------------------------------------------------------------------------
+
+(defn- run-tests [f test-cases]
+  (let [tot (count test-cases)
+        ok  (count (filter (fn [{:keys [args expected]}]
+                             (try (= expected (apply f args)) (catch :default _ false)))
+                           test-cases))]
+    (/ ok (max 1 tot))))
+
+(defn- first-form
+  "Isolate the FIRST complete cljs form from a raw completion and re-emit it, DROPPING any
+   trailing junk. The native GRPO engine does not stop at EOS (mlx-lm does), so a completion
+   is `(valid form)` + `\\n!\\n!...` filler; eval'ing the whole string errors. parse-form reads
+   one form; pr-str re-emits it — preserving a defn NAME (so self-recursion survives, unlike
+   extract-program which canonicalizes defn->anonymous fn)."
+  [completion]
+  (let [raw  (ce/extract-code (reward/strip-think completion))
+        form (ce/parse-form raw)]
+    (if form (pr-str form) raw)))
+
+(defn- function-reward
+  "Behavioral accuracy in [0,1] (floored): garbage -> floor, runnable-but-wrong -> partial,
+   correct -> 1. Mirrors the distill gate but returns a scalar reward, not a verdict."
+  [task completion floor]
+  (let [code (first-form completion)]
+    (cond
+      (str/blank? code)        floor
+      (not (ce/valid-cljs? code)) floor
+      (seq (:transitions task))
+      (let [{:keys [accuracy error]} (ce/verify-transition-fn code (:transitions task))]
+        (if error floor accuracy))
+      (seq (:test-cases task))
+      (let [{f :fn err :error} (ce/eval-fn code)]
+        (if err floor (run-tests f (:test-cases task))))
+      :else floor)))
+
+(defn- program-reward [task completion floor]
+  (let [code (reward/extract-program completion)
+        gf   (score/eval-model code)]
+    (if (or (nil? gf) (not (reward/covered-observations? gf (:observations task))))
+      floor
+      (reward/clamp-floor floor (score/score-model gf (:observations task) {:n-particles 30})))))
+
+(defn- make-reward [band floor]
+  (let [by-prompt (into {} (map (juxt :prompt identity)) band)]
+    (fn [prompt completion]
+      (try
+        (let [user (some #(when (= :user (:role %)) (:content %)) prompt)
+              task (get by-prompt user)]
+          (cond
+            (nil? task)              floor
+            (= :program (:kind task)) (program-reward task completion floor)
+            :else                     (reward/clamp-floor floor (function-reward task completion floor))))
+        (catch :default _ floor)))))
+
+;; ---------------------------------------------------------------------------
+
+(defn- mean [xs] (if (seq xs) (/ (reduce + xs) (count xs)) 0.0))
+(defn- fx [x] (.toFixed (js/Number x) 3))
+
+(defn run! []
+  (let [steps  (envi "STEPS" 4)
+        bsize  (envi "BAND_SIZE" 8)
+        gsize  (envi "GROUP_SIZE" 6)
+        maxlen (envi "MAXLEN" 128)
+        lr     (envf "LR" 2e-6)
+        kl     (envf "KL" 0.0)
+        model-name (env "MODEL" "qwen3.5-0.8b-cljs-sft600")
+        save-to (aget (.-env js/process) "SAVE_TO")
+        model-dir (.join path (.homedir os) ".cache" "models" model-name)
+        plog-path (env "PROGRESS" "/tmp/genmlx-loop/grpo_progress.log")
+        plog   (fn [s] (.appendFileSync fs plog-path (str s "\n")))
+        band   (pick-band bsize)
+        prompts (mapv #(into [] (cond-> []
+                                  (:system-prompt %) (conj {:role :system :content (:system-prompt %)})
+                                  true (conj {:role :user :content (:prompt %)})))
+                      band)
+        reward-fn (make-reward band train-floor)
+        cfg    {:learning-rate lr :temperature 0.9 :gradient-clip-norm 0.5
+                :kl-coef kl :loss-type :grpo :enable-thinking false
+                :group-size gsize :max-completion-length maxlen
+                :lm-head-chunk-size 2 :forward-chunk-size 4}]
+    (println (str "GRPO sharpen: model=" model-name " steps=" steps " band=" (count band)
+                  " group=" gsize " maxlen=" maxlen " lr=" lr " kl=" kl))
+    (println (str "  band tasks: " (str/join ", " (map :id band))))
+    (cond
+      (not (.existsSync fs (.join path model-dir "tokenizer.json")))
+      (do (println (str "  ABORT — no model at " model-dir)) (set! (.-exitCode js/process) 1) (p/resolved nil))
+
+      ;; DIAGNOSE: generate one completion per band task and print it raw + its reward,
+      ;; to see what the native engine actually emits (format vs capability).
+      (aget (.-env js/process) "DIAGNOSE")
+      (p/let [model (.load (.-Qwen35Model gcore) model-dir)
+              _ (println "  policy model loaded:" (some? model))
+              comps (train/with-trainer model cfg
+                      (fn [trainer] (train/generate-batch trainer (vec (take 4 prompts)))))]
+        (doseq [[i c] (map-indexed vector comps)]
+          (let [task (nth band i)
+                rw   (reward-fn (nth prompts i) c)]
+            (println (str "\n=== [" i "] " (:id task) "  reward=" (fx rw) " ==="))
+            (println (str "RAW (" (count c) " chars): " (pr-str (subs c 0 (min 500 (count c))))))))
+        (p/resolved nil))
+
+      :else
+      (p/let [model (.load (.-Qwen35Model gcore) model-dir)
+              _ (println "  policy model loaded:" (some? model))
+              history (train/with-trainer model cfg
+                        (fn [trainer]
+                          (p/loop [step 0, hist []]
+                            (if (= step steps)
+                              (p/resolved hist)
+                              (p/let [r (train/train-step! trainer prompts reward-fn)]
+                                (let [rs (:rewards r)
+                                      valid (/ (count (filter #(> % train-floor) rs)) (double (count rs)))
+                                      ;; per-prompt reward variance present (= learnable groups)
+                                      groups (partition gsize rs)
+                                      varied (count (filter #(> (apply max %) (apply min %)) groups))
+                                      line (str "    step " step
+                                                "  reward-mean=" (fx (:reward-mean r))
+                                                "  valid-rate=" (fx valid)
+                                                "  learnable-groups=" varied "/" (count groups)
+                                                "  applied=" (:gradients-applied? r))]
+                                  (println line)
+                                  (plog line))
+                                (p/recur (inc step) (conj hist r)))))))]
+        (let [means (map :reward-mean history)
+              applied (count (filter :gradients-applied? history))]
+          (println (str "\n  reward-means: " (mapv #(js/Number (fx %)) means)))
+          (println (str "  steps that applied gradients: " applied "/" steps))
+          (when (>= (count means) 2)
+            (println (str "  trend: first=" (fx (first means)) " -> last=" (fx (last means))
+                          "  (" (if (> (last means) (first means)) "UP" "flat/down") ")")))
+          (if save-to
+            (p/let [out (.join path (.homedir os) ".cache" "models" save-to)
+                    _   (.saveModel model out)]
+              (println (str "  saved sharpened weights -> " out)))
+            (p/resolved (println "  (no SAVE_TO — weights not persisted)"))))))))
+
+(-> (p/resolved nil)
+    (p/then run!)
+    (p/catch (fn [e] (println "ERROR:" (.-message e)) (println (.-stack e))
+               (set! (.-exitCode js/process) 1))))

--- a/scripts/llm_server.py
+++ b/scripts/llm_server.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Persistent mlx-lm generation worker for the REPL-synthesis LOOP (genmlx-0yv7 /
+genmlx-wpua). The policy LLM lives OUT-OF-PROCESS, exactly as the GenMLX oracle spine
+(codegen.eval + msa-score) is native-free: the synthesis loop in `genmlx.world.synth` /
+`genmlx.world.search` never loads a model — it shells out to THIS worker for proposals.
+
+WHY A LONG-RUNNING SERVER (not the per-call batch in distill_teacher.py): the loop is
+ADAPTIVE — every prompt is conditioned on the previous step's check feedback, so the
+proposals cannot be pre-generated. The model must stay resident and answer one
+request per propose() call. This holds the model in memory once (~19GB for the 35B-A3B
+teacher on the 32GB mini) and serves K samples per HTTP round-trip.
+
+PROMPT RENDERING is byte-identical to distill_teacher.build_prompt (chat template,
+enable_thinking=False so Qwen3 emits the form directly), so the in-loop proposer and
+the offline distill/SFT pipeline render the same way.
+
+PROTOCOL (single-threaded http.server; the CLJS side curls it synchronously):
+  POST /generate  {prompt, system?, n?, temperature?, max_tokens?, top_p?, seed?}
+                  -> {completions: [str,...], n, gen_time_s, prompt_tokens,
+                      completion_tokens, model}
+  GET  /health    -> {status:"ready", model}
+
+USAGE
+  python3 scripts/llm_server.py --model qwen3.5-0.8b-cljs-sft600 --port 8765
+  python3 scripts/llm_server.py --model Qwen3.6-35B-A3B-4bit   --port 8765
+Prints "READY <model>" to stdout once the weights are loaded (the launcher polls it).
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+def resolve_model(spec):
+    """A local ~/.cache/models/<name> dir if it exists, else the spec verbatim."""
+    local = os.path.expanduser(os.path.join("~/.cache/models", spec))
+    return local if os.path.isdir(local) else spec
+
+
+def build_prompt(tokenizer, system_prompt, user_prompt):
+    """Render a chat prompt with Qwen3 reasoning disabled (emit the code form
+    directly). Identical to scripts/distill_teacher.py."""
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": user_prompt})
+    try:
+        return tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=False,
+            enable_thinking=False)
+    except TypeError:
+        return tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=False)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True,
+                    help="local ~/.cache/models/<name> dir or an HF/mlx-community id")
+    ap.add_argument("--adapter", default=None, help="optional LoRA adapter dir")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=8765)
+    ap.add_argument("--max-tokens", type=int, default=384)
+    ap.add_argument("--temp", type=float, default=0.7)
+    ap.add_argument("--top-p", type=float, default=0.95)
+    args = ap.parse_args()
+
+    import mlx.core as mx
+    from mlx_lm import load, generate
+    from mlx_lm.sample_utils import make_sampler
+
+    model_path = resolve_model(args.model)
+    adapter = resolve_model(args.adapter) if args.adapter else None
+    print(f"Loading model: {model_path}"
+          + (f"  (+LoRA {adapter})" if adapter else ""), flush=True)
+    t0 = time.time()
+    model, tokenizer = load(model_path, adapter_path=adapter)
+    print(f"  loaded in {time.time() - t0:.1f}s", flush=True)
+
+    def generate_n(prompt_text, system, n, temperature, max_tokens, top_p, seed):
+        full = build_prompt(tokenizer, system, prompt_text)
+        prompt_tokens = len(tokenizer.encode(full))
+        sampler = make_sampler(temp=temperature, top_p=top_p)
+        greedy = make_sampler(temp=0.0)
+        outs, comp_tokens = [], 0
+        t = time.time()
+        for i in range(n):
+            # Seed per sample for reproducibility; sample 0 of a >1 batch is greedy
+            # (argmax) so a single deterministic anchor is always present, the rest
+            # sampled for diversity (the stochastic-proposer regime Phase 2 needs).
+            mx.random.seed(seed * 100003 + i)
+            use_greedy = (n > 1 and i == 0) or temperature <= 0.0
+            text = generate(model, tokenizer, prompt=full, max_tokens=max_tokens,
+                            sampler=(greedy if use_greedy else sampler), verbose=False)
+            outs.append(text)
+            comp_tokens += len(tokenizer.encode(text))
+        return {"completions": outs, "n": n, "gen_time_s": round(time.time() - t, 3),
+                "prompt_tokens": prompt_tokens, "completion_tokens": comp_tokens,
+                "model": os.path.basename(model_path)}
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *a):  # quiet
+            pass
+
+        def _send(self, code, obj):
+            body = json.dumps(obj).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            if self.path == "/health":
+                self._send(200, {"status": "ready",
+                                 "model": os.path.basename(model_path)})
+            else:
+                self._send(404, {"error": "not found"})
+
+        def do_POST(self):
+            if self.path != "/generate":
+                self._send(404, {"error": "not found"})
+                return
+            try:
+                length = int(self.headers.get("Content-Length", 0))
+                req = json.loads(self.rfile.read(length) or b"{}")
+                res = generate_n(
+                    req["prompt"], req.get("system"),
+                    int(req.get("n", 1)),
+                    float(req.get("temperature", args.temp)),
+                    int(req.get("max_tokens", args.max_tokens)),
+                    float(req.get("top_p", args.top_p)),
+                    int(req.get("seed", 1)))
+                self._send(200, res)
+            except Exception as e:  # noqa: BLE001 — report, never crash the server
+                self._send(500, {"error": f"{type(e).__name__}: {e}"})
+
+    httpd = HTTPServer((args.host, args.port), Handler)
+    print(f"READY {os.path.basename(model_path)} @ http://{args.host}:{args.port}",
+          flush=True)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_llm_probe.sh
+++ b/scripts/run_llm_probe.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Launch the resident mlx-lm worker (scripts/llm_server.py), wait for READY, run the
+# real-LLM experiment-B probe (scripts/synth_llm_probe.cljs), then tear the worker down.
+# The policy LLM lives OUT-OF-PROCESS; the native-free synthesis loop curls it.
+#
+# Usage:  scripts/run_llm_probe.sh <model> <tier> [PORT=8765]
+#   e.g.  scripts/run_llm_probe.sh qwen3.5-0.8b-cljs-sft600 fast
+#         scripts/run_llm_probe.sh Qwen3.6-35B-A3B-4bit    slow
+# Probe knobs are env vars passed through: K_ONESHOT K_STEP BEAM_WIDTH MAX_STEPS SEEDS NP TEMP TASKS
+set -uo pipefail
+MODEL="${1:?usage: run_llm_probe.sh <model> <tier> [PORT]}"
+TIER="${2:?usage: run_llm_probe.sh <model> <tier> [PORT]}"
+PORT="${3:-${PORT:-8765}}"
+URL="http://127.0.0.1:${PORT}"
+LOG="$(mktemp -t llm_server.XXXXXX).log"
+
+echo "[run] launching worker: $MODEL on :$PORT (log $LOG)"
+python3 scripts/llm_server.py --model "$MODEL" --port "$PORT" >"$LOG" 2>&1 &
+SRV=$!
+trap 'echo "[run] tearing down worker $SRV"; kill "$SRV" 2>/dev/null; wait "$SRV" 2>/dev/null' EXIT
+
+echo "[run] waiting for READY (model load can take minutes for the 35B)..."
+for i in $(seq 1 900); do
+  if curl -s "${URL}/health" >/dev/null 2>&1; then echo "[run] worker READY after ${i}s"; break; fi
+  if ! kill -0 "$SRV" 2>/dev/null; then echo "[run] worker DIED. log:"; cat "$LOG"; exit 1; fi
+  sleep 1
+done
+
+SERVER_URL="$URL" TIER="$TIER" bun run --bun nbb scripts/synth_llm_probe.cljs
+RC=$?
+echo "[run] probe exit $RC. worker log tail:"; tail -5 "$LOG"
+exit $RC

--- a/scripts/sft_eval.cljs
+++ b/scripts/sft_eval.cljs
@@ -27,6 +27,7 @@
    neither SFT nor GRPO can lift it, so it bounds the achievable ceiling)."
   (:require [genmlx.world.sft :as sft]
             [genmlx.world.distill-tasks :as t]
+            [genmlx.world.distill-gen :as g]
             [genmlx.world.distill-sandbox :as sb]
             [clojure.string :as str]
             [promesa.core :as p]))
@@ -107,9 +108,10 @@
 (defn- warn-non-eval!
   "Symmetric to the corpus-side assert-train-disjoint!: warn loudly if any graded
    candidate references a NON-held-out (train) task — its pass@k is then not a held-out
-   measurement and would inflate the reported lift (genmlx-o8w9 review)."
-  [verdicts]
-  (let [non-eval (distinct (remove sft/eval-task? (map :task-id verdicts)))]
+   measurement and would inflate the reported lift (genmlx-o8w9 review). `eval?` is the
+   held-out predicate on a task-id (the seed set's or the scaled distill-gen set's)."
+  [verdicts eval?]
+  (let [non-eval (distinct (remove eval? (map :task-id verdicts)))]
     (when (seq non-eval)
       (println (str "  WARNING: graded candidates reference NON-held-out task(s): "
                     (str/join ", " non-eval)
@@ -117,8 +119,10 @@
                     " measurement (did you point --baseline/--sft at the wrong file? use"
                     " sft_prep --export-eval-tasks).")))))
 
-(defn- run! [{:keys [baseline sft out k n-particles timeout-ms min-log-ml]}]
-  (let [out-dir (or out (default-out-dir))
+(defn- run! [{:keys [baseline sft out k n-particles timeout-ms min-log-ml gen]}]
+  (let [tasks-by-id (if gen g/tasks-by-id t/tasks-by-id)
+        eval?       (if gen #(contains? g/eval-task-ids %) sft/eval-task?)
+        out-dir (or out (default-out-dir))
         kk      (pos-int-or k 4)
         n-part  (pos-int-or n-particles 50)
         tmo     (pos-int-or timeout-ms 15000)

--- a/scripts/sft_eval.cljs
+++ b/scripts/sft_eval.cljs
@@ -65,13 +65,13 @@
 
 (defn- grade
   "Sandbox-grade one candidates file (a student's eval completions). Returns a promise
-   of the verdict vector."
-  [label candidates out-dir eval-opts timeout-ms]
+   of the verdict vector. `gen?` routes the worker against the scaled generated task set."
+  [label candidates out-dir eval-opts timeout-ms gen?]
   (println (str "  grading " label " (" candidates ") ..."))
   (sb/collect-verdicts candidates
                        {:out-path   (.join path-mod out-dir (str "_eval_" label ".edn"))
                         :eval-opts  eval-opts
-                        :timeout-ms timeout-ms :poll-ms 400 :verbose? false}))
+                        :timeout-ms timeout-ms :poll-ms 400 :verbose? false :gen? gen?}))
 
 (defn- print-table [report]
   (let [k (:k report)]
@@ -133,10 +133,10 @@
     (ensure-dir out-dir)
     (when min-ml (println (str "  applying model-evidence floor --min-log-ml " min-ml
                                " (must match the corpus build)")))
-    (p/let [b-verdicts (grade "baseline" baseline out-dir eopts tmo)
-            s-verdicts (grade "sft" sft out-dir eopts tmo)]
-      (warn-non-eval! (concat b-verdicts s-verdicts))
-      (let [report (assoc (sft/eval-report b-verdicts s-verdicts kk t/tasks-by-id)
+    (p/let [b-verdicts (grade "baseline" baseline out-dir eopts tmo gen)
+            s-verdicts (grade "sft" sft out-dir eopts tmo gen)]
+      (warn-non-eval! (concat b-verdicts s-verdicts) eval?)
+      (let [report (assoc (sft/eval-report b-verdicts s-verdicts kk tasks-by-id)
                           :min-log-ml min-ml :n-particles n-part)]
         (write-json (.join path-mod out-dir "eval_report.json") report)
         (print-table report)

--- a/scripts/sft_prep.cljs
+++ b/scripts/sft_prep.cljs
@@ -32,6 +32,7 @@
    the repo."
   (:require [genmlx.world.sft :as sft]
             [genmlx.world.distill-tasks :as t]
+            [genmlx.world.distill-gen :as g]
             [clojure.string :as str]))
 
 (def fs (js/require "fs"))
@@ -97,16 +98,17 @@
 ;; Mode 3 — build the mlx-lm LoRA data dir.
 ;; ---------------------------------------------------------------------------
 
-(defn- build-data-dir! [{:keys [corpus out pairs blend valid-frac]}]
+(defn- build-data-dir! [{:keys [corpus out pairs blend valid-frac eval-ids]}]
   (let [out-dir (or out (default-out-dir))
+        eval-ids (or eval-ids sft/eval-task-ids)
         n-blend (pos-int-or blend 0)
         vfrac   (frac-or valid-frac 0.15)
         {:keys [rows skipped]} (read-jsonl corpus)
         ;; 1. partition by task: drop any held-out eval-task row, report it.
         {:keys [train-rows dropped-eval eval-task-ids-present train-task-ids]}
-        (sft/partition-corpus rows)
+        (sft/partition-corpus rows eval-ids)
         ;; 2. HARD leakage guard — abort if any eval row survived into training.
-        _ (sft/assert-train-disjoint! train-rows)
+        _ (sft/assert-train-disjoint! train-rows eval-ids)
         ;; 3. strip provenance -> bare {messages}; optionally blend volume rows.
         distilled (mapv sft/row->messages train-rows)
         vol       (when (and pairs (pos? n-blend)) (:rows (read-jsonl pairs)))
@@ -133,18 +135,24 @@
     ;; Honesty: partition-corpus + assert-train-disjoint! guarantee the DISTILLED rows are
     ;; disjoint from the held-out eval tasks. Blended volume rows carry no :task-id, so the
     ;; task-id guard cannot see them — say so rather than print an unconditional ✓ (genmlx-o8w9 review).
-    (if (and pairs (pos? n-blend))
-      (println (str "\n  LEAKAGE GUARD: distilled rows are disjoint from held-out eval tasks ["
-                    (str/join ", " (sort sft/eval-task-ids)) "] ✓"
-                    "\n  NOTE: " (min n-blend (count vol)) " blended volume rows are NOT task-id-screened"
-                    " (general-cljs corpus, no :task-id) — assumed task-neutral."))
-      (println (str "\n  LEAKAGE GUARD: held-out eval tasks ["
-                    (str/join ", " (sort sft/eval-task-ids)) "] are absent from training ✓")))))
+    (let [ids   (sort eval-ids)
+          shown (if (<= (count ids) 8) (str "[" (str/join ", " ids) "]")
+                    (str (count ids) " held-out tasks"))]
+      (if (and pairs (pos? n-blend))
+        (println (str "\n  LEAKAGE GUARD: distilled rows are disjoint from held-out eval tasks "
+                      shown " ✓"
+                      "\n  NOTE: " (min n-blend (count vol)) " blended volume rows are NOT task-id-screened"
+                      " (general-cljs corpus, no :task-id) — assumed task-neutral."))
+        (println (str "\n  LEAKAGE GUARD: held-out eval tasks " shown
+                      " are absent from training ✓"))))))
 
 ;; ---------------------------------------------------------------------------
 
 (let [opts (parse-args (vec (drop 2 (.-argv js/process))))
-      {:keys [train eval]} (sft/split-tasks t/tasks)]
+      gen? (:gen opts)
+      {:keys [train eval]} (if gen? {:train g/train-tasks :eval g/eval-tasks}
+                               (sft/split-tasks t/tasks))
+      eval-ids (if gen? g/eval-task-ids sft/eval-task-ids)]
   (cond
     (:export-train-tasks opts)
     (export-side! (if (string? (:export-train-tasks opts)) (:export-train-tasks opts)
@@ -157,7 +165,7 @@
                   :eval eval)
 
     (:corpus opts)
-    (try (build-data-dir! opts)
+    (try (build-data-dir! (assoc opts :eval-ids eval-ids))
          (catch :default e
            (println "ERROR:" (.-message e))
            (set! (.-exitCode js/process) 1)))

--- a/scripts/sft_train.sh
+++ b/scripts/sft_train.sh
@@ -48,6 +48,8 @@ ITERS="${ITERS:-200}"
 BATCH="${BATCH:-1}"
 LR="${LR:-1e-5}"
 MAXSEQ="${MAXSEQ:-2048}"
+VAL_BATCHES="${VAL_BATCHES:--1}"   # -1 = all valid rows; cap it (e.g. 15) to bound the val memory spike on a 32GB box
+SAVE_EVERY="${SAVE_EVERY:-100}"
 FUSE="${FUSE:-1}"
 LOG="${LOG:-$DATA/train.log}"
 
@@ -59,7 +61,7 @@ MODEL="$MODELS/$STUDENT"
 echo "Student:  $MODEL"
 echo "Data:     $DATA ($(wc -l < "$DATA/train.jsonl" | tr -d ' ') train, $(wc -l < "$DATA/valid.jsonl" | tr -d ' ') valid)"
 echo "Adapter:  $ADAPTER"
-echo "Config:   rank=16 (sft_lora.yaml), layers=$NUM_LAYERS, iters=$ITERS, batch=$BATCH, lr=$LR, maxseq=$MAXSEQ, mask-prompt"
+echo "Config:   rank=16 (sft_lora.yaml), layers=$NUM_LAYERS, iters=$ITERS, batch=$BATCH, lr=$LR, maxseq=$MAXSEQ, val-batches=$VAL_BATCHES, save-every=$SAVE_EVERY, mask-prompt"
 echo "Log:      $LOG"
 echo ""
 
@@ -118,8 +120,8 @@ python3 -m mlx_lm lora \
   --max-seq-length "$MAXSEQ" \
   --steps-per-report 20 \
   --steps-per-eval 50 \
-  --val-batches -1 \
-  --save-every 100 \
+  --val-batches "$VAL_BATCHES" \
+  --save-every "$SAVE_EVERY" \
   --adapter-path "$ADAPTER" 2>&1 | tee "$LOG"
 
 echo ""

--- a/scripts/synth_llm_probe.cljs
+++ b/scripts/synth_llm_probe.cljs
@@ -1,0 +1,279 @@
+(ns synth-llm-probe
+  "EXPERIMENT B — WITH A REAL LLM IN THE LOOP (beans genmlx-0yv7 / genmlx-1pan): the
+   north-star's load-bearing empirical test.
+
+   The structured-proposer experiments (synth_repl_probe / synth_search_probe) PROVED the
+   scaffold — the four-level check, the edit ops, the greedy driver, the particle search.
+   They did NOT prove the THESIS, because they never put a real LLM in the loop. This
+   probe does: a real policy LLM is the proposer, conditioned each step on the verifier's
+   feedback, and we ask the load-bearing question directly —
+
+     does the LLM-in-the-loop, conditioned on feedback, beat one-shot best-of-K?
+
+   THREE ARMS PER TASK, SAME MODEL, SAME DSL PROMPT, SAME ORACLE (the only difference is
+   the feedback loop):
+     1. ONE-SHOT best-of-K   — K full programs, NO feedback. The control (the cliff:
+                                whole-program best-of-16 got 0/16 on these models).
+     2. GREEDY loop          — genmlx.world.synth with the LLM proposer (beam-width 1).
+     3. BEAM   loop          — genmlx.world.search with the LLM proposer (population).
+
+   PHASE-2 ROBUSTNESS: greedy vs beam over SEEDS seeds — population search's real
+   justification is robustness to a NOISY/stochastic proposer, which is exactly the LLM
+   regime (each propose is temperature-sampled). We report per-strategy mean evidence +
+   solve-rate over seeds.
+
+   COST: the resident worker reports per-call gen-time + tokens; we accumulate them, so
+   each tier's (solve-rate, cost) is the frontier the Phase-4 fast/slow metareasoner
+   allocates over.
+
+   The 3 tasks are the EXACT-scoreable advanced models whole-program best-of-16 got 0/16
+   on (byte-identical data to synth_repl_probe / particle_advanced_probe), so the
+   comparison is apples-to-apples.
+
+   Requires a running worker (scripts/llm_server.py). Run via scripts/run_llm_probe.sh
+   (which launches the worker, waits for READY, runs this, tears down). Env:
+     SERVER_URL (default http://127.0.0.1:8765), TIER (output label), TASKS (csv subset),
+     K_ONESHOT, K_STEP, BEAM_WIDTH, MAX_STEPS, SEEDS, NP (IS particles), TEMP."
+  (:require [genmlx.world.llm-proposer :as lp]
+            [genmlx.world.synth :as syn]
+            [genmlx.world.search :as se]
+            [clojure.string :as str]))
+
+(def os   (js/require "os"))
+(def path (js/require "path"))
+(def fs   (js/require "fs"))
+(defn home [& xs] (apply (.-join path) (.homedir os) xs))
+(def out-dir (home "genmlx-loop-artifacts" "particle"))
+(defn fx [x] (when (and x (js/isFinite x)) (.toFixed (js/Number x) 2)))
+(defn- env [k d] (or (aget (.-env js/process) k) d))
+(defn- envi [k d] (let [v (env k nil)] (if v (js/parseInt v 10) d)))
+(defn- envf [k d] (let [v (env k nil)] (if v (js/parseFloat v) d)))
+
+(def server-url (env "SERVER_URL" "http://127.0.0.1:8765"))
+(def tier       (env "TIER" "unknown"))
+(def k-oneshot  (envi "K_ONESHOT" 16))
+(def k-step     (envi "K_STEP" 4))
+(def beam-width (envi "BEAM_WIDTH" 4))
+(def max-steps  (envi "MAX_STEPS" 6))
+(def n-seeds    (envi "SEEDS" 3))
+(def temp       (envf "TEMP" 0.7))
+(def max-toks   (envi "MAX_TOKENS" 320))
+(def revise     (envi "REVISE" 2))
+
+;; ---------------------------------------------------------------------------
+;; Cost-counting wrapper around the out-of-process bridge.
+;; ---------------------------------------------------------------------------
+(def stats (atom {:calls 0 :samples 0 :gen-time 0.0 :prompt-tokens 0 :completion-tokens 0 :errors 0}))
+(defn counting-call [req]
+  (let [resp (lp/call-server server-url req)]
+    ;; NB the worker's JSON keys keywordize with UNDERSCORES (gen_time_s, completion_tokens).
+    (swap! stats #(-> %
+                      (update :calls inc)
+                      (update :samples + (count (:completions resp)))
+                      (update :gen-time + (or (:gen_time_s resp) 0))
+                      (update :prompt-tokens + (or (:prompt_tokens resp) 0))
+                      (update :completion-tokens + (or (:completion_tokens resp) 0))
+                      (update :errors + (if (:error resp) 1 0))))
+    (when (:error resp) (println "    [llm error]" (:error resp)))
+    resp))
+
+;; ===========================================================================
+;; Tasks — the 3 exact-scoreable advanced models (byte-identical to synth_repl_probe).
+;; :task-desc gives the SEMANTICS (index/time/group), NOT the structure (slope/AR/pool).
+;; :solve-bar ≈ HALFWAY from the structureless crude baseline to the data-warranted
+;; optimum (gold, from the structured probe). It cleanly separates "found the structure"
+;; (a fixed-σ=1 structural model already clears it) from "structureless" (crude cannot),
+;; so passing it means the LLM actually built the right structure. The loop typically
+;; climbs WELL above the bar toward gold by refining the (fixed) noise scale — that extra
+;; is the loop's iterative-refinement value over a one-shot structural model at σ=1.
+;; ===========================================================================
+
+(def tasks
+  [{:id :linreg
+    :obs {:y0 1.1 :y1 2.0 :y2 2.7 :y3 4.2 :y4 4.8 :y5 6.1 :y6 6.9}
+    :task-desc (str "You have 7 observations y0..y6. Observation yj is the measured response at "
+                    "input x = j (so x = 0,1,2,3,4,5,6). Model how the response y depends on the input x.")
+    :np 0 :solve-bar -12.2 :crude -17.5 :gold -6.90}
+   {:id :kalman
+    :obs {:y0 0.4 :y1 0.9 :y2 1.3 :y3 1.1 :y4 0.6}
+    :task-desc (str "You have a time series of 5 observations y0..y4 recorded at successive times "
+                    "t = 0,1,2,3,4. The underlying signal varies smoothly over time. Model the series.")
+    :np 0 :solve-bar -6.0 :crude -7.0 :gold -4.92}
+   {:id :hier
+    :obs {:a0 5.2 :a1 4.8 :a2 5.5 :b0 -1.1 :b1 -0.7 :b2 -1.4 :c0 2.1 :c1 2.6 :c2 1.9}
+    :task-desc (str "You have 9 observations in three groups: a0,a1,a2 (group A); b0,b1,b2 (group B); "
+                    "c0,c1,c2 (group C). The groups differ from one another. Model the group structure.")
+    :np 0 :solve-bar -18.0 :crude -24.0 :gold -12.36}
+   ;; HARDER (genmlx-0yv7 follow-up): varying-slopes — 3 groups, each a DISTINCT line in x.
+   ;; The data-warranted model needs 6 latents (slope+intercept per group) + 3 linear means
+   ;; + a tuned noise — far more slip surface than the single-idea models, so one-shot
+   ;; best-of-K must get ALL of it right in one program. Exactly scoreable (linear-Gaussian).
+   {:id :vslope
+    :obs {:a0 1.0 :a1 3.1 :a2 4.9 :a3 7.0 :b0 6.1 :b1 4.9 :b2 4.0 :b3 3.0 :c0 0.0 :c1 0.6 :c2 1.0 :c3 1.4}
+    :task-desc (str "You have 12 observations in three groups a, b, c. Each group has 4 measurements "
+                    "g0,g1,g2,g3 taken at inputs x = 0,1,2,3 (so a0 is group a at x=0, a3 is group a at "
+                    "x=3, etc.). Within each group the response changes with x. Model how y depends on x "
+                    "in each of the three groups.")
+    :np 0 :solve-bar -23.5 :crude -30.0 :gold -17.0}])
+
+(defn- only-tasks []
+  (if-let [sel (env "TASKS" nil)]
+    (let [want (set (map keyword (str/split sel #",")))]
+      (filterv #(want (:id %)) tasks))
+    tasks))
+
+;; ===========================================================================
+;; Arms.
+;; ===========================================================================
+
+(defn- best-scored
+  "Among candidates [{:code ...}], check each and return the highest-evidence valid one
+   (exact methods are reproducible; for these exact tasks all valid candidates are exact)."
+  [cands obs np]
+  (let [scored (for [c cands
+                     :let [fb (syn/check (:code c) obs {:n-particles np})]
+                     :when (syn/scored? fb)]
+                 {:code (:code c) :evidence (:evidence fb) :method (:method fb)})]
+    {:n (count cands) :n-valid (count scored)
+     :best (when (seq scored) (apply max-key :evidence scored))}))
+
+(defn run-oneshot [{:keys [task-desc obs np]}]
+  (let [cands (lp/one-shot-candidates {:call-llm counting-call :task-desc task-desc
+                                       :observations obs :k k-oneshot :temperature 0.8 :max-tokens max-toks :seed 1})
+        r     (best-scored cands obs np)]
+    {:arm :oneshot :n-extracted (:n r) :n-valid (:n-valid r)
+     :evidence (get-in r [:best :evidence]) :code (get-in r [:best :code])}))
+
+(defn- init-spec
+  "A crude covering model the loop starts from: one shared mean, every observed key an
+   obs site. Identical role to the structured probe's crude rung."
+  [obs]
+  (syn/spec [(syn/latent 'mu "gaussian" [0 10])]
+            (for [k (keys obs)] (syn/obs k "gaussian" ['mu 3.0]))))
+
+;; Noise-scale refinement — the nuisance hyperparameter the LLM neglects (it proposes
+;; STRUCTURE but leaves σ at ~1; the harder vslope model exposed this). This cheap,
+;; deterministic shared-σ grid is the move the structured proposer (§10-11) used: type-II
+;; ML over ONE observation scale. Unioned into the loop proposer below — LLM for the hard
+;; structural moves, grid for the hyperparameter (the resource-rational split). The grid is
+;; oracle-selected per step (the loop accepts a σ only when it improves exact evidence).
+(def noise-grid [0.1 0.2 0.3 0.5 0.7 1.0 1.5 2.5])
+(defn- noise-refiner [spec _fb]
+  (let [obs (:obs spec)
+        cur (last (:args (first obs)))]
+    (if (and (seq obs) (every? #(>= (count (:args %)) 2) obs))
+      (for [g noise-grid :when (not= g cur)]
+        {:edit :set-noise :desc (str "shared obs σ -> " g)
+         :spec' (reduce #(syn/set-noise %1 %2 g) spec (map :addr obs))})
+      [])))
+(defn- loop-proposer [task-desc obs np seed]
+  (syn/union-proposer
+   (lp/make-proposer {:call-llm counting-call :task-desc task-desc :observations obs
+                      :k k-step :temperature temp :max-tokens max-toks
+                      :revise revise :n-particles (if (pos? np) np 2000) :seed seed})
+   noise-refiner))
+
+(defn run-greedy [{:keys [task-desc obs np]} seed]
+  (let [prop (loop-proposer task-desc obs np seed)
+        res  (syn/synthesize {:init-spec (init-spec obs) :observations obs :propose prop
+                              :max-steps max-steps :plateau-eps 0.05 :n-particles (if (pos? np) np 2000)})]
+    {:arm :greedy :seed seed :evidence (:evidence (:feedback res))
+     :stop-reason (:stop-reason res) :steps (:steps res)
+     :code (get-in res [:feedback :code])
+     :trajectory (mapv #(select-keys % [:step :edit :evidence :delta :method :code]) (:trajectory res))}))
+
+(defn run-beam [{:keys [task-desc obs np]} seed]
+  (let [prop (loop-proposer task-desc obs np seed)
+        res  (se/search {:init-spec (init-spec obs) :observations obs :propose prop
+                         :beam-width beam-width :adaptive? true :strategy :beam
+                         :max-steps max-steps :plateau-eps 0.05 :n-particles (if (pos? np) np 2000) :seed seed})]
+    {:arm :beam :seed seed :evidence (:evidence (:best res))
+     :stop-reason (:stop-reason res) :steps (:steps res)
+     :code (:code (:best res))
+     :trajectory (mapv #(select-keys % [:step :edit :evidence :delta :method :code]) (:trajectory (:best res)))}))
+
+(defn- solved? [bar evidence] (boolean (and evidence (js/isFinite evidence) (>= evidence bar))))
+
+;; ===========================================================================
+;; Run one task: one-shot control + greedy/beam over seeds.
+;; ===========================================================================
+
+(defn run-task [{:keys [id solve-bar crude gold] :as t}]
+  (println (str "\n================  " (name id) "  (tier=" tier ")  ================"))
+  (println (str "  solve-bar " solve-bar "  (structureless crude ~" crude
+                "; structured-proposer gold ~" gold ")"))
+  (let [_ (println "  [one-shot best-of-" k-oneshot " — the control]")
+        os1 (run-oneshot t)
+        _ (println (str "    extracted " (:n-extracted os1) "/" k-oneshot " parseable, "
+                        (:n-valid os1) " valid; best evidence " (fx (:evidence os1))
+                        "  SOLVED=" (solved? solve-bar (:evidence os1))))
+        seeds (range 1 (inc n-seeds))
+        greedy (doall (for [s seeds]
+                        (let [r (run-greedy t s)]
+                          (println (str "  [greedy seed " s "] -> " (fx (:evidence r))
+                                        "  steps=" (:steps r) " stop=" (name (:stop-reason r))
+                                        "  SOLVED=" (solved? solve-bar (:evidence r))))
+                          r)))
+        beam (doall (for [s seeds]
+                      (let [r (run-beam t s)]
+                        (println (str "  [beam   seed " s "] -> " (fx (:evidence r))
+                                      "  steps=" (:steps r) " stop=" (name (:stop-reason r))
+                                      "  SOLVED=" (solved? solve-bar (:evidence r))))
+                        r)))
+        ev    (fn [rs] (keep :evidence rs))
+        mean  (fn [xs] (when (seq xs) (/ (reduce + xs) (count xs))))
+        rate  (fn [rs] (/ (count (filter #(solved? solve-bar (:evidence %)) rs)) (max 1 (count rs))))]
+    {:id id :solve-bar solve-bar :crude crude :gold gold
+     :oneshot os1 :oneshot-solved (solved? solve-bar (:evidence os1))
+     :greedy greedy :beam beam
+     :greedy-mean (mean (ev greedy)) :beam-mean (mean (ev beam))
+     :greedy-best (when (seq (ev greedy)) (apply max (ev greedy)))
+     :beam-best (when (seq (ev beam)) (apply max (ev beam)))
+     :greedy-solve-rate (rate greedy) :beam-solve-rate (rate beam)}))
+
+;; ===========================================================================
+
+(println (str "\n###  EXPERIMENT B WITH A REAL LLM  (tier=" tier ", url=" server-url ")  ###"))
+(println (str "  K_ONESHOT=" k-oneshot " K_STEP=" k-step " BEAM_WIDTH=" beam-width
+              " MAX_STEPS=" max-steps " SEEDS=" n-seeds " TEMP=" temp))
+(let [t0 (js/Date.now)
+      results (mapv run-task (only-tasks))
+      wall (/ (- (js/Date.now) t0) 1000.0)
+      st @stats]
+  (println "\n================  VERDICT (tier=" tier ")  ================")
+  (println (str (.padEnd "model" 10) (.padEnd "one-shot" 11) (.padEnd "greedy(best)" 14)
+                (.padEnd "beam(best)" 12) (.padEnd "g-rate" 9) (.padEnd "b-rate" 9) "loop>one-shot?"))
+  (doseq [r results]
+    (let [os1 (get-in r [:oneshot :evidence])
+          gb  (:greedy-best r) bb (:beam-best r)
+          loopbest (apply max (keep identity [(or gb ##-Inf) (or bb ##-Inf)]))
+          beats (boolean (and (js/isFinite loopbest)
+                              (or (not (and os1 (js/isFinite os1)))
+                                  (> loopbest (+ os1 0.1)))))]
+      (println (str (.padEnd (name (:id r)) 10)
+                    (.padEnd (str (fx os1) (if (:oneshot-solved r) "*" "")) 11)
+                    (.padEnd (str (fx gb)) 14)
+                    (.padEnd (str (fx bb)) 12)
+                    (.padEnd (str (.toFixed (* 100 (:greedy-solve-rate r)) 0) "%") 9)
+                    (.padEnd (str (.toFixed (* 100 (:beam-solve-rate r)) 0) "%") 9)
+                    (str beats)))))
+  (let [n-loop-solve (count (filter #(or (pos? (:greedy-solve-rate %)) (pos? (:beam-solve-rate %))) results))
+        n-os-solve   (count (filter :oneshot-solved results))
+        beam>=greedy (every? #(>= (or (:beam-best %) ##-Inf) (- (or (:greedy-best %) ##-Inf) 0.1)) results)]
+    (println (str "\n  THESIS: the LLM-in-the-loop solves " n-loop-solve "/" (count results)
+                  " advanced models; one-shot best-of-" k-oneshot " solves " n-os-solve "/" (count results) "."))
+    (println (str "  PHASE-2 robustness: beam >= greedy (best evidence) on every model: " beam>=greedy
+                  "  (compare per-seed solve-rates above for the stochastic-regime claim)."))
+    (println (str "\n  COST (tier=" tier "): " (:calls st) " LLM calls, " (:samples st) " samples, "
+                  (fx (:gen-time st)) "s generation, " (:completion-tokens st) " completion tokens"
+                  (when (pos? (:errors st)) (str ", " (:errors st) " transport errors")) "."))
+    (println (str "  wall-clock " (fx wall) "s; " (fx (/ (:gen-time st) (max 1 (:samples st)))) "s/sample avg."))
+    (when-not (.existsSync fs out-dir) (.mkdirSync fs out-dir #js {:recursive true}))
+    (let [outfile (home "genmlx-loop-artifacts" "particle" (str "synth_llm_probe_" tier ".json"))]
+      (.writeFileSync fs outfile
+                      (js/JSON.stringify (clj->js {:tier tier :config {:k-oneshot k-oneshot :k-step k-step
+                                                                       :beam-width beam-width :max-steps max-steps
+                                                                       :seeds n-seeds :temp temp}
+                                                   :results results :cost st :wall-s wall
+                                                   :n-loop-solve n-loop-solve :n-oneshot-solve n-os-solve}) nil 2))
+      (println (str "  wrote " outfile)))))

--- a/scripts/synth_repl_probe.cljs
+++ b/scripts/synth_repl_probe.cljs
@@ -1,0 +1,254 @@
+(ns synth-repl-probe
+  "EXPERIMENT (B) (beans genmlx-n74t / genmlx-77vv): does the minimal REPL synthesis
+   LOOP solve an advanced model that whole-program best-of-16 got 0/16 on?
+
+   For each of the three EXACT-scoreable advanced models (linreg-coupled / kalman-chain
+   / hier-group-means) we start the genmlx.world.synth driver from a CRUDE covering
+   model (the crudest rung of the experiment-A ladder) and give it a STRUCTURED move
+   vocabulary — the structural upgrades a programmer would try (add the slope+intercept
+   structure, couple the latent chain, split into per-group means) PLUS a distractor
+   and the alternative structure (full-vs-no-intercept, independent-vs-hierarchical
+   groups) — and let the EXACT oracle SELECT which edit to keep and WHEN to stop. No
+   LLM: this isolates the load-bearing claim that a feedback loop with an exact verifier
+   turns a 0/16 whole-program problem into a sequence of locally checkable edits.
+   (Phase 2 SEARCHES this vocabulary; Phase 3 LEARNS the proposer.)
+
+   We report, per model: the full per-step trajectory (edit, evidence, delta, method),
+   the loop's final evidence vs the crude start and the whole-program best-of-16
+   baseline, and that the oracle's selection is discriminating (it rejects the
+   distractor; for hier it prefers INDEPENDENT over hierarchical groups, the
+   higher-evidence structure for these well-separated groups — experiment A). NB the
+   driver is GREEDY: it commits to the first improving structural move, so e.g. linreg
+   locks into the no-intercept branch — a greedy local optimum, NOT a global-Occam
+   claim; joint structure+noise search (Phase 2 SMC) may prefer a fuller model.
+
+   Run: bun run --bun nbb scripts/synth_repl_probe.cljs"
+  (:require [genmlx.world.synth :as syn]
+            [clojure.string :as str]))
+
+(def os   (js/require "os"))
+(def path (js/require "path"))
+(def fs   (js/require "fs"))
+(defn home [& xs] (apply (.-join path) (.homedir os) xs))
+(def out-dir (home "genmlx-loop-artifacts" "particle"))
+
+(defn fx [x] (when (and x (js/isFinite x)) (.toFixed (js/Number x) 2)))
+
+;; ---------------------------------------------------------------------------
+;; Small spec builders shared by the per-task proposers.
+;; ---------------------------------------------------------------------------
+
+(defn- cur-noise [sp] (last (:args (first (:obs sp)))))   ; current obs noise scale
+(defn- has-latent? [sp sym] (some #(= sym (:sym %)) (:latents sp)))
+(defn- mx-mul [a b] (list 'mx/multiply a b))
+(defn- mx-add [a b] (list 'mx/add a b))
+(defn- mx-scalar [x] (list 'mx/scalar x))
+
+;; A SHARED-noise refinement: set EVERY obs site to the same scale g. One shared
+;; scale is a single hyperparameter (type-II maximum-marginal-likelihood over it), so
+;; the loop picks the best grid value in ONE step — keeping the trajectory focused on
+;; the STRUCTURAL step rather than a long noise-tuning tail, and matching the
+;; shared-sigma rungs of experiment A. The grid is a COARSE, hand-provided vocabulary
+;; (Phase 2 searches it; Phase 3 learns the proposer); the loop stops on the evidence
+;; plateau over whatever grid it is given, so a finer grid would land slightly higher.
+(defn- set-all-noise [sp g] (reduce #(syn/set-noise %1 %2 g) sp (map :addr (:obs sp))))
+(defn- shared-noise-moves [sp grid]
+  (for [g grid :when (not= g (cur-noise sp))]
+    {:edit :set-noise :desc (str "shared obs noise -> " g) :spec' (set-all-noise sp g)}))
+
+;; ===========================================================================
+;; LINREG — x=0..6, y ~ linear (slope~1, intercept~1). Crude start: one shared
+;; mean. Structural move: introduce slope (+ optional intercept) and re-point each
+;; obs at slope*xj(+intercept). Occam test: the no-intercept model out-scores the
+;; full one for these priors (experiment A), so the oracle should PREFER it.
+;; ===========================================================================
+
+(def linreg-obs {:y0 1.1 :y1 2.0 :y2 2.7 :y3 4.2 :y4 4.8 :y5 6.1 :y6 6.9})
+(def linreg-ys  [:y0 :y1 :y2 :y3 :y4 :y5 :y6])
+
+(def linreg-init
+  (syn/spec [(syn/latent 'mu "gaussian" [0 10])]
+            (for [k linreg-ys] (syn/obs k "gaussian" ['mu 2.5]))))
+
+(defn- linreg-build [intercept? noise]
+  (let [mean (fn [j] (if intercept?
+                       (mx-add (mx-mul 'slope (mx-scalar (double j))) 'intercept)
+                       (mx-mul 'slope (mx-scalar (double j)))))]
+    (syn/spec (cond-> [(syn/latent 'slope "gaussian" [0 3])]
+                intercept? (conj (syn/latent 'intercept "gaussian" [0 5])))
+              (map-indexed (fn [j k] (syn/obs k "gaussian" [(mean j) noise])) linreg-ys))))
+
+(defn linreg-propose [sp _fb]
+  (let [n (cur-noise sp)]
+    (if-not (has-latent? sp 'slope)
+      ;; structural step: offer full-linear, no-intercept-linear, and a distractor
+      ;; (tighten the shared-mean's noise WITHOUT fixing the structure).
+      [{:edit :add-linear        :desc "add slope+intercept, linear mean" :spec' (linreg-build true n)}
+       {:edit :add-linear-noint  :desc "add slope only (no intercept)"    :spec' (linreg-build false n)}
+       {:edit :distractor-tighten :desc "tighten shared-mean noise -> 1 (no structure)"  :spec' (set-all-noise sp 1)}]
+      ;; refinement: tune the (now linear) observation noise (shared scale).
+      (shared-noise-moves sp [0.3 0.5 0.7 1 1.5 2.5]))))
+
+;; ===========================================================================
+;; KALMAN — smooth series; AR(1) coupling is the structural step. Crude start: iid
+;; latents. Structural move: couple z_t ~ N(coef*z_{t-1}, 0.5) over a coef grid.
+;; ===========================================================================
+
+(def kalman-obs {:y0 0.4 :y1 0.9 :y2 1.3 :y3 1.1 :y4 0.6})
+
+(def kalman-init
+  (syn/spec (for [t (range 5)] (syn/latent (symbol (str "z" t)) "gaussian" [0 1]))
+            (for [t (range 5)] (syn/obs (keyword (str "y" t)) "gaussian" [(symbol (str "z" t)) 0.7]))))
+
+(defn- kalman-build [coef proc-noise]
+  (syn/spec (cons (syn/latent 'z0 "gaussian" [0 1])
+                  (for [t (range 1 5)]
+                    (syn/latent (symbol (str "z" t)) "gaussian"
+                                [(mx-mul (mx-scalar coef) (symbol (str "z" (dec t)))) proc-noise])))
+            (for [t (range 5)] (syn/obs (keyword (str "y" t)) "gaussian" [(symbol (str "z" t)) 0.7]))))
+
+(defn- coupled? [sp] (seq? (first (:args (second (:latents sp))))))  ; z1 mean is a form
+
+(defn kalman-propose [sp _fb]
+  (if-not (coupled? sp)
+    ;; structural step: offer AR(1) coupling over a coefficient grid (0.3 is a weak,
+    ;; wrong coupling distractor; 0.9 is the data-warranted one).
+    (for [c [0.3 0.6 0.9 1.0]]
+      {:edit :couple :desc (str "AR(1) couple, coef " c) :spec' (kalman-build c 0.5)})
+    ;; refinement: tune the process noise (a single shared scale).
+    (for [pn [0.1 0.2 0.3 0.4 0.5 0.7 1.0]]
+      {:edit :set-proc-noise :desc (str "process noise -> " pn)
+       :spec' (syn/spec (cons (syn/latent 'z0 "gaussian" [0 1])
+                              (for [t (range 1 5)]
+                                (syn/latent (symbol (str "z" t)) "gaussian"
+                                            [(first (:args (nth (:latents sp) t))) pn])))
+                        (:obs sp))})))
+
+;; ===========================================================================
+;; HIERARCHICAL — 3 well-separated groups. Crude start: single shared mean.
+;; Structural move: per-group means (independent) OR partial-pooled (hierarchical).
+;; Occam test: for well-separated groups the INDEPENDENT model out-scores the
+;; hierarchical one (experiment A), so the oracle should prefer it.
+;; ===========================================================================
+
+(def hier-obs {:a0 5.2 :a1 4.8 :a2 5.5 :b0 -1.1 :b1 -0.7 :b2 -1.4 :c0 2.1 :c1 2.6 :c2 1.9})
+(def hier-groups {'mu-a [:a0 :a1 :a2] 'mu-b [:b0 :b1 :b2] 'mu-c [:c0 :c1 :c2]})
+
+(def hier-init
+  (syn/spec [(syn/latent 'mu "gaussian" [0 5])]
+            (for [k (keys hier-obs)] (syn/obs k "gaussian" ['mu 2]))))
+
+(defn- hier-build [pooled? noise]
+  (syn/spec (cond-> (for [g (keys hier-groups)]
+                      (syn/latent g "gaussian" (if pooled? ['grand 2] [0 5])))
+              pooled? (->> (cons (syn/latent 'grand "gaussian" [0 5]))))
+            (for [[g ks] hier-groups, k ks] (syn/obs k "gaussian" [g noise]))))
+
+(defn hier-propose [sp _fb]
+  (if-not (has-latent? sp 'mu-a)
+    [{:edit :indep-groups  :desc "per-group independent means" :spec' (hier-build false 1)}
+     {:edit :hierarchical  :desc "partial-pooled (hierarchical) means" :spec' (hier-build true 1)}]
+    (shared-noise-moves sp [0.3 0.5 0.7 1 1.5 2])))
+
+;; ===========================================================================
+;; Run the loop on each task; report the trajectory + the comparison.
+;; ===========================================================================
+
+;; :ref-rung = the experiment-A rung for the CORRECT structure at fixed noise=1
+;; (no-intercept linear / AR(0.9) / independent groups). It is a REPORTING reference,
+;; NOT the success gate: it lets us see the structural evidence the loop reaches. The
+;; loop typically ends a bit ABOVE it because it also tunes the shared observation
+;; noise (type-II maximum-marginal-likelihood over ONE fixed scale the rung held at 1)
+;; — that is hyperparameter fitting, not added model structure, so it is not directly
+;; comparable to the rung; the STRUCTURAL step is the result.
+;;
+;; :bestof16 is the whole-program baseline from the PRIOR run (NOT recomputed here):
+;; particle_advanced_probe on the SAME data + SAME oracle — the student got 0/16 on
+;; all four advanced models; the teacher got 1/4 and that one fit at ~ -35 (junk).
+;; See ~/genmlx-loop-artifacts/particle/advanced_probe.json. The :obs below are
+;; byte-identical to that probe's :observations, so the comparison is apples-to-apples.
+(def tasks
+  [{:id :linreg-coupled :init linreg-init :obs linreg-obs :propose linreg-propose
+    :ref-rung -11.05 :bestof16 "student 0/16 ; teacher fit -35 (junk)"}
+   {:id :kalman-chain :init kalman-init :obs kalman-obs :propose kalman-propose
+    :ref-rung -5.37 :bestof16 "student 0/16"}
+   {:id :hier-group-means :init hier-init :obs hier-obs :propose hier-propose
+    :ref-rung -15.79 :bestof16 "student 0/16"}])
+
+;; The STRUCTURAL edits — the key structure the crude covering model lacks and that
+;; whole-program best-of-16 produced 0 valid candidates for.
+(def structural-edits #{:add-linear :add-linear-noint :couple :indep-groups :hierarchical})
+(defn- structural-step? [traj] (boolean (some #(structural-edits (:edit %)) traj)))
+
+;; "solved" = the loop ACCEPTED the key structural edit (driven by exact oracle
+;; evidence, over distractors + the structural alternative), IMPROVED on the crude
+;; start, and SELF-TERMINATED on an evidence plateau (not :stuck / :max-steps). We do
+;; NOT count the monotone climb as a criterion: the driver only appends an improving
+;; step, so a monotone trajectory is true BY CONSTRUCTION, not evidence of success.
+(defn- solved? [{:keys [start final trajectory stop-reason]}]
+  (and (structural-step? trajectory)
+       (> final start)
+       (= :plateau stop-reason)))
+
+(defn run-task [{:keys [id init obs propose ref-rung bestof16]}]
+  (println (str "\n================  " (name id) "  ================"))
+  (let [res  (syn/synthesize {:init-spec init :observations obs :propose propose
+                              :max-steps 12 :plateau-eps 0.05 :n-particles 4000})
+        traj (:trajectory res)
+        start (:evidence (first traj))
+        final (:evidence (last traj))
+        row  {:id id :start start :final final :ref-rung ref-rung
+              :stop-reason (:stop-reason res) :steps (:steps res)
+              :trajectory (mapv #(select-keys % [:step :edit :desc :evidence :delta :method]) traj)
+              :final-code (:code res)}]
+    (println (str (.padEnd "step" 6) (.padEnd "edit" 24) (.padEnd "evidence" 11)
+                  (.padEnd "delta" 9) "method"))
+    (doseq [r traj]
+      (println (str (.padEnd (str (:step r)) 6)
+                    (.padEnd (str (name (:edit r))) 24)
+                    (.padEnd (or (fx (:evidence r)) "--") 11)
+                    (.padEnd (or (fx (:delta r)) "--") 9)
+                    (str (some-> (:method r) name)))))
+    (println (str "\n  stop-reason: " (name (:stop-reason res)) " after " (:steps res) " accepted edits"))
+    (println (str "  structural edit accepted: " (structural-step? traj)
+                  " (the structure the crude model + whole-program best-of-16 lacked)"))
+    (println (str "  crude start evidence    : " (fx start)))
+    (println (str "  LOOP final evidence     : " (fx final)
+                  "   (vs exp-A fixed-noise=1 structural rung ~ " ref-rung
+                  "; any excess = shared-noise type-II ML, not added structure)"))
+    (println (str "  whole-program best-of-16: " bestof16))
+    (println (str "  => loop improvement over crude start: " (fx (- final start)) " nats"
+                  "   SOLVED? " (solved? row)))
+    (println (str "  final model:\n   " (:code res)))
+    row))
+
+(println "\n###  EXPERIMENT (B): does the REPL loop solve an advanced model?  ###")
+(let [results (mapv run-task tasks)]
+  (println "\n================  VERDICT  ================")
+  (println (str (.padEnd "model" 20) (.padEnd "start" 9) (.padEnd "final" 9)
+                (.padEnd "struct?" 9) (.padEnd "stop" 9) "solved?"))
+  (doseq [r results]
+    (println (str (.padEnd (name (:id r)) 20)
+                  (.padEnd (str (fx (:start r))) 9)
+                  (.padEnd (str (fx (:final r))) 9)
+                  (.padEnd (str (structural-step? (:trajectory r))) 9)
+                  (.padEnd (name (:stop-reason r)) 9)
+                  (solved? r))))
+  (let [n-solved (count (filter solved? results))]
+    (println (str "\n  => the REPL loop SOLVES " n-solved "/" (count results)
+                  " advanced models: from a crude covering model it ACCEPTS the key"
+                  " structural edit (oracle-selected over distractors + the structural"
+                  " alternative) and self-terminates — where whole-program best-of-16 got 0/16."))
+    (println "\n  HONEST CAVEATS (this isolates the loop, it is not the whole story):")
+    (println "   - the proposer is a STRUCTURED move-vocabulary, NOT an LLM — deliberately, to")
+    (println "     isolate the loop-vs-cliff claim from generation noise (Phase 3 learns the proposer).")
+    (println "   - GREEDY commits to the first improving STRUCTURAL move and cannot reconsider it")
+    (println "     (e.g. linreg locks into no-intercept; a full-intercept model may score higher under")
+    (println "     JOINT structure+noise search) -> exactly why Phase 2 is SMC/beam over edits.")
+    (println "   - the shared-noise refinement is type-II ML over ONE fixed scale (hyperparameter")
+    (println "     fitting, not structure); the STRUCTURAL jump is the result, not the noise tuning.")
+    (when-not (.existsSync fs out-dir) (.mkdirSync fs out-dir #js {:recursive true}))
+    (.writeFileSync fs (home "genmlx-loop-artifacts" "particle" "synth_repl_probe.json")
+                    (js/JSON.stringify (clj->js {:results results :n-solved n-solved
+                                                 :n-tasks (count results)}) nil 2))
+    (println "  wrote particle/synth_repl_probe.json")))

--- a/scripts/synth_search_probe.cljs
+++ b/scripts/synth_search_probe.cljs
@@ -1,0 +1,194 @@
+(ns synth-search-probe
+  "EXPERIMENT (Phase 2, genmlx-47zx): does the PARTICLE/BEAM search over construction
+   steps measurably beat the greedy Phase-1 loop, and solve >=3/4 advanced models
+   robustly?
+
+   We run a GREEDY baseline and a BEAM search through the SAME genmlx.world.search code
+   path (greedy = beam-width 1) with the SAME structured proposer, so the comparison is
+   apples-to-apples — only the population size differs. The 4 advanced models are the
+   ones whole-program best-of-16 got 0/16 on (linreg / kalman / hier exact; gmm IS).
+
+   The decisive case is linreg: greedy commits to the first improving STRUCTURAL move
+   (no-intercept) and locks in; the beam keeps the full-intercept branch alive too and
+   lets the exact oracle pick the global winner. gmm is the NOISY (importance-sampling)
+   regime where a population is more robust than a single greedy IS draw.
+
+   Run: bun run --bun nbb scripts/synth_search_probe.cljs"
+  (:require [genmlx.world.search :as se]
+            [genmlx.world.synth :as syn]))
+
+(def os   (js/require "os"))
+(def path (js/require "path"))
+(def fs   (js/require "fs"))
+(defn home [& xs] (apply (.-join path) (.homedir os) xs))
+(def out-dir (home "genmlx-loop-artifacts" "particle"))
+(defn fx [x] (when (and x (js/isFinite x)) (.toFixed (js/Number x) 2)))
+
+(defn- cur-noise [sp] (last (:args (first (:obs sp)))))
+(defn- has-latent? [sp sym] (some #(= sym (:sym %)) (:latents sp)))
+(defn- mx-mul [a b] (list 'mx/multiply a b))
+(defn- mx-add [a b] (list 'mx/add a b))
+(defn- mx-scalar [x] (list 'mx/scalar x))
+(defn- set-all-noise [sp g] (reduce #(syn/set-noise %1 %2 g) sp (map :addr (:obs sp))))
+(defn- shared-noise-moves [sp grid]
+  (for [g grid :when (not= g (cur-noise sp))]
+    {:edit :set-noise :desc (str "shared obs noise -> " g) :spec' (set-all-noise sp g)}))
+
+;; ---------------------------------------------------------------------------
+;; LINREG — the decisive case: full-intercept vs no-intercept are competing branches.
+;; ---------------------------------------------------------------------------
+(def linreg-obs {:y0 1.1 :y1 2.0 :y2 2.7 :y3 4.2 :y4 4.8 :y5 6.1 :y6 6.9})
+(def linreg-ys  [:y0 :y1 :y2 :y3 :y4 :y5 :y6])
+(def linreg-init
+  (syn/spec [(syn/latent 'mu "gaussian" [0 10])]
+            (for [k linreg-ys] (syn/obs k "gaussian" ['mu 2.5]))))
+(defn- linreg-build [intercept? noise]
+  (let [mean (fn [j] (if intercept?
+                       (mx-add (mx-mul 'slope (mx-scalar (double j))) 'intercept)
+                       (mx-mul 'slope (mx-scalar (double j)))))]
+    (syn/spec (cond-> [(syn/latent 'slope "gaussian" [0 3])]
+                intercept? (conj (syn/latent 'intercept "gaussian" [0 5])))
+              (map-indexed (fn [j k] (syn/obs k "gaussian" [(mean j) noise])) linreg-ys))))
+(defn linreg-propose [sp _fb]
+  (if-not (has-latent? sp 'slope)
+    [{:edit :add-linear :desc "slope+intercept" :spec' (linreg-build true (cur-noise sp))}
+     {:edit :add-linear-noint :desc "slope only" :spec' (linreg-build false (cur-noise sp))}
+     {:edit :distractor :desc "tighten shared-mean noise" :spec' (set-all-noise sp 1)}]
+    (shared-noise-moves sp [0.3 0.5 0.7 1 1.5 2.5])))
+
+;; ---------------------------------------------------------------------------
+;; KALMAN — AR(1) coupling over a coefficient grid, then process noise.
+;; ---------------------------------------------------------------------------
+(def kalman-obs {:y0 0.4 :y1 0.9 :y2 1.3 :y3 1.1 :y4 0.6})
+(def kalman-init
+  (syn/spec (for [t (range 5)] (syn/latent (symbol (str "z" t)) "gaussian" [0 1]))
+            (for [t (range 5)] (syn/obs (keyword (str "y" t)) "gaussian" [(symbol (str "z" t)) 0.7]))))
+(defn- kalman-build [coef pn]
+  (syn/spec (cons (syn/latent 'z0 "gaussian" [0 1])
+                  (for [t (range 1 5)]
+                    (syn/latent (symbol (str "z" t)) "gaussian"
+                                [(mx-mul (mx-scalar coef) (symbol (str "z" (dec t)))) pn])))
+            (for [t (range 5)] (syn/obs (keyword (str "y" t)) "gaussian" [(symbol (str "z" t)) 0.7]))))
+(defn- coupled? [sp] (seq? (first (:args (second (:latents sp))))))
+(defn kalman-propose [sp _fb]
+  (if-not (coupled? sp)
+    (for [c [0.3 0.6 0.9 1.0]] {:edit :couple :desc (str "AR coef " c) :spec' (kalman-build c 0.5)})
+    (for [pn [0.1 0.2 0.3 0.4 0.5 0.7]]
+      {:edit :proc-noise :desc (str "proc noise " pn)
+       :spec' (syn/spec (cons (syn/latent 'z0 "gaussian" [0 1])
+                              (for [t (range 1 5)]
+                                (syn/latent (symbol (str "z" t)) "gaussian"
+                                            [(first (:args (nth (:latents sp) t))) pn])))
+                        (:obs sp))})))
+
+;; ---------------------------------------------------------------------------
+;; HIER — independent vs hierarchical group means, then noise.
+;; ---------------------------------------------------------------------------
+(def hier-obs {:a0 5.2 :a1 4.8 :a2 5.5 :b0 -1.1 :b1 -0.7 :b2 -1.4 :c0 2.1 :c1 2.6 :c2 1.9})
+(def hier-groups {'mu-a [:a0 :a1 :a2] 'mu-b [:b0 :b1 :b2] 'mu-c [:c0 :c1 :c2]})
+(def hier-init
+  (syn/spec [(syn/latent 'mu "gaussian" [0 5])]
+            (for [k (keys hier-obs)] (syn/obs k "gaussian" ['mu 2]))))
+(defn- hier-build [pooled? noise]
+  (syn/spec (cond-> (for [g (keys hier-groups)]
+                      (syn/latent g "gaussian" (if pooled? ['grand 2] [0 5])))
+              pooled? (->> (cons (syn/latent 'grand "gaussian" [0 5]))))
+            (for [[g ks] hier-groups, k ks] (syn/obs k "gaussian" [g noise]))))
+(defn hier-propose [sp _fb]
+  (if-not (has-latent? sp 'mu-a)
+    [{:edit :indep :desc "independent group means" :spec' (hier-build false 1)}
+     {:edit :hierarchical :desc "hierarchical means" :spec' (hier-build true 1)}]
+    (shared-noise-moves sp [0.3 0.5 0.7 1 1.5 2])))
+
+;; ---------------------------------------------------------------------------
+;; GMM — single cluster -> 2-component mixture. IS-scored (the noisy regime).
+;; ---------------------------------------------------------------------------
+(def gmm-obs {:y0 -2.8 :y1 3.1 :y2 -3.3 :y3 2.6 :y4 -2.5 :y5 3.4})
+(def gmm-init
+  (syn/spec [(syn/latent 'mu "gaussian" [0 3])]
+            (for [j (range 6)] (syn/obs (keyword (str "y" j)) "gaussian" ['mu 2]))))
+(defn- gmm-build [noise]
+  (syn/spec (into [(syn/latent 'mu0 "gaussian" [-3 2])
+                   (syn/latent 'mu1 "gaussian" [3 2])
+                   (syn/latent 'p "beta-dist" [1 1])]
+                  (for [j (range 6)] (syn/latent (symbol (str "z" j)) "bernoulli" ['p])))
+            (for [j (range 6)]
+              (syn/obs (keyword (str "y" j)) "gaussian"
+                       [(mx-add (mx-mul (symbol (str "z" j)) 'mu1)
+                                (mx-mul (list 'mx/subtract (mx-scalar 1) (symbol (str "z" j))) 'mu0))
+                        noise]))))
+(defn gmm-propose [sp _fb]
+  (if-not (has-latent? sp 'mu0)
+    [{:edit :add-mixture :desc "2-component mixture" :spec' (gmm-build 1)}]
+    (shared-noise-moves sp [0.7 1 1.5])))
+
+;; ---------------------------------------------------------------------------
+
+(def structural-edits #{:add-linear :add-linear-noint :couple :indep :hierarchical :add-mixture})
+(defn- structural? [traj] (boolean (some #(structural-edits (:edit %)) traj)))
+
+(def tasks
+  [{:id :linreg :init linreg-init :obs linreg-obs :propose linreg-propose :np 0    :exact? true}
+   {:id :kalman :init kalman-init :obs kalman-obs :propose kalman-propose :np 0    :exact? true}
+   {:id :hier   :init hier-init   :obs hier-obs   :propose hier-propose   :np 0    :exact? true}
+   {:id :gmm    :init gmm-init    :obs gmm-obs    :propose gmm-propose     :np 4000 :exact? false}])
+
+(defn- run [{:keys [init obs propose np]} mode]
+  (let [base {:init-spec init :observations obs :propose propose :max-steps 16
+              :plateau-eps 0.05 :n-particles (if (pos? np) np 2000)}
+        res  (case mode
+               :greedy (se/search (merge base {:beam-width 1 :adaptive? false}))
+               :beam   (se/search (merge base {:beam-width 4 :adaptive? true})))]
+    {:evidence (:evidence (:best res))
+     :structural? (structural? (:trajectory (:best res)))
+     :steps (:steps res) :code (syn/render (:spec (:best res)))}))
+
+(defn run-task [t]
+  (println (str "\n================  " (name (:id t)) (when-not (:exact? t) "  (IS-scored)") "  ================"))
+  (let [g (run t :greedy)
+        b (run t :beam)
+        win (cond (> (:evidence b) (+ (:evidence g) 0.1)) :beam
+                  (> (:evidence g) (+ (:evidence b) 0.1)) :greedy
+                  :else :tie)]
+    (println (str "  greedy (width 1): " (fx (:evidence g)) "  struct=" (:structural? g) "  steps=" (:steps g)))
+    (println (str "  beam   (width 4): " (fx (:evidence b)) "  struct=" (:structural? b) "  steps=" (:steps b)))
+    (println (str "  => " (case win :beam "BEAM WINS" :greedy "greedy wins" :tie "tie")
+                  " (beam - greedy = " (fx (- (:evidence b) (:evidence g))) " nats)"))
+    (when-not (:structural? b)
+      (println (str "  NOTE: the structural edit was DECLINED by BOTH — its oracle-estimated evidence did"
+                    "\n  not clear the crude baseline. For " (name (:id t)) " (IS-scored) this is the SCORING"
+                    "\n  bottleneck, not the search: importance sampling from the prior over the discrete"
+                    "\n  assignments is biased low. The search correctly refuses an edit it cannot verify.")))
+    (when (= win :beam) (println (str "  beam final model:\n   " (:code b))))
+    {:id (:id t) :greedy g :beam b :winner win}))
+
+(println "\n###  EXPERIMENT (Phase 2): particle/beam search vs greedy  ###")
+(let [results (mapv run-task tasks)]
+  (println "\n================  VERDICT  ================")
+  (println (str (.padEnd "model" 10) (.padEnd "greedy" 10) (.padEnd "beam" 10)
+                (.padEnd "winner" 10) "structure-reached"))
+  (doseq [r results]
+    (println (str (.padEnd (name (:id r)) 10)
+                  (.padEnd (str (fx (:evidence (:greedy r)))) 10)
+                  (.padEnd (str (fx (:evidence (:beam r)))) 10)
+                  (.padEnd (name (:winner r)) 10)
+                  (str (:structural? (:beam r))))))
+  (let [solved (count (filter #(:structural? (:beam %)) results))
+        beam>= (every? #(>= (:evidence (:beam %)) (- (:evidence (:greedy %)) 0.1)) results)
+        beam-wins (count (filter #(= :beam (:winner %)) results))]
+    (println (str "\n  solves (reaches correct structure): " solved "/" (count results)))
+    (println (str "  beam >= greedy on every model: " beam>= "  (beam strictly wins on " beam-wins ")"))
+    (println "\n  WHY beam beats greedy: it keeps competing structural branches alive where greedy")
+    (println "  commits to the first improving one; the exact oracle then picks the global winner.")
+    (println "  The headline is linreg: greedy locks into no-intercept, beam keeps the full-intercept")
+    (println "  branch and the oracle prefers it after noise tuning (a clean exact +3 nat win).")
+    (println "\n  HONEST: gmm is NOT solved by EITHER — the 2-component mixture's marginal is estimated")
+    (println "  by importance sampling from the prior over 6 discrete assignments, which is biased LOW")
+    (println "  and never clears the single-cluster baseline, so the search correctly declines it. That")
+    (println "  is an ORACLE/scoring limitation (enumerate / Rao-Blackwellize the assignments), NOT a")
+    (println "  search one — orthogonal to Phase 2. The search beats greedy wherever the oracle is sound.")
+    (when-not (.existsSync fs out-dir) (.mkdirSync fs out-dir #js {:recursive true}))
+    (.writeFileSync fs (home "genmlx-loop-artifacts" "particle" "synth_search_probe.json")
+                    (js/JSON.stringify (clj->js {:results results :solved solved
+                                                 :beam-wins beam-wins :n-tasks (count results)}) nil 2))
+    (println "  wrote particle/synth_search_probe.json")))

--- a/src/genmlx/world/curriculum.cljs
+++ b/src/genmlx/world/curriculum.cljs
@@ -1,0 +1,587 @@
+(ns genmlx.world.curriculum
+  "Phase-3 enabler for the north star (beans genmlx-77vv / genmlx-ilna): the
+   REPL-synthesis CURRICULUM GENERATOR — a graded, oracle-grounded bank of
+   STRUCTURED-MODEL-FITTING tasks whose value is the multi-step construction.
+
+   WHY (the bottleneck). Phase 3 (genmlx-oexl) learns the cheap proposer (the
+   :edit distribution of the programmer-GF) by SFT on REPL traces, and a learned
+   proposer needs traces AT SCALE — but the north-star probe only has ~4 hand-built
+   tasks. This namespace produces ~100-200 reproducible tasks so the 35B loop can
+   run each → genmlx.world.repl-corpus harvests propose-eval-revise transitions →
+   SFT the 0.8B. Its COMPLEXITY SPREAD (one-shot-ties → loop-wins) is also the
+   resource-rational training signal the Phase-4 metareasoner allocates over.
+
+   DISTINCT from genmlx.world.distill-gen (the whole-program distillation task-gen,
+   bean genmlx-7473). distill-gen grades a single conjugate covering model; this
+   grades how much MULTI-STEP STRUCTURE the data warrants, the thing the loop is for.
+
+   ORACLE-GROUNDED, NO LLM (native-free in the synth sense — it reuses synth/check
+   and never loads the policy LLM). Data is SAMPLED from a known ground-truth
+   structured model with a pure seeded PRNG; difficulty (crude / gold / solve-bar)
+   is set by the EXACT Bayesian model-evidence oracle (synth/check → the analytical
+   p/generate marginal), not a judge. Seeded ⇒ byte-reproducible.
+
+   WHAT THE FAMILIES ARE (all LINEAR-GAUSSIAN ⇒ exactly scoreable, verified):
+     :shared-mean      (c1)  repeated measurements of one quantity
+     :linear           (c1)  response linear in an input
+     :per-group-means  (c2)  independent group levels
+     :ar1              (c2)  a smoothly-evolving latent chain (Kalman)
+     :segmented        (c2)  two independent regimes (a composition; HELD-OUT family)
+     :varying-slopes   (c3)  an independent line per group (the loop-wins regime)
+   Centered hierarchical / shared-slope (ancova) families are EXCLUDED: the L3
+   eliminator misroutes a latent-in-latent prior to a broken :kalman path and a
+   shared latent coupling many obs to a non-finite marginal (bug genmlx-iraj). A
+   reproducibility guard at calibration rejects any family the oracle cannot score
+   deterministically + exactly, so the exclusion is enforced, not merely assumed.
+
+   Sections:
+     0. Pure seeded PRNG          — mulberry32 + Box–Muller, eager + reproducible
+     1. Rendering helpers          — mx form constructors + crude covering model
+     2. Family templates           — the structured vocabulary as data
+     3. Calibration                — crude / gold / solve-bar via the exact oracle
+     4. Instance generation        — sample → data → calibrate → well-posed record
+     5. Curriculum assembly + split — graded bank, leakage-safe task-level holdout
+     6. Consumer adapters          — ->probe-task + the no-LLM family-proposer"
+  (:require [genmlx.world.synth :as syn]
+            [clojure.string :as str]))
+
+;; ===========================================================================
+;; 0. Pure seeded PRNG — mulberry32 uniforms + Box–Muller normals.
+;;
+;; NATIVE-FREE and independent of MLX's RNG, so the sampled data is byte-identical
+;; across runs and toolchains for a given seed. CLJS bit-ops are SIGNED 32-bit, so
+;; every shift is `unsigned-bit-shift-right` and the final word is coerced unsigned
+;; before the divide; multiplies use `js/Math.imul` (true 32-bit). Outputs are EAGER
+;; vectors built with loop/recur — no lazy seq, so chunking can never desync a stream.
+;; ===========================================================================
+
+(defn- u32
+  "Coerce x to an unsigned 32-bit double in [0, 2^32)."
+  [x]
+  (unsigned-bit-shift-right x 0))
+
+(defn uniforms
+  "An EAGER vector of `n` mulberry32 uniforms in [0,1) from 32-bit `seed`.
+   Reference mulberry32 (Tommy Ettinger), transcribed with unsigned shifts."
+  [seed n]
+  (loop [a   (bit-or seed 0)
+         i   0
+         acc (transient [])]
+    (if (>= i n)
+      (persistent! acc)
+      (let [a (bit-or (+ a 0x6D2B79F5) 0)
+            t a
+            t (js/Math.imul (bit-xor t (unsigned-bit-shift-right t 15)) (bit-or t 1))
+            t (bit-xor (+ t (js/Math.imul (bit-xor t (unsigned-bit-shift-right t 7))
+                                          (bit-or t 61)))
+                       t)
+            r (bit-xor t (unsigned-bit-shift-right t 14))]
+        (recur a (inc i) (conj! acc (/ (u32 r) 4294967296.0)))))))
+
+(defn normals
+  "An EAGER vector of `n` N(0,1) draws from `seed` via Box–Muller. Consumes 2
+   uniforms per normal in fixed pairs (the cos branch); u1 is clamped to (0,1] so
+   log(0) cannot produce a NaN. Deterministic and reproducible."
+  [seed n]
+  (let [us (uniforms seed (* 2 (max 1 n)))]
+    (vec (for [k (range n)]
+           (let [u1 (max (nth us (* 2 k)) 1e-12)
+                 u2 (nth us (inc (* 2 k)))]
+             (* (js/Math.sqrt (* -2.0 (js/Math.log u1)))
+                (js/Math.cos (* 2.0 js/Math.PI u2))))))))
+
+(defn mix-seed
+  "Fold a sequence of ints into one 32-bit seed (mulberry32 mixing). Injective enough
+   for distinct (round, family, instance, role) tuples and overflow-safe."
+  [& xs]
+  (reduce (fn [h x]
+            (let [h (bit-or (+ h (bit-or x 0) 0x9E3779B9) 0)
+                  h (js/Math.imul (bit-xor h (unsigned-bit-shift-right h 16)) 0x85EBCA6B)
+                  h (js/Math.imul (bit-xor h (unsigned-bit-shift-right h 13)) 0xC2B2AE35)]
+              (bit-xor h (unsigned-bit-shift-right h 16))))
+          0x2545F491 xs))
+
+(defn round1
+  "Round to one decimal — the established probe-data convention. Keeps :observations
+   canonical/hashable and the SFT corpus low-entropy."
+  [x]
+  (/ (js/Math.round (* (double x) 10.0)) 10.0))
+
+;; ===========================================================================
+;; 1. Rendering helpers + the crude covering model.
+;; ===========================================================================
+
+(defn- mul [a b] (list 'mx/multiply a b))
+(defn- add [a b] (list 'mx/add a b))
+(defn- sc  [x]   (list 'mx/scalar (double x)))
+
+(def ^:const crude-sigma
+  "The fixed, untuned noise of the crude covering model — the structureless baseline
+   the solve-bar is measured against. True sigmas are sampled strictly below it so a
+   real gap always exists."
+  3.0)
+
+(def sigma-grid
+  "The shared-σ refinement grid the loop's hybrid uses (genmlx.world.synth /
+   synth_llm_probe). gold = the best-fitting correct-structure model over this grid."
+  [0.1 0.2 0.3 0.5 0.7 1.0 1.5 2.5])
+
+(defn crude-spec
+  "The crude covering model for any task: one shared latent, every observed address an
+   obs site at the fixed crude σ. Identical role to the loop's init-spec."
+  [observations]
+  (syn/spec [(syn/latent 'mu "gaussian" [0 10])]
+            (for [k (keys observations)] (syn/obs k "gaussian" ['mu crude-sigma]))))
+
+;; ===========================================================================
+;; 2. Family templates — the structured vocabulary as data.
+;;
+;; Each template is a map of pure fns over a sampled `params` (true continuous values
+;; + structural knobs + the ordered obs addresses). `:gold` interprets its `noise` arg
+;; as the family's single tunable scale (process noise for :ar1, observation σ
+;; elsewhere). `:complexity` is the structural-decision BAND (the loop-vs-one-shot
+;; proxy); `:n-latents` the latent count (a continuous proxy). The number of GROUP /
+;; POINT knobs is sampled per instance for variety.
+;; ===========================================================================
+
+(defn- pick-int [u lo hi] (+ lo (int (* u (inc (- hi lo))))))   ; uniform int in [lo,hi]
+(def ^:private group-names ["a" "b" "c" "d"])
+
+(defn- sample-sigma
+  "A true observation σ in [0.3, 1.5] — comfortably below crude-sigma so the gap is
+   real for every family (incl. :shared-mean, whose only lever is the scale)."
+  [u]
+  (round1 (+ 0.3 (* u 1.2))))
+
+(def family-defs
+  "The template registry. Order is the family index used in seed mixing + split."
+  [;; --- :shared-mean (c1) — repeated measurements of one quantity ---
+   ;; The ONLY non-structural family: its gold IS the crude shape (one shared latent),
+   ;; so its difficulty is purely the noise scale and :struct-gap is ~0 by design. The
+   ;; :structural? false flag exempts it from the min-struct-gap well-posedness gate.
+   {:family :shared-mean :complexity 1 :structural? false
+    :sample (fn [seed]
+              (let [us (uniforms seed 3)
+                    n  (pick-int (nth us 0) 4 7)
+                    mu (round1 (* 6.0 (- (nth us 1) 0.5)))]
+                {:n n :mu mu :sigma (sample-sigma (nth us 2))
+                 :addrs (mapv #(keyword (str "y" %)) (range n))}))
+    :data (fn [{:keys [n mu sigma addrs]} seed]
+            (let [z (normals (mix-seed seed 991) n)]
+              (zipmap addrs (map #(round1 (+ mu (* sigma %))) z))))
+    :gold (fn [{:keys [addrs]} noise]
+            (syn/spec [(syn/latent 'mu "gaussian" [0 10])]
+                      (for [k addrs] (syn/obs k "gaussian" ['mu noise]))))
+    :n-latents (fn [_] 1)
+    :desc (fn [{:keys [n]}]
+            (str "You have " n " repeated measurements y0.." (dec n)
+                 " of a single quantity taken under identical conditions. "
+                 "Model the quantity that produced them."))}
+
+   ;; --- :linear (c1) — response linear in an input ---
+   {:family :linear :complexity 1
+    :sample (fn [seed]
+              (let [us (uniforms seed 4)
+                    n  (pick-int (nth us 0) 5 8)
+                    slope (round1 (* (if (< (nth us 2) 0.5) -1 1) (+ 0.6 (* (nth us 1) 1.8))))
+                    intercept (round1 (* 4.0 (- (nth us 3) 0.5)))]
+                {:n n :slope slope :intercept intercept
+                 :sigma (sample-sigma (nth (uniforms (mix-seed seed 5) 1) 0))
+                 :xs (vec (range n)) :addrs (mapv #(keyword (str "y" %)) (range n))}))
+    :data (fn [{:keys [slope intercept sigma xs addrs]} seed]
+            (let [z (normals (mix-seed seed 991) (count xs))]
+              (zipmap addrs (map (fn [x zi] (round1 (+ (* slope x) intercept (* sigma zi)))) xs z))))
+    :gold (fn [{:keys [xs addrs]} noise]
+            (syn/spec [(syn/latent 'slope "gaussian" [0 3]) (syn/latent 'intercept "gaussian" [0 5])]
+                      (map (fn [x k] (syn/obs k "gaussian" [(add (mul 'slope (sc x)) 'intercept) noise]))
+                           xs addrs)))
+    :n-latents (fn [_] 2)
+    :desc (fn [{:keys [n]}]
+            (str "You have " n " observations y0.." (dec n) ". Observation yj is the response "
+                 "measured at input x = j (so x = 0,1,.." (dec n) "). Model how the response "
+                 "depends on the input x."))}
+
+   ;; --- :per-group-means (c2) — independent group levels ---
+   {:family :per-group-means :complexity 2
+    :sample (fn [seed]
+              (let [us (uniforms seed 2)
+                    g  (pick-int (nth us 0) 2 4)
+                    pp (pick-int (nth us 1) 3 4)
+                    ;; group values spread out (well separated) so the structure wins
+                    vs (mapv (fn [k] (round1 (* 4.0 (- k (/ (dec g) 2.0)))))
+                             (range g))
+                    gs (subvec group-names 0 g)]
+                {:g g :pp pp :values vs :groups gs
+                 :sigma (sample-sigma (nth (uniforms (mix-seed seed 5) 1) 0))
+                 :addrs (vec (for [gn gs i (range pp)] (keyword (str gn i))))}))
+    :data (fn [{:keys [g pp values groups sigma addrs]} seed]
+            (let [z (normals (mix-seed seed 991) (* g pp))]
+              (zipmap addrs
+                      (map-indexed (fn [idx k]
+                                     (let [gi (quot idx pp)]
+                                       (round1 (+ (nth values gi) (* sigma (nth z idx))))))
+                                   addrs))))
+    :gold (fn [{:keys [groups pp] :as p} noise]
+            (syn/spec (for [gn groups] (syn/latent (symbol (str "m-" gn)) "gaussian" [0 5]))
+                      (for [gn groups i (range pp)]
+                        (syn/obs (keyword (str gn i)) "gaussian" [(symbol (str "m-" gn)) noise]))))
+    :n-latents (fn [{:keys [g]}] g)
+    :desc (fn [{:keys [g groups pp]}]
+            (str "You have observations in " g " groups (" (str/join ", " groups) "). Each group "
+                 "has " pp " measurements g0.." (dec pp) " (e.g. " (first groups) "0 is group "
+                 (first groups) " measurement 0). The groups differ from one another. "
+                 "Model the group structure."))}
+
+   ;; --- :ar1 (c2) — a smoothly-evolving latent chain (Kalman) ---
+   {:family :ar1 :complexity 2
+    :sample (fn [seed]
+              (let [us (uniforms seed 3)
+                    n  (pick-int (nth us 0) 4 6)
+                    coef (round1 (+ 0.6 (* (nth us 1) 0.35)))    ; 0.6..0.95
+                    proc (round1 (+ 0.3 (* (nth us 2) 0.5)))]    ; 0.3..0.8
+                {:n n :coef coef :proc proc :obs-noise 0.7
+                 :addrs (mapv #(keyword (str "y" %)) (range n))}))
+    :data (fn [{:keys [n coef proc obs-noise addrs]} seed]
+            (let [zp (normals (mix-seed seed 991) n)
+                  zo (normals (mix-seed seed 992) n)
+                  ;; z0 ~ N(0,1) matches the gold model's z0 prior, so gold is the TRUE
+                  ;; data-generating model; later z_t = coef*z_{t-1} + proc*noise.
+                  zs (reductions (fn [z t] (+ (* coef z) (* proc (nth zp t)))) (nth zp 0)
+                                 (range 1 n))]
+              (zipmap addrs (map (fn [z zi] (round1 (+ z (* obs-noise zi)))) zs zo))))
+    :gold (fn [{:keys [n coef obs-noise addrs]} noise]   ; `noise` tunes the PROCESS scale
+            (syn/spec (cons (syn/latent 'z0 "gaussian" [0 1])
+                            (for [t (range 1 n)]
+                              (syn/latent (symbol (str "z" t)) "gaussian"
+                                          [(mul (sc coef) (symbol (str "z" (dec t)))) noise])))
+                      (map-indexed (fn [t k] (syn/obs k "gaussian" [(symbol (str "z" t)) obs-noise])) addrs)))
+    :n-latents (fn [{:keys [n]}] n)
+    :desc (fn [{:keys [n]}]
+            (str "You have a time series of " n " observations y0.." (dec n) " recorded at "
+                 "successive times t = 0,1,.." (dec n) ". The underlying signal evolves "
+                 "smoothly over time. Model the series."))}
+
+   ;; --- :segmented (c2, HELD-OUT composition) — two independent regimes ---
+   {:family :segmented :complexity 2
+    :sample (fn [seed]
+              (let [us (uniforms seed 4)
+                    nf (pick-int (nth us 0) 3 4)
+                    nl (pick-int (nth us 1) 3 4)
+                    level (round1 (* 4.0 (- (nth us 2) 0.5)))
+                    slope (round1 (* (if (< (nth us 3) 0.5) -1 1)
+                                     (+ 0.7 (* (nth (uniforms (mix-seed seed 6) 1) 0) 1.5))))
+                    base  (round1 (* 4.0 (- (nth (uniforms (mix-seed seed 7) 1) 0) 0.5)))]
+                {:nf nf :nl nl :level level :slope slope :base base
+                 :sigma (sample-sigma (nth (uniforms (mix-seed seed 5) 1) 0))
+                 :addrs (mapv #(keyword (str "r" %)) (range (+ nf nl)))}))
+    :data (fn [{:keys [nf nl level slope base sigma addrs]} seed]
+            (let [z (normals (mix-seed seed 991) (+ nf nl))]
+              (zipmap addrs
+                      (map-indexed (fn [t k]
+                                     (let [m (if (< t nf) level (+ (* slope (- t nf)) base))]
+                                       (round1 (+ m (* sigma (nth z t)))))) addrs))))
+    :gold (fn [{:keys [nf nl addrs]} noise]
+            (syn/spec [(syn/latent 'level "gaussian" [0 10])
+                       (syn/latent 'slope "gaussian" [0 3])
+                       (syn/latent 'base "gaussian" [0 5])]
+                      (concat (for [t (range nf)] (syn/obs (nth addrs t) "gaussian" ['level noise]))
+                              (for [t (range nf (+ nf nl))]
+                                (syn/obs (nth addrs t) "gaussian"
+                                         [(add (mul 'slope (sc (- t nf))) 'base) noise])))))
+    :n-latents (fn [_] 3)
+    ;; held-out family: the desc is deliberately bare index-semantics (no regime hint), so
+    ;; the structure must be discovered from the data + oracle, not read off the prompt.
+    :desc (fn [{:keys [nf nl]}]
+            (str "You have a sequence of " (+ nf nl) " measurements r0.." (dec (+ nf nl))
+                 " recorded one after another (index 0.." (dec (+ nf nl)) "). Model the sequence."))}
+
+   ;; --- :varying-slopes (c3) — an independent line per group (loop-wins) ---
+   {:family :varying-slopes :complexity 3
+    :sample (fn [seed]
+              (let [us (uniforms seed 2)
+                    g  (pick-int (nth us 0) 2 3)
+                    pp 4
+                    gs (subvec group-names 0 g)
+                    ;; per-group slope (|.|>=0.6) + intercept, drawn from disjoint sub-streams
+                    sl (vec (for [k (range g)]
+                              (let [u (nth (uniforms (mix-seed seed 10 k) 2) 0)
+                                    s (nth (uniforms (mix-seed seed 10 k) 2) 1)]
+                                (round1 (* (if (< s 0.5) -1 1) (+ 0.6 (* u 1.8)))))))
+                    it (vec (for [k (range g)]
+                              (round1 (* 4.0 (- (nth (uniforms (mix-seed seed 11 k) 1) 0) 0.5)))))]
+                {:g g :pp pp :groups gs :slopes sl :intercepts it
+                 :sigma (sample-sigma (nth (uniforms (mix-seed seed 5) 1) 0))
+                 :addrs (vec (for [gn gs i (range pp)] (keyword (str gn i))))}))
+    :data (fn [{:keys [g pp groups slopes intercepts sigma addrs]} seed]
+            (let [z (normals (mix-seed seed 991) (* g pp))]
+              (zipmap addrs
+                      (map-indexed (fn [idx k]
+                                     (let [gi (quot idx pp) x (rem idx pp)]
+                                       (round1 (+ (* (nth slopes gi) x) (nth intercepts gi)
+                                                  (* sigma (nth z idx)))))) addrs))))
+    :gold (fn [{:keys [groups pp]} noise]
+            (syn/spec (mapcat (fn [gn] [(syn/latent (symbol (str "s-" gn)) "gaussian" [0 3])
+                                        (syn/latent (symbol (str "i-" gn)) "gaussian" [0 5])]) groups)
+                      (for [gn groups i (range pp)]
+                        (syn/obs (keyword (str gn i)) "gaussian"
+                                 [(add (mul (symbol (str "s-" gn)) (sc i)) (symbol (str "i-" gn))) noise]))))
+    :n-latents (fn [{:keys [g]}] (* 2 g))
+    :desc (fn [{:keys [g groups pp]}]
+            (str "You have observations in " g " groups (" (str/join ", " groups) "). Each group has "
+                 pp " measurements g0.." (dec pp) " taken at inputs x = 0,1,.." (dec pp)
+                 " (so " (first groups) "0 is group " (first groups) " at x=0). Within each group "
+                 "the response changes with the input x. Model how the response depends on x in "
+                 "each of the groups."))}])
+
+(def family-index
+  "Family keyword → its index (used in seed mixing + a stable split key)."
+  (into {} (map-indexed (fn [i d] [(:family d) i]) family-defs)))
+
+(def family-by-key
+  (into {} (map (juxt :family identity)) family-defs))
+
+;; ===========================================================================
+;; 3. Calibration — crude / gold / solve-bar via the exact oracle.
+;; ===========================================================================
+
+(defn- score
+  "Score a spec's rendered code against `observations`; {:ev <log-evidence> :method}."
+  [spec observations]
+  (let [fb (syn/check (syn/render spec) observations {:n-particles 0})]
+    {:ev (when (syn/scored? fb) (:evidence fb)) :method (:method fb) :code (:code fb)}))
+
+(defn- crude-spec-at
+  "The crude shared-mean covering model at an arbitrary σ (for the crude-tuned sweep)."
+  [observations sigma]
+  (syn/spec [(syn/latent 'mu "gaussian" [0 10])]
+            (for [k (keys observations)] (syn/obs k "gaussian" ['mu sigma]))))
+
+(defn- best-over-grid
+  "Score `build` at every grid σ (+ true σ); the highest finite-evidence result, with
+   its :sigma and rendered :code. nil if none score."
+  [build observations true-sigma]
+  (->> (distinct (conj sigma-grid true-sigma))
+       (map (fn [g] (assoc (score (build g) observations) :sigma g)))
+       (filter (comp some? :ev))
+       (sort-by (comp - :ev))
+       first))
+
+(defn calibrate
+  "Run the exact oracle to grade one instance from the family's `build` (σ → spec), the
+   data's `true-sigma`, and whether the family is `structural?`. Returns
+     {:crude :crude-tuned :gold :gold-scale :ground-truth-code :method :exact?
+      :solve-bar :gap :struct-gap}
+   or nil if it could not be cleanly graded.
+
+   :crude       evidence of the untuned shared-mean covering model (σ=3)
+   :crude-tuned best shared-mean over the σ-grid (best STRUCTURELESS model)
+   :gold        best correct-structure model over the σ-grid (the data-warranted optimum)
+   :gold-scale  the winning σ-grid value (the OBSERVATION scale for most families; the
+                PROCESS-noise scale for :ar1, whose build tunes the latent chain noise)
+   :exact?      gold scored EXACT/Kalman AND reproduces on a re-score (the guard that
+                rejects the broken-eliminator families, genmlx-iraj)
+   :solve-bar   for STRUCTURAL families (crude-tuned+gold)/2 — provably ABOVE the best
+                structureless model, so clearing it REQUIRES structure (not just noise
+                tuning). For non-structural :shared-mean (crude+gold)/2 — there is no
+                structure to find, only the noise scale to tune from the σ=3 default.
+   :gap         gold−crude (headline)        :struct-gap gold−crude-tuned (pure structure)"
+  [true-sigma build observations structural?]
+  (let [crude-r (score (crude-spec observations) observations)
+        ct-r    (best-over-grid #(crude-spec-at observations %) observations true-sigma)
+        gold-r  (best-over-grid build observations true-sigma)]
+    (when (and (:ev crude-r) (:ev gold-r) (:ev ct-r))
+      (let [;; reproducibility guard: re-score the winning gold code; require agreement.
+            re      (:ev (score (build (:sigma gold-r)) observations))
+            method  (:method gold-r)
+            exact?  (boolean (and re (contains? #{:exact :kalman} method)
+                                  (< (js/Math.abs (- re (:ev gold-r))) 1e-3)))
+            crude   (:ev crude-r) ct (:ev ct-r) g (:ev gold-r)
+            ;; the bar sits halfway from the best STRUCTURELESS model (crude-tuned) to
+            ;; gold for structural families, so a structureless model can never clear it.
+            bar-base (if structural? ct crude)]
+        {:crude crude :crude-tuned ct :gold g :gold-scale (:sigma gold-r)
+         :ground-truth-code (:code gold-r) :method method :exact? exact?
+         :solve-bar (/ (+ bar-base g) 2.0) :gap (- g crude) :struct-gap (- g ct)}))))
+
+;; ===========================================================================
+;; 4. Instance generation — sample → data → calibrate → well-posed record.
+;; ===========================================================================
+
+(def ^:const default-min-gap
+  "Minimum gold−crude (nats) for a task to be well-posed — comfortably above float32
+   evidence noise so the bar strictly brackets."
+  3.0)
+
+(def ^:const default-min-struct-gap
+  "Minimum gold−crude-tuned (nats): the structure must beat even the BEST structureless
+   model, so 'solved' means found-the-structure, not noise-tuning."
+  1.0)
+
+(defn- well-posed?
+  "A task is well-posed iff the oracle graded it exactly+reproducibly, the headline gap
+   clears min-gap, the bar strictly brackets (crude < bar < gold), AND (for STRUCTURAL
+   families only) the structure beats the best structureless model by min-struct-gap AND
+   the best structureless model does NOT clear the bar (crude-tuned < bar — guaranteed by
+   the bar definition, asserted here as a guard). Non-structural :shared-mean is exempt
+   from both structure gates (its struct-gap is ~0 by design)."
+  [{:keys [crude crude-tuned solve-bar gold exact? gap struct-gap]} structural? min-gap min-struct-gap]
+  (boolean (and exact?
+                (>= gap min-gap)
+                (or (not structural?)
+                    (and (>= struct-gap min-struct-gap) (< crude-tuned solve-bar)))
+                (< crude solve-bar) (< solve-bar gold))))
+
+(defn gen-instance
+  "Generate one well-posed task for `family` at (round, instance), or nil if it could
+   not be made well-posed within `:max-retries` fresh param draws (counted by the
+   caller as a drop). The samplers are signal-biased (|slope|≥0.6, separated groups,
+   σ≤1.5), so the first attempt usually clears the gap; each retry re-samples from a
+   fresh derived seed as a rare safety net."
+  [family round instance {:keys [min-gap min-struct-gap max-retries]
+                          :or {min-gap default-min-gap min-struct-gap default-min-struct-gap
+                               max-retries 6}}]
+  (let [{:keys [sample data gold complexity structural?] :as fdef
+         :or {structural? true}} (family-by-key family)
+        fidx (family-index family)]
+    (loop [attempt 0]
+      (if (> attempt max-retries)
+        nil
+        (let [seed   (mix-seed round fidx instance attempt)
+              params (sample seed)
+              obs    (data params seed)
+              cal    (calibrate (or (:sigma params) (:proc params) 1.0) #(gold params %) obs structural?)]
+          (if (and cal (well-posed? cal structural? min-gap min-struct-gap))
+            (merge {:id (str (name family) "-r" round "-i" instance)
+                    :family family :complexity complexity
+                    :n-latents ((:n-latents fdef) params)
+                    :task-desc ((:desc fdef) params)
+                    :observations obs
+                    ;; full ordered params (incl :addrs/:xs) so family-proposer can
+                    ;; rebuild the exact gold structure with no hash-map key-order risk
+                    :true-params params
+                    :seed seed}
+                   (select-keys cal [:ground-truth-code :crude :crude-tuned :gold
+                                     :gold-scale :solve-bar :gap :struct-gap :exact? :method]))
+            (recur (inc attempt))))))))
+
+;; ===========================================================================
+;; 5. Curriculum assembly + leakage-safe task-level split.
+;;
+;; TWO eval cohorts, reported separately (the rrps lesson — don't conflate claims):
+;;   :within  — every stride-th instance of a TRAIN family (same-distribution
+;;              generalization; each eval task has same-family train siblings)
+;;   :family  — an entire HELD-OUT family (:segmented by default): a stronger
+;;              COMPOSITIONAL/OOD test (its sub-structures flat+line appear in train,
+;;              so its difficulty is bounded by that overlap — named, not hidden).
+;; :eval-task-ids is the post-(name) STRING set repl-corpus/sft match on, so the split
+;; is not a silent no-op when ids round-trip through (name id).
+;; ===========================================================================
+
+(defn assign-split
+  "Tag each task :split :train|:eval and :cohort :within|:family|nil. A task is eval iff
+   its family is held out OR it is a stride-th instance within its (train) family."
+  [tasks {:keys [eval-families eval-stride] :or {eval-families #{:segmented} eval-stride 4}}]
+  (->> tasks
+       (group-by :family)
+       (mapcat (fn [[fam fam-tasks]]
+                 (if (contains? eval-families fam)
+                   (map #(assoc % :split :eval :cohort :family) fam-tasks)
+                   (map-indexed (fn [i t]
+                                  (if (zero? (mod (inc i) eval-stride))
+                                    (assoc t :split :eval :cohort :within)
+                                    (assoc t :split :train :cohort nil)))
+                                fam-tasks))))
+       vec))
+
+(defn generate-curriculum
+  "Build a graded, leakage-safe curriculum.
+
+   opts:
+     :round              ReST-EM round (seed base + part of every :id); default 0
+     :instances-per-family  instances attempted per family per round; default 20
+     :families           families to include; default all in family-defs
+     :eval-families      whole held-out families (compositional cohort); default #{:segmented}
+     :eval-stride        within-family holdout stride; default 4
+     :min-gap :min-struct-gap :max-retries  passed to gen-instance
+
+   Returns {:tasks :train-tasks :eval-tasks :eval-task-ids :by-family :by-complexity
+            :summary}. :eval-task-ids is the (comp name :id) STRING set repl-corpus
+   consumes. Growth: bump :round (and/or :instances-per-family) for a fresh,
+   reproducible, larger batch."
+  ([] (generate-curriculum {}))
+  ([{:keys [round instances-per-family families eval-families eval-stride]
+     :or   {round 0 instances-per-family 20 eval-families #{:segmented} eval-stride 4}
+     :as   opts}]
+   (let [fams    (or families (mapv :family family-defs))
+         per-fam (into {}
+                       (for [fam fams]
+                         [fam (let [gen (keep #(gen-instance fam round % opts) (range instances-per-family))]
+                                {:tasks (vec gen)
+                                 :drops (- instances-per-family (count gen))})]))
+         tasks   (assign-split (vec (mapcat (comp :tasks val) per-fam))
+                               {:eval-families eval-families :eval-stride eval-stride})
+         train   (filterv #(= :train (:split %)) tasks)
+         evals   (filterv #(= :eval (:split %)) tasks)
+         eval-ids (into #{} (map (comp name :id)) evals)
+         by-complexity (into (sorted-map)
+                             (for [[c ts] (group-by :complexity tasks)]
+                               [c {:n (count ts)
+                                   :mean-gap (when (seq ts) (/ (reduce + (map :gap ts)) (count ts)))
+                                   :mean-struct-gap (when (seq ts) (/ (reduce + (map :struct-gap ts)) (count ts)))
+                                   :mean-n-latents (when (seq ts) (/ (reduce + (map :n-latents ts)) (count ts)))}]))]
+     {:tasks tasks :train-tasks train :eval-tasks evals :eval-task-ids eval-ids
+      :by-family (into (sorted-map)
+                       (for [[fam {:keys [tasks drops]}] per-fam]
+                         [fam {:n (count tasks) :drops drops
+                               :complexity (:complexity (family-by-key fam))}]))
+      :by-complexity by-complexity
+      :summary {:round round
+                :n-tasks (count tasks) :n-train (count train) :n-eval (count evals)
+                :eval-within (count (filter #(= :within (:cohort %)) evals))
+                :eval-family (count (filter #(= :family (:cohort %)) evals))
+                :held-out-families (vec eval-families)
+                :n-families (count fams)
+                :total-drops (reduce + (map (comp :drops val) per-fam))}})))
+
+;; ===========================================================================
+;; 6. Consumer adapters.
+;; ===========================================================================
+
+(defn ->probe-task
+  "Project a canonical task into the shape scripts/synth_llm_probe.cljs consumes
+   ({:id :obs :task-desc :np :solve-bar :crude :gold}). The SOLE place :observations
+   is aliased to :obs — the canonical record keeps one source of truth."
+  [{:keys [id observations task-desc solve-bar crude gold]}]
+  {:id id :obs observations :task-desc task-desc :np 0
+   :solve-bar solve-bar :crude crude :gold gold})
+
+(defn family-proposer
+  "A no-LLM structured move-set for a task, so an end-to-end harvest can run WITHOUT the
+   policy LLM. It is the COLD-START / PLUMBING-VALIDATION proposer (the real proposer is
+   the Phase-3 learned LLM): it offers the family's structural edit (crude → the correct
+   structure at a neutral σ) and, once structured, the shared-σ grid — yielding a
+   MULTI-step trajectory so repl-corpus harvests >1 transition. Its rows are a pipeline
+   smoke test, NOT a training corpus (a one-leap crude→gold proposer teaches nothing the
+   north-star §12 cares about).
+
+   `task` is a canonical curriculum record; it carries the FULL ordered :true-params, so
+   the gold structure is rebuilt exactly (no hash-map key-order risk). Returns
+   (fn [spec feedback] -> [candidates]). For :shared-mean (gold == crude shape) there is
+   no structural step, so it goes straight to noise refinement. The refinement branch
+   tunes the OBSERVATION scale; for :ar1 (whose tunable is the latent PROCESS noise) the
+   structural leap alone clears the bar and obs-refinement is a near-no-op — reaching the
+   exact gold-scale is the real (Phase-3 LLM) proposer's job, not this validation stub's."
+  [{:keys [family true-params]}]
+  (let [{:keys [gold]} (family-by-key family)
+        gold-spec     (gold true-params 1.0)
+        gold-n-latent (count (:latents gold-spec))]
+    (fn [spec _feedback]
+      (if (< (count (:latents spec)) gold-n-latent)
+        ;; structural step: adopt the correct structure at a neutral σ; the oracle keeps
+        ;; it iff it improves evidence.
+        [{:edit :add-structure :desc (str "adopt " (name family) " structure")
+          :spec' gold-spec}]
+        ;; refinement: tune the shared observation scale over the grid.
+        (for [g sigma-grid :when (not= g (last (:args (first (:obs spec)))))]
+          {:edit :set-noise :desc (str "shared obs scale -> " g)
+           :spec' (reduce #(syn/set-noise %1 %2 g) spec (map :addr (:obs spec)))})))))

--- a/src/genmlx/world/distill_gen.cljs
+++ b/src/genmlx/world/distill_gen.cljs
@@ -1,0 +1,648 @@
+(ns genmlx.world.distill-gen
+  "Scaled task / curriculum GENERATOR for the cljs-coder distillation loop (genmlx-7473).
+
+   THE FUEL the loop was missing. The seed set (genmlx.world.distill-tasks, 12 tasks) is
+   too small/narrow: at that scale SFT overfits (the genmlx-o8w9 smoke regressed). ReST-EM
+   shows fixed small task sets regress by iteration 2. This namespace GROWS the set ~15x by
+   PARAMETERIZING the proven seed families and adding a broad hand-authored catalog — every
+   task carrying a REFERENCE solution that is validated against the SAME native-free oracle
+   (genmlx.world.distill/evaluate-candidate) that grades the student.
+
+   GROUNDING — the oracle stays grounded, never an LLM judge:
+     :program  tasks are graded by EXACT Bayesian model evidence (conjugate marginal
+               log p(obs)). The reference is ONE valid covering model; ANY covering conjugate
+               model scores the same analytical marginal, so the oracle is independent of the
+               reference's exact form.
+     :function tasks are graded behaviorally against HAND-WRITTEN ground-truth (args/state ->
+               expected). The expected values are independent mathematical facts authored here,
+               NEVER derived by running the reference (that would make the oracle circular).
+               The reference's only job is to CONFIRM the ground truth is self-consistent — if a
+               reference disagrees with its own test cases, distill_gen_test goes red, catching
+               an authoring bug in EITHER the reference or the ground truth.
+
+   SPLIT — train / held-out eval is assigned per task (:split), family-balanced and
+   leakage-safe: every held-out eval task is a DISTINCT instance/function whose family also
+   appears in train (so passing it is real same-distribution generalization, never the rrps
+   validation-on-train leak). Eval references and completions never enter the training corpus.
+
+   This namespace is PURE data + string building (no oracle call, no I/O, no model). The
+   reference-validation runs in distill_gen_test (CI) and scripts/gen_tasks.cljs (--validate);
+   the teacher/filter/SFT scripts consume `all-tasks` / `train-tasks` / `eval-tasks` exactly as
+   the seed scripts consume distill-tasks/tasks."
+  (:require [clojure.string :as str]
+            [genmlx.world.distill-gen-extra :as extra]))
+
+;; ===========================================================================
+;; System prompts — byte-identical to the seed set, so the teacher (bake-off
+;; tuned on this exact phrasing, 93% kept) generalizes to the scaled prompts.
+;; ===========================================================================
+
+(def program-system-prompt
+  (str "You are a ClojureScript code generator for the GenMLX probabilistic "
+       "programming system. Reply with ONLY a single (fn [trace] ...) form — no "
+       "prose, no markdown, no comments. A random choice is written "
+       "(trace :name (dist/DISTRIBUTION args...)). You may use the distributions "
+       "dist/gaussian, dist/uniform, dist/bernoulli, dist/beta, dist/gamma, "
+       "dist/exponential, dist/poisson and the math ops mx/add, mx/subtract, "
+       "mx/multiply, mx/divide, mx/scalar, mx/exp, mx/log, mx/sqrt, mx/abs. "
+       "Begin your reply with the characters (fn [trace]."))
+
+(def function-system-prompt
+  (str "You are a ClojureScript code generator. Reply with ONLY a single "
+       "ClojureScript function — no prose, no markdown, no comments. Begin your "
+       "reply with ( ."))
+
+;; ===========================================================================
+;; 1. Program tasks — conjugate models, EXACT analytical model evidence
+;; ===========================================================================
+
+(defn- gaussian-mean-prompt
+  "Shared-mean Gaussian scaffold (identical shape to the seed's): full template over
+   the real observation addresses (so a faithful completion clears the coverage guard)
+   with deliberately loose priors, asking the teacher to ADAPT the three numbers."
+  [obs]
+  (let [pairs (sort-by (comp name key) obs)
+        data  (str/join ", " (map (fn [[k v]] (str (name k) "=" v)) pairs))
+        body  (str/join " " (map (fn [[k _]] (str k " (trace " k
+                                                 " (dist/gaussian mu 1))")) pairs))]
+    (str "Write a GenMLX probabilistic model that explains this data: " data ".\n"
+         "It has one shared latent mean :mu and one Gaussian observation site per\n"
+         "data point. Start from this example and ADAPT the three numbers (the prior\n"
+         "mean, the prior std, and the observation noise) so the data is well\n"
+         "explained — a higher marginal likelihood is better:\n\n"
+         "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 10))] {" body "}))\n\n"
+         "Output ONLY your completed (fn [trace] ...) form, nothing else.")))
+
+(defn- gaussian-mean-task
+  "One shared-mean Gaussian instance from a data vector. Reference centres the prior
+   near the data mean with a moderate noise — a covering conjugate model that scores by
+   EXACT marginal. id distinguishes the instance; data is a vector of observed reals."
+  [id data]
+  (let [obs   (into {} (map-indexed (fn [i v] [(keyword (str "y" i)) v]) data))
+        pairs (sort-by (comp name key) obs)
+        m     (/ (reduce + data) (count data))
+        pm    (.toFixed (js/Number m) 1)
+        body  (str/join " " (map (fn [[k _]] (str k " (trace " k
+                                                  " (dist/gaussian mu 1))")) pairs))]
+    {:id id :kind :program :family :gaussian-mean :difficulty :medium
+     :system-prompt program-system-prompt
+     :prompt (gaussian-mean-prompt obs)
+     :observations obs
+     :reference (str "(fn [trace] (let [mu (trace :mu (dist/gaussian " pm " 5))] {"
+                     body "}))")}))
+
+(defn- bernoulli-prompt
+  "Beta-Bernoulli coin scaffold, parameterized over a flip sequence (1 = heads)."
+  [flips]
+  (let [n      (count flips)
+        addrs  (mapv #(str ":f" %) (range n))
+        seqstr (str/join " " flips)
+        body   (str/join " " (map (fn [a] (str a " (trace " a " (dist/bernoulli p))")) addrs))]
+    (str "Write a GenMLX model for a possibly-biased coin observed flipping\n"
+         seqstr " (" n " flips, sites :f0..:f" (dec n) ", 1 = heads). One latent bias\n"
+         ":p with a Beta prior; each flip is Bernoulli(p). Start from this and\n"
+         "ADAPT the two Beta-prior numbers so the data is well explained:\n\n"
+         "(fn [trace] (let [p (trace :p (dist/beta 1 1))] {" body "}))\n\n"
+         "Output ONLY your completed (fn [trace] ...) form, nothing else.")))
+
+(defn- beta-bernoulli-task
+  "One beta-Bernoulli instance from a 0/1 flip vector. Reference uses a Beta(2,2)
+   prior + Bernoulli flips — conjugate, EXACT marginal."
+  [id flips]
+  (let [n     (count flips)
+        addrs (mapv #(str ":f" %) (range n))
+        obs   (into {} (map-indexed (fn [i b] [(keyword (str "f" i)) (double b)]) flips))
+        body  (str/join " " (map (fn [a] (str a " (trace " a " (dist/bernoulli p))")) addrs))]
+    {:id id :kind :program :family :beta-bernoulli :difficulty :medium
+     :system-prompt program-system-prompt
+     :prompt (bernoulli-prompt flips)
+     :observations obs
+     :reference (str "(fn [trace] (let [p (trace :p (dist/beta 2 2))] {" body "}))")}))
+
+(defn- poisson-prompt
+  "Gamma-Poisson count scaffold, parameterized over a count vector."
+  [counts]
+  (let [n      (count counts)
+        addrs  (mapv #(str ":c" %) (range n))
+        seqstr (str/join " " counts)
+        body   (str/join " " (map (fn [a] (str a " (trace " a " (dist/poisson rate))")) addrs))]
+    (str "Write a GenMLX model for count data " seqstr " (sites :c0..:c" (dec n) "). One\n"
+         "latent rate :rate with a Gamma prior; each count is Poisson(rate).\n"
+         "Start from this and ADAPT the two Gamma-prior numbers so the data is\n"
+         "well explained:\n\n"
+         "(fn [trace] (let [rate (trace :rate (dist/gamma 1 1))] {" body "}))\n\n"
+         "Output ONLY your completed (fn [trace] ...) form, nothing else.")))
+
+(defn- gamma-poisson-task
+  "One gamma-Poisson instance from a count vector. Reference uses a Gamma(2,1) prior +
+   Poisson counts — conjugate, EXACT marginal."
+  [id counts]
+  (let [n     (count counts)
+        addrs (mapv #(str ":c" %) (range n))
+        obs   (into {} (map-indexed (fn [i c] [(keyword (str "c" i)) (double c)]) counts))
+        body  (str/join " " (map (fn [a] (str a " (trace " a " (dist/poisson rate))")) addrs))]
+    {:id id :kind :program :family :gamma-poisson :difficulty :medium
+     :system-prompt program-system-prompt
+     :prompt (poisson-prompt counts)
+     :observations obs
+     :reference (str "(fn [trace] (let [rate (trace :rate (dist/gamma 2 1))] {" body "}))")}))
+
+;; --- Parameter banks (deterministic, hand-picked for spread) ----------------
+
+(def ^:private gaussian-datasets
+  "Distinct shared-mean Gaussian datasets: clusters at varied means, 3-6 points each."
+  [["gm-pos2"   [2.0 2.3 1.7 2.1]]
+   ["gm-neg3"   [-3.1 -2.7 -3.4 -2.9]]
+   ["gm-zero"   [0.2 -0.1 0.4 -0.3 0.1]]
+   ["gm-pos5"   [5.2 4.8 5.5 5.0]]
+   ["gm-neg1"   [-1.4 -0.9 -1.7 -1.1 -1.3]]
+   ["gm-pos37"  [3.7 4.1 3.4 3.9]]
+   ["gm-pos8"   [8.1 7.6 8.4 7.9 8.2 7.8]]
+   ["gm-neg6"   [-6.2 -5.8 -6.5 -6.0]]
+   ["gm-pos15"  [1.5 1.2 1.8 1.4]]
+   ["gm-half"   [0.5 0.7 0.3 0.6 0.4]]
+   ["gm-pos10"  [10.3 9.7 10.1 9.9 10.4]]
+   ["gm-neg45"  [-4.5 -4.1 -4.8 -4.3]]
+   ["gm-pos25"  [2.5 2.9 2.2 2.7 2.4 2.6]]
+   ["gm-pos62"  [6.2 5.9 6.5 6.0]]
+   ["gm-neg08"  [-0.8 -1.2 -0.5 -0.9]]
+   ["gm-pos44"  [4.4 4.0 4.7 4.2 4.5]]
+   ["gm-pos33"  [3.3 3.6 3.0 3.4]]
+   ["gm-neg25"  [-2.5 -2.1 -2.8 -2.3 -2.6]]
+   ["gm-pos71"  [7.1 6.8 7.4 6.9]]
+   ["gm-pos18"  [1.8 2.1 1.5 1.9 1.7]]])
+
+(def ^:private bernoulli-datasets
+  "Distinct coin-flip sequences (1 = heads), varied length + bias."
+  [["bb-3of6"   [1 1 1 0 1 0]]
+   ["bb-1of5"   [1 0 0 0 0]]
+   ["bb-4of4"   [1 1 1 1]]
+   ["bb-0of4"   [0 0 0 0]]
+   ["bb-5of8"   [1 0 1 1 0 1 1 0]]
+   ["bb-2of6"   [0 1 0 0 1 0]]
+   ["bb-6of7"   [1 1 1 0 1 1 1]]
+   ["bb-3of5"   [1 0 1 1 0]]
+   ["bb-7of8"   [1 1 1 1 0 1 1 1]]
+   ["bb-1of4"   [1 0 0 0]]
+   ["bb-4of6"   [1 1 0 1 0 1]]
+   ["bb-2of8"   [0 0 1 0 0 1 0 0]]])
+
+(def ^:private poisson-datasets
+  "Distinct count datasets, varied rate."
+  [["gp-mid"    [3 5 4 6 2]]
+   ["gp-low"    [1 0 2 1 0]]
+   ["gp-high"   [9 11 8 10 12]]
+   ["gp-tiny"   [0 1 0 0 1 0]]
+   ["gp-mid2"   [4 4 5 3 6 4]]
+   ["gp-seven"  [7 6 8 7 5]]
+   ["gp-two"    [2 3 1 2 3]]
+   ["gp-big"    [15 13 16 14]]
+   ["gp-onefive"[1 2 1 1 2 1]]
+   ["gp-six"    [6 5 7 6 8 5]]
+   ["gp-three"  [3 2 4 3 3]]
+   ["gp-ten"    [10 9 11 12 8]]])
+
+(def program-tasks
+  (vec (concat
+        (map (fn [[id d]] (gaussian-mean-task id d)) gaussian-datasets)
+        (map (fn [[id d]] (beta-bernoulli-task id d)) bernoulli-datasets)
+        (map (fn [[id d]] (gamma-poisson-task id d)) poisson-datasets))))
+
+;; ===========================================================================
+;; 2. Function tasks — state-machine transitions (hand-written ground truth)
+;; ===========================================================================
+
+(defn- transition-task
+  [{:keys [id family difficulty prompt reference transitions]}]
+  {:id id :kind :function :family family :difficulty (or difficulty :easy)
+   :system-prompt function-system-prompt
+   :prompt prompt :reference reference :transitions transitions})
+
+(def machine-specs
+  [{:id "counter-machine" :family :counter
+    :prompt (str "Write a ClojureScript function (fn [state action] ...) for a "
+                 "counter.\nThe state is a map {:count n}. Actions: :inc adds 1 to "
+                 ":count, :dec\nsubtracts 1, :reset sets :count to 0. Return the new "
+                 "state map.\nExample: (f {:count 5} :inc) => {:count 6}.")
+    :reference "(fn [state action] (case action :inc (update state :count inc) :dec (update state :count dec) :reset (assoc state :count 0) state))"
+    :transitions [{:state {:count 0}  :action :inc   :expected {:count 1}}
+                  {:state {:count 3}  :action :dec   :expected {:count 2}}
+                  {:state {:count 7}  :action :reset :expected {:count 0}}
+                  {:state {:count -2} :action :inc   :expected {:count -1}}]}
+
+   {:id "counter-by-2" :family :counter
+    :prompt (str "Write a ClojureScript function (fn [state action] ...) for a step-2 "
+                 "counter.\nThe state is {:count n}. Actions: :up adds 2, :down "
+                 "subtracts 2, :zero\nsets :count to 0. Return the new state map. "
+                 "Example: (f {:count 4} :up) => {:count 6}.")
+    :reference "(fn [state action] (case action :up (update state :count + 2) :down (update state :count - 2) :zero (assoc state :count 0) state))"
+    :transitions [{:state {:count 4} :action :up   :expected {:count 6}}
+                  {:state {:count 4} :action :down :expected {:count 2}}
+                  {:state {:count 9} :action :zero :expected {:count 0}}
+                  {:state {:count 0} :action :up   :expected {:count 2}}]}
+
+   {:id "bounded-counter" :family :counter :difficulty :medium
+    :prompt (str "Write a ClojureScript function (fn [state action] ...) for a counter "
+                 "clamped to 0..10.\nThe state is {:count n}. :inc adds 1 but never "
+                 "above 10; :dec subtracts 1 but\nnever below 0. Return the new state. "
+                 "Example: (f {:count 10} :inc) => {:count 10}.")
+    :reference "(fn [state action] (case action :inc (update state :count #(min 10 (inc %))) :dec (update state :count #(max 0 (dec %))) state))"
+    :transitions [{:state {:count 10} :action :inc :expected {:count 10}}
+                  {:state {:count 0}  :action :dec :expected {:count 0}}
+                  {:state {:count 5}  :action :inc :expected {:count 6}}
+                  {:state {:count 5}  :action :dec :expected {:count 4}}]}
+
+   {:id "traffic-light" :family :cyclic
+    :prompt (str "Write a ClojureScript function (fn [state action] ...) for a "
+                 "traffic light.\nThe state is {:light color} where color is :red, "
+                 ":green, or :yellow.\nThe only action is :tick, which advances the "
+                 "light: :red -> :green ->\n:yellow -> :red. Return the new state. "
+                 "Example: (f {:light :red} :tick) => {:light :green}.")
+    :reference "(fn [state action] (if (= action :tick) (update state :light {:red :green :green :yellow :yellow :red}) state))"
+    :transitions [{:state {:light :red}    :action :tick :expected {:light :green}}
+                  {:state {:light :green}  :action :tick :expected {:light :yellow}}
+                  {:state {:light :yellow} :action :tick :expected {:light :red}}]}
+
+   {:id "day-cycle" :family :cyclic
+    :prompt (str "Write a ClojureScript function (fn [state action] ...) cycling days.\n"
+                 "The state is {:day d} where d is :mon, :tue, or :wed. The action "
+                 ":next\nadvances :mon -> :tue -> :wed -> :mon. Return the new state.\n"
+                 "Example: (f {:day :mon} :next) => {:day :tue}.")
+    :reference "(fn [state action] (if (= action :next) (update state :day {:mon :tue :tue :wed :wed :mon}) state))"
+    :transitions [{:state {:day :mon} :action :next :expected {:day :tue}}
+                  {:state {:day :tue} :action :next :expected {:day :wed}}
+                  {:state {:day :wed} :action :next :expected {:day :mon}}]}
+
+   {:id "four-phase" :family :cyclic :difficulty :medium
+    :prompt (str "Write a ClojureScript function (fn [state action] ...) for a 4-phase "
+                 "cycle.\nThe state is {:phase p} with p in :a :b :c :d. :step advances "
+                 ":a->:b->:c->:d->:a;\n:back reverses it. Return the new state. "
+                 "Example: (f {:phase :a} :step) => {:phase :b}.")
+    :reference "(fn [state action] (case action :step (update state :phase {:a :b :b :c :c :d :d :a}) :back (update state :phase {:a :d :b :a :c :b :d :c}) state))"
+    :transitions [{:state {:phase :a} :action :step :expected {:phase :b}}
+                  {:state {:phase :d} :action :step :expected {:phase :a}}
+                  {:state {:phase :a} :action :back :expected {:phase :d}}
+                  {:state {:phase :c} :action :back :expected {:phase :b}}]}
+
+   {:id "toggle-switch" :family :toggle
+    :prompt (str "Write a ClojureScript function (fn [state action] ...) for a toggle "
+                 "switch.\nThe state is {:on bool}. The action :flip inverts :on; any "
+                 "other action\nleaves the state unchanged. Return the new state. "
+                 "Example:\n(f {:on false} :flip) => {:on true}.")
+    :reference "(fn [state action] (if (= action :flip) (update state :on not) state))"
+    :transitions [{:state {:on false} :action :flip :expected {:on true}}
+                  {:state {:on true}  :action :flip :expected {:on false}}
+                  {:state {:on true}  :action :noop :expected {:on true}}]}
+
+   {:id "lamp-switch" :family :toggle
+    :prompt (str "Write a ClojureScript function (fn [state action] ...) for a lamp.\n"
+                 "The state is {:on bool}. :turn-on sets :on true, :turn-off sets it "
+                 "false,\n:flip inverts it. Return the new state. "
+                 "Example: (f {:on false} :turn-on) => {:on true}.")
+    :reference "(fn [state action] (case action :turn-on (assoc state :on true) :turn-off (assoc state :on false) :flip (update state :on not) state))"
+    :transitions [{:state {:on false} :action :turn-on  :expected {:on true}}
+                  {:state {:on true}  :action :turn-off :expected {:on false}}
+                  {:state {:on false} :action :flip     :expected {:on true}}
+                  {:state {:on true}  :action :flip     :expected {:on false}}]}
+
+   {:id "accumulator" :family :register :difficulty :medium
+    :prompt (str "Write a ClojureScript function (fn [state action] ...) for an "
+                 "accumulator.\nThe state is {:acc n}. :double multiplies :acc by 2, "
+                 ":negate flips its sign,\n:clear sets it to 0. Return the new state. "
+                 "Example: (f {:acc 3} :double) => {:acc 6}.")
+    :reference "(fn [state action] (case action :double (update state :acc * 2) :negate (update state :acc -) :clear (assoc state :acc 0) state))"
+    :transitions [{:state {:acc 3}  :action :double :expected {:acc 6}}
+                  {:state {:acc 5}  :action :negate :expected {:acc -5}}
+                  {:state {:acc -4} :action :negate :expected {:acc 4}}
+                  {:state {:acc 9}  :action :clear  :expected {:acc 0}}]}
+
+   {:id "turnstile" :family :mode :difficulty :medium
+    :prompt (str "Write a ClojureScript function (fn [state action] ...) for a "
+                 "turnstile.\nThe state is {:mode m} with m :locked or :unlocked. "
+                 ":coin unlocks it,\n:push locks it. Return the new state. "
+                 "Example: (f {:mode :locked} :coin) => {:mode :unlocked}.")
+    :reference "(fn [state action] (case action :coin (assoc state :mode :unlocked) :push (assoc state :mode :locked) state))"
+    :transitions [{:state {:mode :locked}   :action :coin :expected {:mode :unlocked}}
+                  {:state {:mode :unlocked} :action :push :expected {:mode :locked}}
+                  {:state {:mode :locked}   :action :push :expected {:mode :locked}}
+                  {:state {:mode :unlocked} :action :coin :expected {:mode :unlocked}}]}
+
+   {:id "position-1d" :family :position :difficulty :medium
+    :prompt (str "Write a ClojureScript function (fn [state action] ...) for 1-D "
+                 "movement.\nThe state is {:pos n}. :left subtracts 1, :right adds 1, "
+                 ":home sets :pos 0.\nReturn the new state. "
+                 "Example: (f {:pos 2} :left) => {:pos 1}.")
+    :reference "(fn [state action] (case action :left (update state :pos dec) :right (update state :pos inc) :home (assoc state :pos 0) state))"
+    :transitions [{:state {:pos 2}  :action :left  :expected {:pos 1}}
+                  {:state {:pos 2}  :action :right :expected {:pos 3}}
+                  {:state {:pos 5}  :action :home  :expected {:pos 0}}
+                  {:state {:pos -1} :action :right :expected {:pos 0}}]}
+
+   {:id "score-board" :family :register :difficulty :medium
+    :prompt (str "Write a ClojureScript function (fn [state action] ...) for a score "
+                 "board.\nThe state is {:score n}. :goal adds 3, :foul subtracts 1, "
+                 ":reset sets 0.\nReturn the new state. "
+                 "Example: (f {:score 0} :goal) => {:score 3}.")
+    :reference "(fn [state action] (case action :goal (update state :score + 3) :foul (update state :score - 1) :reset (assoc state :score 0) state))"
+    :transitions [{:state {:score 0} :action :goal  :expected {:score 3}}
+                  {:state {:score 3} :action :foul  :expected {:score 2}}
+                  {:state {:score 9} :action :reset :expected {:score 0}}
+                  {:state {:score 6} :action :goal  :expected {:score 9}}]}])
+
+(def transition-tasks (mapv transition-task machine-specs))
+
+;; ===========================================================================
+;; 3. Function tasks — pure functions, HAND-WRITTEN test-case ground truth
+;; ===========================================================================
+
+(defn- function-task
+  "Build a :function/test-case task from a spec. `:tests` is [[args expected]...] of
+   INDEPENDENT ground truth (never derived from the reference). The first `:n-shown`
+   tests (default 2) are revealed as examples in the prompt; ALL tests grade the
+   student. `:sig` is the signature shown to the model; `:desc` the behavior clause."
+  [{:keys [id family difficulty sig desc reference tests n-shown]
+    :or   {n-shown 2 difficulty :easy}}]
+  (let [shown  (take n-shown tests)
+        ex-str (str/join ", "
+                         (map (fn [[args r]]
+                                (str "(f " (str/join " " (map pr-str args)) ") => " (pr-str r)))
+                              shown))]
+    {:id id :kind :function :family family :difficulty difficulty
+     :system-prompt function-system-prompt
+     :prompt (str "Write a ClojureScript function " sig " " desc ". " ex-str ".")
+     :reference reference
+     :test-cases (mapv (fn [[args r]] {:args args :expected r}) tests)}))
+
+(def function-specs
+  "Hand-authored catalog of standard small functions, each with INDEPENDENT ground-truth
+   test cases (well-known mathematical/behavioral facts) + an idiomatic reference. The
+   reference is validated to satisfy these tests in distill_gen_test (catching authoring
+   bugs in either)."
+  [;; --- arithmetic / number theory ---
+   {:id "factorial" :family :arithmetic :sig "(fn [n] ...)"
+    :desc "that returns n! (n factorial) for a non-negative integer n"
+    :reference "(fn [n] (reduce * 1 (range 1 (inc n))))"
+    :tests [[[0] 1] [[4] 24] [[1] 1] [[5] 120] [[6] 720]]}
+   {:id "fib" :family :arithmetic :difficulty :medium :sig "(fn [n] ...)"
+    :desc "returning the n-th Fibonacci number (0-indexed: fib 0 = 0, fib 1 = 1)"
+    :reference "(fn [n] (loop [a 0 b 1 i n] (if (zero? i) a (recur b (+ a b) (dec i)))))"
+    :tests [[[0] 0] [[1] 1] [[2] 1] [[7] 13] [[10] 55]]}
+   {:id "gcd" :family :arithmetic :sig "(fn [a b] ...)"
+    :desc "returning the greatest common divisor of two positive integers a and b"
+    :reference "(fn [a b] (if (zero? b) a (recur b (mod a b))))"
+    :tests [[[12 8] 4] [[54 24] 6] [[7 1] 1] [[100 75] 25] [[17 5] 1]]}
+   {:id "lcm" :family :arithmetic :difficulty :medium :sig "(fn [a b] ...)"
+    :desc "returning the least common multiple of two positive integers a and b"
+    :reference "(fn [a b] (letfn [(g [x y] (if (zero? y) x (g y (mod x y))))] (/ (* a b) (g a b))))"
+    :tests [[[4 6] 12] [[3 5] 15] [[12 8] 24] [[7 7] 7] [[2 10] 10]]}
+   {:id "is-prime" :family :arithmetic :difficulty :medium :sig "(fn [n] ...)"
+    :desc "returning true if the integer n (>= 2) is prime, else false"
+    :reference "(fn [n] (and (> n 1) (not-any? #(zero? (mod n %)) (range 2 n))))"
+    :tests [[[2] true] [[7] true] [[9] false] [[1] false] [[13] true] [[15] false]]}
+   {:id "digit-sum" :family :arithmetic :difficulty :medium :sig "(fn [n] ...)"
+    :desc "returning the sum of the decimal digits of a non-negative integer n"
+    :reference "(fn [n] (loop [x n s 0] (if (zero? x) s (recur (quot x 10) (+ s (mod x 10))))))"
+    :tests [[[0] 0] [[123] 6] [[9] 9] [[1000] 1] [[99] 18]]}
+   {:id "square" :family :arithmetic :sig "(fn [x] ...)"
+    :desc "returning x squared"
+    :reference "(fn [x] (* x x))"
+    :tests [[[3] 9] [[0] 0] [[-4] 16] [[7] 49] [[10] 100]]}
+   {:id "abs-val" :family :arithmetic :sig "(fn [x] ...)"
+    :desc "returning the absolute value of x"
+    :reference "(fn [x] (if (neg? x) (- x) x))"
+    :tests [[[3] 3] [[-5] 5] [[0] 0] [[-12] 12] [[8] 8]]}
+   {:id "sum-to-n" :family :arithmetic :sig "(fn [n] ...)"
+    :desc "returning the sum 1 + 2 + ... + n for a positive integer n"
+    :reference "(fn [n] (reduce + (range 1 (inc n))))"
+    :tests [[[1] 1] [[5] 15] [[10] 55] [[3] 6] [[100] 5050]]}
+   {:id "power" :family :arithmetic :difficulty :medium :sig "(fn [base exp] ...)"
+    :desc "returning base raised to a non-negative integer exp"
+    :reference "(fn [base exp] (reduce * 1 (repeat exp base)))"
+    :tests [[[2 3] 8] [[5 0] 1] [[3 2] 9] [[10 4] 10000] [[7 1] 7]]}
+   {:id "even-odd-label" :family :arithmetic :sig "(fn [n] ...)"
+    :desc "returning the string \"even\" if n is even, else \"odd\""
+    :reference "(fn [n] (if (even? n) \"even\" \"odd\"))"
+    :tests [[[2] "even"] [[3] "odd"] [[0] "even"] [[7] "odd"] [[10] "even"]]}
+   {:id "sign-of" :family :arithmetic :sig "(fn [x] ...)"
+    :desc "returning -1 if x is negative, 0 if zero, 1 if positive"
+    :reference "(fn [x] (cond (neg? x) -1 (pos? x) 1 :else 0))"
+    :tests [[[-5] -1] [[0] 0] [[8] 1] [[-1] -1] [[100] 1]]}
+   {:id "celsius->fahrenheit" :family :arithmetic :sig "(fn [c] ...)"
+    :desc "converting Celsius c to Fahrenheit (F = c * 1.8 + 32)"
+    :reference "(fn [c] (+ (* c 1.8) 32))"
+    :tests [[[0] 32] [[100] 212] [[-40] -40] [[10] 50] [[20] 68]]}
+   {:id "clamp-0-100" :family :arithmetic :sig "(fn [x] ...)"
+    :desc "clamping x into the range 0..100 inclusive"
+    :reference "(fn [x] (max 0 (min 100 x)))"
+    :tests [[[50] 50] [[-10] 0] [[150] 100] [[0] 0] [[100] 100]]}
+   {:id "collatz-steps" :family :arithmetic :difficulty :hard :sig "(fn [n] ...)"
+    :desc "returning how many Collatz steps reduce a positive integer n to 1 (even -> n/2, odd -> 3n+1)"
+    :reference "(fn [n] (loop [x n c 0] (if (= x 1) c (recur (if (even? x) (quot x 2) (inc (* 3 x))) (inc c)))))"
+    :tests [[[1] 0] [[2] 1] [[3] 7] [[6] 8] [[16] 4]]}
+
+   ;; --- collections ---
+   {:id "sum-list" :family :collection :sig "(fn [coll] ...)"
+    :desc "returning the sum of all numbers in the collection coll"
+    :reference "(fn [coll] (reduce + 0 coll))"
+    :tests [[[[1 2 3 4]] 10] [[[]] 0] [[[5]] 5] [[[-1 1 -2 2]] 0] [[[10 20 30]] 60]]}
+   {:id "sum-evens" :family :collection :sig "(fn [coll] ...)"
+    :desc "returning the sum of the even numbers in the collection coll"
+    :reference "(fn [coll] (reduce + 0 (filter even? coll)))"
+    :tests [[[[1 2 3 4]] 6] [[[]] 0] [[[2 4 6]] 12] [[[1 3 5]] 0] [[[10 -2 3]] 8]]}
+   {:id "count-positives" :family :collection :sig "(fn [coll] ...)"
+    :desc "returning how many numbers in coll are strictly positive"
+    :reference "(fn [coll] (count (filter pos? coll)))"
+    :tests [[[[1 -2 3 0 5]] 3] [[[]] 0] [[[-1 -2 -3]] 0] [[[4 4 4]] 3] [[[0 0 1]] 1]]}
+   {:id "max-of-list" :family :collection :sig "(fn [coll] ...)"
+    :desc "returning the largest number in the non-empty collection coll"
+    :reference "(fn [coll] (reduce max coll))"
+    :tests [[[[3 1 4 1 5]] 5] [[[7]] 7] [[[-3 -1 -2]] -1] [[[2 2 2]] 2] [[[10 9 11 8]] 11]]}
+   {:id "min-of-list" :family :collection :sig "(fn [coll] ...)"
+    :desc "returning the smallest number in the non-empty collection coll"
+    :reference "(fn [coll] (reduce min coll))"
+    :tests [[[[3 1 4 1 5]] 1] [[[7]] 7] [[[-3 -1 -2]] -3] [[[2 2 2]] 2] [[[10 9 11 8]] 8]]}
+   {:id "my-reverse" :family :collection :sig "(fn [coll] ...)"
+    :desc "returning the elements of coll in reverse order, as a vector"
+    :reference "(fn [coll] (vec (reverse coll)))"
+    :tests [[[[1 2 3]] [3 2 1]] [[[]] []] [[[9]] [9]] [[[1 2 3 4 5]] [5 4 3 2 1]] [[[7 8]] [8 7]]]}
+   {:id "list-length" :family :collection :sig "(fn [coll] ...)"
+    :desc "returning the number of elements in coll"
+    :reference "(fn [coll] (count coll))"
+    :tests [[[[1 2 3]] 3] [[[]] 0] [[[9 9]] 2] [[[1 2 3 4 5]] 5] [[["a" "b"]] 2]]}
+   {:id "mean-of-list" :family :collection :difficulty :medium :sig "(fn [coll] ...)"
+    :desc "returning the arithmetic mean of the non-empty number collection coll"
+    :reference "(fn [coll] (/ (reduce + coll) (count coll)))"
+    :tests [[[[2 4 6]] 4] [[[5]] 5] [[[1 2 3 4]] 5/2] [[[10 20]] 15] [[[0 0 0]] 0]]}
+   {:id "second-largest" :family :collection :difficulty :medium :sig "(fn [coll] ...)"
+    :desc "returning the second-largest distinct value in coll (which has >= 2 distinct values)"
+    :reference "(fn [coll] (second (sort > (distinct coll))))"
+    :tests [[[[3 1 4 1 5]] 4] [[[7 2]] 2] [[[10 9 11 8]] 10] [[[1 2 3]] 2] [[[5 5 4]] 4]]}
+   {:id "all-positive?" :family :collection :sig "(fn [coll] ...)"
+    :desc "returning true if every number in coll is strictly positive, else false"
+    :reference "(fn [coll] (every? pos? coll))"
+    :tests [[[[1 2 3]] true] [[[1 -2 3]] false] [[[]] true] [[[0 1]] false] [[[5 5 5]] true]]}
+   {:id "running-sum" :family :collection :difficulty :medium :sig "(fn [coll] ...)"
+    :desc "returning a vector of cumulative sums of coll (each element is the sum so far)"
+    :reference "(fn [coll] (vec (rest (reductions + 0 coll))))"
+    :tests [[[[1 2 3]] [1 3 6]] [[[]] []] [[[5]] [5]] [[[1 1 1 1]] [1 2 3 4]] [[[2 -1 3]] [2 1 4]]]}
+   {:id "dedupe-list" :family :collection :sig "(fn [coll] ...)"
+    :desc "returning a vector of the distinct elements of coll, preserving first-seen order"
+    :reference "(fn [coll] (vec (distinct coll)))"
+    :tests [[[[1 1 2 3 3]] [1 2 3]] [[[]] []] [[[5 5 5]] [5]] [[[1 2 1 2]] [1 2]] [[[9 8 9 7]] [9 8 7]]]}
+   {:id "map-square" :family :collection :sig "(fn [coll] ...)"
+    :desc "returning a vector with each element of coll squared"
+    :reference "(fn [coll] (mapv #(* % %) coll))"
+    :tests [[[[1 2 3]] [1 4 9]] [[[]] []] [[[-2 4]] [4 16]] [[[0 5]] [0 25]] [[[10]] [100]]]}
+   {:id "filter-even" :family :collection :sig "(fn [coll] ...)"
+    :desc "returning a vector of just the even numbers of coll, in order"
+    :reference "(fn [coll] (vec (filter even? coll)))"
+    :tests [[[[1 2 3 4]] [2 4]] [[[]] []] [[[1 3 5]] []] [[[2 4 6]] [2 4 6]] [[[7 8 9 10]] [8 10]]]}
+   {:id "dot-product" :family :collection :difficulty :medium :sig "(fn [a b] ...)"
+    :desc "returning the dot product of two equal-length number vectors a and b"
+    :reference "(fn [a b] (reduce + (map * a b)))"
+    :tests [[[[1 2 3] [4 5 6]] 32] [[[0 0] [1 1]] 0] [[[2] [3]] 6] [[[1 1 1] [1 2 3]] 6] [[[-1 1] [2 2]] 0]]}
+
+   ;; --- strings ---
+   {:id "palindrome?" :family :string :sig "(fn [s] ...)"
+    :desc "returning true if the string s reads the same forwards and backwards, else false"
+    :reference "(fn [s] (= (vec s) (vec (reverse s))))"
+    :tests [[["racecar"] true] [["hello"] false] [[""] true] [["abba"] true] [["abc"] false]]}
+   {:id "reverse-str" :family :string :sig "(fn [s] ...)"
+    :desc "returning the string s reversed"
+    :reference "(fn [s] (apply str (reverse s)))"
+    :tests [[["abc"] "cba"] [[""] ""] [["a"] "a"] [["hello"] "olleh"] [["12 3"] "3 21"]]}
+   {:id "count-vowels" :family :string :difficulty :medium :sig "(fn [s] ...)"
+    :desc "returning how many vowels (a e i o u, lowercase) are in the string s"
+    :reference "(fn [s] (count (filter (set \"aeiou\") s)))"
+    :tests [[["hello"] 2] [["xyz"] 0] [[""] 0] [["aeiou"] 5] [["banana"] 3]]}
+   {:id "str-length" :family :string :sig "(fn [s] ...)"
+    :desc "returning the number of characters in the string s"
+    :reference "(fn [s] (count s))"
+    :tests [[["abc"] 3] [[""] 0] [["hello world"] 11] [["x"] 1] [["12345"] 5]]}
+   {:id "fizzbuzz" :family :string :difficulty :medium :sig "(fn [n] ...)"
+    :desc (str "that returns \"Fizz\" if n is divisible by 3, \"Buzz\" if divisible by 5, "
+               "\"FizzBuzz\" if divisible by both, otherwise the number as a string")
+    :reference "(fn [n] (cond (zero? (mod n 15)) \"FizzBuzz\" (zero? (mod n 3)) \"Fizz\" (zero? (mod n 5)) \"Buzz\" :else (str n)))"
+    :tests [[[3] "Fizz"] [[5] "Buzz"] [[15] "FizzBuzz"] [[7] "7"] [[9] "Fizz"]]}
+   {:id "shout" :family :string :sig "(fn [s] ...)"
+    :desc "returning the string s in upper case"
+    :reference "(fn [s] (clojure.string/upper-case s))"
+    :tests [[["hello"] "HELLO"] [[""] ""] [["AbC"] "ABC"] [["x y"] "X Y"] [["123"] "123"]]}
+   {:id "count-char" :family :string :difficulty :medium :sig "(fn [s c] ...)"
+    :desc "returning how many times the character c occurs in the string s"
+    :reference "(fn [s c] (count (filter #(= % c) s)))"
+    :tests [[["banana" \a] 3] [["hello" \l] 2] [["abc" \z] 0] [["" \x] 0] [["aaaa" \a] 4]]}
+
+   ;; --- logic / classification ---
+   {:id "leap-year?" :family :logic :difficulty :medium :sig "(fn [y] ...)"
+    :desc "returning true if year y is a leap year (divisible by 4 but not 100, unless also by 400)"
+    :reference "(fn [y] (and (zero? (mod y 4)) (or (pos? (mod y 100)) (zero? (mod y 400)))))"
+    :tests [[[2000] true] [[1900] false] [[2024] true] [[2023] false] [[2400] true]]}
+   {:id "grade-letter" :family :logic :difficulty :medium :sig "(fn [score] ...)"
+    :desc "returning \"A\" for score >= 90, \"B\" for >= 80, \"C\" for >= 70, else \"F\""
+    :reference "(fn [score] (cond (>= score 90) \"A\" (>= score 80) \"B\" (>= score 70) \"C\" :else \"F\"))"
+    :tests [[[95] "A"] [[85] "B"] [[72] "C"] [[50] "F"] [[90] "A"]]}
+   {:id "max-of-3" :family :logic :sig "(fn [a b c] ...)"
+    :desc "returning the largest of three numbers a, b, c"
+    :reference "(fn [a b c] (max a b c))"
+    :tests [[[1 2 3] 3] [[5 1 2] 5] [[4 9 4] 9] [[-1 -2 -3] -1] [[7 7 7] 7]]}
+   {:id "between?" :family :logic :sig "(fn [x lo hi] ...)"
+    :desc "returning true if lo <= x <= hi, else false"
+    :reference "(fn [x lo hi] (and (<= lo x) (<= x hi)))"
+    :tests [[[5 1 10] true] [[0 1 10] false] [[10 1 10] true] [[1 1 10] true] [[11 1 10] false]]}])
+
+(def test-case-tasks
+  "Hand-authored core (function-specs) + the workflow-expanded catalog (distill-gen-extra),
+   built into :function/test-case tasks. References are oracle-validated downstream; any that
+   fail are listed in `excluded-ids` and dropped here."
+  (mapv function-task (concat function-specs extra/extra-function-specs)))
+
+;; ===========================================================================
+;; 4. Assembly + train/eval split + derived views
+;; ===========================================================================
+
+(def excluded-ids
+  "Task ids dropped because their reference is not admitted by its own oracle (caught by
+   scripts/gen_tasks.cljs --validate / distill_gen_test). Keeping this explicit — rather than
+   silently editing the catalog — documents exactly what the grounding guard rejected."
+  #{})
+
+(defn- dedupe-by-id
+  "Keep the first task per :id (programs/machines/core functions win over later extras),
+   dropping any in `excluded-ids`. Guards against an extra-catalog id colliding with a core id."
+  [tasks]
+  (->> tasks
+       (remove #(contains? excluded-ids (:id %)))
+       (reduce (fn [{:keys [seen out]} t]
+                 (if (contains? seen (:id t))
+                   {:seen seen :out out}
+                   {:seen (conj seen (:id t)) :out (conj out t)}))
+               {:seen #{} :out []})
+       :out))
+
+(def ^:private candidate-tasks
+  "The full generated set (deduped, excluded-pruned), before split assignment."
+  (dedupe-by-id (concat program-tasks transition-tasks test-case-tasks)))
+
+(defn- assign-split
+  "Deterministically hold out every `stride`-th task WITHIN each family for eval, so the
+   held-out set is family-balanced and every eval family keeps train siblings (real
+   same-distribution generalization, never a leaked train instance). Programs are split
+   per conjugate family; functions per behavioral family. Original task order is preserved
+   via a threaded index (group-by reshuffles)."
+  [tasks stride]
+  (->> tasks
+       (map-indexed (fn [i t] (assoc t ::idx i)))
+       (group-by :family)
+       (mapcat (fn [[_ fam-tasks]]
+                 (map-indexed
+                  (fn [i t]
+                    (assoc t :split (if (zero? (mod (inc i) stride)) :eval :train)))
+                  fam-tasks)))
+       (sort-by ::idx)
+       (mapv #(dissoc % ::idx))))
+
+(def all-tasks
+  "Every generated task, each tagged :split :train | :eval. ~1 in 4 per family is held out."
+  (assign-split candidate-tasks 4))
+
+(def train-tasks (vec (filter #(= :train (:split %)) all-tasks)))
+(def eval-tasks  (vec (filter #(= :eval (:split %)) all-tasks)))
+
+(def eval-task-ids
+  "The held-out eval task ids — the scaled analogue of sft/eval-task-ids. Their references
+   and completions must never enter the training corpus."
+  (into #{} (map :id) eval-tasks))
+
+(def tasks-by-id
+  "Map of :id -> task, for joining verdicts/candidates back to their prompts (and oracle)."
+  (into {} (map (juxt :id identity)) all-tasks))
+
+(defn task->prompt-record
+  "TEACHER-FACING projection: only {task_id, kind, system_prompt, prompt}. The held-out
+   oracle signal (:observations / :transitions / :test-cases) AND the :reference are
+   dropped, so neither the test answers nor a canonical solution can leak into a prompt."
+  [task]
+  {:task_id       (:id task)
+   :kind          (name (:kind task))
+   :system_prompt (:system-prompt task)
+   :prompt        (:prompt task)})
+
+(defn reference-record
+  "A teacher-equivalent candidate row carrying the task's REFERENCE solution as the
+   completion — for seeding the SFT corpus with one guaranteed-correct, oracle-validated
+   exemplar per train task (cold-start insurance alongside teacher diversity)."
+  [task]
+  {:task_id    (:id task)
+   :sample_idx -1
+   :raw_text   (:reference task)})
+
+(def summary
+  "At-a-glance generated-set shape (counts by kind / family / split / difficulty)."
+  {:n-total      (count all-tasks)
+   :n-train      (count train-tasks)
+   :n-eval       (count eval-tasks)
+   :by-kind      (frequencies (map :kind all-tasks))
+   :by-family    (into (sorted-map) (frequencies (map :family all-tasks)))
+   :by-difficulty (into (sorted-map) (frequencies (map :difficulty all-tasks)))
+   :eval-by-family (into (sorted-map) (frequencies (map :family eval-tasks)))})

--- a/src/genmlx/world/distill_gen_extra.cljs
+++ b/src/genmlx/world/distill_gen_extra.cljs
@@ -1,0 +1,381 @@
+(ns genmlx.world.distill-gen-extra
+  "Extra function specs for the scaled cljs-coder task set (genmlx-7473), authored by the
+   catalog-expansion workflow (5 agents, oracle-safe ClojureScript function specs across
+   number-theory / sequence / string / logic / applied-math categories). DATA ONLY — these
+   are appended to genmlx.world.distill-gen/function-specs; any spec whose reference fails
+   its own oracle is pruned by distill-gen (see scripts/gen_tasks.cljs --validate and
+   test/genmlx/distill_gen_test.cljs). No requires: the :reference / :desc fields are plain
+   strings, evaluated later by the SCI oracle, not by this namespace.")
+
+(def extra-function-specs
+  [
+   {:id "nth-prime" :family :arithmetic :difficulty :medium :sig "(fn [n] ...)" :desc "that returns the n-th prime number, where n is 1-indexed so n=1 gives 2; treat n=0 as the seed value 1" :reference "(fn [n] (letfn [(prime? [k] (and (> k 1) (loop [d 2] (cond (> (* d d) k) true (zero? (mod k d)) false :else (recur (inc d))))))] (loop [cnt 0 k 1] (if (= cnt n) k (let [k2 (inc k)] (if (prime? k2) (recur (inc cnt) k2) (recur cnt k2)))))))" :tests [[[1] 2] [[2] 3] [[3] 5] [[6] 13] [[0] 1]]}
+
+   {:id "count-divisors" :family :arithmetic :difficulty :easy :sig "(fn [n] ...)" :desc "that returns how many positive integers divide n exactly (including 1 and n itself)" :reference "(fn [n] (loop [d 1 c 0] (cond (> d n) c (zero? (mod n d)) (recur (inc d) (inc c)) :else (recur (inc d) c))))" :tests [[[1] 1] [[6] 4] [[12] 6] [[7] 2] [[28] 6]]}
+
+   {:id "sum-divisors" :family :arithmetic :difficulty :easy :sig "(fn [n] ...)" :desc "that returns the sum of all positive divisors of n (including 1 and n itself)" :reference "(fn [n] (loop [d 1 s 0] (cond (> d n) s (zero? (mod n d)) (recur (inc d) (+ s d)) :else (recur (inc d) s))))" :tests [[[1] 1] [[6] 12] [[12] 28] [[7] 8] [[10] 18]]}
+
+   {:id "aliquot-sum" :family :arithmetic :difficulty :medium :sig "(fn [n] ...)" :desc "that returns the aliquot sum of n: the sum of its proper divisors (all positive divisors strictly less than n)" :reference "(fn [n] (loop [d 1 s 0] (cond (>= d n) s (zero? (mod n d)) (recur (inc d) (+ s d)) :else (recur (inc d) s))))" :tests [[[1] 0] [[6] 6] [[12] 16] [[28] 28] [[10] 8]]}
+
+   {:id "perfect-number?" :family :arithmetic :difficulty :medium :sig "(fn [n] ...)" :desc "that returns true when n is a perfect number, meaning n equals the sum of its proper divisors (e.g. 6 = 1+2+3)" :reference "(fn [n] (and (> n 1) (= n (loop [d 1 s 0] (cond (>= d n) s (zero? (mod n d)) (recur (inc d) (+ s d)) :else (recur (inc d) s))))))" :tests [[[6] true] [[28] true] [[12] false] [[1] false] [[496] true]]}
+
+   {:id "abundant?" :family :arithmetic :difficulty :medium :sig "(fn [n] ...)" :desc "that returns true when n is abundant, meaning the sum of its proper divisors is greater than n itself" :reference "(fn [n] (> (loop [d 1 s 0] (cond (>= d n) s (zero? (mod n d)) (recur (inc d) (+ s d)) :else (recur (inc d) s))) n))" :tests [[[12] true] [[6] false] [[18] true] [[7] false] [[1] false]]}
+
+   {:id "prime-factors" :family :arithmetic :difficulty :hard :sig "(fn [n] ...)" :desc "that returns a vector of the prime factors of n in nondecreasing order, with repetition, so they multiply back to n (returns [] for n=1)" :reference "(fn [n] (loop [n n d 2 acc []] (cond (< n 2) acc (> (* d d) n) (conj acc n) (zero? (mod n d)) (recur (quot n d) d (conj acc d)) :else (recur n (inc d) acc))))" :tests [[[12] [2 2 3]] [[17] [17]] [[1] []] [[60] [2 2 3 5]] [[8] [2 2 2]]]}
+
+   {:id "distinct-prime-factor-count" :family :arithmetic :difficulty :hard :sig "(fn [n] ...)" :desc "that returns how many distinct prime factors n has (e.g. 12 = 2*2*3 has 2 distinct primes), returning 0 for n=1" :reference "(fn [n] (loop [n n d 2 c 0] (cond (< n 2) c (> (* d d) n) (inc c) (zero? (mod n d)) (recur (loop [m n] (if (zero? (mod m d)) (recur (quot m d)) m)) (inc d) (inc c)) :else (recur n (inc d) c))))" :tests [[[12] 2] [[60] 3] [[17] 1] [[1] 0] [[30] 3]]}
+
+   {:id "integer-sqrt" :family :arithmetic :difficulty :medium :sig "(fn [n] ...)" :desc "that returns the integer square root of n, the largest integer k such that k*k <= n (floor of the real square root)" :reference "(fn [n] (loop [k 0] (if (> (* (inc k) (inc k)) n) k (recur (inc k)))))" :tests [[[0] 0] [[1] 1] [[15] 3] [[16] 4] [[26] 5]]}
+
+   {:id "perfect-square?" :family :arithmetic :difficulty :easy :sig "(fn [n] ...)" :desc "that returns true when n is a perfect square (n equals some integer multiplied by itself), and false otherwise" :reference "(fn [n] (and (>= n 0) (loop [k 0] (let [sq (* k k)] (cond (= sq n) true (> sq n) false :else (recur (inc k)))))))" :tests [[[0] true] [[1] true] [[16] true] [[15] false] [[25] true]]}
+
+   {:id "digit-product" :family :arithmetic :difficulty :easy :sig "(fn [n] ...)" :desc "that returns the product of the base-10 digits of n (using its absolute value); the product of no digits, for n=0, is 1 only via the empty loop but here 0 yields 1" :reference "(fn [n] (loop [n (if (neg? n) (- n) n) p 1] (if (zero? n) p (recur (quot n 10) (* p (mod n 10))))))" :tests [[[123] 6] [[0] 1] [[405] 0] [[9] 9] [[111] 1]]}
+
+   {:id "count-digits" :family :arithmetic :difficulty :easy :sig "(fn [n] ...)" :desc "that returns how many base-10 digits n has, using its absolute value, where 0 counts as having one digit" :reference "(fn [n] (let [n (if (neg? n) (- n) n)] (if (zero? n) 1 (loop [n n c 0] (if (zero? n) c (recur (quot n 10) (inc c)))))))" :tests [[[0] 1] [[5] 1] [[123] 3] [[1000] 4] [[-42] 2]]}
+
+   {:id "reverse-number" :family :arithmetic :difficulty :medium :sig "(fn [n] ...)" :desc "that returns the integer formed by reversing the base-10 digits of n (using its absolute value), dropping any leading zeros that result" :reference "(fn [n] (loop [n (if (neg? n) (- n) n) r 0] (if (zero? n) r (recur (quot n 10) (+ (* r 10) (mod n 10))))))" :tests [[[123] 321] [[0] 0] [[100] 1] [[5] 5] [[1200] 21]]}
+
+   {:id "digit-sum-base" :family :arithmetic :difficulty :medium :sig "(fn [n b] ...)" :desc "that returns the sum of the digits of n when written in base b (using the absolute value of n)" :reference "(fn [n b] (loop [n (if (neg? n) (- n) n) s 0] (if (zero? n) s (recur (quot n b) (+ s (mod n b))))))" :tests [[[255 16] 30] [[7 2] 3] [[10 10] 1] [[0 2] 0] [[8 2] 1]]}
+
+   {:id "multiplicative-persistence" :family :arithmetic :difficulty :hard :sig "(fn [n] ...)" :desc "that returns the multiplicative persistence of n: how many times you must replace the number with the product of its base-10 digits before reaching a single digit" :reference "(fn [n] (letfn [(dprod [m] (loop [m m p 1] (if (zero? m) p (recur (quot m 10) (* p (mod m 10))))))] (loop [n (if (neg? n) (- n) n) c 0] (if (< n 10) c (recur (dprod n) (inc c))))))" :tests [[[7] 0] [[39] 3] [[25] 2] [[10] 1] [[77] 4]]}
+
+   {:id "range-product" :family :arithmetic :difficulty :easy :sig "(fn [a b] ...)" :desc "that returns the product of all integers from a to b inclusive, returning 1 when a is greater than b (empty range)" :reference "(fn [a b] (if (> a b) 1 (loop [k a p 1] (if (> k b) p (recur (inc k) (* p k))))))" :tests [[[1 5] 120] [[3 3] 3] [[5 4] 1] [[2 4] 24] [[1 1] 1]]}
+
+   {:id "coprime?" :family :arithmetic :difficulty :medium :sig "(fn [a b] ...)" :desc "that returns true when a and b are coprime, meaning their greatest common divisor is 1 (uses absolute values)" :reference "(fn [a b] (= 1 (loop [a (if (neg? a) (- a) a) b (if (neg? b) (- b) b)] (if (zero? b) a (recur b (mod a b))))))" :tests [[[8 9] true] [[8 12] false] [[1 5] true] [[14 21] false] [[17 5] true]]}
+
+   {:id "gcd-of-list" :family :arithmetic :difficulty :medium :sig "(fn [xs] ...)" :desc "that returns the greatest common divisor of all integers in vector xs (using their absolute values), returning 0 for an empty vector" :reference "(fn [xs] (letfn [(g [a b] (if (zero? b) a (recur b (mod a b))))] (if (empty? xs) 0 (reduce (fn [acc x] (g acc (if (neg? x) (- x) x))) (let [f (first xs)] (if (neg? f) (- f) f)) (rest xs)))))" :tests [[[[12 18 24]] 6] [[[7]] 7] [[[]] 0] [[[10 20 35]] 5] [[[13 26]] 13]]}
+
+   {:id "lcm-of-list" :family :arithmetic :difficulty :hard :sig "(fn [xs] ...)" :desc "that returns the least common multiple of all integers in vector xs, returning 1 for an empty vector" :reference "(fn [xs] (letfn [(g [a b] (if (zero? b) a (recur b (mod a b)))) (l [a b] (if (or (zero? a) (zero? b)) 0 (quot (* a b) (g a b))))] (if (empty? xs) 1 (reduce l (first xs) (rest xs)))))" :tests [[[[2 3 4]] 12] [[[5]] 5] [[[]] 1] [[[6 8]] 24] [[[1 2 3 4 5]] 60]]}
+
+   {:id "clamp-range" :family :arithmetic :difficulty :easy :sig "(fn [x lo hi] ...)" :desc "that clamps integer x into the inclusive range [lo, hi], returning lo if x is below it, hi if above it, otherwise x" :reference "(fn [x lo hi] (cond (< x lo) lo (> x hi) hi :else x))" :tests [[[5 0 10] 5] [[-3 0 10] 0] [[15 0 10] 10] [[0 0 10] 0] [[10 0 10] 10]]}
+
+   {:id "sliding-windows-2" :family :collection :difficulty :easy :sig "(fn [v] ...)"
+ :desc "that returns a vector of all consecutive overlapping pairs (windows of size 2) of the input vector, each window itself a vector"
+ :reference "(fn [v] (mapv vec (partition 2 1 v)))"
+ :tests [[[[1 2 3 4]] [[1 2] [2 3] [3 4]]] [[[5 6]] [[5 6]]] [[[7]] []] [[[]] []] [[[1 1 1]] [[1 1] [1 1]]]]}
+
+   {:id "chunk-into-n" :family :collection :difficulty :easy :sig "(fn [n v] ...)"
+ :desc "that partitions the vector v into consecutive chunks of size n (the final chunk may be shorter), returning a vector of vectors"
+ :reference "(fn [n v] (mapv vec (partition-all n v)))"
+ :tests [[[2 [1 2 3 4 5]] [[1 2] [3 4] [5]]] [[3 [1 2 3 4 5 6]] [[1 2 3] [4 5 6]]] [[2 []] []] [[1 [9 8]] [[9] [8]]] [[5 [1 2 3]] [[1 2 3]]]]}
+
+   {:id "zip-pairs" :family :collection :difficulty :easy :sig "(fn [a b] ...)"
+ :desc "that zips two vectors a and b into a vector of [a-elem b-elem] pairs, stopping at the shorter length"
+ :reference "(fn [a b] (mapv vector a b))"
+ :tests [[[[1 2 3] [4 5 6]] [[1 4] [2 5] [3 6]]] [[[1 2] [9 8 7]] [[1 9] [2 8]]] [[[] [1 2]] []] [[[1] [2]] [[1 2]]] [[[1 2 3] []] []]]}
+
+   {:id "interleave-vec" :family :collection :difficulty :easy :sig "(fn [a b] ...)"
+ :desc "that interleaves two vectors a and b into a single flat vector (a0 b0 a1 b1 ...), stopping at the shorter length"
+ :reference "(fn [a b] (vec (interleave a b)))"
+ :tests [[[[1 2 3] [4 5 6]] [1 4 2 5 3 6]] [[[1 2] [9 8 7]] [1 9 2 8]] [[[] [1]] []] [[[1] [2]] [1 2]] [[[1 2 3] []] []]]}
+
+   {:id "rotate-left-n" :family :collection :difficulty :medium :sig "(fn [n v] ...)"
+ :desc "that rotates the vector v to the left by n positions (elements shifted off the front wrap to the back), returning a vector"
+ :reference "(fn [n v] (if (empty? v) [] (let [k (mod n (count v))] (vec (concat (drop k v) (take k v))))))"
+ :tests [[[1 [1 2 3 4]] [2 3 4 1]] [[2 [1 2 3 4]] [3 4 1 2]] [[0 [1 2 3]] [1 2 3]] [[5 [1 2 3 4]] [2 3 4 1]] [[3 []] []]]}
+
+   {:id "run-lengths" :family :collection :difficulty :medium :sig "(fn [v] ...)"
+ :desc "that run-length-encodes the vector v into a vector of [value count] pairs for each maximal run of equal consecutive elements"
+ :reference "(fn [v] (mapv (fn [g] [(first g) (count g)]) (partition-by identity v)))"
+ :tests [[[[1 1 2 3 3 3]] [[1 2] [2 1] [3 3]]] [[[5 5 5]] [[5 3]]] [[[1 2 3]] [[1 1] [2 1] [3 1]]] [[[]] []] [[[7]] [[7 1]]]]}
+
+   {:id "flatten-one-level" :family :collection :difficulty :medium :sig "(fn [v] ...)"
+ :desc "that flattens a vector of vectors by exactly one level, concatenating the inner vectors into one flat vector"
+ :reference "(fn [v] (vec (apply concat v)))"
+ :tests [[[[[1 2] [3 4]]] [1 2 3 4]] [[[[1] [2 3] [4 5 6]]] [1 2 3 4 5 6]] [[[]] []] [[[[] [1] []]] [1]] [[[[1 2 3]]] [1 2 3]]]}
+
+   {:id "take-then-drop" :family :collection :difficulty :easy :sig "(fn [n v] ...)"
+ :desc "that returns a vector containing two parts: the first n elements of v, then the elements of v after dropping the first n, packaged as [taken-vec dropped-vec]"
+ :reference "(fn [n v] [(vec (take n v)) (vec (drop n v))])"
+ :tests [[[2 [1 2 3 4 5]] [[1 2] [3 4 5]]] [[0 [1 2 3]] [[] [1 2 3]]] [[5 [1 2 3]] [[1 2 3] []]] [[1 []] [[] []]] [[3 [9 8 7 6]] [[9 8 7] [6]]]]}
+
+   {:id "count-above" :family :collection :difficulty :easy :sig "(fn [t v] ...)"
+ :desc "that counts how many elements of the integer vector v are strictly greater than the threshold t"
+ :reference "(fn [t v] (count (filter (fn [x] (> x t)) v)))"
+ :tests [[[3 [1 2 3 4 5]] 2] [[0 [-1 -2 5 0 7]] 2] [[10 [1 2 3]] 0] [[0 []] 0] [[2 [2 2 2]] 0]]}
+
+   {:id "second-smallest" :family :collection :difficulty :medium :sig "(fn [v] ...)"
+ :desc "that returns the second-smallest value in the integer vector v (by sorted position, allowing duplicates); returns -1 if v has fewer than two elements"
+ :reference "(fn [v] (if (< (count v) 2) -1 (second (sort v))))"
+ :tests [[[[3 1 2]] 2] [[[5 5 1]] 5] [[[10 -3 4 -3]] -3] [[[7]] -1] [[[]] -1]]}
+
+   {:id "build-step-range" :family :collection :difficulty :easy :sig "(fn [start n step] ...)"
+ :desc "that builds a vector of n integers beginning at start and increasing by step each time"
+ :reference "(fn [start n step] (vec (take n (iterate (fn [x] (+ x step)) start))))"
+ :tests [[[0 5 1] [0 1 2 3 4]] [[2 4 3] [2 5 8 11]] [[10 0 5] []] [[7 1 2] [7]] [[0 3 -2] [0 -2 -4]]]}
+
+   {:id "cumulative-sum" :family :collection :difficulty :medium :sig "(fn [v] ...)"
+ :desc "that returns a vector of running (prefix) sums of the integer vector v, where element i is the sum of v[0..i]"
+ :reference "(fn [v] (vec (rest (reductions + 0 v))))"
+ :tests [[[[1 2 3 4]] [1 3 6 10]] [[[5 -2 7]] [5 3 10]] [[[]] []] [[[9]] [9]] [[[0 0 0]] [0 0 0]]]}
+
+   {:id "pairwise-diffs" :family :collection :difficulty :medium :sig "(fn [v] ...)"
+ :desc "that returns a vector of differences between each pair of consecutive elements (v[i+1] - v[i]) of the integer vector v"
+ :reference "(fn [v] (mapv (fn [[a b]] (- b a)) (partition 2 1 v)))"
+ :tests [[[[1 3 6 10]] [2 3 4]] [[[5 2 9]] [-3 7]] [[[7]] []] [[[]] []] [[[4 4 4]] [0 0]]]}
+
+   {:id "index-of-val" :family :collection :difficulty :medium :sig "(fn [x v] ...)"
+ :desc "that returns the index of the first occurrence of x in the vector v, or -1 if x is not present"
+ :reference "(fn [x v] (loop [i 0 s (seq v)] (cond (nil? s) -1 (= (first s) x) i :else (recur (inc i) (next s)))))"
+ :tests [[[3 [1 2 3 4]] 2] [[1 [1 1 1]] 0] [[9 [1 2 3]] -1] [[5 []] -1] [[4 [0 4 4]] 1]]}
+
+   {:id "contains-val?" :family :collection :difficulty :easy :sig "(fn [x v] ...)"
+ :desc "that returns true if x is an element of the vector v and false otherwise"
+ :reference "(fn [x v] (boolean (some (fn [y] (= y x)) v)))"
+ :tests [[[3 [1 2 3]] true] [[9 [1 2 3]] false] [[1 []] false] [[0 [0]] true] [[2 [1 2 2 2]] true]]}
+
+   {:id "most-common-count" :family :collection :difficulty :hard :sig "(fn [v] ...)"
+ :desc "that returns the count of the most frequently occurring integer in the vector v (the size of the largest group of equal elements); returns 0 for an empty vector"
+ :reference "(fn [v] (if (empty? v) 0 (apply max (vals (frequencies v)))))"
+ :tests [[[[1 1 2 3 1]] 3] [[[4 5 6]] 1] [[[2 2 2 2]] 4] [[[]] 0] [[[7 7 8 8]] 2]]}
+
+   {:id "char-count" :family :string :difficulty :easy :sig "(fn [s] ...)"
+ :desc "that returns the number of characters in string s"
+ :reference "(fn [s] (count s))"
+ :tests [[["hello"] 5] [[""] 0] [["a"] 1] [["abc def"] 7]]}
+
+   {:id "word-count" :family :string :difficulty :easy :sig "(fn [s] ...)"
+ :desc "that counts the words in string s (whitespace-separated)"
+ :reference "(fn [s] (if (clojure.string/blank? s) 0 (count (clojure.string/split (clojure.string/trim s) #\"\\s+\"))))"
+ :tests [[["hello world"] 2] [[""] 0] [["   "] 0] [["one"] 1] [["  a  b  c  "] 3]]}
+
+   {:id "reverse-words" :family :string :difficulty :medium :sig "(fn [s] ...)"
+ :desc "that reverses the order of the words in string s"
+ :reference "(fn [s] (if (clojure.string/blank? s) \"\" (clojure.string/join \" \" (reverse (clojure.string/split (clojure.string/trim s) #\"\\s+\")))))"
+ :tests [[["hello world"] "world hello"] [[""] ""] [["one"] "one"] [["a b c"] "c b a"]]}
+
+   {:id "capitalize-first" :family :string :difficulty :easy :sig "(fn [s] ...)"
+ :desc "that uppercases the first character of string s and leaves the rest unchanged"
+ :reference "(fn [s] (if (= s \"\") \"\" (str (clojure.string/upper-case (subs s 0 1)) (subs s 1))))"
+ :tests [[["hello"] "Hello"] [[""] ""] [["a"] "A"] [["hello world"] "Hello world"]]}
+
+   {:id "count-uppercase" :family :string :difficulty :medium :sig "(fn [s] ...)"
+ :desc "that counts the uppercase letters in string s"
+ :reference "(fn [s] (count (filter (fn [c] (let [u (clojure.string/upper-case (str c)) l (clojure.string/lower-case (str c))] (and (not= u l) (= (str c) u)))) s)))"
+ :tests [[["Hello World"] 2] [[""] 0] [["ABC"] 3] [["abc"] 0] [["a1B2"] 1]]}
+
+   {:id "remove-vowels" :family :string :difficulty :medium :sig "(fn [s] ...)"
+ :desc "that removes all vowels (aeiou, any case) from string s"
+ :reference "(fn [s] (clojure.string/join \"\" (remove (fn [c] (contains? #{\"a\" \"e\" \"i\" \"o\" \"u\"} (clojure.string/lower-case (str c)))) s)))"
+ :tests [[["hello"] "hll"] [[""] ""] [["aeiou"] ""] [["xyz"] "xyz"] [["AEIOU"] ""]]}
+
+   {:id "repeat-string" :family :string :difficulty :easy :sig "(fn [s n] ...)"
+ :desc "that returns string s repeated n times"
+ :reference "(fn [s n] (clojure.string/join \"\" (repeat n s)))"
+ :tests [[["ab" 3] "ababab"] [["x" 0] ""] [["" 5] ""] [["a" 1] "a"]]}
+
+   {:id "is-substring?" :family :string :difficulty :easy :sig "(fn [s sub] ...)"
+ :desc "that returns true if string sub occurs inside string s"
+ :reference "(fn [s sub] (clojure.string/includes? s sub))"
+ :tests [[["hello world" "world"] true] [["hello" ""] true] [["abc" "xyz"] false] [["" ""] true] [["" "a"] false]]}
+
+   {:id "initials" :family :string :difficulty :medium :sig "(fn [s] ...)"
+ :desc "that returns the uppercase first letter of each word in string s joined together"
+ :reference "(fn [s] (if (clojure.string/blank? s) \"\" (clojure.string/join \"\" (map (fn [w] (clojure.string/upper-case (subs w 0 1))) (clojure.string/split (clojure.string/trim s) #\"\\s+\")))))"
+ :tests [[["john ronald tolkien"] "JRT"] [[""] ""] [["alice"] "A"] [["mary jane"] "MJ"]]}
+
+   {:id "swap-case" :family :string :difficulty :hard :sig "(fn [s] ...)"
+ :desc "that swaps the case of every letter in string s (upper to lower and lower to upper)"
+ :reference "(fn [s] (clojure.string/join \"\" (map (fn [c] (let [u (clojure.string/upper-case (str c)) l (clojure.string/lower-case (str c))] (cond (= u l) (str c) (= (str c) u) l :else u))) s)))"
+ :tests [[["Hello"] "hELLO"] [[""] ""] [["abc"] "ABC"] [["ABC"] "abc"] [["aB3c"] "Ab3C"]]}
+
+   {:id "censor-word" :family :string :difficulty :medium :sig "(fn [s word] ...)"
+ :desc "that replaces every occurrence of word in string s with stars of the same length"
+ :reference "(fn [s word] (clojure.string/replace s word (clojure.string/join \"\" (repeat (count word) \"*\"))))"
+ :tests [[["i hate mondays" "hate"] "i **** mondays"] [["clean text" "bad"] "clean text"] [["" "x"] ""] [["aa bb aa" "aa"] "** bb **"]]}
+
+   {:id "count-occurrences" :family :string :difficulty :easy :sig "(fn [s c] ...)"
+ :desc "that counts how many times the single-character string c appears in string s"
+ :reference "(fn [s c] (count (filter (fn [ch] (= (str ch) c)) s)))"
+ :tests [[["banana" "a"] 3] [["" "a"] 0] [["xyz" "q"] 0] [["aaa" "a"] 3]]}
+
+   {:id "longest-run" :family :string :difficulty :hard :sig "(fn [s] ...)"
+ :desc "that returns the length of the longest run of consecutive identical characters in string s"
+ :reference "(fn [s] (if (= s \"\") 0 (loop [cs (seq s) prev nil cur 0 best 0] (if (empty? cs) (max best cur) (let [c (first cs)] (if (= c prev) (recur (rest cs) c (inc cur) best) (recur (rest cs) c 1 (max best cur))))))))"
+ :tests [[["aabbbc"] 3] [[""] 0] [["a"] 1] [["aaaa"] 4] [["abc"] 1]]}
+
+   {:id "title-case" :family :string :difficulty :hard :sig "(fn [s] ...)"
+ :desc "that title-cases string s (uppercase first letter of each word, lowercase the rest)"
+ :reference "(fn [s] (if (clojure.string/blank? s) \"\" (clojure.string/join \" \" (map (fn [w] (str (clojure.string/upper-case (subs w 0 1)) (clojure.string/lower-case (subs w 1)))) (clojure.string/split (clojure.string/trim s) #\"\\s+\")))))"
+ :tests [[["hello world"] "Hello World"] [[""] ""] [["a b"] "A B"] [["HELLO"] "Hello"]]}
+
+   {:id "trim-ends" :family :string :difficulty :easy :sig "(fn [s] ...)"
+ :desc "that removes leading and trailing whitespace from string s"
+ :reference "(fn [s] (clojure.string/trim s))"
+ :tests [[["  hi  "] "hi"] [[""] ""] [["   "] ""] [["no-space"] "no-space"]]}
+
+   {:id "starts-with-vowel?" :family :string :difficulty :easy :sig "(fn [s] ...)"
+ :desc "that returns true if string s starts with a vowel (any case)"
+ :reference "(fn [s] (if (= s \"\") false (contains? #{\"a\" \"e\" \"i\" \"o\" \"u\"} (clojure.string/lower-case (subs s 0 1)))))"
+ :tests [[["apple"] true] [[""] false] [["banana"] false] [["Orange"] true]]}
+
+   {:id "vowel-count" :family :string :difficulty :easy :sig "(fn [s] ...)"
+ :desc "that counts the vowels (aeiou, any case) in string s"
+ :reference "(fn [s] (count (filter (fn [c] (contains? #{\"a\" \"e\" \"i\" \"o\" \"u\"} (str c))) (clojure.string/lower-case s))))"
+ :tests [[["hello"] 2] [[""] 0] [["xyz"] 0] [["AEIOU"] 5]]}
+
+   {:id "split-words" :family :string :difficulty :medium :sig "(fn [s] ...)"
+ :desc "that splits string s into a vector of whitespace-separated words"
+ :reference "(fn [s] (if (clojure.string/blank? s) [] (vec (clojure.string/split (clojure.string/trim s) #\"\\s+\"))))"
+ :tests [[["a b c"] ["a" "b" "c"]] [[""] []] [["solo"] ["solo"]] [["  x  y  "] ["x" "y"]]]}
+
+   {:id "double-chars" :family :string :difficulty :medium :sig "(fn [s] ...)"
+ :desc "that doubles every character of string s"
+ :reference "(fn [s] (clojure.string/join \"\" (mapcat (fn [c] (list c c)) s)))"
+ :tests [[["abc"] "aabbcc"] [[""] ""] [["x"] "xx"] [["12"] "1122"]]}
+
+   {:id "ends-with-q?" :family :string :difficulty :easy :sig "(fn [s suf] ...)"
+ :desc "that returns true if string s ends with string suf"
+ :reference "(fn [s suf] (clojure.string/ends-with? s suf))"
+ :tests [[["hello" "lo"] true] [["hello" ""] true] [["abc" "z"] false] [["" ""] true]]}
+
+   {:id "all-equal?" :family :logic :difficulty :easy :sig "(fn [xs] ...)"
+ :desc "that returns true if all elements of vector xs are equal (and true for an empty vector)"
+ :reference "(fn [xs] (if (empty? xs) true (apply = xs)))"
+ :tests [[[[1 1 1]] true] [[[1 2 1]] false] [[[]] true] [[[7]] true] [[[3 3 3 3]] true] [[[0 0 1]] false]]}
+
+   {:id "any-even?" :family :logic :difficulty :easy :sig "(fn [xs] ...)"
+ :desc "that returns true if at least one element of integer vector xs is even"
+ :reference "(fn [xs] (if (some even? xs) true false))"
+ :tests [[[[1 3 4]] true] [[[1 3 5]] false] [[[]] false] [[[2]] true] [[[7 7 7 8]] true] [[[9]] false]]}
+
+   {:id "all-odd?" :family :logic :difficulty :easy :sig "(fn [xs] ...)"
+ :desc "that returns true if every element of integer vector xs is odd (and true for an empty vector)"
+ :reference "(fn [xs] (every? odd? xs))"
+ :tests [[[[1 3 5]] true] [[[1 2 3]] false] [[[]] true] [[[4]] false] [[[7]] true] [[[11 13 15 17]] true]]}
+
+   {:id "strictly-increasing?" :family :logic :difficulty :medium :sig "(fn [xs] ...)"
+ :desc "that returns true if integer vector xs is strictly increasing (each element greater than the previous; true for empty or single-element vectors)"
+ :reference "(fn [xs] (if (< (count xs) 2) true (apply < xs)))"
+ :tests [[[[1 2 3]] true] [[[1 1 2]] false] [[[]] true] [[[5]] true] [[[3 2 1]] false] [[[10 20 30 40]] true]]}
+
+   {:id "non-decreasing?" :family :logic :difficulty :medium :sig "(fn [xs] ...)"
+ :desc "that returns true if integer vector xs is sorted in non-decreasing order (each element greater than or equal to the previous)"
+ :reference "(fn [xs] (if (< (count xs) 2) true (apply <= xs)))"
+ :tests [[[[1 1 2 3]] true] [[[1 3 2]] false] [[[]] true] [[[4]] true] [[[5 5 5]] true] [[[9 8]] false]]}
+
+   {:id "is-sorted-desc?" :family :logic :difficulty :medium :sig "(fn [xs] ...)"
+ :desc "that returns true if integer vector xs is sorted in non-increasing (descending) order"
+ :reference "(fn [xs] (if (< (count xs) 2) true (apply >= xs)))"
+ :tests [[[[5 4 3 2]] true] [[[5 5 4]] true] [[[1 2 3]] false] [[[]] true] [[[7]] true] [[[3 1 2]] false]]}
+
+   {:id "bool-xor" :family :logic :difficulty :easy :sig "(fn [a b] ...)"
+ :desc "that returns the exclusive-or of two booleans a and b (true when exactly one is true)"
+ :reference "(fn [a b] (not= (boolean a) (boolean b)))"
+ :tests [[[true false] true] [[false true] true] [[true true] false] [[false false] false]]}
+
+   {:id "bool-nand" :family :logic :difficulty :easy :sig "(fn [a b] ...)"
+ :desc "that returns the logical NAND of two booleans a and b (false only when both are true)"
+ :reference "(fn [a b] (not (and a b)))"
+ :tests [[[true true] false] [[true false] true] [[false true] true] [[false false] true]]}
+
+   {:id "bool-implies" :family :logic :difficulty :easy :sig "(fn [a b] ...)"
+ :desc "that returns the logical implication a implies b (false only when a is true and b is false)"
+ :reference "(fn [a b] (or (not a) (boolean b)))"
+ :tests [[[true false] false] [[true true] true] [[false false] true] [[false true] true]]}
+
+   {:id "majority-int" :family :logic :difficulty :hard :sig "(fn [xs] ...)"
+ :desc "that returns the integer appearing in vector xs strictly more than half the time, or -1 if no such majority exists (-1 for an empty vector)"
+ :reference "(fn [xs] (let [n (count xs) freqs (frequencies xs) winner (when (seq freqs) (apply max-key val freqs))] (if (and winner (> (* 2 (val winner)) n)) (key winner) -1)))"
+ :tests [[[[1 1 1 2]] 1] [[[1 2 3]] -1] [[[5 5 5 5]] 5] [[[]] -1] [[[2 2 1 1]] -1] [[[7 7 7 9 9]] 7]]}
+
+   {:id "triangle-type" :family :logic :difficulty :hard :sig "(fn [a b c] ...)"
+ :desc "that classifies a triangle by side lengths a b c, returning the string \"equilateral\" if all sides equal, \"isosceles\" if exactly two are equal, otherwise \"scalene\""
+ :reference "(fn [a b c] (cond (= a b c) \"equilateral\" (or (= a b) (= b c) (= a c)) \"isosceles\" :else \"scalene\"))"
+ :tests [[[3 3 3] "equilateral"] [[3 3 5] "isosceles"] [[3 4 5] "scalene"] [[5 3 5] "isosceles"] [[2 2 2] "equilateral"] [[7 8 9] "scalene"]]}
+
+   {:id "sign-str" :family :logic :difficulty :easy :sig "(fn [n] ...)"
+ :desc "that returns the string \"positive\", \"negative\", or \"zero\" describing the sign of integer n"
+ :reference "(fn [n] (cond (pos? n) \"positive\" (neg? n) \"negative\" :else \"zero\"))"
+ :tests [[[5] "positive"] [[-3] "negative"] [[0] "zero"] [[100] "positive"] [[-1] "negative"]]}
+
+   {:id "parity-match?" :family :logic :difficulty :easy :sig "(fn [a b] ...)"
+ :desc "that returns true if integers a and b have the same parity (both even or both odd)"
+ :reference "(fn [a b] (= (even? a) (even? b)))"
+ :tests [[[2 4] true] [[1 3] true] [[2 3] false] [[0 7] false] [[6 8] true] [[9 4] false]]}
+
+   {:id "count-in-range" :family :logic :difficulty :medium :sig "(fn [xs lo hi] ...)"
+ :desc "that counts how many integers in vector xs fall inclusively between lo and hi"
+ :reference "(fn [xs lo hi] (count (filter (fn [x] (and (>= x lo) (<= x hi))) xs)))"
+ :tests [[[[1 5 10 15] 5 10] 2] [[[1 2 3] 0 10] 3] [[[] 0 5] 0] [[[1 2 3] 5 10] 0] [[[5 5 5] 5 5] 3] [[[-2 0 4 9] 0 5] 2]]}
+
+   {:id "ordered-chain?" :family :logic :difficulty :medium :sig "(fn [a b c] ...)"
+ :desc "that returns true if the three integers satisfy the chain a < b < c"
+ :reference "(fn [a b c] (< a b c))"
+ :tests [[[1 2 3] true] [[1 3 2] false] [[3 2 1] false] [[1 1 2] false] [[0 5 10] true] [[-1 0 1] true]]}
+
+   {:id "minutes->seconds" :family :arithmetic :difficulty :easy :sig "(fn [m] ...)"
+ :desc "converting whole minutes to seconds"
+ :reference "(fn [m] (* m 60))"
+ :tests [[[1] 60] [[2] 120] [[0] 0] [[10] 600] [[90] 5400]]}
+
+   {:id "seconds->minutes-exact" :family :arithmetic :difficulty :easy :sig "(fn [s] ...)"
+ :desc "converting seconds to whole minutes using integer division (truncating)"
+ :reference "(fn [s] (quot s 60))"
+ :tests [[[60] 1] [[120] 2] [[0] 0] [[150] 2] [[59] 0]]}
+
+   {:id "hours->minutes" :family :arithmetic :difficulty :easy :sig "(fn [h] ...)"
+ :desc "converting whole hours to minutes"
+ :reference "(fn [h] (* h 60))"
+ :tests [[[1] 60] [[3] 180] [[0] 0] [[24] 1440] [[2] 120]]}
+
+   {:id "dollars->cents" :family :arithmetic :difficulty :easy :sig "(fn [d c] ...)"
+ :desc "converting a dollars-and-cents amount (whole dollars and whole cents) into a total number of cents"
+ :reference "(fn [d c] (+ (* d 100) c))"
+ :tests [[[1 0] 100] [[1 50] 150] [[0 0] 0] [[5 25] 525] [[10 99] 1099]]}
+
+   {:id "cents->dollars-and-cents" :family :arithmetic :difficulty :medium :sig "(fn [total] ...)"
+ :desc "splitting a total in cents into a two-element vector [dollars cents]"
+ :reference "(fn [total] [(quot total 100) (mod total 100)])"
+ :tests [[[100] [1 0]] [[150] [1 50]] [[0] [0 0]] [[525] [5 25]] [[99] [0 99]]]}
+
+   {:id "exact-percent" :family :arithmetic :difficulty :medium :sig "(fn [part whole] ...)"
+ :desc "computing what percent part is of whole, given the result divides evenly into a whole-number percent (return 0 when whole is 0)"
+ :reference "(fn [part whole] (if (zero? whole) 0 (quot (* part 100) whole)))"
+ :tests [[[1 4] 25] [[1 2] 50] [[3 4] 75] [[0 10] 0] [[5 0] 0] [[10 10] 100]]}
+
+   {:id "clock-add-12" :family :arithmetic :difficulty :medium :sig "(fn [hour delta] ...)"
+ :desc "advancing a 12-hour clock hour (1..12) by delta hours, wrapping correctly so the result is in 1..12"
+ :reference "(fn [hour delta] (inc (mod (+ (dec hour) delta) 12)))"
+ :tests [[[12 1] 1] [[11 2] 1] [[1 0] 1] [[12 12] 12] [[3 24] 3] [[10 5] 3]]}
+
+   {:id "clock-add-24" :family :arithmetic :difficulty :easy :sig "(fn [hour delta] ...)"
+ :desc "advancing a 24-hour clock hour (0..23) by delta hours, wrapping with mod 24"
+ :reference "(fn [hour delta] (mod (+ hour delta) 24))"
+ :tests [[[23 1] 0] [[0 0] 0] [[20 5] 1] [[12 24] 12] [[10 14] 0]]}
+
+   {:id "countdown-vec" :family :arithmetic :difficulty :medium :sig "(fn [n] ...)"
+ :desc "building a countdown vector from n down to 0 inclusive (empty handling: for n=0 return [0])"
+ :reference "(fn [n] (loop [i n acc []] (if (neg? i) acc (recur (dec i) (conj acc i)))))"
+ :tests [[[3] [3 2 1 0]] [[0] [0]] [[1] [1 0]] [[5] [5 4 3 2 1 0]]]}
+
+   {:id "rect-perimeter" :family :arithmetic :difficulty :easy :sig "(fn [w h] ...)"
+ :desc "computing the perimeter of an integer-sided rectangle with width w and height h"
+ :reference "(fn [w h] (* 2 (+ w h)))"
+ :tests [[[2 3] 10] [[5 5] 20] [[0 0] 0] [[1 1] 4] [[10 4] 28]]}
+
+   {:id "rect-area" :family :arithmetic :difficulty :easy :sig "(fn [w h] ...)"
+ :desc "computing the area of an integer-sided rectangle with width w and height h"
+ :reference "(fn [w h] (* w h))"
+ :tests [[[2 3] 6] [[5 5] 25] [[0 7] 0] [[1 1] 1] [[10 4] 40]]}
+
+   {:id "distance-squared" :family :arithmetic :difficulty :medium :sig "(fn [x1 y1 x2 y2] ...)"
+ :desc "computing the squared euclidean distance between two integer points (avoiding sqrt)"
+ :reference "(fn [x1 y1 x2 y2] (let [dx (- x2 x1) dy (- y2 y1)] (+ (* dx dx) (* dy dy))))"
+ :tests [[[0 0 3 4] 25] [[0 0 0 0] 0] [[1 1 1 1] 0] [[1 2 4 6] 25] [[-1 -1 2 3] 25]]}
+
+   {:id "steps-to-meters" :family :arithmetic :difficulty :medium :sig "(fn [steps] ...)"
+ :desc "converting a step count to whole meters assuming each step is exactly 1 meter for every full pair of steps (i.e. integer-divide steps by 2 to get meters), truncating"
+ :reference "(fn [steps] (quot steps 2))"
+ :tests [[[2] 1] [[4] 2] [[0] 0] [[5] 2] [[1] 0]]}
+
+   {:id "even-average" :family :arithmetic :difficulty :hard :sig "(fn [xs] ...)"
+ :desc "computing the exact integer average of a non-empty vector of integers whose sum is evenly divisible by the count (return 0 for an empty vector)"
+ :reference "(fn [xs] (if (empty? xs) 0 (quot (reduce + 0 xs) (count xs))))"
+ :tests [[[[2 4 6]] 4] [[[10 20]] 15] [[[]] 0] [[[5]] 5] [[[1 2 3 4 5]] 3] [[[0 0 0]] 0]]}
+
+   {:id "days->hours" :family :arithmetic :difficulty :easy :sig "(fn [d] ...)"
+ :desc "converting whole days to hours"
+ :reference "(fn [d] (* d 24))"
+ :tests [[[1] 24] [[2] 48] [[0] 0] [[7] 168] [[10] 240]]}
+])

--- a/src/genmlx/world/distill_sandbox.cljs
+++ b/src/genmlx/world/distill_sandbox.cljs
@@ -34,6 +34,7 @@
    (reassembled by row :index, deduped, sentinels dropped)."
   (:require [genmlx.world.distill :as d]
             [genmlx.world.distill-tasks :as t]
+            [genmlx.world.distill-gen :as g]
             [clojure.string :as str]
             [cljs.reader :as reader]
             [promesa.core :as p]))
@@ -56,11 +57,12 @@
                           (catch :default _ nil))))
        vec))
 
-(defn- spawn-worker [candidates-file out-path start eval-opts]
+(defn- spawn-worker [candidates-file out-path start eval-opts gen?]
   (let [args (cond-> ["run" "--bun" "nbb" "scripts/distill_check.cljs"
                       "--candidates" candidates-file "--out" out-path "--start" (str start)
                       "--n-particles" (str (:n-particles eval-opts 50))]
-               (:min-log-ml eval-opts) (conj "--min-log-ml" (str (:min-log-ml eval-opts))))]
+               (:min-log-ml eval-opts) (conj "--min-log-ml" (str (:min-log-ml eval-opts)))
+               gen?                     (conj "--gen"))]
     ;; detached -> the worker leads its own process group, so we can kill the whole
     ;; tree (wrapper + nbb/node grandchild). stdout ignored (wrapper is noisy; verdicts
     ;; go to the file); stderr inherited so a worker error surfaces on our stderr.
@@ -132,23 +134,32 @@
                   (default 15000; must exceed the worker's cold-start ~2-4s)
      :poll-ms     watchdog poll interval (default 400)
      :verbose?    print per-worker / per-kill progress"
-  [candidates-file {:keys [out-path eval-opts timeout-ms poll-ms verbose?]
+  [candidates-file {:keys [out-path eval-opts timeout-ms poll-ms verbose? gen?]
                     :or   {timeout-ms 15000 poll-ms 400}}]
   (let [rows (read-candidates candidates-file)
-        n    (count rows)]
+        n    (count rows)
+        ;; sentinel (:timeout/:crashed) verdicts carry the task's :kind; resolve against the
+        ;; SAME source the worker uses (--gen scaled set or the seeds) so :kind is correct.
+        tasks-by-id (if gen? g/tasks-by-id t/tasks-by-id)]
     (.writeFileSync fs out-path "")
     (letfn [(step [start]
               (if (>= start n)
                 (p/resolved (assemble out-path))
                 (do (when verbose? (println (str "  [sandbox] worker resuming at row " start "/" n)))
-                    (-> (watch-worker (spawn-worker candidates-file out-path start eval-opts)
+                    (-> (watch-worker (spawn-worker candidates-file out-path start eval-opts gen?)
                                       out-path timeout-ms poll-ms)
                         (p/then (fn [{:keys [status index]}]
-                                  (if (= :done status)
+                                  (if (or (= :done status) (>= index n))
+                                    ;; :done, OR the worker exited non-zero but had already
+                                    ;; written every row (index == n): a dirty exit on teardown
+                                    ;; after finishing (Metal cleanup can do this). Treat as done
+                                    ;; rather than (nth rows n) — an out-of-bounds that crashed the
+                                    ;; whole grade on larger batches (a real crash mid-batch still
+                                    ;; has index < n and resumes normally).
                                     (assemble out-path)
                                     (let [reason (if (= :stall status) :timeout :crashed)
                                           {:keys [task-id sample-idx]} (d/candidate->fields (nth rows index))
-                                          task   (or (get t/tasks-by-id task-id) {:id task-id :kind nil})]
+                                          task   (or (get tasks-by-id task-id) {:id task-id :kind nil})]
                                       (when verbose?
                                         (println (str "  [sandbox] row " index " (" task-id " #" sample-idx
                                                       ") -> " reason "; resuming")))

--- a/src/genmlx/world/llm_proposer.cljs
+++ b/src/genmlx/world/llm_proposer.cljs
@@ -1,0 +1,440 @@
+(ns genmlx.world.llm-proposer
+  "A REAL-LLM proposer for the REPL-synthesis loop (beans genmlx-0yv7 / genmlx-wpua):
+   the design's mechanism (a) — INSTRUCT-DRIVEN, FEEDBACK-CONDITIONED, STEPWISE.
+
+   This is the piece that puts a real LLM in the loop. `genmlx.world.synth` (Phase 1)
+   and `genmlx.world.search` (Phase 2) take an INJECTED proposer
+   `(fn [spec feedback] -> [{:edit :desc :spec' ...} ...])`; until now that slot held a
+   hand-coded structured move-vocabulary, so feedback-conditioning was plumbed but never
+   exercised. `make-proposer` here fills the slot with an LLM:
+
+     render the current partial model + its check feedback  ->  PROMPT
+     call the policy LLM K times (temperature)              ->  K completions
+     extract the (fn [trace] ...) form from each            ->  candidate :code
+     parse it (best-effort) back to a synth spec            ->  candidate :spec'
+
+   The candidates flow into the SAME four-level `check` node and oracle — so a real DSL
+   slip (mx/0 unbound, a dist bound without `trace`, (:p trace)->nil, a non-static loop)
+   reaches the check node as the LLM actually wrote it (the check node's raison d'être),
+   producing real :error feedback that the NEXT step is conditioned on. That closed loop
+   is the north-star thesis; this namespace is where the loop meets a real generator.
+
+   NATIVE-FREE, like the oracle spine it complements. The policy LLM lives OUT-OF-PROCESS
+   (a resident `scripts/llm_server.py` mlx-lm worker); `call-server` is the one I/O
+   boundary (a synchronous curl — the driver is synchronous, and an LLM call is a genuine
+   I/O boundary). The pure core — `extract-form`, `parse-spec`, the prompt builders, and
+   `make-proposer` itself (which takes an injected `:call-llm`) — needs no model and is
+   unit-tested with a mock generator.
+
+   Sections:
+     1. The DSL system prompt — teaches the exact skeleton + the anti-cliff rules
+     2. Prompt builders — task block / step (feedback-conditioned) / one-shot (control)
+     3. extract-form — LLM completion -> a (fn [trace] ...) code string (the slips kept)
+     4. parse-spec — code string -> a synth spec (the inverse of synth/render)
+     5. make-proposer / one-shot-candidates — the injected proposer + the control
+     6. call-server — the out-of-process mlx-lm bridge (the sole I/O)"
+  (:require [genmlx.world.synth :as syn]
+            [genmlx.codegen.eval :as ce]
+            [clojure.string :as str]))
+
+;; ===========================================================================
+;; 1. The DSL system prompt
+;;
+;; The cliff (genmlx-d4q4) was the one-shot INTERFACE, not capability: a model that
+;; understands the structure still emits one-eval-away GenMLX slips. This system prompt
+;; teaches the EXACT skeleton + the precise rules that each documented slip violates.
+;; It is given IDENTICALLY to the loop and the one-shot control, so the only difference
+;; the experiment measures is the feedback loop, never the prompt.
+;; ===========================================================================
+
+(def default-system
+  (str
+   "You are an expert ClojureScript programmer writing probabilistic models in GenMLX.\n"
+   "A GenMLX model is a single ClojureScript function: a (fn [trace] ...) whose body is a\n"
+   "`let` of latent variables and returns a map of observations (see the example below).\n\n"
+   "RULES (each one is a real mistake to avoid):\n"
+   "1. Every random variable is  (trace :address (dist/NAME arg ...)).  Latents are\n"
+   "   let-bindings; observations are entries in the RETURNED MAP (a keyword key whose\n"
+   "   value is a trace form). A `dist/...` bound WITHOUT `trace` is NOT a site.\n"
+   "2. Reference a latent in a later expression by its binding SYMBOL (e.g. slope) —\n"
+   "   NEVER by (:slope trace); `trace` is not a map.\n"
+   "3. Numbers are PLAIN literals:  (dist/gaussian 0 2.5).  NEVER write mx/0 or mx/2.5.\n"
+   "4. To compute a mean from latents use mx ops:\n"
+   "     (mx/add (mx/multiply slope (mx/scalar 2.0)) intercept)\n"
+   "   mx/scalar wraps a constant; +,*,-,/ are mx/add, mx/multiply, mx/subtract, mx/divide.\n"
+   "5. Distributions: (dist/gaussian mean std) (dist/uniform lo hi) (dist/bernoulli p)\n"
+   "   (dist/exponential rate) (dist/beta-dist a b) (dist/gamma-dist shape rate).\n"
+   "6. NO loops (doseq/for/map), NO combinators, NO inference calls. Write EVERY site\n"
+   "   explicitly and flat. The form must be STATIC: literal keyword addresses, no `if`.\n"
+   "7. To be scored EXACTLY (not approximately), an observation must be\n"
+   "   (trace :addr (dist/gaussian MEAN NOISE)) where (a) NOISE is a FIXED positive number\n"
+   "   (e.g. 1.0) — NOT a latent (trace :sigma ...) — and (b) MEAN is written DIRECTLY\n"
+   "   inside the (dist/gaussian ...) call as an mx expression of the latents, NOT bound to\n"
+   "   a separate let variable. Example of an exactly-scoreable observation:\n"
+   "     (trace :y3 (dist/gaussian (mx/add (mx/multiply slope (mx/scalar 3.0)) intercept) 1.0))\n"
+   "   A latent noise or a let-factored mean falls back to noisy approximate scoring, so the\n"
+   "   model looks worse than it is. (Try a smaller fixed noise if the data is tightly clustered.)\n\n"
+   "Example (a complete, valid 1-latent model — yours will have DIFFERENT structure):\n"
+   "(fn [trace]\n"
+   "  (let [mu (trace :mu (dist/gaussian 0 5))]\n"
+   "    {:o0 (trace :o0 (dist/gaussian mu 1.0))\n"
+   "     :o1 (trace :o1 (dist/gaussian mu 1.0))}))\n\n"
+   "Respond with ONLY the model: one ```clojure code block with a single (fn [trace] ...) form."))
+
+;; ===========================================================================
+;; 2. Prompt builders
+;; ===========================================================================
+
+(defn- fmt [x] (when (and x (js/isFinite x)) (.toFixed (js/Number x) 2)))
+
+(defn- render-obs
+  "Render the observed data as readable `:addr = value` lines (sorted by address)."
+  [observations]
+  (->> observations
+       (sort-by (comp str key))
+       (map (fn [[k v]] (str "  " k " = " v)))
+       (str/join "\n")))
+
+(defn- feedback-line
+  "Turn a check feedback map into the one instruction the LLM is conditioned on. This is
+   the defining feedback-conditioning step: the model's NEXT proposal sees the exact
+   verifier verdict on its PREVIOUS one (a parse failure, a coverage gap, an eval error,
+   or a model-evidence number to beat)."
+  [fb]
+  (cond
+    (nil? fb)              "(no current model yet — propose an initial model)"
+    (not (:parses? fb))    "The current model does NOT parse as a complete ClojureScript form. Return a complete (fn [trace] ...) form."
+    (not (:schema-ok? fb)) (str "The current model is not a well-formed GenMLX model: " (:error fb)
+                                ". Every latent and observation must be a (trace :addr (dist/... )) site, and the body must return a map of observations.")
+    (not (:covered? fb))   (str "Coverage problem: " (:error fb)
+                                ". Every observed address below must appear as a (trace :addr (dist/...)) entry in the returned map.")
+    (not (:evals? fb))     (str "Evaluating the current model RAISED AN ERROR: " (:error fb)
+                                ". Fix exactly this error in your next model (check rule 2/3/4 above).")
+    (nil? (:evidence fb))  (str "The model is well-formed and evaluates, but its model evidence is NON-FINITE "
+                                "(the data could not be scored). The usual cause is an invalid distribution "
+                                "parameter: a standard deviation / scale that can be non-positive — e.g. a "
+                                "(dist/gaussian ..) PRIOR on a noise scale, which can go negative. Use a FIXED "
+                                "positive number (like 1.0) for observation noise, or a positive-support prior "
+                                "(dist/exponential, dist/gamma-dist); and make sure every distribution name is real.")
+    (:evidence fb)         (str "The current model is VALID. Its Bayesian model evidence (log marginal likelihood; HIGHER is better) is "
+                                (fmt (:evidence fb))
+                                ". Propose a model that fits the data BETTER — add or adjust ONE piece of structure (a latent, a coupling, a per-group mean, a noise scale).")
+    :else                  (str "Current status: " (pr-str (select-keys fb [:parses? :schema-ok? :covered? :evals? :error])))))
+
+(defn step-prompt
+  "The feedback-conditioned step prompt: task + data + the current model + the verifier's
+   verdict on it + the instruction to make ONE targeted improvement."
+  [task-desc observations cur-code fb]
+  (str "TASK\n" task-desc
+       "\n\nOBSERVED DATA\n" (render-obs observations)
+       "\n\nCURRENT MODEL\n" cur-code
+       "\n\nVERIFIER FEEDBACK\n" (feedback-line fb)
+       "\n\nReturn an IMPROVED model as a single (fn [trace] (let [...] {...})) form. "
+       "Make ONE targeted change (fix the error above, or add/adjust one piece of structure "
+       "so the model fits the data better)."))
+
+(defn oneshot-prompt
+  "The one-shot CONTROL prompt: task + data, no current model, no feedback — the model
+   writes its best program in one shot (this is the best-of-K baseline the loop must beat)."
+  [task-desc observations]
+  (str "TASK\n" task-desc
+       "\n\nOBSERVED DATA\n" (render-obs observations)
+       "\n\nWrite the best GenMLX generative model you can for this data, as a single "
+       "(fn [trace] (let [...] {...})) form."))
+
+;; ===========================================================================
+;; 3. extract-form — pull the (fn [trace] ...) form out of an LLM completion
+;;
+;; The slips stay IN: this strips chat scaffolding (a stray <think> block, a ```fence,
+;; prose) and returns the model form the LLM actually wrote — mx/0, (:p trace) and all —
+;; so the check node sees real garbage, not a sanitized version.
+;; ===========================================================================
+
+(defn- strip-think
+  "Drop a (defensive) <think>...</think> block — closed, or unclosed to end-of-string."
+  [s]
+  (-> s
+      (str/replace #"<think>[\s\S]*?</think>" "")
+      (str/replace #"<think>[\s\S]*$" "")))
+
+(defn- strip-fence
+  "If a ```...``` code block is present, return its CONTENTS; else the string unchanged."
+  [s]
+  (if-let [m (re-find #"```[a-zA-Z]*\n?([\s\S]*?)```" s)] (second m) s))
+
+(defn- balanced-from
+  "From index `i` (a `(` in `s`) return the balanced-paren substring, or nil if it never
+   closes. String literals are tracked so parens inside \"...\" do not miscount."
+  [s i]
+  (let [n (count s)]
+    (loop [j i, depth 0, in-str? false, esc? false]
+      (if (>= j n)
+        nil
+        (let [c (nth s j)]
+          (cond
+            (and in-str? esc?)    (recur (inc j) depth true false)
+            (and in-str? (= c \\)) (recur (inc j) depth true true)
+            (and in-str? (= c \")) (recur (inc j) depth false false)
+            in-str?               (recur (inc j) depth true false)
+            (= c \")              (recur (inc j) depth true false)
+            (= c \()              (recur (inc j) (inc depth) false false)
+            (= c \))              (if (= depth 1)
+                                    (subs s i (inc j))
+                                    (recur (inc j) (dec depth) false false))
+            :else                 (recur (inc j) depth false false)))))))
+
+(defn extract-form
+  "An LLM completion -> the (fn [trace] ...) model code string it contains, or nil.
+   Strips a <think> block and a ``` fence, finds the first (fn ...) form and returns the
+   balanced substring (validated by the reader). Slip recovery: if the model emitted a
+   bare (let ...) body without the (fn [trace] ...) wrapper, wrap it — the only
+   normalization done; everything inside the form is left exactly as written."
+  [completion]
+  (when (string? completion)
+    (let [t  (-> completion strip-think strip-fence str/trim)
+          fi (.search t (js/RegExp. "\\(fn\\*?[\\s\\[]"))]
+      (if (>= fi 0)
+        (let [f (balanced-from t fi)]
+          (when (and f (ce/valid-cljs? f)) f))
+        (let [li (.search t (js/RegExp. "\\(let\\*?[\\s\\[]"))]
+          (when (>= li 0)
+            (let [b (balanced-from t li)
+                  w (when b (str "(fn [trace] " b ")"))]
+              (when (and w (ce/valid-cljs? w)) w))))))))
+
+;; ===========================================================================
+;; 4. parse-spec — code string -> a synth spec (the inverse of synth/render)
+;;
+;; Best-effort: it reads exactly the model class the spec represents (flat latents +
+;; an observation map of (trace :addr (dist ...)) sites), preserving argument FORMS
+;; verbatim (so an mx/add mean expression round-trips). It returns nil for anything
+;; off-grammar (a loop, a non-trace binding, a nested helper) — and that is fine: the
+;; candidate still carries its raw :code (what the check node scores), and only ACCEPTED
+;; candidates need a spec (a scored, well-formed, static model is always in-grammar).
+;; ===========================================================================
+
+(defn- dist-name
+  "A dist constructor symbol -> its name string: dist/gaussian -> \"gaussian\"."
+  [sym]
+  (when (symbol? sym) (name sym)))
+
+(defn- parse-site
+  "(trace :addr (dist/NAME arg ...)) -> {:addr :dist :args}, or nil."
+  [expr]
+  (when (and (seq? expr) (= 'trace (first expr)) (keyword? (second expr)))
+    (let [dexpr (nth expr 2 nil)]
+      (when (and (seq? dexpr) (symbol? (first dexpr)))
+        {:addr (second expr) :dist (dist-name (first dexpr)) :args (vec (rest dexpr))}))))
+
+(defn- collect-let-sites
+  "A let binding vector [sym1 e1 sym2 e2 ...] -> [{:sym :addr :dist :args} ...] (one per
+   binding), or nil if any binding is not `symbol + a trace-site`. (Both latents and —
+   in the common 'everything in the let, return a map of references' shape that strong
+   instruct models emit — observations live here; the return map classifies which is which.)"
+  [binds]
+  (when (and (vector? binds) (even? (count binds)))
+    (reduce (fn [acc [sym e]]
+              (let [s (parse-site e)]
+                (if (and (symbol? sym) s) (conj acc (assoc s :sym sym)) (reduced nil))))
+            [] (partition 2 binds))))
+
+(defn- classify-return-map
+  "Split `let-sites` into [latents obs] using the return map. A map value that is a SYMBOL
+   referencing a let site marks that site an OBSERVATION; a map value that is an inline
+   (trace :addr (dist ...)) form is an inline observation (the canonical render shape). A
+   returned symbol that is ALSO referenced in another site's args is a latent DEPENDENCY,
+   not a fresh observation — it must stay let-bound (in scope for that reference), so its
+   return entry is dropped (its trace-site already covers the address); otherwise the
+   round-tripped spec would render an unbound symbol. Observations are deduped by address
+   (a latent returned under multiple keys collapses to one). Latents are the let sites not
+   reclassified as observations. Returns [latents obs] or nil if any map value is neither a
+   known-site reference nor an inline trace site."
+  [let-sites retmap]
+  (when (map? retmap)
+    (let [by-sym     (into {} (map (juxt :sym identity)) let-sites)
+          referenced (into #{} (mapcat #(filter symbol? (tree-seq coll? seq (:args %)))) let-sites)]
+      (when-let [tagged (reduce (fn [acc [_ v]]
+                                  (let [inline (parse-site v)]
+                                    (cond
+                                      (and (symbol? v) (referenced v)) acc   ; latent dependency, not a fresh obs
+                                      (and (symbol? v) (by-sym v))     (conj acc (assoc (by-sym v) :ref (by-sym v)))
+                                      inline                           (conj acc inline)
+                                      :else                            (reduced nil))))
+                                [] retmap)]
+        (let [obs-syms (set (keep #(:sym (:ref %)) tagged))
+              latents  (remove #(obs-syms (:sym %)) let-sites)
+              obs      (->> tagged
+                            (reduce (fn [[seen acc] s]
+                                      (if (seen (:addr s))
+                                        [seen acc]
+                                        [(conj seen (:addr s)) (conj acc (syn/obs (:addr s) (:dist s) (:args s)))]))
+                                    [#{} []])
+                            second)]
+          [(mapv #(syn/latent (:sym %) (:addr %) (:dist %) (:args %)) latents) obs])))))
+
+(defn parse-spec
+  "A (fn [trace] (let [...] {...})) code string -> a synth spec, or nil if off-grammar.
+   Unwraps let/let*/do; handles the canonical shape (latents in the let, observations
+   inline in the return map) AND the 'everything in the let, return a map of references'
+   shape; supports the no-latent case (a bare observation-map body). Arg FORMS are
+   preserved verbatim, so a mean expression round-trips."
+  [code]
+  (let [form (ce/parse-form code)]
+    (when (and (seq? form) (#{'fn 'fn*} (first form)) (vector? (second form)))
+      (loop [b (last (drop 2 form))]
+        (cond
+          (map? b)
+          (when-let [[lat obs] (classify-return-map [] b)] (syn/spec lat obs))
+
+          (and (seq? b) (#{'let 'let*} (first b)) (vector? (second b)))
+          (when-let [sites (collect-let-sites (second b))]
+            (when-let [[lat obs] (classify-return-map sites (last b))] (syn/spec lat obs)))
+
+          (and (seq? b) (= 'do (first b)))
+          (recur (last b))
+
+          :else nil)))))
+
+;; ===========================================================================
+;; 5. make-proposer / one-shot-candidates
+;; ===========================================================================
+
+(defn- candidate-desc [sp]
+  (if sp
+    (str "LLM: " (count (:latents sp)) "L/" (count (:obs sp)) "O")
+    "LLM: off-grammar (raw)"))
+
+(defn progress-level
+  "How far a check verdict got, 0..5 — the depth of the self-check a candidate cleared.
+   Used to pick the MOST-PROGRESSED failed candidate to revise from (the one whose error
+   is the most actionable): 0 not-parse, 1 not-schema, 2 not-covered, 3 eval-error,
+   4 evaluates-but-non-finite-evidence, 5 scored."
+  [fb]
+  (cond (not (:parses? fb))    0
+        (not (:schema-ok? fb)) 1
+        (not (:covered? fb))   2
+        (not (:evals? fb))     3
+        (nil? (:evidence fb))  4
+        :else                  5))
+
+(defn- extract-distinct
+  "The distinct (fn [trace] ...) code strings a batch of completions contains — the shared
+   extract+dedup contract for both candidate builders (slips kept; nils dropped)."
+  [completions]
+  (->> completions (map extract-form) (filter some?) distinct))
+
+(defn completions->candidates
+  "Map raw LLM completions to driver/search candidates: extract the form (slips kept),
+   dedup identical forms, attach the raw :code (what the check node scores) and a
+   best-effort :spec' (for the trajectory / search / backtrack; falls back to the current
+   `spec` when the form is off-grammar, so the loop state stays valid)."
+  [completions spec]
+  (->> (extract-distinct completions)
+       (mapv (fn [code]
+               (let [sp (parse-spec code)]
+                 {:edit (if sp :llm :llm-raw)
+                  :desc (candidate-desc sp)
+                  :code code
+                  :spec' (or sp spec)})))))
+
+(defn make-proposer
+  "Build an injected proposer `(fn [spec feedback] -> [candidate ...])` backed by an LLM —
+   a mini-REPL: the proposer PROPOSES, CHECKS its own output against the verifier, and on a
+   slip RE-PROMPTS the model with that specific error to fix, up to `:revise` times. This
+   is the north-star inner loop (propose → eval → read error → revise); without it a real
+   LLM stalls, because a slip that blocks every candidate (a non-positive σ, a hallucinated
+   distribution, a coverage miss) never produces a scoring candidate for the driver to
+   accept, so the model is never told why. The DRIVER's outer loop still owns FIT
+   improvement (accept a candidate only when its exact evidence climbs); this inner loop
+   owns SELF-CORRECTION. The returned candidates carry raw `:code` (the driver re-checks +
+   selects); the proposer's internal check decides only whether to revise.
+
+   opts:
+     :call-llm     (fn [{:system :prompt :n :temperature :max_tokens :seed}]
+                       -> {:completions [str ...] ...})   REQUIRED (inject `call-server`,
+                   or a mock in tests).
+     :task-desc    natural-language description of the data/goal (no structure given away)
+     :observations the {:addr value} data, rendered into the prompt + used for the check
+     :k            samples per generation call (default 4)
+     :temperature  sampling temperature (default 0.7)
+     :max-tokens   per-sample cap (default 384)
+     :revise       max self-correction re-prompts when no candidate scores (default 0 =
+                   no revision — a pure best-of-K-per-step proposer)
+     :n-particles  IS particles for the internal revise-decision check (default 2000)
+     :system       system prompt (default the DSL reference above)
+     :seed         RNG seed for the worker (reproducible; default 1)
+
+   The current model rendered into the prompt is `(:code feedback)` (the check node
+   records it) falling back to `(syn/render spec)`; on a revision round it is the
+   most-progressed FAILED candidate's own code + the error it hit, so the model fixes
+   its own attempt."
+  [{:keys [call-llm task-desc observations k temperature max-tokens system seed revise n-particles]
+    :or {k 4 temperature 0.7 max-tokens 384 seed 1 revise 0 n-particles 2000}}]
+  (let [sys (or system default-system)]
+    (fn [spec feedback]
+      (loop [r       0
+             cur     (or (:code feedback) (syn/render spec))
+             prompt-fb feedback
+             seen    #{}
+             acc     []]
+        (let [prompt  (step-prompt task-desc observations cur prompt-fb)
+              resp    (call-llm {:system sys :prompt prompt :n k :temperature temperature
+                                 :max_tokens max-tokens :seed (+ seed (* 1000 r))})
+              fresh   (remove #(seen (:code %)) (completions->candidates (:completions resp) spec))
+              checked (mapv (fn [c] (assoc c :feedback (syn/check (:code c) observations {:n-particles n-particles})
+                                           :revised? (pos? r)))
+                            fresh)
+              acc'    (into acc checked)
+              scored  (filter #(syn/scored? (:feedback %)) checked)]
+          (if (or (seq scored) (>= r revise) (empty? checked))
+            ;; done: a candidate scores, budget exhausted, or nothing new to revise.
+            ;; Strip the internal :feedback (the driver re-checks + selects).
+            (mapv #(dissoc % :feedback) acc')
+            ;; revise: re-prompt the most-progressed failed candidate with its own error.
+            (let [worst (last (sort-by (comp progress-level :feedback) checked))]
+              (recur (inc r) (:code worst) (:feedback worst)
+                     (into seen (map :code checked)) acc'))))))))
+
+(defn one-shot-candidates
+  "The best-of-K CONTROL: K full programs from the SAME model + DSL prompt with NO
+   feedback loop. Returns [{:code ...} ...] for the probe to `check`-score and rank — the
+   baseline the LLM-in-the-loop must beat. (`:spec'` defaults to nil; the probe scores
+   `:code` directly.)"
+  [{:keys [call-llm task-desc observations k temperature max-tokens system seed]
+    :or {k 16 temperature 0.8 max-tokens 384 seed 1}}]
+  (let [resp (call-llm {:system (or system default-system)
+                        :prompt (oneshot-prompt task-desc observations)
+                        :n k :temperature temperature :max_tokens max-tokens :seed seed})]
+    (mapv (fn [code] {:code code}) (extract-distinct (:completions resp)))))
+
+;; ===========================================================================
+;; 6. call-server — the out-of-process mlx-lm bridge (the sole I/O boundary)
+;; ===========================================================================
+
+(def ^:private cp (js/require "child_process"))
+(def ^:private fs (js/require "fs"))
+(def ^:private os (js/require "os"))
+(def ^:private node-path (js/require "path"))
+(def ^:private req-counter (atom 0))
+
+(defn call-server
+  "Synchronous POST <url>/generate with the request map (`{:system :prompt :n
+   :temperature :max_tokens :seed}`); returns the parsed worker response
+   `{:completions [...] :gen-time-s :prompt-tokens :completion-tokens :model}`.
+
+   Blocking (execSync + curl): the synthesis driver is synchronous, and the resident
+   policy LLM is a genuine out-of-process I/O boundary. The body is written to a temp
+   file (the prompt is paren/quote/newline-heavy — shell-hostile). On any transport error
+   returns `{:completions [] :error msg}` so the loop degrades gracefully (no candidates
+   -> the driver plateaus) instead of throwing."
+  [url req]
+  (let [tmp (.join node-path (.tmpdir os)
+                   (str "genmlx-llm-req-" (.-pid js/process) "-" (swap! req-counter inc) ".json"))]
+    (try
+      (.writeFileSync fs tmp (js/JSON.stringify (clj->js req)))
+      (let [cmd (str "curl -s --max-time 900 -X POST " url "/generate "
+                     "-H 'content-type: application/json' --data-binary @" tmp)
+            out (.execSync cp cmd #js {:encoding "utf8" :maxBuffer (* 64 1024 1024)})]
+        (js->clj (js/JSON.parse out) :keywordize-keys true))
+      (catch :default e {:completions [] :error (.-message e)})
+      (finally (try (.unlinkSync fs tmp) (catch :default _ nil))))))

--- a/src/genmlx/world/repl_corpus.cljs
+++ b/src/genmlx/world/repl_corpus.cljs
@@ -1,0 +1,94 @@
+(ns genmlx.world.repl-corpus
+  "Phase 3 (genmlx-oexl), done-means #1: harvest the GFI/REPL trace of a SUCCESSFUL loop
+   run into an SFT corpus that teaches the *propose-eval-revise POLICY* — given a partial
+   model + the verifier's feedback, produce the good next edit — NOT whole programs (the
+   distinction the north star rests on: §12 showed the loop's value is the policy, and a
+   cheap 0.8B SFT'd on whole programs can't drive the loop; this corpus is what fixes that).
+
+   THE TRACE OF A GOOD RUN *IS* THE CORPUS. Each accepted step transition (model_i,
+   feedback_i) → model_{i+1} becomes one chat row whose user turn is exactly the step-prompt
+   the proposer saw and whose assistant turn is the edit that improved the exact evidence.
+   So the student learns to imitate the loop's accepted moves (including, on the harder
+   models, the structure→refine sequence the 35B teacher produced).
+
+   NATIVE-FREE: reuses the proposer's prompt builders (`genmlx.world.llm-proposer`) and the
+   four-level `check` node (`genmlx.world.synth`) — no model loads here. Rows match
+   `genmlx.world.sft`'s chat-row shape (`{:task-id :kind :messages}`), so sft_prep /
+   sft_train / sft_eval consume them unchanged, and the SAME leakage-guarded task split
+   applies (the rrps lesson: split at the TASK level, before training).
+
+   Sections:
+     1. trajectory->rows — one successful run's accepted transitions → SFT rows
+     2. build-corpus — many (task, trajectory) runs → rows + a leakage-safe report"
+  (:require [genmlx.world.synth :as syn]
+            [genmlx.world.llm-proposer :as lp]
+            [genmlx.world.sft :as sft]))
+
+;; ===========================================================================
+;; 1. trajectory->rows
+;; ===========================================================================
+
+(defn trajectory->rows
+  "A successful run's trajectory (a vector of accepted states, each at least `{:code ...}`,
+   step 0 = the crude init) + its `task` ({:id :task-desc :observations}) → SFT rows, one
+   per step TRANSITION i→i+1:
+     system    = the DSL prompt (genmlx.world.llm-proposer/default-system)
+     user      = the step-prompt the proposer SAW at step i: task + data + model_i + the
+                 verifier's feedback on model_i (re-derived by `check`, so it is exactly
+                 what conditioned the real proposal)
+     assistant = the model ACCEPTED at step i+1 (fenced — what extract-form expects)
+
+   ORACLE FILTER: a transition is kept only when model_{i+1} scores AND strictly improves
+   model_i's evidence (or model_i was unscored and model_{i+1} scores). An accepted step is
+   improving by construction, but re-verifying makes the corpus self-consistent and lets
+   this run over ANY trajectory source (e.g. a re-loaded artifact) — never trusting a label."
+  ([task trajectory] (trajectory->rows task trajectory {}))
+  ([{:keys [id task-desc observations]} trajectory {:keys [n-particles] :or {n-particles 2000}}]
+   (let [steps (vec trajectory)
+         chk   (fn [code] (when code (syn/check code observations {:n-particles n-particles})))]
+     (vec
+      (for [i (range (dec (count steps)))
+            :let [code-i  (:code (nth steps i))
+                  code-i1 (:code (nth steps (inc i)))
+                  fb-i    (chk code-i)
+                  fb-i1   (chk code-i1)]
+            :when (and code-i code-i1 fb-i fb-i1
+                       (syn/scored? fb-i1)
+                       (or (not (syn/scored? fb-i))
+                           (> (:evidence fb-i1) (:evidence fb-i))))]
+        {:task-id  (name id)
+         :kind     :repl-edit
+         :rank-key (:evidence fb-i1)
+         :messages [{:role "system"    :content lp/default-system}
+                    {:role "user"      :content (lp/step-prompt task-desc observations code-i fb-i)}
+                    {:role "assistant" :content (str "```clojure\n" code-i1 "\n```")}]})))))
+
+;; ===========================================================================
+;; 2. build-corpus
+;; ===========================================================================
+
+(defn build-corpus
+  "Harvest many successful runs into one REPL-edit corpus. `runs` is a seq of
+   `{:task {:id :task-desc :observations} :trajectory [...]}`. Returns
+     {:rows [...]                 ; ALL harvested transition rows
+      :train-rows [...]           ; rows whose task is NOT held out (sft/eval-task-ids or
+                                  ;   the supplied `eval-ids`) — the leakage-safe training set
+      :dropped-eval [...]         ; rows dropped because their task is held out
+      :n-runs n :n-rows n :per-task {task-id count} :train-task-ids #{...}}
+
+   The held-out split is applied at the TASK level via genmlx.world.sft/partition-corpus,
+   so a student trained on `:train-rows` is graded only on tasks it never saw — the same
+   leakage guarantee the distill→SFT pipeline enforces."
+  ([runs] (build-corpus runs {}))
+  ([runs {:keys [n-particles eval-ids] :or {n-particles 2000}}]
+   (let [rows (vec (mapcat (fn [{:keys [task trajectory]}]
+                             (trajectory->rows task trajectory {:n-particles n-particles}))
+                           runs))
+         part (if eval-ids (sft/partition-corpus rows eval-ids) (sft/partition-corpus rows))]
+     {:rows rows
+      :train-rows (:train-rows part)
+      :dropped-eval (:dropped-eval part)
+      :n-runs (count runs)
+      :n-rows (count rows)
+      :per-task (frequencies (map :task-id rows))
+      :train-task-ids (:train-task-ids part)})))

--- a/src/genmlx/world/search.cljs
+++ b/src/genmlx/world/search.cljs
@@ -76,7 +76,10 @@
                      (if expand-k (take expand-k cs) cs))
           cur-ev   (or (:evidence p) ##-Inf)
           children (for [c cands
-                         :let [code (syn/render (:spec' c))
+                         ;; a candidate may carry raw `:code` (a real-LLM proposer emits
+                         ;; the program text directly — genmlx.world.llm-proposer); check
+                         ;; it VERBATIM so DSL slips reach the check node. Else render :spec'.
+                         :let [code (or (:code c) (syn/render (:spec' c)))
                                fb   (syn/check code observations opts)]
                          :when (syn/scored? fb)]
                      {:spec (:spec' c) :feedback fb :evidence (:evidence fb) :done? false

--- a/src/genmlx/world/search.cljs
+++ b/src/genmlx/world/search.cljs
@@ -1,0 +1,300 @@
+(ns genmlx.world.search
+  "Phase 2 of the north star (milestone genmlx-77vv, bean genmlx-47zx): turn the greedy
+   Phase-1 kernel into a PARTICLE SEARCH over construction steps. The best-of-K wrapper
+   moves to the STEP level, where the oracle signal is dense (experiment A): instead of
+   one greedy state that commits to the single best edit, keep a POPULATION of partial
+   models and resample/beam them by INTERMEDIATE model evidence — SMC over construction
+   steps, not whole programs.
+
+   WHY (the Phase-1 limitation it fixes). Greedy commits to the first improving
+   STRUCTURAL move and cannot reconsider it (Phase-1 linreg locked into the no-intercept
+   branch). A population explores competing branches in parallel; a wider beam keeps both
+   the no-intercept and full-intercept linreg branches alive and lets the exact oracle
+   pick the global winner. It is also the right tool for the NOISY-evidence regime (the
+   IS-scored GMM): a single greedy importance-sampling draw oscillates, a population
+   averages it out.
+
+   Builds entirely on genmlx.world.synth — same model-spec, same edit ops, the same
+   four-level `check` node and exact oracle, the same INJECTED proposer
+   `(fn [spec feedback] -> [candidate ...])`. Native-free; the proposer here is the
+   structured move-vocabulary (native particles); an LLM proposer is a drop-in (Phase 3).
+
+   Sections:
+     1. Particles — a partial-model trajectory as a search state
+     2. Expansion — propose K edits per particle, render + check + keep the improving
+     3. Selection — :beam (deterministic top-B) | :smc (resample by evidence) + dedup
+     4. Adaptive allocation — wider beam on ambiguous (close-evidence) steps
+     5. search — the population loop (stop when the whole population plateaus)
+     6. backtrack-refine — deterministic backtracking (best-first re-search over a trajectory)"
+  (:require [genmlx.world.synth :as syn]))
+
+;; ===========================================================================
+;; 1. Particles — a partial-model trajectory as a search state
+;;
+;; A particle carries its current spec, the check feedback, its evidence (nil until
+;; scored), a :done? flag (set once no proposed edit improves it), and its trajectory
+;; (one row per accepted state — each row keeps its :spec so backtrack can re-open it).
+;; ===========================================================================
+
+(defn- init-particle
+  [spec observations opts]
+  (let [code (syn/render spec)
+        fb   (syn/check code observations opts)]
+    {:spec spec :feedback fb :evidence (:evidence fb) :done? false
+     :trajectory [{:step 0 :edit :init :desc "crude covering model" :code code
+                   :evidence (:evidence fb) :method (:method fb) :delta nil :spec spec}]}))
+
+(defn- deterministic-method?
+  [fb] (contains? #{:exact :kalman} (:method fb)))
+
+(defn- particle-rank
+  "Ascending sort key: deterministically-scored particles first (an exact marginal
+   never loses to a noisy IS estimate), then higher evidence, then — among genuine
+   evidence ties (e.g. two routes to the same program in dedup) — a LIVE particle
+   before a :done? one, then shorter trajectory (Occam tie-break)."
+  [p]
+  [(if (deterministic-method? (:feedback p)) 0 1)
+   (- (or (:evidence p) ##-Inf))
+   (if (:done? p) 1 0)
+   (count (:trajectory p))])
+
+(defn- particle-code [p] (syn/render (:spec p)))
+
+;; ===========================================================================
+;; 2. Expansion — propose K edits per particle, render + check, keep the improving
+;; ===========================================================================
+
+(defn- expand
+  "Expand one particle: render+check up to `expand-k` proposed candidate edits and keep
+   the ones that are valid AND improve the particle's evidence beyond :plateau-eps. If
+   none improves, the particle STAYS (returned once, marked :done?) — so a plateaued
+   particle persists in the beam as a terminal until the whole population is done."
+  [p propose observations {:keys [plateau-eps expand-k] :or {plateau-eps 0.05} :as opts}]
+  (if (:done? p)
+    [p]
+    (let [cands    (let [cs (propose (:spec p) (:feedback p))]
+                     (if expand-k (take expand-k cs) cs))
+          cur-ev   (or (:evidence p) ##-Inf)
+          children (for [c cands
+                         :let [code (syn/render (:spec' c))
+                               fb   (syn/check code observations opts)]
+                         :when (syn/scored? fb)]
+                     {:spec (:spec' c) :feedback fb :evidence (:evidence fb) :done? false
+                      :trajectory (conj (:trajectory p)
+                                        {:step (count (:trajectory p)) :edit (:edit c) :desc (:desc c)
+                                         :code code :evidence (:evidence fb) :method (:method fb)
+                                         :delta (when (:evidence p) (- (:evidence fb) (:evidence p)))
+                                         :spec (:spec' c)})})
+          improving (filter #(> (:evidence %) (+ cur-ev plateau-eps)) children)]
+      (if (seq improving)
+        improving
+        [(assoc p :done? true)]))))
+
+;; ===========================================================================
+;; 3. Selection — :beam (deterministic top-B) | :smc (resample) + dedup
+;; ===========================================================================
+
+(defn- dedup-pool
+  "Collapse particles whose current program renders identically to one (best-ranked)
+   particle — the same partial model is the same search state, however it was reached."
+  [pool]
+  (->> pool
+       (group-by particle-code)
+       vals
+       (mapv #(first (sort-by particle-rank %)))))
+
+(defn- select-beam
+  "Deterministic top-`width` particles by particle-rank."
+  [pool width]
+  (vec (take width (sort-by particle-rank pool))))
+
+;; A tiny pure LCG so :smc resampling (and the stochastic-proposer experiment) is
+;; reproducible without touching js/Math.random (which nbb can't seed in required nses).
+(defn- lcg-next [s] (mod (+ (* 1103515245 s) 12345) 2147483648))
+(defn- uniforms [seed n]
+  (loop [s (lcg-next (+ seed 1)), i 0, acc []]
+    (if (>= i n) acc (recur (lcg-next s) (inc i) (conj acc (/ s 2147483648.0))))))
+
+(defn- softmax [xs temp]
+  (let [t  (max temp 1e-6)
+        m  (apply max xs)
+        es (map #(js/Math.exp (/ (- % m) t)) xs)
+        z  (reduce + es)]
+    (map #(/ % z) es)))
+
+(defn- weighted-pick [items weights u]
+  (loop [is items, ws weights, acc 0.0]
+    (let [acc' (+ acc (first ws))]
+      (if (or (empty? (rest is)) (<= u acc')) (first is) (recur (rest is) (rest ws) acc')))))
+
+(defn- select-smc
+  "Resample `width` UNIQUE particles from the pool with replacement, proportional to
+   softmax(evidence / temperature), then dedup — SMC's stochastic exploration biased to
+   high-evidence branches. Deterministically-scored particles get a small weight bonus
+   so a noisy IS draw cannot crowd out an exact one. Reproducible via `seed`."
+  [pool width seed temperature]
+  (let [pool (dedup-pool pool)]
+    (if (<= (count pool) width)
+      (vec pool)
+      (let [evs  (mapv (fn [p] (+ (or (:evidence p) ##-Inf)
+                                  (if (deterministic-method? (:feedback p)) 1.0 0.0))) pool)]
+        (if (every? #(= ##-Inf %) evs)
+          ;; no particle scored — softmax would be all-NaN; fall back to a deterministic
+          ;; top-width by rank rather than feed NaN weights to weighted-pick.
+          (vec (take width (sort-by particle-rank pool)))
+          (let [ws    (softmax evs temperature)
+                us    (uniforms seed (* 3 width))
+                picks (->> us (map #(weighted-pick pool ws %)) distinct (take width))]
+            (vec (if (seq picks) picks (take width (sort-by particle-rank pool))))))))))
+
+;; ===========================================================================
+;; 4. Adaptive allocation — wider beam on ambiguous (close-evidence) steps
+;; ===========================================================================
+
+(defn- pool-spread
+  "Evidence gap between the best and 2nd-best DISTINCT-program particle in the pool. A
+   small gap = an ambiguous step (competing structures score alike -> widen the beam to
+   keep them); a large gap = one move dominates (narrow). ##Inf when <2 distinct."
+  [pool]
+  (let [evs (->> (dedup-pool pool) (keep :evidence) sort reverse)]
+    (if (>= (count evs) 2) (- (first evs) (second evs)) ##Inf)))
+
+(defn- adapt-width
+  "Resource-rational beam width for this step: spend MORE particles when the top
+   candidates are within :spread-margin (uncertain/structural), fewer when one dominates."
+  [base spread {:keys [min-width max-width spread-margin]
+                :or {min-width 1 max-width 6 spread-margin 1.0}}]
+  (cond
+    (< spread spread-margin) (max base max-width)
+    (> spread (* 3 spread-margin)) (max min-width (min base 2))
+    :else base))
+
+;; ===========================================================================
+;; 5. search — the population loop
+;; ===========================================================================
+
+(declare backtrack-refine)
+
+(defn search
+  "Particle/beam search over construction steps. Maintains a population of partial-model
+   particles; each step expands every non-done particle by its proposed edits, dedups,
+   adaptively allocates the beam width, and selects the next population (:beam top-B or
+   :smc resampling). Stops when the WHOLE population has plateaued (no particle improves)
+   or :max-steps is reached.
+
+   opts:
+     :init-spec     the crude covering model to start from (or :init-specs for many)
+     :observations  {:addr value ...} the data the oracle scores against
+     :propose       (fn [spec feedback] -> [{:edit :desc :spec'} ...])  (injected)
+     :beam-width    base population size B (default 4)
+     :expand-k      max candidate edits considered per particle per step (default all)
+     :strategy      :beam (deterministic top-B, default) | :smc (resample by evidence)
+     :adaptive?     adapt the beam width to the per-step evidence spread (default true)
+     :backtrack?    after the population plateaus, run backtrack-refine on the best
+                    particle to escape a lock-in (default false)
+     :min-width :max-width :spread-margin   adaptive-width bounds + the evidence-spread
+                    threshold below which a step is treated as ambiguous (widen the beam)
+     :max-steps :plateau-eps :n-particles :temperature :seed   (search controls)
+
+   Returns {:best :population :trajectory :steps :stop-reason :diagnostics} where :best
+   is the highest-evidence particle ever seen (method-aware) and :trajectory is its
+   development trace; :diagnostics is one row per step (width, spread, best-evidence)."
+  [{:keys [init-spec init-specs observations propose beam-width expand-k strategy
+           adaptive? backtrack? max-steps plateau-eps n-particles temperature seed
+           min-width max-width spread-margin]
+    :or   {beam-width 4 strategy :beam adaptive? true backtrack? false
+           max-steps 16 plateau-eps 0.05 n-particles 2000 temperature 0.5 seed 1}}]
+  (let [opts  {:plateau-eps plateau-eps :n-particles n-particles :expand-k expand-k}
+        awopts {:min-width (or min-width 1) :max-width (or max-width (* 2 beam-width))
+                :spread-margin (or spread-margin 1.0)}
+        pop0  (mapv #(init-particle % observations opts)
+                    (or init-specs [init-spec]))
+        better (fn [a b] (if (neg? (compare (particle-rank a) (particle-rank b))) a b))]
+    (loop [pop  pop0
+           t    0
+           best (reduce better (first pop0) (rest pop0))
+           diag []]
+      (let [all-done? (every? :done? pop)]
+        (if (or all-done? (>= t max-steps))
+          (let [final-best best
+                refined (when (and backtrack? (syn/scored? (:feedback final-best)))
+                          (backtrack-refine final-best observations propose
+                                            (assoc opts :max-steps max-steps :plateau-eps plateau-eps)))
+                best' (if (:improved? refined) (:result refined) final-best)]
+            {:best best' :population pop :trajectory (:trajectory best')
+             :steps t :stop-reason (if all-done? :plateau :max-steps)
+             :diagnostics diag
+             :backtrack (when refined (dissoc refined :result))})
+          (let [pool    (dedup-pool (vec (mapcat #(expand % propose observations opts) pop)))
+                spread  (pool-spread pool)
+                width   (if adaptive? (adapt-width beam-width spread awopts) beam-width)
+                pop'    (if (= strategy :smc)
+                          (select-smc pool width (+ seed t) temperature)
+                          (select-beam pool width))
+                ;; track the global best over the FULL pre-selection pool, not just the
+                ;; selected pop' — :smc resampling (or a narrow beam) can drop the best
+                ;; particle from the active population, but it must never be lost.
+                best'   (reduce better best pool)
+                row     {:t (inc t) :pool (count pool) :width width
+                         :spread (when (js/isFinite spread) spread)
+                         :best-evidence (:evidence best') :n-done (count (filter :done? pop'))}]
+            (recur pop' (inc t) best' (conj diag row))))))))
+
+;; ===========================================================================
+;; 6. backtrack-refine — deterministic backtracking (best-first re-search) over a trajectory
+;;
+;; The design's "backtracking = reconsider an earlier decision given later feedback"
+;; (genmlx-47zx). OPERATIONAL realization: for each earlier decision point in the best
+;; particle's trajectory, re-open it — take a ROAD NOT TAKEN (an alternative proposed
+;; edit ≠ the one originally accepted) from the spec BEFORE that step, greedy-continue
+;; it, and keep the best-evidence result. This lets even a NARROW search (beam-width 1 =
+;; greedy) escape a structural lock-in (e.g. the Phase-1 linreg no-intercept commitment).
+;; It is DETERMINISTIC best-first re-search, NOT MCMC (no stochastic accept/reject); it
+;; operates on the trajectory directly rather than through a materialized programmer-GF +
+;; GenMLX p/regenerate (the stochastic regenerate move — the §2 fixpoint, deferred).
+;; ===========================================================================
+
+(defn- greedy-from
+  "Greedy continuation from `spec`: beam-width 1, no adaptation/backtrack — the Phase-1
+   driver expressed in the search loop, used as the re-proposal continuation."
+  [spec observations propose opts]
+  (:best (search (merge opts {:init-spec spec :observations observations :propose propose
+                              :beam-width 1 :adaptive? false :backtrack? false}))))
+
+(defn backtrack-refine
+  "Re-open each earlier decision in `particle`'s trajectory: at each step take a road
+   NOT taken (an alternative proposed edit ≠ the one originally accepted) from the spec
+   BEFORE that step, greedy-continue it, and keep the best result (method-aware rank —
+   an exact alternative never loses to a noisy IS one). Taking the alternative — not
+   re-running greedy, which would re-commit to the same locally-best move — is what
+   escapes a step-1 structural lock-in. The returned :result's :trajectory SPLICES the
+   original prefix in front of the re-search continuation (with the re-opened edit
+   relabeled :reopened?), so it reads as the full development path, not a fresh run.
+   Returns {:improved? :result :from :to :reopened-at}; :result is the better particle,
+   or the original when nothing beats it."
+  [particle observations propose opts]
+  (let [traj  (:trajectory particle)
+        alts  (for [t     (range 1 (count traj))
+                    :let  [prefix    (:spec (nth traj (dec t)))
+                           prefix-fb (syn/check (syn/render prefix) observations opts)
+                           taken     (:code (nth traj t))]
+                    c     (propose prefix prefix-fb)
+                    :let  [alt-spec (:spec' c)
+                           alt-code (syn/render alt-spec)]
+                    :when (not= alt-code taken)            ; a road not taken at step t
+                    :let  [res (greedy-from alt-spec observations propose opts)]
+                    :when (syn/scored? (:feedback res))]
+                {:res res :reopened-at t :edit (:edit c) :desc (:desc c)
+                 :prefix-rows (subvec traj 0 t)})
+        best  (first (sort-by (comp particle-rank :res) alts))]
+    (if (and best
+             (> (or (:evidence (:res best)) ##-Inf)
+                (+ (or (:evidence particle) ##-Inf) (or (:plateau-eps opts) 0.05))))
+      (let [res      (:res best)
+            cont     (:trajectory res)                       ; re-search path (cont[0] = its :init)
+            reopened (assoc (first cont) :edit (:edit best) :desc (:desc best) :reopened? true)
+            rows     (into (vec (:prefix-rows best)) (cons reopened (rest cont)))
+            spliced  (vec (map-indexed (fn [i r] (assoc r :step i)) rows))]
+        {:improved? true :result (assoc res :trajectory spliced)
+         :from (:evidence particle) :to (:evidence res) :reopened-at (:reopened-at best)})
+      {:improved? false :result particle})))

--- a/src/genmlx/world/sft.cljs
+++ b/src/genmlx/world/sft.cljs
@@ -106,7 +106,10 @@
                                        the teacher only generated over train tasks)"
   ([rows] (partition-corpus rows eval-task-ids))
   ([rows eval-ids]
-   (let [{train true dropped false} (group-by #(train-task? (:task-id %)) rows)]
+   ;; group on `eval-ids` directly (NOT the hardcoded train-task?), so a custom
+   ;; held-out set — e.g. the scaled genmlx.world.distill-gen eval ids — is honored.
+   (let [train? (fn [r] (not (contains? eval-ids (:task-id r))))
+         {train true dropped false} (group-by train? rows)]
      {:train-rows            (vec train)
       :dropped-eval          (vec dropped)
       :train-task-ids        (into (sorted-set) (map :task-id) train)

--- a/src/genmlx/world/synth.cljs
+++ b/src/genmlx/world/synth.cljs
@@ -333,10 +333,14 @@
 ;; ===========================================================================
 
 (defn- score-candidates
-  "Render + check every proposed candidate against the observations."
+  "Render + check every proposed candidate against the observations. A candidate may
+   carry a raw `:code` string (a real-LLM proposer emits the program text directly — see
+   genmlx.world.llm-proposer); that raw code is checked VERBATIM so the LLM's DSL slips
+   reach the check node exactly as written. Otherwise the code is rendered from `:spec'`
+   (the structured-proposer path)."
   [candidates observations opts]
   (for [c candidates
-        :let [code (render (:spec' c))
+        :let [code (or (:code c) (render (:spec' c)))
               fb   (check code observations opts)]]
     (assoc c :code code :feedback fb :evidence (:evidence fb))))
 
@@ -395,8 +399,12 @@
                    :method (:method init-fb) :delta nil :accepted? true
                    :n-candidates 0}]]
       (if (>= t max-steps)
-        {:spec (:spec state) :code (render (:spec state)) :feedback (:feedback state)
-         :trajectory traj :stop-reason :max-steps :steps t}
+        ;; report the VERBATIM checked code (the feedback's :code — what actually scored);
+        ;; falls back to render. For the structured proposer these are identical (the spec
+        ;; round-trips); for a real-LLM proposer the verbatim code is authoritative even if
+        ;; its parsed :spec' is an imperfect round-trip (genmlx.world.llm-proposer).
+        {:spec (:spec state) :code (or (:code (:feedback state)) (render (:spec state)))
+         :feedback (:feedback state) :trajectory traj :stop-reason :max-steps :steps t}
         (let [cands (vec (propose (:spec state) (:feedback state)))
               {:keys [best improved?]} (step state cands observations opts)]
           (if-not improved?
@@ -404,8 +412,8 @@
             ;; :stuck = the current state never reached a finite evidence AND no valid
             ;; candidate did either (a structurally-incomplete init the proposer could
             ;; not complete) — NOT a fitted plateau, so report it distinctly.
-            {:spec (:spec state) :code (render (:spec state)) :feedback (:feedback state)
-             :trajectory traj :steps t
+            {:spec (:spec state) :code (or (:code (:feedback state)) (render (:spec state)))
+             :feedback (:feedback state) :trajectory traj :steps t
              :stop-reason (if (scored? (:feedback state)) :plateau :stuck)}
             (let [prev-ev (:evidence (:feedback state))
                   delta   (when (and prev-ev (:evidence best)) (- (:evidence best) prev-ev))]

--- a/src/genmlx/world/synth.cljs
+++ b/src/genmlx/world/synth.cljs
@@ -1,0 +1,464 @@
+(ns genmlx.world.synth
+  "Phase 1 of the north star (beans genmlx-77vv / genmlx-n74t): the minimal
+   REPL-driven program-synthesis KERNEL — *the programmer as a GenMLX model*.
+
+   THE IDEA (docs/programmer-as-genmlx-model.md). Whole-program one-shot best-of-K
+   CLIFFS to ~0/16 on advanced models (linreg/hier/gmm/kalman) for BOTH a 0.8B AND a
+   35B teacher — it is the one-shot INTERFACE, not capability (each failure is a
+   one-eval-away DSL slip on a structurally-correct model). The lever is the closed
+   FEEDBACK loop a generic code LLM lacks: GenMLX gives (a) exact per-PARTIAL model
+   evidence (a calibrated model-selection gradient — experiment A) and (b) in-process
+   SCI eval (parse/eval/error/value per step). So synthesis becomes: build the model
+   INCREMENTALLY by small edits, CHECK each partial with the exact oracle, and let the
+   oracle SELECT which edit to keep and WHEN to stop (add structure while evidence
+   climbs, stop on plateau — self-terminating, resource-rational).
+
+   THIS NAMESPACE IS NATIVE-FREE. Like its siblings genmlx.world.distill and
+   genmlx.world.train-reward it reuses the same oracle spine — codegen.eval (edamame
+   reader + SCI) and msa-score (Bayesian model evidence) — and never loads the policy
+   LLM. The proposer is INJECTED as a plain `(fn [spec feedback] -> [candidate ...])`,
+   so the driver is identical whether the proposer is the structured move-vocabulary
+   used to isolate the loop (experiment B) or a real LLM wired in by a caller.
+
+   DIVISION OF LABOUR ACROSS THE PHASES (kept honest here):
+     - Phase 1 (this) proves the LOOP: the four-level self-check, the form-level edit
+       ops, and a greedy oracle-driven driver that climbs evidence and self-terminates.
+       The proposer's move VOCABULARY is provided.
+     - Phase 2 SEARCHES that vocabulary (SMC/beam over construction steps).
+     - Phase 3 LEARNS the proposer (REPL-trace SFT + GRPO on the 0.8B).
+     - Phase 4 is the metareasoner (genmlx.control) over the control sites.
+
+   A NOTE ON GFI edit/CompositeEdit. genmlx.edit's edits (Constraint/Selection/
+   ArgsUpdate/Proposal/Composite) rewrite a *trace* of a FIXED model and carry a GFI
+   weight; they are the inference-time analog. Building the MODEL itself changes the
+   program's SOURCE FORM, a different layer — so the construction edits here are
+   form-level (the homoiconic 'code is data' path, design-doc §5), not trace edits.
+
+   Sections:
+     1. Model spec — a partial GenMLX program as data
+     2. Rendering — spec -> a (fn [trace] ...) code string
+     3. Edit operations — pure spec -> spec moves (the typed action space)
+     4. The check node — the four-level self-check (the programmer's senses)
+     5. The greedy REPL driver — propose -> check -> accept / backtrack / stop
+     6. Proposer helpers — generic parameter-refinement moves + combinators"
+  (:require [genmlx.llm.msa-score :as score]
+            [genmlx.codegen.eval :as ce]
+            [genmlx.world.train-reward :as reward]
+            [genmlx.schema :as schema]
+            [clojure.string :as str]))
+
+;; ===========================================================================
+;; 1. Model spec — a partial GenMLX program as data
+;;
+;; A partial model is a VALUE: an ordered list of latent trace sites (rendered as
+;; let-bindings) and an ordered list of observation trace sites (rendered as the
+;; returned map). A SITE is data: an address keyword, a distribution name, and a
+;; vector of argument FORMS (numbers, latent-referencing symbols, or s-expressions
+;; — code is data). A latent additionally carries the :sym other sites reference.
+;;
+;;   latent {:sym 'slope :addr :slope :dist "gaussian" :args [0 3]}
+;;   obs    {:addr :y0    :dist "gaussian"
+;;           :args [(list 'mx/add (list 'mx/multiply 'slope (list 'mx/scalar 0.0))
+;;                        'intercept) 1]}
+;;   spec   {:latents [latent ...] :obs [obs ...]}
+;; ===========================================================================
+
+(defn latent
+  "A latent trace site (a let-binding). `sym` is the binding symbol later sites
+   reference; `addr` its trace address (defaults to (keyword sym)); `dist` the
+   distribution constructor name (string, e.g. \"gaussian\"); `args` a vector of
+   argument forms."
+  ([sym dist args] (latent sym (keyword sym) dist args))
+  ([sym addr dist args] {:sym sym :addr addr :dist dist :args (vec args)}))
+
+(defn obs
+  "An observation trace site (an entry in the returned map). `addr` the observed
+   address; `dist` the distribution name; `args` a vector of argument forms (the
+   first is the mean expression, the last the noise scale, by GenMLX convention)."
+  [addr dist args]
+  {:addr addr :dist dist :args (vec args)})
+
+(defn spec
+  "Assemble a model spec from a seq of latents and a seq of obs sites."
+  [latents obs-sites]
+  {:latents (vec latents) :obs (vec obs-sites)})
+
+(defn site-by-addr
+  "Find the [collection-key index site] of the trace site with `addr`, searching
+   latents then obs, or nil. Used by the edit ops to target a site generically.
+   INVARIANT: latent and obs addresses must be DISJOINT (they share one trace-address
+   namespace, so a collision would render a duplicate address and shadow the obs here).
+   Constructors keep them disjoint by convention (latents :mu/:slope, obs :y*/:a*)."
+  [{:keys [latents obs]} addr]
+  (or (some (fn [[i s]] (when (= addr (:addr s)) [:latents i s]))
+            (map-indexed vector latents))
+      (some (fn [[i s]] (when (= addr (:addr s)) [:obs i s]))
+            (map-indexed vector obs))))
+
+;; ===========================================================================
+;; 2. Rendering — spec -> a (fn [trace] ...) code string
+;;
+;; The rendered string is exactly the shape the oracle expects (and the shape the
+;; advanced-probe reference programs use): (fn [trace] (let [<bindings>] {<obs>})).
+;; Arg forms are emitted with pr-str (a number renders as a literal, a symbol as a
+;; bare name resolving to a let-binding, an s-expression as itself).
+;; ===========================================================================
+
+(defn- render-arg
+  "Render one distribution argument FORM to source text."
+  [a]
+  (pr-str a))
+
+(defn- render-dist
+  "Render a (dist/NAME args...) constructor call from a site's :dist and :args."
+  [{:keys [dist args]}]
+  (str "(dist/" dist
+       (when (seq args) (str " " (str/join " " (map render-arg args))))
+       ")"))
+
+(defn- render-site
+  "Render a (trace :addr (dist/NAME args...)) form for a site."
+  [{:keys [addr] :as site}]
+  (str "(trace " (pr-str addr) " " (render-dist site) ")"))
+
+(defn render
+  "Render a model spec to a complete (fn [trace] (let [...] {...})) code string —
+   the input the check node parses, evals, and scores."
+  [{:keys [latents obs]}]
+  (let [bindings (str/join " " (for [l latents] (str (:sym l) " " (render-site l))))
+        body     (str/join " " (for [o obs] (str (pr-str (:addr o)) " " (render-site o))))]
+    (str "(fn [trace] (let [" bindings "] {" body "}))")))
+
+;; ===========================================================================
+;; 3. Edit operations — pure spec -> spec moves (the typed action space)
+;;
+;; Each op is a pure spec -> spec function: the homoiconic build-up moves the design
+;; doc names. add-latent / add-obs / set-args / set-mean / set-noise are the
+;; load-bearing moves for the advanced models. The named `wrap-combinator` MOVE is
+;; deferred — folding repeated sites into a Map combinator needs the synthesis SCI
+;; sandbox to expose the combinators, and the three exact targets are flat — so this
+;; section ships `homogeneous-obs?`, the pure predicate that DETECTS the fold
+;; opportunity, instead of a rewrite that would render an un-evaluable form.
+;; ===========================================================================
+
+(defn add-latent
+  "Append a latent trace site to the spec (a new let-binding)."
+  [spec lat]
+  (update spec :latents (fnil conj []) lat))
+
+(defn add-obs
+  "Append (or, when `addr` already exists, REPLACE) an observation trace site."
+  [spec ob]
+  (update spec :obs
+          (fn [obs] (let [obs (vec obs)
+                          i   (first (keep-indexed #(when (= (:addr %2) (:addr ob)) %1) obs))]
+                      (if i (assoc obs i ob) (conj obs ob))))))
+
+(defn set-args
+  "Replace the full argument vector of the site at `addr` (latent or obs). The
+   canonical 'set-prior' move on a latent, and the general parameter edit."
+  [spec addr new-args]
+  (if-let [[coll i _] (site-by-addr spec addr)]
+    (assoc-in spec [coll i :args] (vec new-args))
+    spec))
+
+(defn set-mean
+  "Replace the MEAN (first argument) of the site at `addr`, keeping its remaining
+   args. The move that re-points an observation at a latent-dependent mean (e.g.
+   shared-mean -> slope*x+intercept, or pooled -> per-group)."
+  [spec addr mean-form]
+  (if-let [[coll i s] (site-by-addr spec addr)]
+    (assoc-in spec [coll i :args] (assoc (vec (:args s)) 0 mean-form))
+    spec))
+
+(defn set-noise
+  "Replace the NOISE (last argument) of the site at `addr`, keeping its mean. The
+   parameter-refinement move on an observation's scale. Expects a [mean noise] site
+   (>= 2 args); a site with fewer args has no distinct noise slot, so it is left
+   unchanged rather than clobber the mean."
+  [spec addr noise]
+  (if-let [[coll i s] (site-by-addr spec addr)]
+    (let [args (vec (:args s))]
+      (if (< (count args) 2)
+        spec
+        (assoc-in spec [coll i :args] (assoc args (dec (count args)) noise))))
+    spec))
+
+(defn homogeneous-obs?
+  "True iff every observation site shares the same distribution, the same noise (last
+   arg), and the SAME single LATENT symbol as its mean — the precondition for folding
+   them into one Map combinator. A pure QUERY, not a rewrite: the actual fold awaits
+   the synthesis SCI sandbox exposing the combinators (the three advanced targets are
+   heterogeneous + flat, so it is not needed here). Kept honest — it detects the
+   fold opportunity rather than render a combinator form that would not eval."
+  [{:keys [obs latents]}]
+  (let [lat-syms (set (map :sym latents))
+        m0       (first (:args (first obs)))]
+    (boolean (and (seq obs)
+                  (every? #(>= (count (:args %)) 2) obs)
+                  (apply = (map :dist obs))
+                  (apply = (map (comp last :args) obs))
+                  (symbol? m0) (contains? lat-syms m0)
+                  (every? #(= m0 (first (:args %))) obs)))))
+
+;; ===========================================================================
+;; 4. The check node — the four-level self-check (the programmer's senses)
+;;
+;; (partial-program code) -> a feedback map. Four altitudes, each gating the next;
+;; the fitness level is EXACT math, never an LLM-judge:
+;;   syntax    :parses?    edamame reader      — a complete cljs form?
+;;   semantics :schema-ok? GenMLX schema       — a well-formed MODEL? (sites, returns
+;;                                                a map, no delta point-mass hack)
+;;   coverage  :covered?   schema vs data       — every observed addr is a trace site?
+;;   behavior  :evals?/:error  SCI eval         — runs to a DynamicGF / what errored?
+;;   fit       :evidence/:method  the oracle    — Bayesian model evidence of the data
+;; (:delta is relative to a PRIOR accepted state, so it is computed by the driver,
+;; not by a single check.)
+;; ===========================================================================
+
+(defn- uses-delta?
+  "Does the form CALL a `delta` distribution constructor anywhere — a list whose head
+   symbol is `delta` / `dist/delta`? A delta point-mass at an observed site is a
+   degenerate reward-hack (log-evidence ~0 beats any honest noisy fit). Matches only a
+   constructor in HEAD position, so an honest latent/variable merely NAMED `delta` (a
+   common offset/difference name) is NOT rejected — narrower (and more precise) than
+   genmlx.world.distill/form-uses-delta?, which flags any mention of the name."
+  [form]
+  (cond
+    (seq? form)  (or (and (symbol? (first form)) (= "delta" (name (first form))))
+                     (boolean (some uses-delta? form)))
+    (coll? form) (boolean (some uses-delta? form))
+    :else        false))
+
+(defn- result-form
+  "The expression a model body ultimately RETURNS: unwrap let/let*/do wrappers to
+   their tail form (the schema's :return-form is the outer let, whose tail is the
+   observation map)."
+  [form]
+  (if (and (seq? form) (contains? #{'let 'let* 'do} (first form)))
+    (recur (last form))
+    form))
+
+(defn- eval-gf
+  "Eval a model code string to a DynamicGF, CAPTURING any error message (msa-score's
+   eval-model swallows the error to nil). {:gf gf} on success, {:error msg} otherwise."
+  [code]
+  (try
+    (let [f (score/eval-model-fn code)]
+      (if (fn? f)
+        {:gf (score/wrap-model f (score/code->source-form code))}
+        {:error "result is not a (fn [trace] ...) form"}))
+    (catch :default e {:error (.-message e)})))
+
+(defn check
+  "Run the four-level self-check on a candidate partial program against
+   `observations`. Returns a uniform feedback map (every key present, nil where a
+   level was not reached):
+
+     {:code :parses? :schema-ok? :n-sites :returns-map? :uses-delta?
+      :covered? :evals? :error :evidence :method}
+
+   `:evidence` is the exact/IS Bayesian model log-evidence (nil if not scored).
+   opts: {:n-particles n}  importance samples for the non-conjugate IS fallback."
+  ([code observations] (check code observations {}))
+  ([code observations {:keys [n-particles] :or {n-particles 2000}}]
+   (let [code       (str/trim (str code))
+         parses?    (ce/valid-cljs? code)
+         src        (when parses? (score/code->source-form code))
+         sm         (when src (schema/extract-schema src))
+         sites      (:trace-sites sm)
+         site-addrs (set (map :addr sites))
+         returns-map? (boolean (and sm (map? (result-form (:return-form sm)))))
+         delta?     (boolean (when-let [f (ce/parse-form code)] (uses-delta? f)))
+         n-sites    (count sites)
+         schema-ok? (boolean (and src (pos? n-sites) returns-map? (not delta?)))
+         base       {:code code :parses? parses? :schema-ok? schema-ok?
+                     :n-sites n-sites :returns-map? returns-map? :uses-delta? delta?
+                     :covered? false :evals? false :error nil :evidence nil :method nil}]
+     (cond
+       (not parses?)
+       (assoc base :error "does not parse as a complete ClojureScript form")
+
+       (not schema-ok?)
+       (assoc base :error (cond delta?            "uses a delta (point-mass) distribution at a site"
+                                (not returns-map?) "model body does not return an observation map"
+                                (zero? n-sites)    "no trace sites — not a model"
+                                :else              "not a well-formed model form"))
+
+       ;; No data is a misconfiguration, NOT a perfectly-explained model: scoring an
+       ;; empty choicemap returns log p({}) = 0, the best possible evidence, which
+       ;; would dominate any real candidate. Leave it unscored (scored? false).
+       (empty? observations)
+       (assoc base :error "no observations to score against")
+
+       (not (every? site-addrs (keys observations)))
+       (assoc base :error "an observed address is not a trace site (uncovered)")
+
+       :else
+       (let [{:keys [gf error]} (eval-gf code)]
+         (if error
+           (assoc base :covered? true :evals? false :error error)
+           (let [{:keys [log-ml method]} (score/score-model* gf observations {:n-particles n-particles})
+                 ok? (reward/finite? log-ml)]
+             ;; only report :method for a verdict that was VALIDLY scored — do not
+             ;; leak a method label alongside a nil (non-finite) evidence.
+             (assoc base :covered? true :evals? true
+                    :evidence (when ok? log-ml) :method (when ok? method)
+                    :error (when-not ok? "model evidence is non-finite")))))))))
+
+(defn scored?
+  "True iff a check verdict reached a finite model evidence (the only candidates the
+   driver compares / accepts)."
+  [feedback]
+  (and (:evals? feedback) (some? (:evidence feedback))))
+
+;; ===========================================================================
+;; 5. The greedy REPL driver — propose -> check -> accept / backtrack / stop
+;;
+;; A PROPOSER is an injected (fn [spec feedback] -> [candidate ...]) where a
+;; candidate is {:edit <kw> :desc <str> :spec' <spec>} (it is conditioned on the
+;; previous step's feedback, satisfying 'condition each step on verified feedback').
+;; Each step renders + checks every candidate, ACCEPTS the best valid one that
+;; improves evidence beyond :plateau-eps (BACKTRACK = a broken/uncovered candidate is
+;; simply never the max, so the loop steps past it), and STOPS when none improves
+;; (the experiment-A self-terminating rule — 'add while evidence climbs').
+;;
+;; CANDIDATE RANKING is method-aware (mirrors genmlx.world.distill/select-key): an
+;; EXACT/Kalman analytical evidence is reproducible, so it outranks a noisy
+;; importance-sampling estimate that happened to draw high — only then by evidence.
+;; CAVEAT: when the WHOLE search is non-conjugate (every candidate IS-scored), the
+;; greedy accept compares two noisy estimates and can mis-accept / oscillate on a
+;; lucky draw; that regime is Phase-2 SMC territory (a particle population averages
+;; out the noise). The three experiment-B targets are exact, so this does not bite.
+;; ===========================================================================
+
+(defn- score-candidates
+  "Render + check every proposed candidate against the observations."
+  [candidates observations opts]
+  (for [c candidates
+        :let [code (render (:spec' c))
+              fb   (check code observations opts)]]
+    (assoc c :code code :feedback fb :evidence (:evidence fb))))
+
+(defn- deterministic-method?
+  "True iff a verdict's evidence came from a reproducible analytical method (not IS)."
+  [feedback]
+  (contains? #{:exact :kalman} (:method feedback)))
+
+(defn- candidate-rank
+  "Ascending sort key for VALID candidates: deterministically-scored first (an exact
+   marginal never loses to a noisy IS estimate), then higher evidence."
+  [c]
+  [(if (deterministic-method? (:feedback c)) 0 1) (- (:evidence c))])
+
+(defn step
+  "One greedy REPL step from `state` ({:spec :feedback}). Returns
+   {:candidates [...] :best <candidate-or-nil> :improved? bool}: the best VALID
+   candidate (method-aware rank) whose evidence beats the current by more than
+   :plateau-eps, if any."
+  [{:keys [feedback]} candidates observations {:keys [plateau-eps] :or {plateau-eps 0.05} :as opts}]
+  (let [cur-ev (:evidence feedback)
+        scored (score-candidates candidates observations opts)
+        valid  (filter (comp scored? :feedback) scored)
+        best   (first (sort-by candidate-rank valid))]
+    {:candidates scored
+     :best best
+     :improved? (boolean (and best (or (nil? cur-ev)
+                                       (> (:evidence best) (+ cur-ev plateau-eps)))))}))
+
+(defn synthesize
+  "Run the greedy REPL synthesis loop.
+
+   opts:
+     :init-spec     the starting partial model spec (a crude covering model)
+     :observations  {:addr value ...} the data the oracle scores against
+     :propose       (fn [spec feedback] -> [{:edit :desc :spec'} ...])
+     :max-steps     hard cap on accepted edits (default 12)
+     :plateau-eps   min evidence gain to accept an edit / not stop (default 0.05)
+     :n-particles   IS samples for the non-conjugate fallback (default 2000)
+
+   Returns {:spec :code :feedback :trajectory :stop-reason :steps}, where :stop-reason
+   is :plateau (no edit improves a fitted model), :stuck (never reached a scored model)
+   or :max-steps. The trajectory is the development trace: one row per state with the
+   edit taken, the chosen code, its exact evidence, the scoring :method, and the :delta
+   from the prior state — the reportable artifact AND (design-doc §2) the shape of the
+   future SFT corpus."
+  [{:keys [init-spec observations propose max-steps plateau-eps n-particles]
+    :or   {max-steps 12 plateau-eps 0.05 n-particles 2000}}]
+  (let [opts      {:plateau-eps plateau-eps :n-particles n-particles}
+        init-code (render init-spec)
+        init-fb   (check init-code observations opts)]
+    (loop [state {:spec init-spec :feedback init-fb}
+           t     0
+           traj  [{:step 0 :edit :init :desc "crude covering model"
+                   :code init-code :evidence (:evidence init-fb)
+                   :method (:method init-fb) :delta nil :accepted? true
+                   :n-candidates 0}]]
+      (if (>= t max-steps)
+        {:spec (:spec state) :code (render (:spec state)) :feedback (:feedback state)
+         :trajectory traj :stop-reason :max-steps :steps t}
+        (let [cands (vec (propose (:spec state) (:feedback state)))
+              {:keys [best improved?]} (step state cands observations opts)]
+          (if-not improved?
+            ;; :plateau = stopped at a genuinely scored model no edit improves;
+            ;; :stuck = the current state never reached a finite evidence AND no valid
+            ;; candidate did either (a structurally-incomplete init the proposer could
+            ;; not complete) — NOT a fitted plateau, so report it distinctly.
+            {:spec (:spec state) :code (render (:spec state)) :feedback (:feedback state)
+             :trajectory traj :steps t
+             :stop-reason (if (scored? (:feedback state)) :plateau :stuck)}
+            (let [prev-ev (:evidence (:feedback state))
+                  delta   (when (and prev-ev (:evidence best)) (- (:evidence best) prev-ev))]
+              (recur {:spec (:spec' best) :feedback (:feedback best)}
+                     (inc t)
+                     (conj traj {:step (inc t) :edit (:edit best) :desc (:desc best)
+                                 :code (:code best) :evidence (:evidence best)
+                                 :method (:method (:feedback best)) :delta delta
+                                 :accepted? true :n-candidates (count cands)})))))))))
+
+;; ===========================================================================
+;; 6. Proposer helpers — generic parameter-refinement moves + combinators
+;;
+;; These are the structure-NEUTRAL moves any proposer can offer: tune an existing
+;; site's noise / prior over a small grid. A caller composes them with the
+;; (task-shaped, Phase-1-provided) STRUCTURAL moves via `union-proposer`. Phase 2
+;; replaces the provided vocabulary with a search; Phase 3 with a learned LLM.
+;; ===========================================================================
+
+(defn noise-refinements
+  "Candidate edits that set each observation site's noise to each value in `grid` —
+   the parameter-refinement vocabulary. Skips the no-op (current value)."
+  ([spec] (noise-refinements spec [0.3 0.5 0.7 1 1.5 2.5]))
+  ([spec grid]
+   (for [o (:obs spec)
+         g grid
+         :when (not= g (last (:args o)))]
+     {:edit :set-noise :desc (str "set " (:addr o) " noise -> " g)
+      :spec' (set-noise spec (:addr o) g)})))
+
+(defn prior-std-refinements
+  "Candidate edits that set each latent's prior std (its last arg) to each value in
+   `grid` — refines how tightly a latent is regularized."
+  ([spec] (prior-std-refinements spec [1 2 5]))
+  ([spec grid]
+   (for [l (:latents spec)
+         g grid
+         :when (not= g (last (:args l)))]
+     {:edit :set-prior :desc (str "set " (:addr l) " prior-std -> " g)
+      :spec' (set-args spec (:addr l) (assoc (vec (:args l)) (dec (count (:args l))) g))})))
+
+(defn union-proposer
+  "Combine several proposers into one whose candidates are the concatenation of all
+   their candidates (deduped WITHIN a step by rendered code so identical moves are not
+   re-scored). It does not dedup across steps, but that is harmless: a re-offered
+   already-accepted move renders to the current state, so its evidence does not beat
+   the current by :plateau-eps and it is never re-accepted."
+  [& proposers]
+  (fn [spec feedback]
+    (let [cands (mapcat (fn [p] (p spec feedback)) proposers)]
+      (->> cands
+           (reduce (fn [[seen acc] c]
+                     (let [k (render (:spec' c))]
+                       (if (contains? seen k) [seen acc] [(conj seen k) (conj acc c)])))
+                   [#{} []])
+           second))))

--- a/test/genmlx/curriculum_test.cljs
+++ b/test/genmlx/curriculum_test.cljs
@@ -1,0 +1,212 @@
+(ns genmlx.curriculum-test
+  "Well-posedness + integration tests for the REPL-synthesis curriculum generator
+   (genmlx.world.curriculum, bean genmlx-ilna). NATIVE-FREE: uses the exact oracle
+   (synth/check) but never the policy LLM.
+
+   Every assertion is one the curriculum's value depends on:
+     - PRNG correctness (the signed-shift / NaN bugs the critique flagged)
+     - per-task well-posedness (crude<bar<gold, exact+reproducible oracle, no structure
+       leak in the task-desc, ground-truth re-scores to gold)
+     - the complexity SPREAD (the resource-rational training signal)
+     - leakage-safe split, proven END-TO-END through repl-corpus (a planted held-out
+       trajectory is actually DROPPED — the rrps no-op-guard failure mode)
+     - consumer compatibility (->probe-task; a multi-step family-proposer harvest)"
+  (:require [genmlx.world.curriculum :as cur]
+            [genmlx.world.synth :as syn]
+            [genmlx.world.repl-corpus :as rc]
+            [clojure.set :as set]
+            [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; Minimal assertion helpers (project convention — no framework).
+;; ---------------------------------------------------------------------------
+(def ^:dynamic *fails* (atom 0))
+(def ^:dynamic *passes* (atom 0))
+(defn assert-true [msg x]
+  (if x (swap! *passes* inc)
+      (do (swap! *fails* inc) (println "  FAIL:" msg))))
+(defn assert-close [msg expected actual tol]
+  (assert-true (str msg " (exp " expected " got " actual ")")
+               (and (number? actual) (< (js/Math.abs (- expected actual)) tol))))
+
+;; ===========================================================================
+;; 1. PRNG correctness — the signed-shift / NaN failure modes.
+;; ===========================================================================
+(println "\n-- PRNG --")
+(let [us (cur/uniforms 7 5000)
+      ns (cur/normals 9 5000)
+      mean (fn [xs] (/ (reduce + xs) (count xs)))
+      std  (fn [xs] (let [m (mean xs)] (js/Math.sqrt (mean (map #(* (- % m) (- % m)) xs)))))]
+  (assert-true "uniforms all in [0,1) (catches signed-shift negatives)"
+               (every? #(and (>= % 0.0) (< % 1.0)) us))
+  (assert-true "uniforms reproducible (same seed)" (= (cur/uniforms 123 200) (cur/uniforms 123 200)))
+  (assert-true "uniforms differ across seeds" (not= (cur/uniforms 1 50) (cur/uniforms 2 50)))
+  (assert-close "uniform mean ~ 0.5 (catches skew from arithmetic shift)" 0.5 (mean us) 0.03)
+  (assert-true "normals all finite (catches Box-Muller log(0) NaN)" (every? js/isFinite ns))
+  (assert-true "normals reproducible" (= (cur/normals 55 200) (cur/normals 55 200)))
+  (assert-close "normal mean ~ 0" 0.0 (mean ns) 0.06)
+  (assert-close "normal std ~ 1" 1.0 (std ns) 0.06))
+(let [s1 (cur/mix-seed 0 1 2 3) s2 (cur/mix-seed 0 1 2 4) s3 (cur/mix-seed 0 1 2 3)]
+  (assert-true "mix-seed deterministic" (= s1 s3))
+  (assert-true "mix-seed distinguishes tuples" (not= s1 s2))
+  (assert-true "mix-seed is a 32-bit int" (and (integer? s1) (<= (js/Math.abs s1) 4294967296))))
+(assert-close "round1 rounds down below .05" 1.0 (cur/round1 1.0499999) 1e-9)
+(assert-close "round1 rounds up at/above .05" 1.1 (cur/round1 1.06) 1e-9)
+
+;; ===========================================================================
+;; 2. Generate a curriculum exercising BOTH eval cohorts.
+;; ===========================================================================
+(println "\n-- generating curriculum (6/family, stride 3) --")
+(def C (cur/generate-curriculum {:round 0 :instances-per-family 6 :eval-stride 3}))
+(def tasks (:tasks C))
+(println "  " (pr-str (:summary C)))
+(assert-true "curriculum is non-empty" (pos? (count tasks)))
+(assert-true "covers all 6 families" (= 6 (count (group-by :family tasks))))
+(assert-true "both eval cohorts present"
+             (and (pos? (:eval-within (:summary C))) (pos? (:eval-family (:summary C)))))
+
+;; ===========================================================================
+;; 3. Per-task well-posedness (the core spec).
+;; ===========================================================================
+(println "\n-- per-task well-posedness --")
+(def banned-structure
+  ["slope" "intercept" "linear" "regress" "coefficient" "autoreg" "markov" "pool"
+   "hierarch" "latent" "prior" "gaussian" "distribution" "variance" "covariance"
+   "mean" "noise" "scale" "drift"])
+(defn rounded-1dp? [x] (< (js/Math.abs (- x (cur/round1 x))) 1e-9))
+
+(doseq [t tasks]
+  (let [{:keys [id family crude crude-tuned gold solve-bar gap struct-gap exact? method
+                task-desc observations ground-truth-code complexity structural?]} t
+        struct? (get (cur/family-by-key family) :structural? true)]
+    ;; oracle quality
+    (assert-true (str id " exact? true") exact?)
+    (assert-true (str id " method exact/kalman") (contains? #{:exact :kalman} method))
+    ;; bar strictly brackets, with margin
+    (assert-true (str id " crude < solve-bar < gold") (and (< crude solve-bar) (< solve-bar gold)))
+    (assert-true (str id " gap >= min-gap") (>= gap cur/default-min-gap))
+    (when struct?
+      (assert-true (str id " struct-gap >= min (structure beats best structureless)")
+                   (>= struct-gap cur/default-min-struct-gap))
+      ;; the core admissibility guarantee: the best STRUCTURELESS noise-tuned model must
+      ;; NOT clear the bar, so 'solved' provably means found-the-structure (not noise tuning).
+      (assert-true (str id " best structureless model does NOT clear the bar")
+                   (< crude-tuned solve-bar)))
+    ;; ground-truth code re-scores to gold (tolerance, float32) + parses + covers
+    (let [fb (syn/check ground-truth-code observations {:n-particles 0})]
+      (assert-true (str id " ground-truth parses+covers+scored") (syn/scored? fb))
+      (assert-close (str id " ground-truth re-scores to gold") gold (:evidence fb)
+                    (+ 1e-3 (* 1e-4 (js/Math.abs gold))))
+      (assert-true (str id " ground-truth clears its own bar") (>= (:evidence fb) solve-bar)))
+    ;; task-desc semantics-only (no structural vocabulary)
+    (let [low (str/lower-case task-desc)]
+      (assert-true (str id " task-desc omits structural words")
+                   (not-any? #(str/includes? low %) banned-structure)))
+    ;; observations rounded; id is a stable string
+    (assert-true (str id " observations rounded to 1dp") (every? rounded-1dp? (vals observations)))
+    (assert-true (str id " :id is a string") (string? id))))
+
+;; global id uniqueness
+(assert-true "all task ids unique" (= (count tasks) (count (distinct (map :id tasks)))))
+
+;; ===========================================================================
+;; 4. The complexity SPREAD — the resource-rational training signal.
+;; ===========================================================================
+(println "\n-- complexity spread --")
+(let [bc (:by-complexity C)
+      cs (sort (keys bc))
+      n-lats (map #(:mean-n-latents (bc %)) cs)]
+  (assert-true "spans >= 3 complexity bands" (>= (count cs) 3))
+  (assert-true "mean n-latents monotone non-decreasing in complexity"
+               (apply <= n-lats))
+  (assert-true "hardest band has a bigger mean gap than the easiest band"
+               (> (:mean-gap (bc (last cs))) (:mean-gap (bc (first cs)))))
+  (doseq [c cs]
+    (println "  c" c " n=" (:n (bc c)) " mean-gap=" (.toFixed (:mean-gap (bc c)) 2)
+             " mean-n-lat=" (.toFixed (:mean-n-latents (bc c)) 2))))
+
+;; ===========================================================================
+;; 5. Reproducibility — same opts ⇒ byte-identical observations.
+;; ===========================================================================
+(println "\n-- reproducibility --")
+(let [C2 (cur/generate-curriculum {:round 0 :instances-per-family 6 :eval-stride 3})
+      by-id  (into {} (map (juxt :id :observations) tasks))
+      by-id2 (into {} (map (juxt :id :observations) (:tasks C2)))]
+  (assert-true "same ids regenerated" (= (set (keys by-id)) (set (keys by-id2))))
+  (assert-true "observations byte-identical across runs" (= by-id by-id2)))
+(let [Cr1 (cur/generate-curriculum {:round 1 :instances-per-family 3})]
+  (assert-true "ReST-EM round changes the data (fresh batch)"
+               (not= (map :observations (:tasks Cr1))
+                     (take (count (:tasks Cr1)) (map :observations tasks)))))
+
+;; ===========================================================================
+;; 6. Leakage-safe split — proven END-TO-END through repl-corpus.
+;; ===========================================================================
+(println "\n-- leakage-safe split (end-to-end) --")
+(let [eval-ids (:eval-task-ids C)
+      train-ids (into #{} (map (comp name :id)) (:train-tasks C))]
+  (assert-true "eval-task-ids are strings ((name id) form)"
+               (every? string? eval-ids))
+  (assert-true "eval-task-ids = (name id) of every eval task"
+               (= eval-ids (into #{} (map (comp name :id)) (:eval-tasks C))))
+  (assert-true "train/eval task-id sets are disjoint"
+               (empty? (set/intersection eval-ids train-ids)))
+  (assert-true "held-out family (:segmented) is entirely eval"
+               (every? #(= :eval (:split %)) (filter #(= :segmented (:family %)) tasks))))
+
+;; Build a real trajectory for one held-out (eval) task + one train task, harvest with
+;; the curriculum's eval-ids, and assert the planted eval rows are DROPPED (not silently
+;; kept) — the no-op-guard failure the rrps lesson is about.
+(defn harvest-run [task]
+  (let [obs (:observations task)
+        res (syn/synthesize {:init-spec (cur/crude-spec obs) :observations obs
+                             :propose (cur/family-proposer task) :max-steps 8})]
+    {:task task :trajectory (:trajectory res) :steps (:steps res)
+     :final (get-in res [:feedback :evidence])}))
+
+(let [eval-task  (first (filter #(= :segmented (:family %)) (:eval-tasks C)))  ; held-out FAMILY
+      train-task (first (filter #(= :varying-slopes (:family %)) (:train-tasks C)))
+      runs (mapv harvest-run [eval-task train-task])
+      corpus (rc/build-corpus runs {:eval-ids (:eval-task-ids C)})]
+  (println "  eval task" (:id eval-task) "trajectory steps:" (:steps (first runs)))
+  (println "  train task" (:id train-task) "trajectory steps:" (:steps (second runs)))
+  (println "  corpus:" (pr-str (select-keys corpus [:n-runs :n-rows :train-task-ids])))
+  (assert-true "harvest produced rows" (pos? (:n-rows corpus)))
+  (assert-true "planted EVAL-task rows are DROPPED (not silently kept)"
+               (seq (:dropped-eval corpus)))
+  (assert-true "no train-row belongs to a held-out eval task"
+               (not-any? #(contains? (:eval-task-ids C) (:task-id %)) (:train-rows corpus)))
+  (assert-true "the train task's rows ARE in train-rows"
+               (some #(= (name (:id train-task)) (:task-id %)) (:train-rows corpus)))
+  ;; close the multi-step harvest claim THROUGH build-corpus (not just at trajectory level):
+  ;; the >1-step train trajectory must yield >1 SFT row.
+  (assert-true "multi-step trajectory harvests >1 row for the train task"
+               (> (count (filter #(= (name (:id train-task)) (:task-id %)) (:train-rows corpus))) 1)))
+
+;; ===========================================================================
+;; 7. Consumer adapter + multi-step family-proposer harvest.
+;; ===========================================================================
+(println "\n-- consumers --")
+(let [t (first (filter #(= :linear (:family %)) tasks))
+      p (cur/->probe-task t)]
+  (assert-true "->probe-task :obs == :observations" (= (:observations t) (:obs p)))
+  (assert-true "->probe-task carries probe knobs"
+               (and (= 0 (:np p)) (= (:solve-bar t) (:solve-bar p))
+                    (= (:crude t) (:crude p)) (= (:gold t) (:gold p)))))
+
+;; the family-proposer must yield a MULTI-step trajectory (structure + noise refinement)
+;; on a structural task, and the loop must SOLVE it (final evidence clears the bar) —
+;; proving the curriculum is consumable by the loop without the LLM.
+(let [t   (first (filter #(= :varying-slopes (:family %)) tasks))
+      res (syn/synthesize {:init-spec (cur/crude-spec (:observations t))
+                           :observations (:observations t)
+                           :propose (cur/family-proposer t) :max-steps 8})]
+  (println "  vslope family-proposer: steps=" (:steps res) " final=" (.toFixed (get-in res [:feedback :evidence]) 2)
+           " bar=" (.toFixed (:solve-bar t) 2))
+  (assert-true "family-proposer trajectory is multi-step (>1 accepted edit)" (> (:steps res) 1))
+  (assert-true "family-proposer solves the task (clears the bar)"
+               (>= (get-in res [:feedback :evidence]) (:solve-bar t))))
+
+;; ===========================================================================
+(println (str "\n=== curriculum_test: " @*passes* " passed, " @*fails* " failed ==="))
+(when (pos? @*fails*) (js/process.exit 1))

--- a/test/genmlx/distill_gen_test.cljs
+++ b/test/genmlx/distill_gen_test.cljs
@@ -1,0 +1,128 @@
+(ns genmlx.distill-gen-test
+  "Tests for the scaled task/curriculum generator (genmlx.world.distill-gen, genmlx-7473).
+
+   TWO LAYERS:
+     1. PURE structure — split disjointness + leakage safety + teacher-projection hygiene +
+        family balance (no GPU).
+     2. GROUNDING — the load-bearing guarantee: EVERY generated task's :reference is admitted
+        by the SAME oracle that grades the student (genmlx.world.distill/evaluate-candidate),
+        programs by EXACT marginal; and the oracle DISCRIMINATES (a deliberately wrong
+        completion is rejected), so 'kept' is real, not a rubber stamp. This is the
+        independent-oracle / non-circular guarantee: program evidence is GenMLX analytics
+        (not the reference's form); function ground truth is hand-written (not derived from
+        the reference).
+
+   Run: bun run --bun nbb test/genmlx/distill_gen_test.cljs"
+  (:require [genmlx.world.distill-gen :as g]
+            [genmlx.world.distill :as d]
+            [clojure.set]
+            [clojure.string :as str]))
+
+(def ^:private fails (atom 0))
+(def ^:private passes (atom 0))
+
+(defn assert-true [desc x]
+  (if x (do (swap! passes inc) (println (str "  ok   " desc)))
+        (do (swap! fails inc) (println (str "  FAIL " desc)))))
+
+(defn assert-eq [desc expected actual]
+  (assert-true (str desc " (expected " (pr-str expected) ", got " (pr-str actual) ")")
+               (= expected actual)))
+
+;; ===========================================================================
+(println "\n== 1. generated-set shape ==")
+
+(assert-true "a substantial set was generated (>= 120 tasks)" (>= (count g/all-tasks) 120))
+(assert-eq "all-tasks = train + eval" (count g/all-tasks)
+           (+ (count g/train-tasks) (count g/eval-tasks)))
+(assert-true "both oracle kinds present" (= #{:program :function} (set (map :kind g/all-tasks))))
+(assert-true "every task has an :id, :kind, :prompt, :reference, :family, :split"
+             (every? (fn [t] (and (:id t) (:kind t) (:prompt t) (:reference t)
+                                  (:family t) (:split t)))
+                     g/all-tasks))
+(assert-true "every program carries :observations"
+             (every? :observations (filter #(= :program (:kind %)) g/all-tasks)))
+(assert-true "every function carries :transitions XOR :test-cases"
+             (every? (fn [t] (or (seq (:transitions t)) (seq (:test-cases t))))
+                     (filter #(= :function (:kind %)) g/all-tasks)))
+
+;; ===========================================================================
+(println "\n== 2. split: disjoint, leakage-safe, family-balanced ==")
+
+(let [train-ids (set (map :id g/train-tasks))
+      eval-ids  (set (map :id g/eval-tasks))]
+  (assert-true "train/eval disjoint by id"
+               (empty? (clojure.set/intersection train-ids eval-ids)))
+  (assert-eq "eval-task-ids = the eval ids" eval-ids g/eval-task-ids)
+  (assert-true "all ids unique (no dupes across program/machine/extra catalogs)"
+               (= (count g/all-tasks) (count (set (map :id g/all-tasks)))))
+  (assert-true "held-out fraction is a sane minority (10%-40%)"
+               (let [f (/ (count g/eval-tasks) (count g/all-tasks))] (and (>= f 0.1) (<= f 0.4)))))
+
+(let [train-fams (set (map :family g/train-tasks))
+      eval-fams  (set (map :family g/eval-tasks))]
+  ;; every held-out family has TRAIN siblings — passing an eval task is same-distribution
+  ;; generalization, never a leaked train instance (the rrps test-split lesson).
+  (assert-true "every eval family also appears in train (no orphan eval family)"
+               (clojure.set/subset? eval-fams train-fams)))
+
+;; ===========================================================================
+(println "\n== 3. teacher-projection hygiene (no leakage) ==")
+
+(let [rec (g/task->prompt-record (first g/program-tasks))]
+  (assert-eq "prompt record has exactly the 4 teacher-facing keys"
+             #{:task_id :kind :system_prompt :prompt} (set (keys rec)))
+  (assert-true "prompt record drops :observations / :transitions / :test-cases / :reference"
+               (every? #(not (contains? rec %)) [:observations :transitions :test-cases :reference])))
+
+(assert-true "no exported prompt text contains the literal reference solution"
+             (every? (fn [t]
+                       (let [p (str (:system-prompt t) " " (:prompt t))]
+                         (not (str/includes? p (:reference t)))))
+                     ;; functions only — program scaffolds legitimately echo a generic
+                     ;; (fn [trace] ...) template; the reference (different priors) is not in it.
+                     (filter #(= :function (:kind %)) g/all-tasks)))
+
+;; ===========================================================================
+(println "\n== 4. GROUNDING — every reference admitted by its own oracle ==")
+
+(def ^:private verdicts
+  (mapv (fn [t] (assoc (d/evaluate-candidate (assoc t :n-particles 50) (:reference t) -1)
+                       :family (:family t)))
+        g/all-tasks))
+
+(let [failed (remove :kept? verdicts)]
+  (when (seq failed)
+    (println "  -- references NOT admitted: --")
+    (doseq [v failed] (println (str "     " (:task-id v) " -> " (:reason v)
+                                    (when (:error v) (str " : " (:error v)))))))
+  (assert-eq "ALL references are admitted (kept?) by the oracle" [] (vec failed)))
+
+(let [progs (filter #(= :program (:kind %)) verdicts)
+      exact (filter #(contains? #{:exact :kalman} (:method %)) progs)]
+  (assert-eq "EVERY program reference scores by EXACT analytical marginal (reproducible)"
+             (count progs) (count exact)))
+
+;; ===========================================================================
+(println "\n== 5. the oracle DISCRIMINATES (kept is not a rubber stamp) ==")
+
+;; A function reference graded against a DIFFERENT task's oracle should usually fail —
+;; pick a clear mismatch: factorial code vs sum-evens tests.
+(let [fact (g/tasks-by-id "factorial")
+      sev  (g/tasks-by-id "sum-evens")]
+  (when (and fact sev)
+    (let [wrong (d/evaluate-candidate sev (:reference fact) 0)]
+      (assert-true "factorial code is REJECTED against sum-evens tests"
+                   (not (:kept? wrong))))))
+
+;; A degenerate constant program must be rejected (uncovered / not a model).
+(let [prog (first (filter #(= :program (:kind %)) g/all-tasks))]
+  (when prog
+    (let [wrong (d/evaluate-candidate (assoc prog :n-particles 20)
+                                      "(fn [trace] {:nope 1})" 0)]
+      (assert-true "a program ignoring the observed sites is REJECTED (coverage guard)"
+                   (not (:kept? wrong))))))
+
+;; ===========================================================================
+(println (str "\n== SUMMARY: " @passes " passed, " @fails " failed =="))
+(when (pos? @fails) (set! (.-exitCode js/process) 1))

--- a/test/genmlx/llm_proposer_test.cljs
+++ b/test/genmlx/llm_proposer_test.cljs
@@ -1,0 +1,264 @@
+;; @tier slow
+(ns genmlx.llm-proposer-test
+  "Acceptance for genmlx.world.llm-proposer — the REAL-LLM proposer for the REPL loop
+   (genmlx-0yv7 / genmlx-wpua). NATIVE-FREE and deterministic: the policy LLM is MOCKED
+   (an injected :call-llm), so every assertion is reproducible and no model loads. The
+   live big/small-model experiment lives in scripts/synth_llm_probe.cljs; this file pins
+   the pure, unit-testable parts AND the end-to-end wiring (a scripted 'LLM' drives the
+   real genmlx.world.synth driver).
+
+   Run: bun run --bun nbb test/genmlx/llm_proposer_test.cljs
+
+   PARTS:
+     A — extract-form: pulls the (fn [trace] ...) form out of fenced / prosey / <think>'d
+         completions, recovers a bare (let ...) body, returns nil on no-form, and KEEPS
+         a DSL slip (mx/0) verbatim (the check node, not the extractor, judges it).
+     B — parse-spec: round-trips render <-> parse for in-grammar models (arg FORMS
+         preserved), and returns nil for off-grammar code (a dist bound without trace,
+         a non-static loop).
+     C — completions->candidates: dedups, attaches :code (raw) + best-effort :spec',
+         labels in-grammar :llm vs off-grammar :llm-raw.
+     D — prompt builders: the step prompt is FEEDBACK-CONDITIONED (the verifier verdict
+         is in the text); the system prompt teaches the anti-cliff rules.
+     E — make-proposer (mock): returns candidates AND passes the feedback into the prompt.
+     F — INTEGRATION: a scripted feedback-sensitive 'LLM' drives the real synth driver —
+         real garbage reaches the check node and is REJECTED, the clean improvement is
+         ACCEPTED, the loop climbs exact evidence and self-terminates on plateau."
+  (:require [genmlx.world.llm-proposer :as lp]
+            [genmlx.world.synth :as s]
+            [genmlx.codegen.eval :as ce]
+            [clojure.string :as str]))
+
+(def ^:private pass (atom 0))
+(def ^:private fail (atom 0))
+(defn assert-true [label v]
+  (if v (do (swap! pass inc) (println "  PASS" label))
+      (do (swap! fail inc) (println "  FAIL" label))))
+(defn assert-close [label expected actual tol]
+  (let [ok (and (number? actual) (js/isFinite actual) (<= (js/Math.abs (- expected actual)) tol))]
+    (if ok (do (swap! pass inc) (println "  PASS" label (str "(" actual " ~ " expected ")")))
+        (do (swap! fail inc) (println "  FAIL" label (str "(" actual " vs " expected ")"))))))
+
+;; ===========================================================================
+(println "\n-- A. extract-form --")
+
+(def good-form
+  "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 5))] {:y0 (trace :y0 (dist/gaussian mu 1.0))}))")
+
+(assert-true "bare form returned verbatim"
+             (= good-form (lp/extract-form good-form)))
+(assert-true "fenced ```clojure block extracted"
+             (= good-form (lp/extract-form (str "Here:\n```clojure\n" good-form "\n```"))))
+(assert-true "prose + bare form: the form is found"
+             (= good-form (lp/extract-form (str "Sure, here is the model: " good-form " — done."))))
+(assert-true "<think> block stripped before extraction"
+             (= good-form (lp/extract-form (str "<think>let me reason (a b c</think>\n" good-form))))
+(assert-true "no model form -> nil"
+             (nil? (lp/extract-form "I cannot help with that. (just prose, no fn)")))
+(assert-true "bare (let ...) body recovered by wrapping in (fn [trace] ..)"
+             (let [r (lp/extract-form "(let [mu (trace :mu (dist/gaussian 0 5))] {:y0 (trace :y0 (dist/gaussian mu 1.0))})")]
+               (and r (str/starts-with? r "(fn [trace]") (ce/valid-cljs? r))))
+;; the slip is KEPT — the extractor never sanitizes; the check node judges it. (mx/zero
+;; is a readable symbol that is UNBOUND at eval — a real cliff slip; mx/0 is not even
+;; reader-valid, so it is caught one level earlier, at the :parses? gate.)
+(assert-true "DSL slip (mx/zero unbound) preserved verbatim in the extracted form"
+             (let [slip "(fn [trace] (let [mu (trace :mu (dist/gaussian mx/zero 1))] {:y0 (trace :y0 (dist/gaussian mu 1.0))}))"]
+               (= slip (lp/extract-form (str "```clojure\n" slip "\n```")))))
+(assert-true "parens inside a string literal don't break balancing"
+             (let [c "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 5))] {:y0 (trace :y0 (dist/gaussian mu 1.0))}))  ;; note: \"a ( b\""]
+               (some? (lp/extract-form c))))
+
+;; ===========================================================================
+(println "\n-- B. parse-spec (inverse of render) --")
+
+(def spec1
+  (s/spec [(s/latent 'slope "gaussian" [0 3])
+           (s/latent 'intercept "gaussian" [0 5])]
+          [(s/obs :y0 "gaussian" [(list 'mx/add (list 'mx/multiply 'slope (list 'mx/scalar 0.0)) 'intercept) 1.0])
+           (s/obs :y1 "gaussian" [(list 'mx/add (list 'mx/multiply 'slope (list 'mx/scalar 1.0)) 'intercept) 1.0])]))
+
+(assert-true "render -> parse-spec round-trips to an equal spec (arg FORMS preserved)"
+             (= spec1 (lp/parse-spec (s/render spec1))))
+(assert-true "round-trip re-renders identically"
+             (= (s/render spec1) (s/render (lp/parse-spec (s/render spec1)))))
+(assert-true "no-latent body (bare obs map) parses"
+             (let [sp (lp/parse-spec "(fn [trace] {:y0 (trace :y0 (dist/gaussian 0 1))})")]
+               (and sp (empty? (:latents sp)) (= 1 (count (:obs sp))))))
+(assert-true "off-grammar: a dist bound WITHOUT trace -> nil (raw :code still checkable)"
+             (nil? (lp/parse-spec "(fn [trace] (let [mu (dist/gaussian 0 5)] {:y0 (trace :y0 (dist/gaussian mu 1))}))")))
+(assert-true "off-grammar: a non-static loop body -> nil"
+             (nil? (lp/parse-spec "(fn [trace] (doseq [i (range 3)] (trace :y (dist/gaussian 0 1))))")))
+(assert-true "an arg-form slip ((:p trace)) round-trips structurally (caught later at eval)"
+             (let [sp (lp/parse-spec "(fn [trace] (let [p (trace :p (dist/beta-dist 1 1))] {:y0 (trace :y0 (dist/bernoulli (:p trace)))}))")]
+               (and sp (= '(:p trace) (first (:args (first (:obs sp))))))))
+;; the shape strong instruct models actually emit: EVERYTHING in the let, return a map of
+;; symbol references. parse-spec classifies referenced sites as observations.
+(assert-true "'everything in the let, map-of-refs' shape (the 35B's shape) parses correctly"
+             (let [sp (lp/parse-spec
+                       (str "(fn [trace] (let [slope (trace :slope (dist/gaussian 1 2)) "
+                            "intercept (trace :intercept (dist/gaussian 0 2)) "
+                            "y0 (trace :y0 (dist/gaussian (mx/add (mx/multiply slope (mx/scalar 0.0)) intercept) 1.0)) "
+                            "y1 (trace :y1 (dist/gaussian (mx/add (mx/multiply slope (mx/scalar 1.0)) intercept) 1.0))] "
+                            "{:y0 y0 :y1 y1}))"))]
+               (and sp (= 2 (count (:latents sp))) (= 2 (count (:obs sp)))
+                    (= #{'slope 'intercept} (set (map :sym (:latents sp))))
+                    (= #{:y0 :y1} (set (map :addr (:obs sp)))))))
+;; regression (review finding): a latent that is BOTH returned in the map AND referenced in
+;; another site's args must STAY let-bound, or the re-render has an unbound symbol.
+(assert-true "a returned latent also referenced in another site's args stays let-bound (no unbound re-render)"
+             (let [code "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 5)) y0 (trace :y0 (dist/gaussian mu 1.0))] {:mu mu :y0 y0}))"
+                   sp (lp/parse-spec code)
+                   fb (s/check (s/render sp) {:y0 1.0} {})]
+               (and sp
+                    (= #{'mu} (set (map :sym (:latents sp))))
+                    (some #(= :y0 (:addr %)) (:obs sp))
+                    (:evals? fb))))
+
+;; ===========================================================================
+(println "\n-- C. completions->candidates --")
+
+(let [comps [(str "```clojure\n" good-form "\n```")
+             (str "```clojure\n" good-form "\n```")               ; duplicate -> deduped
+             "(fn [trace] (doseq [i (range 3)] (trace :y (dist/gaussian 0 1))))" ; off-grammar
+             "sorry, no code here"]                                ; no form -> dropped
+      cands (lp/completions->candidates comps :CURRENT-SPEC)]
+  (assert-true "dedup + drop-no-form -> 2 candidates" (= 2 (count cands)))
+  (assert-true "every candidate carries raw :code" (every? :code cands))
+  (assert-true "in-grammar candidate labeled :llm with a parsed :spec'"
+               (some #(and (= :llm (:edit %)) (map? (:spec' %)) (not= :CURRENT-SPEC (:spec' %))) cands))
+  (assert-true "off-grammar candidate labeled :llm-raw, :spec' falls back to current"
+               (some #(and (= :llm-raw (:edit %)) (= :CURRENT-SPEC (:spec' %))) cands)))
+
+;; ===========================================================================
+(println "\n-- D. prompt builders (feedback-conditioning) --")
+
+(let [obs {:y0 5.0 :y1 5.2}
+      p-err (lp/step-prompt "fit y" obs "(fn [trace] ...)"
+                            {:parses? true :schema-ok? true :covered? true :evals? false
+                             :error "Unbound: mx/0" :evidence nil})
+      p-ev  (lp/step-prompt "fit y" obs "(fn [trace] ...)"
+                            {:parses? true :schema-ok? true :covered? true :evals? true
+                             :error nil :evidence -7.25})]
+  (assert-true "step prompt embeds the data" (str/includes? p-err ":y0 = 5"))
+  (assert-true "step prompt embeds the current model" (str/includes? p-err "CURRENT MODEL"))
+  (assert-true "ERROR feedback is conditioned on (the eval error is in the prompt)"
+               (str/includes? p-err "Unbound: mx/0"))
+  (assert-true "EVIDENCE feedback is conditioned on (the number to beat is in the prompt)"
+               (str/includes? p-ev "-7.25"))
+  (assert-true "system prompt teaches the anti-cliff rules (no mx/0, trace not a map)"
+               (and (str/includes? lp/default-system "mx/0")
+                    (str/includes? lp/default-system "(:slope trace)"))))
+
+;; ===========================================================================
+(println "\n-- E. make-proposer with a mock LLM --")
+
+(let [seen (atom nil)
+      mock (fn [req] (reset! seen req)
+             {:completions [(str "```clojure\n" good-form "\n```")]})
+      prop (lp/make-proposer {:call-llm mock :task-desc "fit y" :observations {:y0 5.0}
+                              :k 1 :temperature 0.5})
+      fb   {:code "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 9))] {:y0 (trace :y0 (dist/gaussian mu 9))}))"
+            :parses? true :schema-ok? true :covered? true :evals? true :evidence -12.0}
+      cands (prop {:dummy :spec} fb)]
+  (assert-true "proposer returns >=1 candidate from the LLM" (pos? (count cands)))
+  (assert-true "candidate carries the LLM's raw :code" (= good-form (:code (first cands))))
+  (assert-true "proposer fed the verifier feedback (evidence -12.0) into the prompt"
+               (str/includes? (:prompt @seen) "-12.0"))
+  (assert-true "proposer rendered the CURRENT model (from :code feedback) into the prompt"
+               (str/includes? (:prompt @seen) "dist/gaussian mu 9")))
+
+;; one-shot control: no feedback, just task+data
+(let [mock (fn [_] {:completions [(str "```clojure\n" good-form "\n```")
+                                  (str "```clojure\n" good-form "\n```")]})
+      cands (lp/one-shot-candidates {:call-llm mock :task-desc "fit y" :observations {:y0 5.0} :k 2})]
+  (assert-true "one-shot-candidates dedups to 1 :code-carrying candidate"
+               (and (= 1 (count cands)) (:code (first cands)))))
+
+;; ===========================================================================
+(println "\n-- F. INTEGRATION: a scripted 'LLM' drives the real synth driver --")
+
+;; Tightly-clustered data near 5 -> a tighter obs noise has HIGHER evidence. Confirm the
+;; direction with an INDEPENDENT closed-form Gaussian-Gaussian marginal (non-circular).
+(def f-obs {:y0 5.0 :y1 5.2 :y2 4.8})
+(defn gg-marginal [ys m0 s0 sn]
+  (let [n (count ys) s0² (* s0 s0) sn² (* sn sn)
+        ds (map #(- % m0) ys) sd (reduce + ds) sd² (reduce + (map #(* % %) ds))
+        denom (+ sn² (* n s0²))
+        logdet (+ (js/Math.log denom) (* (dec n) (js/Math.log sn²)))
+        quad (* (/ 1.0 sn²) (- sd² (* (/ s0² denom) (* sd sd))))]
+    (- (* -0.5 n (js/Math.log (* 2 js/Math.PI))) (* 0.5 logdet) (* 0.5 quad))))
+(assert-true "direction check: tighter noise (1.0) out-scores loose (3.0) for tight data"
+             (> (gg-marginal (vals f-obs) 5 3 1.0) (gg-marginal (vals f-obs) 5 3 3.0)))
+
+;; crude (loose) init: mu ~ N(5,3), each :yj ~ N(mu, 3.0)
+(def f-init (s/spec [(s/latent 'mu "gaussian" [5 3])]
+                    (for [k [:y0 :y1 :y2]] (s/obs k "gaussian" ['mu 3.0]))))
+
+;; scripted 'LLM': each propose returns TWO completions —
+;;  (1) a real DSL slip (a dist bound WITHOUT trace — readable, but evals to garbage) the
+;;      check node must REJECT, and
+;;  (2) a clean improvement (the same model with obs noise tightened to 1.0).
+(def f-tight
+  "(fn [trace] (let [mu (trace :mu (dist/gaussian 5 3))] {:y0 (trace :y0 (dist/gaussian mu 1.0)) :y1 (trace :y1 (dist/gaussian mu 1.0)) :y2 (trace :y2 (dist/gaussian mu 1.0))}))")
+(def f-garbage
+  "(fn [trace] (let [mu (dist/gaussian 0 5)] {:y0 (trace :y0 (dist/gaussian mu 1.0)) :y1 (trace :y1 (dist/gaussian mu 1.0)) :y2 (trace :y2 (dist/gaussian mu 1.0))}))")
+(defn scripted-llm [_req]
+  {:completions [(str "```clojure\n" f-garbage "\n```")
+                 (str "```clojure\n" f-tight "\n```")]})
+
+(let [prop (lp/make-proposer {:call-llm scripted-llm :task-desc "fit y" :observations f-obs :k 2})
+      res  (s/synthesize {:init-spec f-init :observations f-obs :propose prop
+                          :max-steps 4 :plateau-eps 0.05})
+      traj (:trajectory res)
+      start (:evidence (first traj))
+      final (:evidence (last traj))]
+  (assert-true "loop CLIMBS exact evidence (loose -> tight) via the LLM proposer"
+               (> final (+ start 0.05)))
+  (assert-true "loop self-terminates on plateau (not :stuck/:max-steps)"
+               (= :plateau (:stop-reason res)))
+  (assert-true "accepted edit came from the LLM (:llm), garbage rejected"
+               (= :llm (:edit (last traj))))
+  ;; the accepted trajectory row carries the LLM's RAW code (the top-level :code is
+  ;; re-rendered from the spec, where CLJS prints 1.0 as 1 — so assert on the raw row).
+  (assert-true "accepted (raw) model is the tightened one (obs noise 1.0)"
+               (str/includes? (:code (last traj)) "mu 1.0"))
+  (assert-true "the loose noise (3.0) is gone from the re-rendered final model"
+               (not (str/includes? (:code res) "mu 3")))
+  ;; the rejected garbage really WAS scored against the check node and failed (raison d'être)
+  (let [code (lp/extract-form (first (:completions (scripted-llm nil))))
+        fb   (s/check code f-obs {})]
+    (assert-true "the real LLM garbage (dist bound w/o trace) reached check and was NOT scored"
+                 (and code (not (s/scored? fb))))))
+
+;; ===========================================================================
+(println "\n-- G. proposer self-correction (the inner REPL revision loop) --")
+
+(def g-obs {:y0 5.0 :y1 5.2 :y2 4.8})
+;; coverage slip: the model copies the EXAMPLE's :o addresses instead of the observed :y
+(def g-bad
+  "(fn [trace] (let [mu (trace :mu (dist/gaussian 5 3))] {:o0 (trace :o0 (dist/gaussian mu 1.0)) :o1 (trace :o1 (dist/gaussian mu 1.0)) :o2 (trace :o2 (dist/gaussian mu 1.0))}))")
+(def g-good
+  "(fn [trace] (let [mu (trace :mu (dist/gaussian 5 3))] {:y0 (trace :y0 (dist/gaussian mu 1.0)) :y1 (trace :y1 (dist/gaussian mu 1.0)) :y2 (trace :y2 (dist/gaussian mu 1.0))}))")
+;; a scripted 'LLM' that slips until it is told the coverage error, then fixes it
+(defn g-llm [req]
+  {:completions [(str "```clojure\n" (if (str/includes? (:prompt req) "Coverage problem") g-good g-bad) "\n```")]})
+
+(let [prop  (lp/make-proposer {:call-llm g-llm :task-desc "fit y" :observations g-obs :k 1 :revise 2})
+      cands (prop (s/spec [(s/latent 'mu "gaussian" [5 3])] [(s/obs :y0 "gaussian" ['mu 3.0])])
+                  {:parses? true :schema-ok? true :covered? true :evals? true :evidence -20.0})
+      scored (filter #(s/scored? (s/check (:code %) g-obs {})) cands)]
+  (assert-true "with :revise=0 (default) the coverage slip is NOT corrected (control)"
+               (let [p0 (lp/make-proposer {:call-llm g-llm :task-desc "fit y" :observations g-obs :k 1})
+                     c0 (p0 (s/spec [(s/latent 'mu "gaussian" [5 3])] [(s/obs :y0 "gaussian" ['mu 3.0])])
+                            {:parses? true :schema-ok? true :covered? true :evals? true :evidence -20.0})]
+                 (empty? (filter #(s/scored? (s/check (:code %) g-obs {})) c0))))
+  (assert-true "revision turns the coverage-slipped proposer into a SCORING candidate"
+               (seq scored))
+  (assert-true "the scoring candidate is the corrected (:y-address) model"
+               (some #(str/includes? (:code %) ":y0") scored))
+  (assert-true "the corrected candidate is flagged :revised?"
+               (some :revised? cands)))
+
+;; ===========================================================================
+(println (str "\n==== llm_proposer_test: " @pass " passed, " @fail " failed ===="))
+(when (pos? @fail) (js/process.exit 1))

--- a/test/genmlx/repl_corpus_test.cljs
+++ b/test/genmlx/repl_corpus_test.cljs
@@ -1,0 +1,66 @@
+;; @tier slow
+(ns genmlx.repl-corpus-test
+  "Acceptance for genmlx.world.repl-corpus — the REPL-trace SFT-corpus harvester
+   (Phase 3, genmlx-oexl). NATIVE-FREE + deterministic (conjugate models score exact, no
+   model loads): a successful trajectory becomes propose-eval-revise chat rows, the oracle
+   filter drops non-improving transitions, and the leakage-safe task split holds.
+
+   Run: bun run --bun nbb test/genmlx/repl_corpus_test.cljs"
+  (:require [genmlx.world.repl-corpus :as rc]
+            [genmlx.world.synth :as syn]
+            [clojure.string :as str]))
+
+(def ^:private pass (atom 0))
+(def ^:private fail (atom 0))
+(defn assert-true [label v]
+  (if v (do (swap! pass inc) (println "  PASS" label))
+      (do (swap! fail inc) (println "  FAIL" label))))
+
+;; tightly-clustered data near 5 -> a tighter obs noise has higher exact evidence.
+;; Models are RENDERED from specs (no hand-written code strings).
+(def obs {:y0 5.0 :y1 5.2 :y2 4.8})
+(defn- model [noise]
+  (syn/render (syn/spec [(syn/latent 'mu "gaussian" [5 3])]
+                        (for [k [:y0 :y1 :y2]] (syn/obs k "gaussian" ['mu noise])))))
+(def crude (model 3))
+(def tight (model 1))
+(def task {:id :gtest :task-desc "Fit the y observations." :observations obs})
+
+(println "\n-- trajectory->rows --")
+(def rows1 (rc/trajectory->rows task [{:code crude} {:code tight}]))
+(assert-true "an improving transition -> exactly one row" (= 1 (count rows1)))
+(def r1 (first rows1))
+(def msgs1 (:messages r1))
+(def user1 (:content (second msgs1)))
+(def asst1 (:content (nth msgs1 2)))
+(assert-true "row carries the task-id (for the leakage split)" (= "gtest" (:task-id r1)))
+(assert-true "row is a :repl-edit" (= :repl-edit (:kind r1)))
+(assert-true "messages are system/user/assistant" (= ["system" "user" "assistant"] (map :role msgs1)))
+(assert-true "user turn embeds the data" (str/includes? user1 ":y0 = 5"))
+(assert-true "user turn embeds model_i (crude state)" (str/includes? user1 "dist/gaussian mu 3"))
+(assert-true "user turn embeds the verifier feedback (evidence)" (str/includes? user1 "evidence"))
+(assert-true "assistant turn is the ACCEPTED next model (fenced, tightened)"
+             (and (str/includes? asst1 "dist/gaussian mu 1") (str/includes? asst1 "```clojure")))
+
+(println "\n-- oracle filter --")
+(assert-true "a NON-improving transition (same model) is dropped"
+             (empty? (rc/trajectory->rows task [{:code crude} {:code crude}])))
+(assert-true "a 3-step improving trajectory yields 2 rows"
+             (= 2 (count (rc/trajectory->rows task [{:code (model 3)} {:code (model 2)} {:code (model 1)}]))))
+(def broken "(fn [trace] (let [mu (dist/gaussian 0 5)] {:y0 (trace :y0 (dist/gaussian mu 1.0))}))")
+(assert-true "a transition to a BROKEN model is dropped (target must score)"
+             (empty? (rc/trajectory->rows task [{:code crude} {:code broken}])))
+
+(println "\n-- build-corpus + leakage-safe split --")
+(def runs [{:task task :trajectory [{:code crude} {:code tight}]}
+           {:task {:id :held :task-desc "other" :observations obs} :trajectory [{:code crude} {:code tight}]}])
+(def res (rc/build-corpus runs {:eval-ids #{"held"}}))
+(assert-true "harvests rows from both runs" (= 2 (:n-rows res)))
+(assert-true "per-task counts present" (= {"gtest" 1 "held" 1} (:per-task res)))
+(assert-true "train-rows EXCLUDE the held-out task (no leakage)"
+             (and (= 1 (count (:train-rows res))) (= "gtest" (:task-id (first (:train-rows res))))))
+(assert-true "the held-out task's row is reported as dropped, not folded in"
+             (= 1 (count (:dropped-eval res))))
+
+(println (str "\n==== repl_corpus_test: " @pass " passed, " @fail " failed ===="))
+(when (pos? @fail) (js/process.exit 1))

--- a/test/genmlx/search_test.cljs
+++ b/test/genmlx/search_test.cljs
@@ -1,0 +1,158 @@
+;; @tier slow
+(ns genmlx.search-test
+  "Acceptance for genmlx.world.search — the Phase-2 particle/beam search over construction
+   steps (genmlx-47zx). Deterministic, native-free: every partial model is a shared-mean
+   Gaussian scored by the EXACT analytical marginal, so the orderings are reproducible and
+   checkable against an INDEPENDENT closed form. The 4-advanced-model + greedy-vs-beam
+   head-to-head lives in scripts/synth_search_probe.cljs; this file pins the search core.
+
+   Run: bun run --bun nbb test/genmlx/search_test.cljs
+
+   PARTS:
+     A — particles + expansion + selection: beam keeps a POPULATION (>1 branch alive),
+         dedups identical programs, ranks deterministic evidence first.
+     B — BEAM BEATS GREEDY on a constructed two-branch trap: greedy locks into the
+         locally-best branch A; beam (width 2) keeps branch B alive and finds the global
+         optimum B2 (exact evidence, verified against the closed form).
+     C — backtrack-refine rescues a NARROW search: greedy (beam-width 1) + backtrack
+         re-opens the step-1 decision, takes the road not taken, and recovers B2.
+     D — :smc resampling reaches the optimum; adaptive width widens on an ambiguous step;
+         the search self-terminates on a whole-population plateau with per-step diagnostics."
+  (:require [genmlx.world.search :as se]
+            [genmlx.world.synth :as syn]))
+
+(def ^:private pass (atom 0))
+(def ^:private fail (atom 0))
+(defn assert-true [label v]
+  (if v (do (swap! pass inc) (println "  PASS" label))
+        (do (swap! fail inc) (println "  FAIL" label))))
+(defn assert-close [label expected actual tol]
+  (let [ok (and (number? actual) (js/isFinite actual) (<= (js/Math.abs (- expected actual)) tol))]
+    (if ok (do (swap! pass inc) (println "  PASS" label (str "(" actual " ~ " expected ")")))
+           (do (swap! fail inc) (println "  FAIL" label (str "(" actual " vs " expected ")"))))))
+
+;; Independent closed-form Gaussian-Gaussian marginal (mu ~ N(m0,s0), y_i ~ N(mu, sn)).
+(defn gaussian-gaussian-marginal [ys m0 s0 sn]
+  (let [n (count ys) s0² (* s0 s0) sn² (* sn sn)
+        ds (map #(- % m0) ys) sd (reduce + ds) sd² (reduce + (map #(* % %) ds))
+        denom (+ sn² (* n s0²))
+        logdet (+ (js/Math.log denom) (* (dec n) (js/Math.log sn²)))
+        quad (* (/ 1.0 sn²) (- sd² (* (/ s0² denom) (* sd sd))))]
+    (- (* -0.5 n (js/Math.log (* 2 js/Math.PI))) (* 0.5 logdet) (* 0.5 quad))))
+
+(def ^:private obs4 {:y0 2.0 :y1 2.3 :y2 1.7 :y3 2.1})
+(def ^:private obs-ys (mapv obs4 [:y0 :y1 :y2 :y3]))
+
+(defn smean
+  "A shared-mean Gaussian spec mu~N(m0,s0), :yj~N(mu,noise), tagged with :branch (an
+   extra key render ignores) so the trap proposer can route on which branch a spec is in."
+  [m0 s0 noise branch]
+  (assoc (syn/spec [(syn/latent 'mu "gaussian" [m0 s0])]
+                   (for [k [:y0 :y1 :y2 :y3]] (syn/obs k "gaussian" ['mu noise])))
+         :branch branch))
+
+(defn ev [spec] (:evidence (syn/check (syn/render spec) obs4)))
+
+;; ---- The two-branch trap (all exact). Evidence rises as sn -> data spread (~0.22):
+;;   E(sn=1.5) < E(sn=1.0) < E(sn=0.7) < E(sn=0.3). So branch A (1.0->0.7) is locally
+;;   better at step 1 (greedy takes it) but branch B (1.5->0.3) is the GLOBAL optimum. ----
+(def crude (smean 2 1 2.5 nil))
+(def A1 (smean 2 1 1.0 :a))
+(def A2 (smean 2 1 0.7 :a))
+(def B1 (smean 2 1 1.5 :b))
+(def B2 (smean 2 1 0.3 :b))
+
+(defn trap-propose [sp _fb]
+  (let [n (last (:args (first (:obs sp)))) br (:branch sp)]
+    (cond
+      (nil? br)                  [{:edit :a1 :desc "branch A start (sn 1.0)" :spec' A1}
+                                  {:edit :b1 :desc "branch B start (sn 1.5)" :spec' B1}]
+      (and (= br :a) (= n 1.0))  [{:edit :a2 :desc "refine A -> 0.7" :spec' A2}]
+      (and (= br :b) (= n 1.5))  [{:edit :b2 :desc "refine B -> 0.3" :spec' B2}]
+      :else                      [])))
+
+(defn part-a []
+  (println "\n== PART A: particles + expansion + selection ==")
+  ;; the trap is real: branch ordering as designed
+  (assert-true "trap ordering E(B1) < E(A1) < E(A2) < E(B2)"
+               (< (ev B1) (ev A1) (ev A2) (ev B2)))
+  ;; beam (width 2) keeps BOTH branches alive after step 1
+  (let [res (se/search {:init-spec crude :observations obs4 :propose trap-propose
+                        :beam-width 2 :adaptive? false :max-steps 6})
+        branches (set (map (comp :branch :spec) (:population res)))]
+    (assert-true "beam population explores >1 branch (both A and B kept alive)"
+                 (= #{:a :b} branches)))
+  ;; selection ranks an EXACT-scored particle ahead of an IS one (method-aware)
+  (let [det {:feedback {:method :exact} :evidence -5.0}
+        is  {:feedback {:method :handler-is} :evidence -4.0}]
+    (assert-true "exact evidence outranks a higher IS estimate"
+                 (= det (first (sort-by @#'se/particle-rank [is det]))))))
+
+(defn part-b []
+  (println "\n== PART B: BEAM BEATS GREEDY on the two-branch trap ==")
+  (let [greedy (se/search {:init-spec crude :observations obs4 :propose trap-propose
+                           :beam-width 1 :adaptive? false :max-steps 6})
+        beam   (se/search {:init-spec crude :observations obs4 :propose trap-propose
+                           :beam-width 2 :adaptive? false :max-steps 6})
+        ge (:evidence (:best greedy)) be (:evidence (:best beam))]
+    (assert-true "greedy (width 1) locks into branch A" (= :a (:branch (:spec (:best greedy)))))
+    (assert-close "greedy final == E(A2) (the local optimum)" (ev A2) ge 1e-2)
+    (assert-true "beam (width 2) finds branch B" (= :b (:branch (:spec (:best beam)))))
+    (assert-close "beam final == E(B2) (the global optimum)" (ev B2) be 1e-2)
+    (assert-true "BEAM STRICTLY BEATS GREEDY (be > ge)" (> be ge))
+    (println (str "  greedy -> " (.toFixed (js/Number ge) 3) " (A) | beam -> "
+                  (.toFixed (js/Number be) 3) " (B)"))))
+
+(defn part-c []
+  (println "\n== PART C: backtrack-refine rescues a narrow (greedy) search ==")
+  (let [greedy (se/search {:init-spec crude :observations obs4 :propose trap-propose
+                           :beam-width 1 :adaptive? false :max-steps 6})
+        bt     (se/backtrack-refine (:best greedy) obs4 trap-propose {:plateau-eps 0.05 :n-particles 2000 :max-steps 6})]
+    (assert-true "backtrack reports an improvement" (:improved? bt))
+    (assert-true "backtrack re-opened the step-1 decision" (= 1 (:reopened-at bt)))
+    (assert-close "backtrack recovers B2 (the global optimum)" (ev B2) (:evidence (:result bt)) 1e-2)
+    ;; the spliced result trajectory reads as the FULL path (original prefix in front)
+    ;; with the re-opened edit flagged, not a fresh run rooted at the alternative.
+    (assert-true "backtrack result trajectory splices the original prefix (starts at :init)"
+                 (= :init (:edit (first (:trajectory (:result bt))))))
+    (assert-true "backtrack result flags the re-opened edit (:reopened?)"
+                 (boolean (some :reopened? (:trajectory (:result bt)))))
+    (assert-true "backtrack result trajectory steps are renumbered 0..n"
+                 (= (range (count (:trajectory (:result bt))))
+                    (map :step (:trajectory (:result bt)))))
+    ;; and search with :backtrack? on beam-width 1 does it end-to-end
+    (let [g+bt (se/search {:init-spec crude :observations obs4 :propose trap-propose
+                           :beam-width 1 :adaptive? false :backtrack? true :max-steps 6})]
+      (assert-close "search beam-width 1 + :backtrack? reaches B2" (ev B2) (:evidence (:best g+bt)) 1e-2)
+      (assert-true "search reports the backtrack improvement" (:improved? (:backtrack g+bt))))))
+
+(defn part-d []
+  (println "\n== PART D: :smc strategy, adaptive width, plateau termination ==")
+  ;; :smc resampling still reaches the global optimum (seeded -> reproducible)
+  (let [smc (se/search {:init-spec crude :observations obs4 :propose trap-propose
+                        :strategy :smc :beam-width 3 :temperature 0.3 :seed 7
+                        :adaptive? false :max-steps 6})]
+    (assert-close "smc reaches the global optimum B2" (ev B2) (:evidence (:best smc)) 1e-2))
+  ;; adaptive width WIDENS on the ambiguous first step (A1 and B1 score close) ...
+  (let [res  (se/search {:init-spec crude :observations obs4 :propose trap-propose
+                         :beam-width 1 :adaptive? true :spread-margin 5.0 :max-width 4 :max-steps 6})
+        d1   (first (:diagnostics res))]
+    (assert-true "adaptive width > base on the ambiguous step-1" (> (:width d1) 1))
+    ;; ... and with the wider beam even base-width-1 now finds the global optimum
+    (assert-close "adaptive search reaches B2" (ev B2) (:evidence (:best res)) 1e-2))
+  ;; self-terminates on plateau (not max-steps) with one diagnostics row per step
+  (let [res (se/search {:init-spec crude :observations obs4 :propose trap-propose
+                        :beam-width 2 :adaptive? false :max-steps 20})]
+    (assert-true "search self-terminates on plateau" (= :plateau (:stop-reason res)))
+    (assert-true "diagnostics has one row per step" (= (:steps res) (count (:diagnostics res))))
+    (assert-true "trajectory of the best particle is recorded" (>= (count (:trajectory (:best res))) 2))))
+
+(defn- summary []
+  (println (str "\n== search (genmlx-47zx): " @pass " passed, " @fail " failed =="))
+  (when (pos? @fail) (set! (.-exitCode js/process) 1)))
+
+(part-a)
+(part-b)
+(part-c)
+(part-d)
+(summary)

--- a/test/genmlx/synth_test.cljs
+++ b/test/genmlx/synth_test.cljs
@@ -1,0 +1,237 @@
+;; @tier slow
+(ns genmlx.synth-test
+  "Acceptance for genmlx.world.synth — the Phase-1 REPL-synthesis KERNEL (genmlx-n74t):
+   the model-spec + form-level edit ops, the four-level self-check, and the greedy
+   oracle-driven driver. Deterministic, NATIVE-FREE (no policy LLM): conjugate partial
+   models score the EXACT analytical marginal, so every assertion is reproducible. The
+   end-to-end loop-solves-an-advanced-model demonstration (experiment B) lives in
+   scripts/synth_repl_probe.cljs; this file pins the pure, unit-testable parts.
+
+   Run: bun run --bun nbb test/genmlx/synth_test.cljs
+
+   PARTS:
+     A — spec + render + edit ops: each move is a pure spec->spec transform whose
+         render is valid ClojureScript with the expected structure.
+     B — the check node: the four levels gate correctly (parse / schema / coverage /
+         eval / fit), with the right :error, and a valid model's :evidence matches an
+         INDEPENDENT closed-form Gaussian-Gaussian marginal (non-circular).
+     C — the greedy driver: climbs exact evidence, rejects distractor + broken
+         candidates (backtrack), self-terminates on plateau, and lands at the
+         grid-optimal model the closed form predicts."
+  (:require [genmlx.world.synth :as s]
+            [genmlx.codegen.eval :as ce]
+            [clojure.string :as str]))
+
+(def ^:private pass (atom 0))
+(def ^:private fail (atom 0))
+
+(defn assert-true [label v]
+  (if v
+    (do (swap! pass inc) (println "  PASS" label))
+    (do (swap! fail inc) (println "  FAIL" label))))
+
+(defn assert-close [label expected actual tol]
+  (let [ok (and (number? actual) (js/isFinite actual) (<= (js/Math.abs (- expected actual)) tol))]
+    (if ok
+      (do (swap! pass inc) (println "  PASS" label (str "(" actual " ~ " expected ")")))
+      (do (swap! fail inc) (println "  FAIL" label (str "(" actual " vs " expected " tol " tol ")"))))))
+
+;; Independent closed-form Gaussian-Gaussian marginal (DERIVED outside GenMLX —
+;; mu ~ N(m0,s0), y_i ~ N(mu, sn) — so the evidence check is not circular).
+(defn gaussian-gaussian-marginal [ys m0 s0 sn]
+  (let [n (count ys) s0² (* s0 s0) sn² (* sn sn)
+        ds (map #(- % m0) ys) sd (reduce + ds) sd² (reduce + (map #(* % %) ds))
+        denom (+ sn² (* n s0²))
+        logdet (+ (js/Math.log denom) (* (dec n) (js/Math.log sn²)))
+        quad (* (/ 1.0 sn²) (- sd² (* (/ s0² denom) (* sd sd))))]
+    (- (* -0.5 n (js/Math.log (* 2 js/Math.PI))) (* 0.5 logdet) (* 0.5 quad))))
+
+(def ^:private obs4 {:y0 2.0 :y1 2.3 :y2 1.7 :y3 2.1})
+(def ^:private obs-ys (mapv obs4 [:y0 :y1 :y2 :y3]))
+
+;; A shared-mean spec helper: mu ~ N(m0, s0), each :yj ~ N(mu, noise).
+(defn shared-mean-spec [m0 s0 noise]
+  (s/spec [(s/latent 'mu "gaussian" [m0 s0])]
+          (for [k [:y0 :y1 :y2 :y3]]
+            (s/obs k "gaussian" ['mu noise]))))
+
+;; ===========================================================================
+;; PART A — spec + render + edit operations
+;; ===========================================================================
+
+(defn part-a []
+  (println "\n== PART A: spec + render + edit ops ==")
+  (let [sp (shared-mean-spec 2 1 0.5)
+        code (s/render sp)]
+    (assert-true "render produces a complete cljs form" (ce/valid-cljs? code))
+    (assert-true "render reads as (fn [trace] ...)" (str/starts-with? code "(fn [trace] (let ["))
+    (assert-true "render emits the latent let-binding"
+                 (str/includes? code "mu (trace :mu (dist/gaussian 2 1))"))
+    (assert-true "render emits an obs trace site in the returned map"
+                 (str/includes? code ":y0 (trace :y0 (dist/gaussian mu 0.5))")))
+
+  ;; add-latent / add-obs
+  (let [sp (-> (s/spec [] [])
+               (s/add-latent (s/latent 'slope "gaussian" [0 3]))
+               (s/add-obs (s/obs :y0 "gaussian" ['slope 1])))]
+    (assert-true "add-latent appends a latent" (= 1 (count (:latents sp))))
+    (assert-true "add-obs appends an obs site" (= 1 (count (:obs sp))))
+    (assert-true "add-latent + add-obs render to valid cljs" (ce/valid-cljs? (s/render sp)))
+    (assert-true "add-obs REPLACES an existing addr (no duplicate)"
+                 (= 1 (count (:obs (s/add-obs sp (s/obs :y0 "gaussian" ['slope 2])))))))
+
+  ;; set-args (set-prior) / set-mean / set-noise
+  (let [sp (shared-mean-spec 2 1 0.5)]
+    (assert-true "set-args replaces a latent's prior"
+                 (str/includes? (s/render (s/set-args sp :mu [0 10]))
+                                "mu (trace :mu (dist/gaussian 0 10))"))
+    (assert-true "set-mean re-points an obs at a latent-dependent mean"
+                 (str/includes? (s/render (s/set-mean sp :y0 (list 'mx/multiply 'mu (list 'mx/scalar 2.0))))
+                                ":y0 (trace :y0 (dist/gaussian (mx/multiply mu (mx/scalar 2)) 0.5))"))
+    (assert-true "set-noise replaces an obs site's last arg"
+                 (str/includes? (s/render (s/set-noise sp :y0 1.5))
+                                ":y0 (trace :y0 (dist/gaussian mu 1.5))"))
+    (assert-true "edit ops leave other sites untouched"
+                 (str/includes? (s/render (s/set-noise sp :y0 1.5))
+                                ":y1 (trace :y1 (dist/gaussian mu 0.5))")))
+
+  ;; homogeneous-obs?: detects the Map-fold opportunity (same dist, same noise, same
+  ;; single latent mean) without rewriting; false for heterogeneous / non-latent means.
+  (let [homo     (s/spec [(s/latent 'mu "gaussian" [0 5])]
+                         (for [k [:y0 :y1 :y2]] (s/obs k "gaussian" ['mu 1])))
+        hetero   (s/spec [(s/latent 'a "gaussian" [0 5]) (s/latent 'b "gaussian" [0 5])]
+                         [(s/obs :y0 "gaussian" ['a 1]) (s/obs :y1 "gaussian" ['b 1])])
+        non-lat  (s/spec [(s/latent 'mu "gaussian" [0 5])]
+                         [(s/obs :y0 "gaussian" [(list 'mx/scalar 0.0) 1])])]
+    (assert-true "homogeneous-obs? true for same dist+noise+single latent mean"
+                 (s/homogeneous-obs? homo))
+    (assert-true "homogeneous-obs? false for distinct per-site latents"
+                 (not (s/homogeneous-obs? hetero)))
+    (assert-true "homogeneous-obs? false when the mean is not a latent symbol"
+                 (not (s/homogeneous-obs? non-lat))))
+
+  ;; set-noise is robust on a no-arg site (pure no-op, never throws).
+  (let [sp (s/spec [] [(s/obs :y0 "gaussian" [])])]
+    (assert-true "set-noise on an empty-args site is a no-op (no throw)"
+                 (= sp (s/set-noise sp :y0 1.0)))))
+
+;; ===========================================================================
+;; PART B — the four-level self-check
+;; ===========================================================================
+
+(defn part-b []
+  (println "\n== PART B: the check node (four levels) ==")
+
+  ;; level 1: syntax
+  (let [fb (s/check "(fn [trace] (let [" obs4)]
+    (assert-true "unparseable -> :parses? false" (false? (:parses? fb)))
+    (assert-true "unparseable -> not evaluated, has an :error"
+                 (and (false? (:evals? fb)) (string? (:error fb)))))
+
+  ;; level 2: semantics — body does not return a map
+  (let [fb (s/check "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 1))] mu))" obs4)]
+    (assert-true "non-map return -> :schema-ok? false" (false? (:schema-ok? fb)))
+    (assert-true "non-map return -> :returns-map? false" (false? (:returns-map? fb))))
+
+  ;; level 2: semantics — a delta DISTRIBUTION CONSTRUCTOR is the point-mass hack
+  (let [fb (s/check (str "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 1))] "
+                         "{:y0 (trace :y0 (dist/delta mu))}))") {:y0 2.0})]
+    (assert-true "(dist/delta ...) -> :uses-delta? true" (true? (:uses-delta? fb)))
+    (assert-true "(dist/delta ...) -> :schema-ok? false (rejected)" (false? (:schema-ok? fb))))
+
+  ;; but an honest latent merely NAMED `delta` (a common offset name) is NOT rejected
+  (let [fb (s/check (str "(fn [trace] (let [delta (trace :delta (dist/gaussian 0 1))] "
+                         "{:y0 (trace :y0 (dist/gaussian delta 1))}))") {:y0 2.0})]
+    (assert-true "a variable named `delta` is NOT a point-mass hack" (false? (:uses-delta? fb)))
+    (assert-true "a variable named `delta` -> :schema-ok? true (accepted + scored)"
+                 (and (:schema-ok? fb) (s/scored? fb))))
+
+  ;; empty observations is a misconfiguration, not a perfectly-explained (evidence-0) model
+  (let [fb (s/check (s/render (shared-mean-spec 2 1 0.5)) {})]
+    (assert-true "empty observations -> not scored (no vacuous evidence 0)"
+                 (and (not (s/scored? fb)) (nil? (:evidence fb))))
+    (assert-true "empty observations -> carries an explanatory :error" (string? (:error fb))))
+
+  ;; level 3: coverage — declares a latent but ignores the data addresses
+  (let [fb (s/check "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 5))] {:result (trace :result (dist/gaussian mu 1))}))" obs4)]
+    (assert-true "uncovered -> :schema-ok? true but :covered? false"
+                 (and (:schema-ok? fb) (false? (:covered? fb))))
+    (assert-true "uncovered -> not scored (no evidence)" (nil? (:evidence fb))))
+
+  ;; level 4: behavior — covered, well-formed, but errors at eval (unknown dist)
+  (let [fb (s/check (str "(fn [trace] {:y0 (trace :y0 (dist/student-t 0 1))})") {:y0 2.0})]
+    (assert-true "eval error -> :covered? true but :evals? false"
+                 (and (:covered? fb) (false? (:evals? fb))))
+    (assert-true "eval error -> captures an :error message" (string? (:error fb))))
+
+  ;; level 5: fit — a valid model scores the EXACT marginal (matches the closed form)
+  (let [m0 2 s0 1 sn 0.5
+        fb (s/check (s/render (shared-mean-spec m0 s0 sn)) obs4)
+        truth (gaussian-gaussian-marginal obs-ys m0 s0 sn)]
+    (assert-true "valid model -> parses/schema-ok/covered/evals all true"
+                 (and (:parses? fb) (:schema-ok? fb) (:covered? fb) (:evals? fb)))
+    (assert-true "valid conjugate model scored by an EXACT method" (= :exact (:method fb)))
+    (assert-close "check evidence == independent closed-form marginal" truth (:evidence fb) 1e-2))
+
+  ;; scored? predicate
+  (assert-true "scored? true for a finite-evidence verdict"
+               (s/scored? (s/check (s/render (shared-mean-spec 2 1 0.5)) obs4)))
+  (assert-true "scored? false for an unparseable verdict"
+               (not (s/scored? (s/check "(fn [trace] (let [" obs4)))))
+
+;; ===========================================================================
+;; PART C — the greedy driver climbs, backtracks, self-terminates
+;; ===========================================================================
+
+(defn part-c []
+  (println "\n== PART C: greedy REPL driver ==")
+  (let [grid       [0.3 0.5 0.7 1 1.5 2.5]
+        init       (shared-mean-spec 2 1 2.5)   ; loose noise: headroom to climb
+        ;; proposer = noise-grid refinements (good) + a clearly-worse distractor
+        ;; (noise 9.0) + a BROKEN candidate (drops :y3 -> uncovered). The oracle must
+        ;; pick only improving valid moves; the distractor/broken never get accepted.
+        broken     (update (shared-mean-spec 2 1 0.5) :obs (comp vec butlast))
+        propose    (fn [sp _fb]
+                     (concat (s/noise-refinements sp grid)
+                             [{:edit :distractor :desc "noise -> 9.0 (worse)" :spec' (s/set-noise sp :y0 9.0)}
+                              {:edit :broken :desc "drop :y3 (uncovered)" :spec' broken}]))
+        res        (s/synthesize {:init-spec init :observations obs4 :propose propose})
+        traj       (:trajectory res)
+        init-ev    (:evidence (first traj))
+        final-ev   (:evidence (last traj))
+        grid-best  (apply max (map #(gaussian-gaussian-marginal obs-ys 2 1 %) grid))]
+    (assert-true "driver self-terminates on plateau" (= :plateau (:stop-reason res)))
+    (assert-true "driver makes >=1 accepted edit" (>= (count traj) 2))
+    (assert-true "final evidence strictly improves on the crude start" (> final-ev init-ev))
+    (assert-true "every accepted step has a positive delta (monotone climb)"
+                 (every? #(or (nil? (:delta %)) (pos? (:delta %))) traj))
+    ;; the per-site noise search STRICTLY CONTAINS the homogeneous-noise grid (setting
+    ;; every site to the same sigma is reachable), so the driver does at least as well
+    ;; as the best shared-sigma model the closed form predicts — here strictly better.
+    (assert-true "driver does at least as well as the best shared-sigma model (closed-form max)"
+                 (>= final-ev (- grid-best 1e-2)))
+    (assert-true "no distractor/broken edit was ever accepted"
+                 (every? #(not (contains? #{:distractor :broken} (:edit %))) traj))
+    (assert-true "final model is valid + covered + scored" (s/scored? (:feedback res)))
+
+    ;; a never-scored init (uncovered) the proposer cannot complete -> :stuck, NOT a
+    ;; spurious :plateau (which would falsely read as a fitted model).
+    (let [stuck-init (s/spec [(s/latent 'mu "gaussian" [0 1])] [(s/obs :result "gaussian" ['mu 1])])
+          stuck (s/synthesize {:init-spec stuck-init :observations obs4 :propose (fn [_ _] [])})]
+      (assert-true "never-scored init + no candidate -> :stop-reason :stuck (not :plateau)"
+                   (= :stuck (:stop-reason stuck))))
+
+    (println (str "  trajectory: "
+                  (str/join " -> " (map (fn [r] (str (name (:edit r)) "@"
+                                                     (.toFixed (js/Number (:evidence r)) 2))) traj))))))
+
+;; ===========================================================================
+
+(defn- summary []
+  (println (str "\n== synth (genmlx-n74t): " @pass " passed, " @fail " failed =="))
+  (when (pos? @fail) (set! (.-exitCode js/process) 1)))
+
+(part-a)
+(part-b)
+(part-c)
+(summary)


### PR DESCRIPTION
## North-star milestone: the programmer as a GenMLX model

Lands the REPL-driven resource-rational program-synthesis foundation (epic genmlx-77vv) — synthesis as **Bayesian inference over a generative model of the programmer**, with an **exact model-evidence likelihood on PARTIAL programs** and the REPL trace as the harvestable latent.

### Phases 1–3 (the headline)
- **Phase 1 — kernel** (`genmlx-n74t`, `world/synth.cljs`): the four-level self-check (`check`), form-level edit ops, the greedy oracle-driven `synthesize` driver. Native-free (reuses `msa-score` + `codegen.eval`, never the policy LLM). `synth_test` 43/43.
- **Phase 2 — search** (`genmlx-47zx`, `world/search.cljs`): particle/beam search over construction steps (beam beats greedy, escaping greedy lock-in). `search_test` 22/22.
- **Real LLM in the loop** (`genmlx-0yv7`, `world/llm_proposer.cljs` + `scripts/llm_server.py` resident mlx-lm worker): a real policy LLM as the feedback-conditioned proposer, with REPL revision + the LLM⊕σ-grid hybrid. **35B result: the loop beats one-shot and the margin grows with structural complexity** (linreg tie / kalman +0.6 / varying-slopes +10.6 nats). `llm_proposer_test` 41/41.
- **Phase 3 foundation — harvester** (`genmlx-oexl` #1, `world/repl_corpus.cljs`): REPL-trace → SFT-corpus (each accepted transition → a propose-eval-revise chat row, oracle-filtered + leakage-safe). `repl_corpus_test` 15/15.
- **Curriculum generator** (`genmlx-ilna`, `world/curriculum.cljs`): graded, oracle-grounded, leakage-safe bank of structured linear-Gaussian model-fitting tasks; 6 families × 3 complexity bands; a 149-task run is well-posed end-to-end (0 leaks, no-LLM loop solves 6/6). `curriculum_test` 456/456.

### Why it also carries the cljs-coder-loop substrate
The foundation depends on a small **`sft.cljs` correctness fix** (`partition-corpus` must honor its `eval-ids` arg — main's version ignored it for a hardcoded set) that lives in the cljs-coder-loop commits (`genmlx-7473`/`genmlx-2ctu`/`genmlx-qsoa`). `repl-corpus`'s leakage-safety relies on it, so those commits are included rather than risk a silently-broken split. This also brings `distill_gen` (oracle-grounding precedent the curriculum reuses conceptually), the SFT harness scripts, and one **experimental** GRPO-sharpening commit (`genmlx-2ctu`, documented: SFT is the shipped deliverable; the native-engine GRPO path hit a wedge).

### Test status
Foundation suites green: synth 43, search 22, llm_proposer 41, repl_corpus 15, curriculum 456; distill_gen committed green. (The Kalman-chain-detection correctness fix `genmlx-iraj` is split into its own PR #157.)

### Next
Phase 3 proper (`genmlx-oexl`): run the 35B loop over this curriculum → harvest at scale → SFT the 0.8B → GRPO → eval on the task-disjoint split. Then Phase 4 `genmlx.control`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)