### PR TITLE
feat(synth): REPL-synthesis Phase 3 — real LLM in the loop + harvester + curriculum

### DIFF
--- a/docs/programmer-as-genmlx-model.md
+++ b/docs/programmer-as-genmlx-model.md
@@ -302,7 +302,8 @@ verifier turns a 0/16 whole-program problem into a sequence of locally-checkable
   *isolate* the loop-vs-cliff claim from generation noise. The driver is
   proposer-agnostic (an injected `(fn [spec feedback] → candidates)`), so wiring a real
   LLM proposer is a drop-in; **Phase 3 learns it**. So experiment B proves the loop +
-  oracle, not (yet) that a cheap LLM is the proposer.
+  oracle, not (yet) that a cheap LLM is the proposer. **§12 now closes that gap — it puts a
+  real LLM (both tiers) in this exact loop.**
 - The monotone evidence climb is **true by construction** (the driver only appends an
   improving step), so it is *not* itself evidence of success — the discriminating facts
   are that the **structural** edit was accepted and the loop self-terminated.
@@ -381,3 +382,208 @@ bottleneck is cleanly localized to the oracle, not the search. Phase 3 (`genmlx-
 swaps the structured proposer for a *learned* one (REPL-trace SFT + GRPO); Phase 4
 (`genmlx-gjih`) is the resource-rational metareasoner over the control sites (beam
 width, particle budget, when to stop — the adaptive allocation here is its seed).
+
+## 12. A REAL LLM in the loop — the load-bearing thesis test (`genmlx-0yv7`)
+
+Sections 10–11 proved the *scaffold* with a hand-coded structured move-vocabulary. They
+did **not** prove the *thesis*, because they never put a real LLM in the loop —
+feedback-conditioning was plumbed but never exercised against a real generator. This
+section closes that gap: a real policy LLM is the proposer, conditioned each step on the
+verifier's feedback, run via `scripts/synth_llm_probe.cljs` against the three
+exact-scoreable advanced models (`linreg` / `kalman` / `hier`) — plus a deliberately
+*harder*, multi-piece model (`vslope`, below) — and the same exact oracle.
+
+**Architecture (native-free, out-of-process).** The synthesis loop never loads a model.
+A resident `scripts/llm_server.py` mlx-lm worker holds the policy LLM in memory;
+`genmlx.world.llm-proposer/call-server` reaches it over HTTP with a synchronous `curl`
+(the driver is synchronous; an LLM call is a genuine I/O boundary). The proposer is a
+drop-in for the already-injected `(fn [spec feedback] → candidates)` slot — so the Phase-1
+driver and the Phase-2 search run **unchanged**; only the proposer differs from the
+structured control. The check node sees the LLM's *literal* code (`synth`/`search` prefer
+a candidate's raw `:code`), so a real DSL slip reaches the verifier exactly as written.
+
+**The mechanism that putting a real LLM in the loop forced us to build: REPL revision.**
+The decisive empirical finding is that a strong instruct model (Qwen3.6-35B-A3B) produces
+the *correct model structure* (e.g. `slope·x + intercept` for `linreg`) but with a
+*one-eval-away DSL slip* — most often a noise **scale given a `(dist/gaussian ..)` prior**
+(which can go negative → non-finite evidence), or a **hallucinated distribution**
+(`dist/positiveskew`). With *no* feedback (one-shot best-of-K) every candidate carried the
+slip, so **0/K scored** — the cliff, reproduced with a real model under a good DSL prompt.
+And a naïve loop that only conditions on the *accepted* model's status **stalls**: when a
+slip blocks *every* candidate, the model is never told *why*. So the proposer
+(`make-proposer`) is a **mini-REPL**: it proposes K candidates, **checks its own output
+against the verifier**, and on a slip **re-prompts the model with that specific error**
+(the most-progressed failure's verdict — a non-positive scale, a missing distribution, an
+uncovered address) up to `:revise` times. This is the north-star inner loop — *propose →
+eval → read the error → revise* — and it is exactly what a one-shot interface denies the
+model. The driver's outer loop still owns **fit** (accept only when exact evidence climbs);
+the proposer's inner loop owns **self-correction**. The structured proposer never slipped,
+so this was invisible until a real LLM exposed it — which is precisely why the step-up
+mattered.
+
+**Exactly-scoreable models, not just valid ones.** The exact oracle is the north star's
+edge, so the DSL prompt also guides the model to write models the oracle can score
+*exactly*: a Gaussian observation with a **fixed positive noise** and its **mean written
+inline** in the `(dist/gaussian ..)` is conjugate → `:exact`; a *latent* σ or a
+*let-factored* mean falls back to noisy importance sampling / HMC and looks worse than it
+is. This is legitimate domain guidance (it aligns the generator with the exact eliminator;
+the structured probe used fixed σ for the same reason) and is given identically to both
+arms. Making the eliminator itself handle latent-σ / let-factored means is the orthogonal
+oracle-reach work (`genmlx-w47t` / `genmlx-aw46`).
+
+### What we ran
+
+Three arms per task, **same model, same DSL prompt, same exact oracle** — the only
+difference is the feedback loop: (1) **one-shot best-of-K** (K full programs, no feedback —
+the control); (2) **greedy loop** (`synth/synthesize` + the LLM proposer); (3) **beam loop**
+(`search/search`, population). Two tiers — the resource-rational fast/slow pair the Phase-4
+metareasoner allocates between: **fast** = `qwen3.5-0.8b-cljs-sft600` (1.4 GB), **slow** =
+`Qwen3.6-35B-A3B-4bit` (19 GB, 3 B-active MoE). "Solved" = reached evidence above a bar set
+≈ halfway from the structureless crude baseline to the data-warranted optimum (so passing
+it requires the *structure*, which the crude model cannot reach). Artifacts: the **fast
+tier** is the complete JSON `~/genmlx-loop-artifacts/particle/synth_llm_probe_fast.json`;
+the **slow-tier** numbers below are read from the run logs (`/tmp/probe_linreg3.log`,
+`/tmp/probe_kh.log`) — those runs were stopped after their decisive arms to free the 19 GB
+model for the fast tier, before the end-of-run artifact write, so there is no slow-tier
+JSON (the only on-disk slow artifact is a *stale* pre-fix run that should be ignored).
+
+### Results — the slow tier (Qwen3.6-35B-A3B, ~10 s/sample)
+
+```
+model    bar     one-shot best-of-K       greedy loop (+revision)   verdict
+linreg   −12.2   −7.51  (6/8 valid)  ✓    −8.31  (1 step)      ✓    both SOLVE  — a tie on the bar
+kalman   −6.0    −6.37  (2/6 valid)  ✗    −5.79  (1 step)      ✓    LOOP SOLVES, one-shot does not
+```
+(K=8 for linreg, K=6 for kalman — the valid-count denominators show it.)
+
+Two clean, opposite outcomes that together tell the honest story. On **linreg** (one
+structural idea — a line) the strong model + the DSL prompt produces 6/8 valid candidates
+and one-shot best-of-8 nails it at −7.51; the loop **ties on the solve-bar** at −8.31
+(though one-shot is ~0.8 nats higher in raw evidence — the "tie" is on solving, not on the
+number). On **kalman** (the harder temporal structure — an AR(1) latent chain) the slip
+rate is higher (only 2/6 one-shot candidates valid) and **one-shot best-of-6 falls short of
+the structure bar (−6.37)**, while the **loop, conditioned on the verifier's feedback,
+climbs past it (−5.79)** in a single accepted step. So where one-shot is *good enough* the loop ties; where
+one-shot *isn't* — exactly the regime the north star targets — the loop wins. (The 0/16
+cliff itself was reproduced earlier in this session with the *weaker* whole-program prompt:
+0/8 valid one-shot; the DSL prompt + the loop is what dissolves it.) The kalman margin is
+**modest** and is really a noise-scale *refinement* + *reliability* win (one-shot's
+best-of-K lottery left the structural model's σ un-tuned at −6.37; the loop tuned it to
+−5.79) rather than a pure structure win — and a fast-tier sample even found a *simpler*
+model at −3.28, the exact oracle correctly preferring the **simplest adequate** model
+(experiment A's Occam) over the 35B's more elaborate AR coupling.
+
+### Results — the fast tier (`qwen3.5-0.8b-cljs-sft600`, ~4 s/sample)
+
+(The 0.8B is only ~2.4× cheaper per sample than the 35B here, not ~10×: its frequent
+**degenerate runs hit the token cap** instead of stopping at EOS, eroding the cheap model's
+speed advantage — another reason the cheap tier needs Phase-3 specialization.)
+
+```
+model    bar     one-shot best-of-8        greedy loop (2 seeds)     beam loop (2 seeds)
+linreg   −12.2   −110.2 (1/8 valid)   ✗    −17.92, −17.92      ✗     −17.92, −17.92      ✗
+kalman   −6.0    −3.28  (2/8 valid)   ✓    −7.27,  −10.15      ✗     −7.27,  −10.15      ✗
+hier     −18.0   −138.6 (1/8 valid)   ✗    −23.77, −23.77      ✗     −23.77, −23.77      ✗
+```
+
+The cheap student **fails the advanced models in *both* arms** — one-shot best-of-8 mostly
+emits malformed or structureless candidates (1/8 valid on linreg/hier, scoring junk), and
+the loop **stalls at the crude baseline** (−17.92 on linreg, greedy *and* beam, both seeds).
+Worse, on kalman the **loop is *below* one-shot** (−7.27/−10.15 vs −3.28): a single lucky
+one-shot sample found a good simple model, but the weak model's *incremental* edits in the
+loop are poor, and a poor proposer makes the population (beam) no better than greedy
+(identical −7.27/−10.15) — a population only helps if at least one of its members is good.
+Revision recovers its *format* slips (coverage, syntax) but cannot supply the *structure
+inference* it lacks: SFT'd on whole-program cljs (not REPL traces), it does not propose the
+slope / coupling / group-split the crude model is missing. This is the honest two-tier
+result — the cheap proposer is **not yet capable** of driving the loop on these models — and
+it is exactly what **Phase 3 (`genmlx-oexl`) exists to fix**: specialize the 0.8B on the
+REPL-trace corpus (the very trajectories the slow-tier runs here produce), so it learns the
+*propose-eval-revise policy*, not whole programs. Until then the metareasoner escalates to
+the big model for structure (the fast/slow `:which` decision).
+
+### A harder benchmark — does the loop's edge grow with structural complexity?
+
+The three models above are *single-idea* (one line / one chain / one group-split), and a
+strong model + the DSL prompt one-shots the easy ones — so they under-test the loop. The
+`vslope` model is deliberately *multi-piece*: **3 groups, each a distinct line in `x`** —
+the data-warranted model needs **6 latents** (a slope *and* an intercept per group), **3
+linear means**, and a tuned noise, all in one program (exactly scoreable, linear-Gaussian,
+calibrated crude ≈ −30 / gold ≈ −17, bar −23.5). The hypothesis: with more pieces, each a
+chance to slip, one-shot best-of-K's joint success rate drops while the loop's revision +
+per-step selection recover the slips — so the loop's margin over one-shot should *widen*.
+
+**Result — and the diagnosis it forced (35B):**
+
+```
+vslope    bar     one-shot best-of-8       loop (greedy / beam)      verdict
+−23.5             −25.25  (4/8 valid)  ✗    −14.61  (both solve) ✓    LOOP WINS by ~10.6 nats
+```
+(greedy reaches −14.61 in 2 steps, beam in 4 — both converge to the σ-grid optimum.)
+
+The first cut **inverted the hypothesis and was the more useful for it.** One-shot best-of-8
+fell short (−25.25); the greedy loop *also* fell short (−26.08) and even slightly *below*
+one-shot — it had **built the full 6-latent structure** (−26.08 is, to the decimal, the
+calibrated full model at σ=1) but then **plateaued without tuning the noise scale**. The
+LLM proposes structure and neglects the nuisance σ — the exact move the *structured*
+proposer (§§10–11) supplied via a σ-grid. Adding that one move back — **union the LLM
+proposer (hard structural moves) with a cheap deterministic shared-σ grid (the
+hyperparameter), the oracle selecting per step** — flips it cleanly: the loop builds the
+structure (step 1, −26) then the oracle tunes σ to the data's true scale (step 2, **−14.61**,
+past even the σ=0.2 gold), while one-shot, which cannot refine, stays at −25.25. **A ~10.6-nat
+win on the model one-shot can't crack** — and a sharp statement of *where* the loop's value
+lives: the LLM for structure, the exact oracle for refinement, and one-shot has neither
+loop. This is the resource-rational split made concrete (cheap grid for the scalar
+hyperparameter, expensive model only for structure).
+
+### Honest verdict — does a real LLM in the loop beat one-shot best-of-K?
+
+**The thesis scaffold holds with a real generator, and the answer is resource-rational, not
+unconditional.**
+
+1. **Validated.** The loop — a *real* LLM proposer + the exact oracle + REPL revision —
+   builds the advanced models that whole-program best-of-16 got 0/16 on (linreg −8.31,
+   kalman −5.79, both above the structure bar). The feedback loop is no longer a scaffold
+   demonstrated only with a hand-coded vocabulary; it works end-to-end with a real model.
+   (Honest attribution: the 0/16 cliff used a *weaker* whole-program prompt, so it is the
+   **DSL prompt + the loop together** that dissolve it — not the loop alone; with the DSL
+   prompt, one-shot already clears the easier models, see below.)
+2. **The load-bearing addition was forced by the real LLM: revision.** A strong model emits
+   correct structure with one-eval-away slips; with no feedback every candidate carries one
+   (0/K valid), and a fit-only loop stalls because it never sees *why*. Re-prompting with the
+   verifier's specific error is what closes the loop. This was invisible with the structured
+   proposer — discovering it is the concrete payoff of *actually putting an LLM in the loop*.
+3. **Beats one-shot, and the margin grows with structural complexity.** On *easy* structure
+   with a *strong* model and a good DSL prompt, one-shot best-of-K already succeeds and the
+   loop **ties** it (linreg). On *harder* structure one-shot's slip rate rises and the loop
+   **wins**: kalman −5.79 vs −6.37, and — decisively — the multi-piece **`vslope`** model
+   (6 latents + 3 lines + a tuned scale) where one-shot tops out at −25.25 (can't assemble
+   *and* tune in one program) while the loop reaches **−14.61, a ~10.6-nat win**. The loop's
+   value is the *composition* one-shot lacks: **LLM for hard structure + exact oracle for
+   refinement**, applied step by step. On the *weak* tier the loop is necessary but not
+   sufficient — the 0.8B needs Phase-3 specialization. So the loop's value is **conditional
+   on the regime** (the resource-rational claim itself): spend one shot when it suffices,
+   spend the loop — and escalate the model — when it does not.
+4. **Honest limitations.** (a) The loop must carry *both* kinds of move: the harder `vslope`
+   model exposed that an LLM proposes structure but neglects the nuisance noise scale, so the
+   loop needs a cheap σ-refinement move (a grid) alongside the LLM's structural edits — with
+   only the LLM it built the structure but stalled at σ=1 (−26); the win required adding the
+   grid back. (b) The DSL
+   prompt is tuned to produce *exactly-scoreable* models (fixed σ, inline means), aligning
+   the generator with the exact eliminator; broadening the eliminator to score latent-σ /
+   let-factored models (`genmlx-w47t` / `genmlx-aw46`) would let the model write more natural
+   code and is the binding oracle-reach constraint. (c) Phase-2 beam-vs-greedy in the
+   *stochastic* regime is only weakly exercised here: the strong tier solves greedily in one
+   step (no room for the population to help) and the weak tier fails both — so the clean
+   beam-beats-greedy evidence remains the structured probe's (§11, linreg +3.24 nats). The
+   structured-proposer results (§§10–11) stand as the deterministic **control**.
+
+**Bottom line:** putting a real LLM in the loop confirms the north star's core bet — the
+closed feedback loop with an exact verifier turns one-shot-fragile model-building into
+locally-checkable, self-correcting construction — and the win is **largest exactly where it
+should be**: on the hardest, multi-piece model the loop beats one-shot by ~10.6 nats
+(−14.6 vs −25.3), because it *composes* what one-shot cannot — LLM-proposed structure with
+oracle-driven refinement, step by step. It also sharpens honestly: the win is
+regime-dependent (one shot suffices on easy models), the loop must carry both structural and
+hyperparameter moves, the cheap proposer needs Phase 3, and the exact oracle's reach is the
+next lever. This is the validated ground Phase 3 (`genmlx-oexl`) now builds on.

--- a/scripts/curriculum_probe.cljs
+++ b/scripts/curriculum_probe.cljs
@@ -1,0 +1,113 @@
+(ns curriculum-probe
+  "RUN + inspect the REPL-synthesis CURRICULUM (genmlx.world.curriculum, bean genmlx-ilna).
+
+   Generates a graded, oracle-grounded, leakage-safe curriculum of structured-model
+   tasks, writes it as a JSON artifact (out-of-tree), and proves end-to-end that it is
+   consumable by BOTH downstream consumers:
+     - the run loop  (scripts/synth_llm_probe.cljs)  via cur/->probe-task
+     - the harvester (genmlx.world.repl-corpus)       via a no-LLM family-proposer loop
+
+   It reports the COMPLEXITY SPREAD (the resource-rational training signal: gap/n-latents
+   by complexity band) and the two eval cohorts (within-family same-distribution vs the
+   held-out family compositional/OOD).
+
+   Run: bun run --bun nbb scripts/curriculum_probe.cljs
+   Env: INSTANCES (per family, default 25), ROUND (default 0)."
+  (:require [genmlx.world.curriculum :as cur]
+            [genmlx.world.synth :as syn]
+            [genmlx.world.repl-corpus :as rc]
+            [clojure.string :as str]))
+
+(def os   (js/require "os"))
+(def path (js/require "path"))
+(def fs   (js/require "fs"))
+(defn home [& xs] (apply (.-join path) (.homedir os) xs))
+(def out-dir (home "genmlx-loop-artifacts" "curriculum"))
+(defn- env [k d] (or (aget (.-env js/process) k) d))
+(defn- envi [k d] (let [v (env k nil)] (if v (js/parseInt v 10) d)))
+(defn fx [x] (if (and x (js/isFinite x)) (.toFixed (js/Number x) 2) (str x)))
+
+(def instances (envi "INSTANCES" 25))
+(def round     (envi "ROUND" 0))
+
+(println (str "\n=== curriculum RUN  (round " round ", " instances " instances/family) ===\n"))
+(def C (cur/generate-curriculum {:round round :instances-per-family instances}))
+(def tasks (:tasks C))
+
+;; ---------------------------------------------------------------------------
+;; Report.
+;; ---------------------------------------------------------------------------
+(let [s (:summary C)]
+  (println "SUMMARY")
+  (println "  tasks:" (:n-tasks s) " train:" (:n-train s) " eval:" (:n-eval s)
+           " (within-family:" (:eval-within s) " held-out-family:" (:eval-family s) ")")
+  (println "  held-out families:" (:held-out-families s) "  total drops:" (:total-drops s)))
+
+(println "\nBY FAMILY")
+(doseq [[fam {:keys [n drops complexity]}] (:by-family C)]
+  (println (str "  " (name fam)) "  c=" complexity "  n=" n "  drops=" drops))
+
+(println "\nBY COMPLEXITY  (the resource-rational spread)")
+(doseq [[c {:keys [n mean-gap mean-struct-gap mean-n-latents]}] (:by-complexity C)]
+  (println (str "  complexity " c ":  n=" n
+                "  mean-gap=" (fx mean-gap) " nats"
+                "  mean-struct-gap=" (fx mean-struct-gap)
+                "  mean-n-latents=" (fx mean-n-latents))))
+(let [bc (:by-complexity C) cs (sort (keys bc))]
+  (println "  -> n-latents monotone:" (apply <= (map #(:mean-n-latents (bc %)) cs))
+           " | hardest gap > easiest gap:"
+           (> (:mean-gap (bc (last cs))) (:mean-gap (bc (first cs))))))
+
+(println "\nEXAMPLE TASKS (one per family)")
+(doseq [fam (map :family cur/family-defs)
+        :let [t (first (filter #(= fam (:family %)) tasks))]
+        :when t]
+  (println (str "  [" (name fam) "] " (:id t) "  exact?=" (:exact? t)
+                "  crude=" (fx (:crude t)) " gold=" (fx (:gold t))
+                " bar=" (fx (:solve-bar t)) " gap=" (fx (:gap t))))
+  (println (str "      desc: " (:task-desc t))))
+
+;; ---------------------------------------------------------------------------
+;; End-to-end harvest proof (no LLM): run one task/family through the family-proposer
+;; loop, harvest with repl-corpus using the curriculum's eval-ids, show leakage-safety.
+;; ---------------------------------------------------------------------------
+(println "\nEND-TO-END HARVEST (no LLM; family-proposer loop -> repl-corpus)")
+(defn harvest-run [t]
+  (let [obs (:observations t)
+        res (syn/synthesize {:init-spec (cur/crude-spec obs) :observations obs
+                             :propose (cur/family-proposer t) :max-steps 8})]
+    {:task t :trajectory (:trajectory res)
+     :steps (:steps res) :final (get-in res [:feedback :evidence])
+     :solved? (>= (get-in res [:feedback :evidence] -1e9) (:solve-bar t))}))
+
+(def sample-runs
+  (vec (for [fam (map :family cur/family-defs)
+             :let [t (first (filter #(= fam (:family %)) tasks))] :when t]
+         (harvest-run t))))
+(doseq [r sample-runs]
+  (println (str "  [" (name (:family (:task r))) "] steps=" (:steps r)
+                " final=" (fx (:final r)) " bar=" (fx (:solve-bar (:task r)))
+                " solved=" (:solved? r))))
+(println "  loop solves" (count (filter :solved? sample-runs)) "/" (count sample-runs)
+         "sampled tasks via the no-LLM structured proposer")
+
+(let [corpus (rc/build-corpus sample-runs {:eval-ids (:eval-task-ids C)})]
+  (println "\nHARVEST CORPUS")
+  (println "  rows:" (:n-rows corpus) " train-rows:" (count (:train-rows corpus))
+           " dropped-eval-rows:" (count (:dropped-eval corpus)))
+  (println "  train task ids:" (:train-task-ids corpus))
+  (println "  leakage-safe:" (not-any? #(contains? (:eval-task-ids C) (:task-id %))
+                                       (:train-rows corpus))))
+
+;; ---------------------------------------------------------------------------
+;; Write the JSON artifact (out-of-tree).
+;; ---------------------------------------------------------------------------
+(.mkdirSync fs out-dir #js {:recursive true})
+(def artifact (.join path out-dir (str "curriculum-r" round ".json")))
+(.writeFileSync fs artifact
+  (.stringify js/JSON (clj->js {:summary (:summary C)
+                                :by-family (:by-family C)
+                                :by-complexity (:by-complexity C)
+                                :eval-task-ids (vec (:eval-task-ids C))
+                                :tasks tasks}) nil 2))
+(println (str "\nwrote " (count tasks) " tasks -> " artifact))

--- a/scripts/llm_server.py
+++ b/scripts/llm_server.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Persistent mlx-lm generation worker for the REPL-synthesis LOOP (genmlx-0yv7 /
+genmlx-wpua). The policy LLM lives OUT-OF-PROCESS, exactly as the GenMLX oracle spine
+(codegen.eval + msa-score) is native-free: the synthesis loop in `genmlx.world.synth` /
+`genmlx.world.search` never loads a model — it shells out to THIS worker for proposals.
+
+WHY A LONG-RUNNING SERVER (not the per-call batch in distill_teacher.py): the loop is
+ADAPTIVE — every prompt is conditioned on the previous step's check feedback, so the
+proposals cannot be pre-generated. The model must stay resident and answer one
+request per propose() call. This holds the model in memory once (~19GB for the 35B-A3B
+teacher on the 32GB mini) and serves K samples per HTTP round-trip.
+
+PROMPT RENDERING is byte-identical to distill_teacher.build_prompt (chat template,
+enable_thinking=False so Qwen3 emits the form directly), so the in-loop proposer and
+the offline distill/SFT pipeline render the same way.
+
+PROTOCOL (single-threaded http.server; the CLJS side curls it synchronously):
+  POST /generate  {prompt, system?, n?, temperature?, max_tokens?, top_p?, seed?}
+                  -> {completions: [str,...], n, gen_time_s, prompt_tokens,
+                      completion_tokens, model}
+  GET  /health    -> {status:"ready", model}
+
+USAGE
+  python3 scripts/llm_server.py --model qwen3.5-0.8b-cljs-sft600 --port 8765
+  python3 scripts/llm_server.py --model Qwen3.6-35B-A3B-4bit   --port 8765
+Prints "READY <model>" to stdout once the weights are loaded (the launcher polls it).
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+def resolve_model(spec):
+    """A local ~/.cache/models/<name> dir if it exists, else the spec verbatim."""
+    local = os.path.expanduser(os.path.join("~/.cache/models", spec))
+    return local if os.path.isdir(local) else spec
+
+
+def build_prompt(tokenizer, system_prompt, user_prompt):
+    """Render a chat prompt with Qwen3 reasoning disabled (emit the code form
+    directly). Identical to scripts/distill_teacher.py."""
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": user_prompt})
+    try:
+        return tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=False,
+            enable_thinking=False)
+    except TypeError:
+        return tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=False)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True,
+                    help="local ~/.cache/models/<name> dir or an HF/mlx-community id")
+    ap.add_argument("--adapter", default=None, help="optional LoRA adapter dir")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=8765)
+    ap.add_argument("--max-tokens", type=int, default=384)
+    ap.add_argument("--temp", type=float, default=0.7)
+    ap.add_argument("--top-p", type=float, default=0.95)
+    args = ap.parse_args()
+
+    import mlx.core as mx
+    from mlx_lm import load, generate
+    from mlx_lm.sample_utils import make_sampler
+
+    model_path = resolve_model(args.model)
+    adapter = resolve_model(args.adapter) if args.adapter else None
+    print(f"Loading model: {model_path}"
+          + (f"  (+LoRA {adapter})" if adapter else ""), flush=True)
+    t0 = time.time()
+    model, tokenizer = load(model_path, adapter_path=adapter)
+    print(f"  loaded in {time.time() - t0:.1f}s", flush=True)
+
+    def generate_n(prompt_text, system, n, temperature, max_tokens, top_p, seed):
+        full = build_prompt(tokenizer, system, prompt_text)
+        prompt_tokens = len(tokenizer.encode(full))
+        sampler = make_sampler(temp=temperature, top_p=top_p)
+        greedy = make_sampler(temp=0.0)
+        outs, comp_tokens = [], 0
+        t = time.time()
+        for i in range(n):
+            # Seed per sample for reproducibility; sample 0 of a >1 batch is greedy
+            # (argmax) so a single deterministic anchor is always present, the rest
+            # sampled for diversity (the stochastic-proposer regime Phase 2 needs).
+            mx.random.seed(seed * 100003 + i)
+            use_greedy = (n > 1 and i == 0) or temperature <= 0.0
+            text = generate(model, tokenizer, prompt=full, max_tokens=max_tokens,
+                            sampler=(greedy if use_greedy else sampler), verbose=False)
+            outs.append(text)
+            comp_tokens += len(tokenizer.encode(text))
+        return {"completions": outs, "n": n, "gen_time_s": round(time.time() - t, 3),
+                "prompt_tokens": prompt_tokens, "completion_tokens": comp_tokens,
+                "model": os.path.basename(model_path)}
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *a):  # quiet
+            pass
+
+        def _send(self, code, obj):
+            body = json.dumps(obj).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            if self.path == "/health":
+                self._send(200, {"status": "ready",
+                                 "model": os.path.basename(model_path)})
+            else:
+                self._send(404, {"error": "not found"})
+
+        def do_POST(self):
+            if self.path != "/generate":
+                self._send(404, {"error": "not found"})
+                return
+            try:
+                length = int(self.headers.get("Content-Length", 0))
+                req = json.loads(self.rfile.read(length) or b"{}")
+                res = generate_n(
+                    req["prompt"], req.get("system"),
+                    int(req.get("n", 1)),
+                    float(req.get("temperature", args.temp)),
+                    int(req.get("max_tokens", args.max_tokens)),
+                    float(req.get("top_p", args.top_p)),
+                    int(req.get("seed", 1)))
+                self._send(200, res)
+            except Exception as e:  # noqa: BLE001 — report, never crash the server
+                self._send(500, {"error": f"{type(e).__name__}: {e}"})
+
+    httpd = HTTPServer((args.host, args.port), Handler)
+    print(f"READY {os.path.basename(model_path)} @ http://{args.host}:{args.port}",
+          flush=True)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_llm_probe.sh
+++ b/scripts/run_llm_probe.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Launch the resident mlx-lm worker (scripts/llm_server.py), wait for READY, run the
+# real-LLM experiment-B probe (scripts/synth_llm_probe.cljs), then tear the worker down.
+# The policy LLM lives OUT-OF-PROCESS; the native-free synthesis loop curls it.
+#
+# Usage:  scripts/run_llm_probe.sh <model> <tier> [PORT=8765]
+#   e.g.  scripts/run_llm_probe.sh qwen3.5-0.8b-cljs-sft600 fast
+#         scripts/run_llm_probe.sh Qwen3.6-35B-A3B-4bit    slow
+# Probe knobs are env vars passed through: K_ONESHOT K_STEP BEAM_WIDTH MAX_STEPS SEEDS NP TEMP TASKS
+set -uo pipefail
+MODEL="${1:?usage: run_llm_probe.sh <model> <tier> [PORT]}"
+TIER="${2:?usage: run_llm_probe.sh <model> <tier> [PORT]}"
+PORT="${3:-${PORT:-8765}}"
+URL="http://127.0.0.1:${PORT}"
+LOG="$(mktemp -t llm_server.XXXXXX).log"
+
+echo "[run] launching worker: $MODEL on :$PORT (log $LOG)"
+python3 scripts/llm_server.py --model "$MODEL" --port "$PORT" >"$LOG" 2>&1 &
+SRV=$!
+trap 'echo "[run] tearing down worker $SRV"; kill "$SRV" 2>/dev/null; wait "$SRV" 2>/dev/null' EXIT
+
+echo "[run] waiting for READY (model load can take minutes for the 35B)..."
+for i in $(seq 1 900); do
+  if curl -s "${URL}/health" >/dev/null 2>&1; then echo "[run] worker READY after ${i}s"; break; fi
+  if ! kill -0 "$SRV" 2>/dev/null; then echo "[run] worker DIED. log:"; cat "$LOG"; exit 1; fi
+  sleep 1
+done
+
+SERVER_URL="$URL" TIER="$TIER" bun run --bun nbb scripts/synth_llm_probe.cljs
+RC=$?
+echo "[run] probe exit $RC. worker log tail:"; tail -5 "$LOG"
+exit $RC

--- a/scripts/synth_llm_probe.cljs
+++ b/scripts/synth_llm_probe.cljs
@@ -1,0 +1,279 @@
+(ns synth-llm-probe
+  "EXPERIMENT B — WITH A REAL LLM IN THE LOOP (beans genmlx-0yv7 / genmlx-1pan): the
+   north-star's load-bearing empirical test.
+
+   The structured-proposer experiments (synth_repl_probe / synth_search_probe) PROVED the
+   scaffold — the four-level check, the edit ops, the greedy driver, the particle search.
+   They did NOT prove the THESIS, because they never put a real LLM in the loop. This
+   probe does: a real policy LLM is the proposer, conditioned each step on the verifier's
+   feedback, and we ask the load-bearing question directly —
+
+     does the LLM-in-the-loop, conditioned on feedback, beat one-shot best-of-K?
+
+   THREE ARMS PER TASK, SAME MODEL, SAME DSL PROMPT, SAME ORACLE (the only difference is
+   the feedback loop):
+     1. ONE-SHOT best-of-K   — K full programs, NO feedback. The control (the cliff:
+                                whole-program best-of-16 got 0/16 on these models).
+     2. GREEDY loop          — genmlx.world.synth with the LLM proposer (beam-width 1).
+     3. BEAM   loop          — genmlx.world.search with the LLM proposer (population).
+
+   PHASE-2 ROBUSTNESS: greedy vs beam over SEEDS seeds — population search's real
+   justification is robustness to a NOISY/stochastic proposer, which is exactly the LLM
+   regime (each propose is temperature-sampled). We report per-strategy mean evidence +
+   solve-rate over seeds.
+
+   COST: the resident worker reports per-call gen-time + tokens; we accumulate them, so
+   each tier's (solve-rate, cost) is the frontier the Phase-4 fast/slow metareasoner
+   allocates over.
+
+   The 3 tasks are the EXACT-scoreable advanced models whole-program best-of-16 got 0/16
+   on (byte-identical data to synth_repl_probe / particle_advanced_probe), so the
+   comparison is apples-to-apples.
+
+   Requires a running worker (scripts/llm_server.py). Run via scripts/run_llm_probe.sh
+   (which launches the worker, waits for READY, runs this, tears down). Env:
+     SERVER_URL (default http://127.0.0.1:8765), TIER (output label), TASKS (csv subset),
+     K_ONESHOT, K_STEP, BEAM_WIDTH, MAX_STEPS, SEEDS, NP (IS particles), TEMP."
+  (:require [genmlx.world.llm-proposer :as lp]
+            [genmlx.world.synth :as syn]
+            [genmlx.world.search :as se]
+            [clojure.string :as str]))
+
+(def os   (js/require "os"))
+(def path (js/require "path"))
+(def fs   (js/require "fs"))
+(defn home [& xs] (apply (.-join path) (.homedir os) xs))
+(def out-dir (home "genmlx-loop-artifacts" "particle"))
+(defn fx [x] (when (and x (js/isFinite x)) (.toFixed (js/Number x) 2)))
+(defn- env [k d] (or (aget (.-env js/process) k) d))
+(defn- envi [k d] (let [v (env k nil)] (if v (js/parseInt v 10) d)))
+(defn- envf [k d] (let [v (env k nil)] (if v (js/parseFloat v) d)))
+
+(def server-url (env "SERVER_URL" "http://127.0.0.1:8765"))
+(def tier       (env "TIER" "unknown"))
+(def k-oneshot  (envi "K_ONESHOT" 16))
+(def k-step     (envi "K_STEP" 4))
+(def beam-width (envi "BEAM_WIDTH" 4))
+(def max-steps  (envi "MAX_STEPS" 6))
+(def n-seeds    (envi "SEEDS" 3))
+(def temp       (envf "TEMP" 0.7))
+(def max-toks   (envi "MAX_TOKENS" 320))
+(def revise     (envi "REVISE" 2))
+
+;; ---------------------------------------------------------------------------
+;; Cost-counting wrapper around the out-of-process bridge.
+;; ---------------------------------------------------------------------------
+(def stats (atom {:calls 0 :samples 0 :gen-time 0.0 :prompt-tokens 0 :completion-tokens 0 :errors 0}))
+(defn counting-call [req]
+  (let [resp (lp/call-server server-url req)]
+    ;; NB the worker's JSON keys keywordize with UNDERSCORES (gen_time_s, completion_tokens).
+    (swap! stats #(-> %
+                      (update :calls inc)
+                      (update :samples + (count (:completions resp)))
+                      (update :gen-time + (or (:gen_time_s resp) 0))
+                      (update :prompt-tokens + (or (:prompt_tokens resp) 0))
+                      (update :completion-tokens + (or (:completion_tokens resp) 0))
+                      (update :errors + (if (:error resp) 1 0))))
+    (when (:error resp) (println "    [llm error]" (:error resp)))
+    resp))
+
+;; ===========================================================================
+;; Tasks — the 3 exact-scoreable advanced models (byte-identical to synth_repl_probe).
+;; :task-desc gives the SEMANTICS (index/time/group), NOT the structure (slope/AR/pool).
+;; :solve-bar ≈ HALFWAY from the structureless crude baseline to the data-warranted
+;; optimum (gold, from the structured probe). It cleanly separates "found the structure"
+;; (a fixed-σ=1 structural model already clears it) from "structureless" (crude cannot),
+;; so passing it means the LLM actually built the right structure. The loop typically
+;; climbs WELL above the bar toward gold by refining the (fixed) noise scale — that extra
+;; is the loop's iterative-refinement value over a one-shot structural model at σ=1.
+;; ===========================================================================
+
+(def tasks
+  [{:id :linreg
+    :obs {:y0 1.1 :y1 2.0 :y2 2.7 :y3 4.2 :y4 4.8 :y5 6.1 :y6 6.9}
+    :task-desc (str "You have 7 observations y0..y6. Observation yj is the measured response at "
+                    "input x = j (so x = 0,1,2,3,4,5,6). Model how the response y depends on the input x.")
+    :np 0 :solve-bar -12.2 :crude -17.5 :gold -6.90}
+   {:id :kalman
+    :obs {:y0 0.4 :y1 0.9 :y2 1.3 :y3 1.1 :y4 0.6}
+    :task-desc (str "You have a time series of 5 observations y0..y4 recorded at successive times "
+                    "t = 0,1,2,3,4. The underlying signal varies smoothly over time. Model the series.")
+    :np 0 :solve-bar -6.0 :crude -7.0 :gold -4.92}
+   {:id :hier
+    :obs {:a0 5.2 :a1 4.8 :a2 5.5 :b0 -1.1 :b1 -0.7 :b2 -1.4 :c0 2.1 :c1 2.6 :c2 1.9}
+    :task-desc (str "You have 9 observations in three groups: a0,a1,a2 (group A); b0,b1,b2 (group B); "
+                    "c0,c1,c2 (group C). The groups differ from one another. Model the group structure.")
+    :np 0 :solve-bar -18.0 :crude -24.0 :gold -12.36}
+   ;; HARDER (genmlx-0yv7 follow-up): varying-slopes — 3 groups, each a DISTINCT line in x.
+   ;; The data-warranted model needs 6 latents (slope+intercept per group) + 3 linear means
+   ;; + a tuned noise — far more slip surface than the single-idea models, so one-shot
+   ;; best-of-K must get ALL of it right in one program. Exactly scoreable (linear-Gaussian).
+   {:id :vslope
+    :obs {:a0 1.0 :a1 3.1 :a2 4.9 :a3 7.0 :b0 6.1 :b1 4.9 :b2 4.0 :b3 3.0 :c0 0.0 :c1 0.6 :c2 1.0 :c3 1.4}
+    :task-desc (str "You have 12 observations in three groups a, b, c. Each group has 4 measurements "
+                    "g0,g1,g2,g3 taken at inputs x = 0,1,2,3 (so a0 is group a at x=0, a3 is group a at "
+                    "x=3, etc.). Within each group the response changes with x. Model how y depends on x "
+                    "in each of the three groups.")
+    :np 0 :solve-bar -23.5 :crude -30.0 :gold -17.0}])
+
+(defn- only-tasks []
+  (if-let [sel (env "TASKS" nil)]
+    (let [want (set (map keyword (str/split sel #",")))]
+      (filterv #(want (:id %)) tasks))
+    tasks))
+
+;; ===========================================================================
+;; Arms.
+;; ===========================================================================
+
+(defn- best-scored
+  "Among candidates [{:code ...}], check each and return the highest-evidence valid one
+   (exact methods are reproducible; for these exact tasks all valid candidates are exact)."
+  [cands obs np]
+  (let [scored (for [c cands
+                     :let [fb (syn/check (:code c) obs {:n-particles np})]
+                     :when (syn/scored? fb)]
+                 {:code (:code c) :evidence (:evidence fb) :method (:method fb)})]
+    {:n (count cands) :n-valid (count scored)
+     :best (when (seq scored) (apply max-key :evidence scored))}))
+
+(defn run-oneshot [{:keys [task-desc obs np]}]
+  (let [cands (lp/one-shot-candidates {:call-llm counting-call :task-desc task-desc
+                                       :observations obs :k k-oneshot :temperature 0.8 :max-tokens max-toks :seed 1})
+        r     (best-scored cands obs np)]
+    {:arm :oneshot :n-extracted (:n r) :n-valid (:n-valid r)
+     :evidence (get-in r [:best :evidence]) :code (get-in r [:best :code])}))
+
+(defn- init-spec
+  "A crude covering model the loop starts from: one shared mean, every observed key an
+   obs site. Identical role to the structured probe's crude rung."
+  [obs]
+  (syn/spec [(syn/latent 'mu "gaussian" [0 10])]
+            (for [k (keys obs)] (syn/obs k "gaussian" ['mu 3.0]))))
+
+;; Noise-scale refinement — the nuisance hyperparameter the LLM neglects (it proposes
+;; STRUCTURE but leaves σ at ~1; the harder vslope model exposed this). This cheap,
+;; deterministic shared-σ grid is the move the structured proposer (§10-11) used: type-II
+;; ML over ONE observation scale. Unioned into the loop proposer below — LLM for the hard
+;; structural moves, grid for the hyperparameter (the resource-rational split). The grid is
+;; oracle-selected per step (the loop accepts a σ only when it improves exact evidence).
+(def noise-grid [0.1 0.2 0.3 0.5 0.7 1.0 1.5 2.5])
+(defn- noise-refiner [spec _fb]
+  (let [obs (:obs spec)
+        cur (last (:args (first obs)))]
+    (if (and (seq obs) (every? #(>= (count (:args %)) 2) obs))
+      (for [g noise-grid :when (not= g cur)]
+        {:edit :set-noise :desc (str "shared obs σ -> " g)
+         :spec' (reduce #(syn/set-noise %1 %2 g) spec (map :addr obs))})
+      [])))
+(defn- loop-proposer [task-desc obs np seed]
+  (syn/union-proposer
+   (lp/make-proposer {:call-llm counting-call :task-desc task-desc :observations obs
+                      :k k-step :temperature temp :max-tokens max-toks
+                      :revise revise :n-particles (if (pos? np) np 2000) :seed seed})
+   noise-refiner))
+
+(defn run-greedy [{:keys [task-desc obs np]} seed]
+  (let [prop (loop-proposer task-desc obs np seed)
+        res  (syn/synthesize {:init-spec (init-spec obs) :observations obs :propose prop
+                              :max-steps max-steps :plateau-eps 0.05 :n-particles (if (pos? np) np 2000)})]
+    {:arm :greedy :seed seed :evidence (:evidence (:feedback res))
+     :stop-reason (:stop-reason res) :steps (:steps res)
+     :code (get-in res [:feedback :code])
+     :trajectory (mapv #(select-keys % [:step :edit :evidence :delta :method :code]) (:trajectory res))}))
+
+(defn run-beam [{:keys [task-desc obs np]} seed]
+  (let [prop (loop-proposer task-desc obs np seed)
+        res  (se/search {:init-spec (init-spec obs) :observations obs :propose prop
+                         :beam-width beam-width :adaptive? true :strategy :beam
+                         :max-steps max-steps :plateau-eps 0.05 :n-particles (if (pos? np) np 2000) :seed seed})]
+    {:arm :beam :seed seed :evidence (:evidence (:best res))
+     :stop-reason (:stop-reason res) :steps (:steps res)
+     :code (:code (:best res))
+     :trajectory (mapv #(select-keys % [:step :edit :evidence :delta :method :code]) (:trajectory (:best res)))}))
+
+(defn- solved? [bar evidence] (boolean (and evidence (js/isFinite evidence) (>= evidence bar))))
+
+;; ===========================================================================
+;; Run one task: one-shot control + greedy/beam over seeds.
+;; ===========================================================================
+
+(defn run-task [{:keys [id solve-bar crude gold] :as t}]
+  (println (str "\n================  " (name id) "  (tier=" tier ")  ================"))
+  (println (str "  solve-bar " solve-bar "  (structureless crude ~" crude
+                "; structured-proposer gold ~" gold ")"))
+  (let [_ (println "  [one-shot best-of-" k-oneshot " — the control]")
+        os1 (run-oneshot t)
+        _ (println (str "    extracted " (:n-extracted os1) "/" k-oneshot " parseable, "
+                        (:n-valid os1) " valid; best evidence " (fx (:evidence os1))
+                        "  SOLVED=" (solved? solve-bar (:evidence os1))))
+        seeds (range 1 (inc n-seeds))
+        greedy (doall (for [s seeds]
+                        (let [r (run-greedy t s)]
+                          (println (str "  [greedy seed " s "] -> " (fx (:evidence r))
+                                        "  steps=" (:steps r) " stop=" (name (:stop-reason r))
+                                        "  SOLVED=" (solved? solve-bar (:evidence r))))
+                          r)))
+        beam (doall (for [s seeds]
+                      (let [r (run-beam t s)]
+                        (println (str "  [beam   seed " s "] -> " (fx (:evidence r))
+                                      "  steps=" (:steps r) " stop=" (name (:stop-reason r))
+                                      "  SOLVED=" (solved? solve-bar (:evidence r))))
+                        r)))
+        ev    (fn [rs] (keep :evidence rs))
+        mean  (fn [xs] (when (seq xs) (/ (reduce + xs) (count xs))))
+        rate  (fn [rs] (/ (count (filter #(solved? solve-bar (:evidence %)) rs)) (max 1 (count rs))))]
+    {:id id :solve-bar solve-bar :crude crude :gold gold
+     :oneshot os1 :oneshot-solved (solved? solve-bar (:evidence os1))
+     :greedy greedy :beam beam
+     :greedy-mean (mean (ev greedy)) :beam-mean (mean (ev beam))
+     :greedy-best (when (seq (ev greedy)) (apply max (ev greedy)))
+     :beam-best (when (seq (ev beam)) (apply max (ev beam)))
+     :greedy-solve-rate (rate greedy) :beam-solve-rate (rate beam)}))
+
+;; ===========================================================================
+
+(println (str "\n###  EXPERIMENT B WITH A REAL LLM  (tier=" tier ", url=" server-url ")  ###"))
+(println (str "  K_ONESHOT=" k-oneshot " K_STEP=" k-step " BEAM_WIDTH=" beam-width
+              " MAX_STEPS=" max-steps " SEEDS=" n-seeds " TEMP=" temp))
+(let [t0 (js/Date.now)
+      results (mapv run-task (only-tasks))
+      wall (/ (- (js/Date.now) t0) 1000.0)
+      st @stats]
+  (println "\n================  VERDICT (tier=" tier ")  ================")
+  (println (str (.padEnd "model" 10) (.padEnd "one-shot" 11) (.padEnd "greedy(best)" 14)
+                (.padEnd "beam(best)" 12) (.padEnd "g-rate" 9) (.padEnd "b-rate" 9) "loop>one-shot?"))
+  (doseq [r results]
+    (let [os1 (get-in r [:oneshot :evidence])
+          gb  (:greedy-best r) bb (:beam-best r)
+          loopbest (apply max (keep identity [(or gb ##-Inf) (or bb ##-Inf)]))
+          beats (boolean (and (js/isFinite loopbest)
+                              (or (not (and os1 (js/isFinite os1)))
+                                  (> loopbest (+ os1 0.1)))))]
+      (println (str (.padEnd (name (:id r)) 10)
+                    (.padEnd (str (fx os1) (if (:oneshot-solved r) "*" "")) 11)
+                    (.padEnd (str (fx gb)) 14)
+                    (.padEnd (str (fx bb)) 12)
+                    (.padEnd (str (.toFixed (* 100 (:greedy-solve-rate r)) 0) "%") 9)
+                    (.padEnd (str (.toFixed (* 100 (:beam-solve-rate r)) 0) "%") 9)
+                    (str beats)))))
+  (let [n-loop-solve (count (filter #(or (pos? (:greedy-solve-rate %)) (pos? (:beam-solve-rate %))) results))
+        n-os-solve   (count (filter :oneshot-solved results))
+        beam>=greedy (every? #(>= (or (:beam-best %) ##-Inf) (- (or (:greedy-best %) ##-Inf) 0.1)) results)]
+    (println (str "\n  THESIS: the LLM-in-the-loop solves " n-loop-solve "/" (count results)
+                  " advanced models; one-shot best-of-" k-oneshot " solves " n-os-solve "/" (count results) "."))
+    (println (str "  PHASE-2 robustness: beam >= greedy (best evidence) on every model: " beam>=greedy
+                  "  (compare per-seed solve-rates above for the stochastic-regime claim)."))
+    (println (str "\n  COST (tier=" tier "): " (:calls st) " LLM calls, " (:samples st) " samples, "
+                  (fx (:gen-time st)) "s generation, " (:completion-tokens st) " completion tokens"
+                  (when (pos? (:errors st)) (str ", " (:errors st) " transport errors")) "."))
+    (println (str "  wall-clock " (fx wall) "s; " (fx (/ (:gen-time st) (max 1 (:samples st)))) "s/sample avg."))
+    (when-not (.existsSync fs out-dir) (.mkdirSync fs out-dir #js {:recursive true}))
+    (let [outfile (home "genmlx-loop-artifacts" "particle" (str "synth_llm_probe_" tier ".json"))]
+      (.writeFileSync fs outfile
+                      (js/JSON.stringify (clj->js {:tier tier :config {:k-oneshot k-oneshot :k-step k-step
+                                                                       :beam-width beam-width :max-steps max-steps
+                                                                       :seeds n-seeds :temp temp}
+                                                   :results results :cost st :wall-s wall
+                                                   :n-loop-solve n-loop-solve :n-oneshot-solve n-os-solve}) nil 2))
+      (println (str "  wrote " outfile)))))

--- a/src/genmlx/world/curriculum.cljs
+++ b/src/genmlx/world/curriculum.cljs
@@ -1,0 +1,587 @@
+(ns genmlx.world.curriculum
+  "Phase-3 enabler for the north star (beans genmlx-77vv / genmlx-ilna): the
+   REPL-synthesis CURRICULUM GENERATOR — a graded, oracle-grounded bank of
+   STRUCTURED-MODEL-FITTING tasks whose value is the multi-step construction.
+
+   WHY (the bottleneck). Phase 3 (genmlx-oexl) learns the cheap proposer (the
+   :edit distribution of the programmer-GF) by SFT on REPL traces, and a learned
+   proposer needs traces AT SCALE — but the north-star probe only has ~4 hand-built
+   tasks. This namespace produces ~100-200 reproducible tasks so the 35B loop can
+   run each → genmlx.world.repl-corpus harvests propose-eval-revise transitions →
+   SFT the 0.8B. Its COMPLEXITY SPREAD (one-shot-ties → loop-wins) is also the
+   resource-rational training signal the Phase-4 metareasoner allocates over.
+
+   DISTINCT from genmlx.world.distill-gen (the whole-program distillation task-gen,
+   bean genmlx-7473). distill-gen grades a single conjugate covering model; this
+   grades how much MULTI-STEP STRUCTURE the data warrants, the thing the loop is for.
+
+   ORACLE-GROUNDED, NO LLM (native-free in the synth sense — it reuses synth/check
+   and never loads the policy LLM). Data is SAMPLED from a known ground-truth
+   structured model with a pure seeded PRNG; difficulty (crude / gold / solve-bar)
+   is set by the EXACT Bayesian model-evidence oracle (synth/check → the analytical
+   p/generate marginal), not a judge. Seeded ⇒ byte-reproducible.
+
+   WHAT THE FAMILIES ARE (all LINEAR-GAUSSIAN ⇒ exactly scoreable, verified):
+     :shared-mean      (c1)  repeated measurements of one quantity
+     :linear           (c1)  response linear in an input
+     :per-group-means  (c2)  independent group levels
+     :ar1              (c2)  a smoothly-evolving latent chain (Kalman)
+     :segmented        (c2)  two independent regimes (a composition; HELD-OUT family)
+     :varying-slopes   (c3)  an independent line per group (the loop-wins regime)
+   Centered hierarchical / shared-slope (ancova) families are EXCLUDED: the L3
+   eliminator misroutes a latent-in-latent prior to a broken :kalman path and a
+   shared latent coupling many obs to a non-finite marginal (bug genmlx-iraj). A
+   reproducibility guard at calibration rejects any family the oracle cannot score
+   deterministically + exactly, so the exclusion is enforced, not merely assumed.
+
+   Sections:
+     0. Pure seeded PRNG          — mulberry32 + Box–Muller, eager + reproducible
+     1. Rendering helpers          — mx form constructors + crude covering model
+     2. Family templates           — the structured vocabulary as data
+     3. Calibration                — crude / gold / solve-bar via the exact oracle
+     4. Instance generation        — sample → data → calibrate → well-posed record
+     5. Curriculum assembly + split — graded bank, leakage-safe task-level holdout
+     6. Consumer adapters          — ->probe-task + the no-LLM family-proposer"
+  (:require [genmlx.world.synth :as syn]
+            [clojure.string :as str]))
+
+;; ===========================================================================
+;; 0. Pure seeded PRNG — mulberry32 uniforms + Box–Muller normals.
+;;
+;; NATIVE-FREE and independent of MLX's RNG, so the sampled data is byte-identical
+;; across runs and toolchains for a given seed. CLJS bit-ops are SIGNED 32-bit, so
+;; every shift is `unsigned-bit-shift-right` and the final word is coerced unsigned
+;; before the divide; multiplies use `js/Math.imul` (true 32-bit). Outputs are EAGER
+;; vectors built with loop/recur — no lazy seq, so chunking can never desync a stream.
+;; ===========================================================================
+
+(defn- u32
+  "Coerce x to an unsigned 32-bit double in [0, 2^32)."
+  [x]
+  (unsigned-bit-shift-right x 0))
+
+(defn uniforms
+  "An EAGER vector of `n` mulberry32 uniforms in [0,1) from 32-bit `seed`.
+   Reference mulberry32 (Tommy Ettinger), transcribed with unsigned shifts."
+  [seed n]
+  (loop [a   (bit-or seed 0)
+         i   0
+         acc (transient [])]
+    (if (>= i n)
+      (persistent! acc)
+      (let [a (bit-or (+ a 0x6D2B79F5) 0)
+            t a
+            t (js/Math.imul (bit-xor t (unsigned-bit-shift-right t 15)) (bit-or t 1))
+            t (bit-xor (+ t (js/Math.imul (bit-xor t (unsigned-bit-shift-right t 7))
+                                          (bit-or t 61)))
+                       t)
+            r (bit-xor t (unsigned-bit-shift-right t 14))]
+        (recur a (inc i) (conj! acc (/ (u32 r) 4294967296.0)))))))
+
+(defn normals
+  "An EAGER vector of `n` N(0,1) draws from `seed` via Box–Muller. Consumes 2
+   uniforms per normal in fixed pairs (the cos branch); u1 is clamped to (0,1] so
+   log(0) cannot produce a NaN. Deterministic and reproducible."
+  [seed n]
+  (let [us (uniforms seed (* 2 (max 1 n)))]
+    (vec (for [k (range n)]
+           (let [u1 (max (nth us (* 2 k)) 1e-12)
+                 u2 (nth us (inc (* 2 k)))]
+             (* (js/Math.sqrt (* -2.0 (js/Math.log u1)))
+                (js/Math.cos (* 2.0 js/Math.PI u2))))))))
+
+(defn mix-seed
+  "Fold a sequence of ints into one 32-bit seed (mulberry32 mixing). Injective enough
+   for distinct (round, family, instance, role) tuples and overflow-safe."
+  [& xs]
+  (reduce (fn [h x]
+            (let [h (bit-or (+ h (bit-or x 0) 0x9E3779B9) 0)
+                  h (js/Math.imul (bit-xor h (unsigned-bit-shift-right h 16)) 0x85EBCA6B)
+                  h (js/Math.imul (bit-xor h (unsigned-bit-shift-right h 13)) 0xC2B2AE35)]
+              (bit-xor h (unsigned-bit-shift-right h 16))))
+          0x2545F491 xs))
+
+(defn round1
+  "Round to one decimal — the established probe-data convention. Keeps :observations
+   canonical/hashable and the SFT corpus low-entropy."
+  [x]
+  (/ (js/Math.round (* (double x) 10.0)) 10.0))
+
+;; ===========================================================================
+;; 1. Rendering helpers + the crude covering model.
+;; ===========================================================================
+
+(defn- mul [a b] (list 'mx/multiply a b))
+(defn- add [a b] (list 'mx/add a b))
+(defn- sc  [x]   (list 'mx/scalar (double x)))
+
+(def ^:const crude-sigma
+  "The fixed, untuned noise of the crude covering model — the structureless baseline
+   the solve-bar is measured against. True sigmas are sampled strictly below it so a
+   real gap always exists."
+  3.0)
+
+(def sigma-grid
+  "The shared-σ refinement grid the loop's hybrid uses (genmlx.world.synth /
+   synth_llm_probe). gold = the best-fitting correct-structure model over this grid."
+  [0.1 0.2 0.3 0.5 0.7 1.0 1.5 2.5])
+
+(defn crude-spec
+  "The crude covering model for any task: one shared latent, every observed address an
+   obs site at the fixed crude σ. Identical role to the loop's init-spec."
+  [observations]
+  (syn/spec [(syn/latent 'mu "gaussian" [0 10])]
+            (for [k (keys observations)] (syn/obs k "gaussian" ['mu crude-sigma]))))
+
+;; ===========================================================================
+;; 2. Family templates — the structured vocabulary as data.
+;;
+;; Each template is a map of pure fns over a sampled `params` (true continuous values
+;; + structural knobs + the ordered obs addresses). `:gold` interprets its `noise` arg
+;; as the family's single tunable scale (process noise for :ar1, observation σ
+;; elsewhere). `:complexity` is the structural-decision BAND (the loop-vs-one-shot
+;; proxy); `:n-latents` the latent count (a continuous proxy). The number of GROUP /
+;; POINT knobs is sampled per instance for variety.
+;; ===========================================================================
+
+(defn- pick-int [u lo hi] (+ lo (int (* u (inc (- hi lo))))))   ; uniform int in [lo,hi]
+(def ^:private group-names ["a" "b" "c" "d"])
+
+(defn- sample-sigma
+  "A true observation σ in [0.3, 1.5] — comfortably below crude-sigma so the gap is
+   real for every family (incl. :shared-mean, whose only lever is the scale)."
+  [u]
+  (round1 (+ 0.3 (* u 1.2))))
+
+(def family-defs
+  "The template registry. Order is the family index used in seed mixing + split."
+  [;; --- :shared-mean (c1) — repeated measurements of one quantity ---
+   ;; The ONLY non-structural family: its gold IS the crude shape (one shared latent),
+   ;; so its difficulty is purely the noise scale and :struct-gap is ~0 by design. The
+   ;; :structural? false flag exempts it from the min-struct-gap well-posedness gate.
+   {:family :shared-mean :complexity 1 :structural? false
+    :sample (fn [seed]
+              (let [us (uniforms seed 3)
+                    n  (pick-int (nth us 0) 4 7)
+                    mu (round1 (* 6.0 (- (nth us 1) 0.5)))]
+                {:n n :mu mu :sigma (sample-sigma (nth us 2))
+                 :addrs (mapv #(keyword (str "y" %)) (range n))}))
+    :data (fn [{:keys [n mu sigma addrs]} seed]
+            (let [z (normals (mix-seed seed 991) n)]
+              (zipmap addrs (map #(round1 (+ mu (* sigma %))) z))))
+    :gold (fn [{:keys [addrs]} noise]
+            (syn/spec [(syn/latent 'mu "gaussian" [0 10])]
+                      (for [k addrs] (syn/obs k "gaussian" ['mu noise]))))
+    :n-latents (fn [_] 1)
+    :desc (fn [{:keys [n]}]
+            (str "You have " n " repeated measurements y0.." (dec n)
+                 " of a single quantity taken under identical conditions. "
+                 "Model the quantity that produced them."))}
+
+   ;; --- :linear (c1) — response linear in an input ---
+   {:family :linear :complexity 1
+    :sample (fn [seed]
+              (let [us (uniforms seed 4)
+                    n  (pick-int (nth us 0) 5 8)
+                    slope (round1 (* (if (< (nth us 2) 0.5) -1 1) (+ 0.6 (* (nth us 1) 1.8))))
+                    intercept (round1 (* 4.0 (- (nth us 3) 0.5)))]
+                {:n n :slope slope :intercept intercept
+                 :sigma (sample-sigma (nth (uniforms (mix-seed seed 5) 1) 0))
+                 :xs (vec (range n)) :addrs (mapv #(keyword (str "y" %)) (range n))}))
+    :data (fn [{:keys [slope intercept sigma xs addrs]} seed]
+            (let [z (normals (mix-seed seed 991) (count xs))]
+              (zipmap addrs (map (fn [x zi] (round1 (+ (* slope x) intercept (* sigma zi)))) xs z))))
+    :gold (fn [{:keys [xs addrs]} noise]
+            (syn/spec [(syn/latent 'slope "gaussian" [0 3]) (syn/latent 'intercept "gaussian" [0 5])]
+                      (map (fn [x k] (syn/obs k "gaussian" [(add (mul 'slope (sc x)) 'intercept) noise]))
+                           xs addrs)))
+    :n-latents (fn [_] 2)
+    :desc (fn [{:keys [n]}]
+            (str "You have " n " observations y0.." (dec n) ". Observation yj is the response "
+                 "measured at input x = j (so x = 0,1,.." (dec n) "). Model how the response "
+                 "depends on the input x."))}
+
+   ;; --- :per-group-means (c2) — independent group levels ---
+   {:family :per-group-means :complexity 2
+    :sample (fn [seed]
+              (let [us (uniforms seed 2)
+                    g  (pick-int (nth us 0) 2 4)
+                    pp (pick-int (nth us 1) 3 4)
+                    ;; group values spread out (well separated) so the structure wins
+                    vs (mapv (fn [k] (round1 (* 4.0 (- k (/ (dec g) 2.0)))))
+                             (range g))
+                    gs (subvec group-names 0 g)]
+                {:g g :pp pp :values vs :groups gs
+                 :sigma (sample-sigma (nth (uniforms (mix-seed seed 5) 1) 0))
+                 :addrs (vec (for [gn gs i (range pp)] (keyword (str gn i))))}))
+    :data (fn [{:keys [g pp values groups sigma addrs]} seed]
+            (let [z (normals (mix-seed seed 991) (* g pp))]
+              (zipmap addrs
+                      (map-indexed (fn [idx k]
+                                     (let [gi (quot idx pp)]
+                                       (round1 (+ (nth values gi) (* sigma (nth z idx))))))
+                                   addrs))))
+    :gold (fn [{:keys [groups pp] :as p} noise]
+            (syn/spec (for [gn groups] (syn/latent (symbol (str "m-" gn)) "gaussian" [0 5]))
+                      (for [gn groups i (range pp)]
+                        (syn/obs (keyword (str gn i)) "gaussian" [(symbol (str "m-" gn)) noise]))))
+    :n-latents (fn [{:keys [g]}] g)
+    :desc (fn [{:keys [g groups pp]}]
+            (str "You have observations in " g " groups (" (str/join ", " groups) "). Each group "
+                 "has " pp " measurements g0.." (dec pp) " (e.g. " (first groups) "0 is group "
+                 (first groups) " measurement 0). The groups differ from one another. "
+                 "Model the group structure."))}
+
+   ;; --- :ar1 (c2) — a smoothly-evolving latent chain (Kalman) ---
+   {:family :ar1 :complexity 2
+    :sample (fn [seed]
+              (let [us (uniforms seed 3)
+                    n  (pick-int (nth us 0) 4 6)
+                    coef (round1 (+ 0.6 (* (nth us 1) 0.35)))    ; 0.6..0.95
+                    proc (round1 (+ 0.3 (* (nth us 2) 0.5)))]    ; 0.3..0.8
+                {:n n :coef coef :proc proc :obs-noise 0.7
+                 :addrs (mapv #(keyword (str "y" %)) (range n))}))
+    :data (fn [{:keys [n coef proc obs-noise addrs]} seed]
+            (let [zp (normals (mix-seed seed 991) n)
+                  zo (normals (mix-seed seed 992) n)
+                  ;; z0 ~ N(0,1) matches the gold model's z0 prior, so gold is the TRUE
+                  ;; data-generating model; later z_t = coef*z_{t-1} + proc*noise.
+                  zs (reductions (fn [z t] (+ (* coef z) (* proc (nth zp t)))) (nth zp 0)
+                                 (range 1 n))]
+              (zipmap addrs (map (fn [z zi] (round1 (+ z (* obs-noise zi)))) zs zo))))
+    :gold (fn [{:keys [n coef obs-noise addrs]} noise]   ; `noise` tunes the PROCESS scale
+            (syn/spec (cons (syn/latent 'z0 "gaussian" [0 1])
+                            (for [t (range 1 n)]
+                              (syn/latent (symbol (str "z" t)) "gaussian"
+                                          [(mul (sc coef) (symbol (str "z" (dec t)))) noise])))
+                      (map-indexed (fn [t k] (syn/obs k "gaussian" [(symbol (str "z" t)) obs-noise])) addrs)))
+    :n-latents (fn [{:keys [n]}] n)
+    :desc (fn [{:keys [n]}]
+            (str "You have a time series of " n " observations y0.." (dec n) " recorded at "
+                 "successive times t = 0,1,.." (dec n) ". The underlying signal evolves "
+                 "smoothly over time. Model the series."))}
+
+   ;; --- :segmented (c2, HELD-OUT composition) — two independent regimes ---
+   {:family :segmented :complexity 2
+    :sample (fn [seed]
+              (let [us (uniforms seed 4)
+                    nf (pick-int (nth us 0) 3 4)
+                    nl (pick-int (nth us 1) 3 4)
+                    level (round1 (* 4.0 (- (nth us 2) 0.5)))
+                    slope (round1 (* (if (< (nth us 3) 0.5) -1 1)
+                                     (+ 0.7 (* (nth (uniforms (mix-seed seed 6) 1) 0) 1.5))))
+                    base  (round1 (* 4.0 (- (nth (uniforms (mix-seed seed 7) 1) 0) 0.5)))]
+                {:nf nf :nl nl :level level :slope slope :base base
+                 :sigma (sample-sigma (nth (uniforms (mix-seed seed 5) 1) 0))
+                 :addrs (mapv #(keyword (str "r" %)) (range (+ nf nl)))}))
+    :data (fn [{:keys [nf nl level slope base sigma addrs]} seed]
+            (let [z (normals (mix-seed seed 991) (+ nf nl))]
+              (zipmap addrs
+                      (map-indexed (fn [t k]
+                                     (let [m (if (< t nf) level (+ (* slope (- t nf)) base))]
+                                       (round1 (+ m (* sigma (nth z t)))))) addrs))))
+    :gold (fn [{:keys [nf nl addrs]} noise]
+            (syn/spec [(syn/latent 'level "gaussian" [0 10])
+                       (syn/latent 'slope "gaussian" [0 3])
+                       (syn/latent 'base "gaussian" [0 5])]
+                      (concat (for [t (range nf)] (syn/obs (nth addrs t) "gaussian" ['level noise]))
+                              (for [t (range nf (+ nf nl))]
+                                (syn/obs (nth addrs t) "gaussian"
+                                         [(add (mul 'slope (sc (- t nf))) 'base) noise])))))
+    :n-latents (fn [_] 3)
+    ;; held-out family: the desc is deliberately bare index-semantics (no regime hint), so
+    ;; the structure must be discovered from the data + oracle, not read off the prompt.
+    :desc (fn [{:keys [nf nl]}]
+            (str "You have a sequence of " (+ nf nl) " measurements r0.." (dec (+ nf nl))
+                 " recorded one after another (index 0.." (dec (+ nf nl)) "). Model the sequence."))}
+
+   ;; --- :varying-slopes (c3) — an independent line per group (loop-wins) ---
+   {:family :varying-slopes :complexity 3
+    :sample (fn [seed]
+              (let [us (uniforms seed 2)
+                    g  (pick-int (nth us 0) 2 3)
+                    pp 4
+                    gs (subvec group-names 0 g)
+                    ;; per-group slope (|.|>=0.6) + intercept, drawn from disjoint sub-streams
+                    sl (vec (for [k (range g)]
+                              (let [u (nth (uniforms (mix-seed seed 10 k) 2) 0)
+                                    s (nth (uniforms (mix-seed seed 10 k) 2) 1)]
+                                (round1 (* (if (< s 0.5) -1 1) (+ 0.6 (* u 1.8)))))))
+                    it (vec (for [k (range g)]
+                              (round1 (* 4.0 (- (nth (uniforms (mix-seed seed 11 k) 1) 0) 0.5)))))]
+                {:g g :pp pp :groups gs :slopes sl :intercepts it
+                 :sigma (sample-sigma (nth (uniforms (mix-seed seed 5) 1) 0))
+                 :addrs (vec (for [gn gs i (range pp)] (keyword (str gn i))))}))
+    :data (fn [{:keys [g pp groups slopes intercepts sigma addrs]} seed]
+            (let [z (normals (mix-seed seed 991) (* g pp))]
+              (zipmap addrs
+                      (map-indexed (fn [idx k]
+                                     (let [gi (quot idx pp) x (rem idx pp)]
+                                       (round1 (+ (* (nth slopes gi) x) (nth intercepts gi)
+                                                  (* sigma (nth z idx)))))) addrs))))
+    :gold (fn [{:keys [groups pp]} noise]
+            (syn/spec (mapcat (fn [gn] [(syn/latent (symbol (str "s-" gn)) "gaussian" [0 3])
+                                        (syn/latent (symbol (str "i-" gn)) "gaussian" [0 5])]) groups)
+                      (for [gn groups i (range pp)]
+                        (syn/obs (keyword (str gn i)) "gaussian"
+                                 [(add (mul (symbol (str "s-" gn)) (sc i)) (symbol (str "i-" gn))) noise]))))
+    :n-latents (fn [{:keys [g]}] (* 2 g))
+    :desc (fn [{:keys [g groups pp]}]
+            (str "You have observations in " g " groups (" (str/join ", " groups) "). Each group has "
+                 pp " measurements g0.." (dec pp) " taken at inputs x = 0,1,.." (dec pp)
+                 " (so " (first groups) "0 is group " (first groups) " at x=0). Within each group "
+                 "the response changes with the input x. Model how the response depends on x in "
+                 "each of the groups."))}])
+
+(def family-index
+  "Family keyword → its index (used in seed mixing + a stable split key)."
+  (into {} (map-indexed (fn [i d] [(:family d) i]) family-defs)))
+
+(def family-by-key
+  (into {} (map (juxt :family identity)) family-defs))
+
+;; ===========================================================================
+;; 3. Calibration — crude / gold / solve-bar via the exact oracle.
+;; ===========================================================================
+
+(defn- score
+  "Score a spec's rendered code against `observations`; {:ev <log-evidence> :method}."
+  [spec observations]
+  (let [fb (syn/check (syn/render spec) observations {:n-particles 0})]
+    {:ev (when (syn/scored? fb) (:evidence fb)) :method (:method fb) :code (:code fb)}))
+
+(defn- crude-spec-at
+  "The crude shared-mean covering model at an arbitrary σ (for the crude-tuned sweep)."
+  [observations sigma]
+  (syn/spec [(syn/latent 'mu "gaussian" [0 10])]
+            (for [k (keys observations)] (syn/obs k "gaussian" ['mu sigma]))))
+
+(defn- best-over-grid
+  "Score `build` at every grid σ (+ true σ); the highest finite-evidence result, with
+   its :sigma and rendered :code. nil if none score."
+  [build observations true-sigma]
+  (->> (distinct (conj sigma-grid true-sigma))
+       (map (fn [g] (assoc (score (build g) observations) :sigma g)))
+       (filter (comp some? :ev))
+       (sort-by (comp - :ev))
+       first))
+
+(defn calibrate
+  "Run the exact oracle to grade one instance from the family's `build` (σ → spec), the
+   data's `true-sigma`, and whether the family is `structural?`. Returns
+     {:crude :crude-tuned :gold :gold-scale :ground-truth-code :method :exact?
+      :solve-bar :gap :struct-gap}
+   or nil if it could not be cleanly graded.
+
+   :crude       evidence of the untuned shared-mean covering model (σ=3)
+   :crude-tuned best shared-mean over the σ-grid (best STRUCTURELESS model)
+   :gold        best correct-structure model over the σ-grid (the data-warranted optimum)
+   :gold-scale  the winning σ-grid value (the OBSERVATION scale for most families; the
+                PROCESS-noise scale for :ar1, whose build tunes the latent chain noise)
+   :exact?      gold scored EXACT/Kalman AND reproduces on a re-score (the guard that
+                rejects the broken-eliminator families, genmlx-iraj)
+   :solve-bar   for STRUCTURAL families (crude-tuned+gold)/2 — provably ABOVE the best
+                structureless model, so clearing it REQUIRES structure (not just noise
+                tuning). For non-structural :shared-mean (crude+gold)/2 — there is no
+                structure to find, only the noise scale to tune from the σ=3 default.
+   :gap         gold−crude (headline)        :struct-gap gold−crude-tuned (pure structure)"
+  [true-sigma build observations structural?]
+  (let [crude-r (score (crude-spec observations) observations)
+        ct-r    (best-over-grid #(crude-spec-at observations %) observations true-sigma)
+        gold-r  (best-over-grid build observations true-sigma)]
+    (when (and (:ev crude-r) (:ev gold-r) (:ev ct-r))
+      (let [;; reproducibility guard: re-score the winning gold code; require agreement.
+            re      (:ev (score (build (:sigma gold-r)) observations))
+            method  (:method gold-r)
+            exact?  (boolean (and re (contains? #{:exact :kalman} method)
+                                  (< (js/Math.abs (- re (:ev gold-r))) 1e-3)))
+            crude   (:ev crude-r) ct (:ev ct-r) g (:ev gold-r)
+            ;; the bar sits halfway from the best STRUCTURELESS model (crude-tuned) to
+            ;; gold for structural families, so a structureless model can never clear it.
+            bar-base (if structural? ct crude)]
+        {:crude crude :crude-tuned ct :gold g :gold-scale (:sigma gold-r)
+         :ground-truth-code (:code gold-r) :method method :exact? exact?
+         :solve-bar (/ (+ bar-base g) 2.0) :gap (- g crude) :struct-gap (- g ct)}))))
+
+;; ===========================================================================
+;; 4. Instance generation — sample → data → calibrate → well-posed record.
+;; ===========================================================================
+
+(def ^:const default-min-gap
+  "Minimum gold−crude (nats) for a task to be well-posed — comfortably above float32
+   evidence noise so the bar strictly brackets."
+  3.0)
+
+(def ^:const default-min-struct-gap
+  "Minimum gold−crude-tuned (nats): the structure must beat even the BEST structureless
+   model, so 'solved' means found-the-structure, not noise-tuning."
+  1.0)
+
+(defn- well-posed?
+  "A task is well-posed iff the oracle graded it exactly+reproducibly, the headline gap
+   clears min-gap, the bar strictly brackets (crude < bar < gold), AND (for STRUCTURAL
+   families only) the structure beats the best structureless model by min-struct-gap AND
+   the best structureless model does NOT clear the bar (crude-tuned < bar — guaranteed by
+   the bar definition, asserted here as a guard). Non-structural :shared-mean is exempt
+   from both structure gates (its struct-gap is ~0 by design)."
+  [{:keys [crude crude-tuned solve-bar gold exact? gap struct-gap]} structural? min-gap min-struct-gap]
+  (boolean (and exact?
+                (>= gap min-gap)
+                (or (not structural?)
+                    (and (>= struct-gap min-struct-gap) (< crude-tuned solve-bar)))
+                (< crude solve-bar) (< solve-bar gold))))
+
+(defn gen-instance
+  "Generate one well-posed task for `family` at (round, instance), or nil if it could
+   not be made well-posed within `:max-retries` fresh param draws (counted by the
+   caller as a drop). The samplers are signal-biased (|slope|≥0.6, separated groups,
+   σ≤1.5), so the first attempt usually clears the gap; each retry re-samples from a
+   fresh derived seed as a rare safety net."
+  [family round instance {:keys [min-gap min-struct-gap max-retries]
+                          :or {min-gap default-min-gap min-struct-gap default-min-struct-gap
+                               max-retries 6}}]
+  (let [{:keys [sample data gold complexity structural?] :as fdef
+         :or {structural? true}} (family-by-key family)
+        fidx (family-index family)]
+    (loop [attempt 0]
+      (if (> attempt max-retries)
+        nil
+        (let [seed   (mix-seed round fidx instance attempt)
+              params (sample seed)
+              obs    (data params seed)
+              cal    (calibrate (or (:sigma params) (:proc params) 1.0) #(gold params %) obs structural?)]
+          (if (and cal (well-posed? cal structural? min-gap min-struct-gap))
+            (merge {:id (str (name family) "-r" round "-i" instance)
+                    :family family :complexity complexity
+                    :n-latents ((:n-latents fdef) params)
+                    :task-desc ((:desc fdef) params)
+                    :observations obs
+                    ;; full ordered params (incl :addrs/:xs) so family-proposer can
+                    ;; rebuild the exact gold structure with no hash-map key-order risk
+                    :true-params params
+                    :seed seed}
+                   (select-keys cal [:ground-truth-code :crude :crude-tuned :gold
+                                     :gold-scale :solve-bar :gap :struct-gap :exact? :method]))
+            (recur (inc attempt))))))))
+
+;; ===========================================================================
+;; 5. Curriculum assembly + leakage-safe task-level split.
+;;
+;; TWO eval cohorts, reported separately (the rrps lesson — don't conflate claims):
+;;   :within  — every stride-th instance of a TRAIN family (same-distribution
+;;              generalization; each eval task has same-family train siblings)
+;;   :family  — an entire HELD-OUT family (:segmented by default): a stronger
+;;              COMPOSITIONAL/OOD test (its sub-structures flat+line appear in train,
+;;              so its difficulty is bounded by that overlap — named, not hidden).
+;; :eval-task-ids is the post-(name) STRING set repl-corpus/sft match on, so the split
+;; is not a silent no-op when ids round-trip through (name id).
+;; ===========================================================================
+
+(defn assign-split
+  "Tag each task :split :train|:eval and :cohort :within|:family|nil. A task is eval iff
+   its family is held out OR it is a stride-th instance within its (train) family."
+  [tasks {:keys [eval-families eval-stride] :or {eval-families #{:segmented} eval-stride 4}}]
+  (->> tasks
+       (group-by :family)
+       (mapcat (fn [[fam fam-tasks]]
+                 (if (contains? eval-families fam)
+                   (map #(assoc % :split :eval :cohort :family) fam-tasks)
+                   (map-indexed (fn [i t]
+                                  (if (zero? (mod (inc i) eval-stride))
+                                    (assoc t :split :eval :cohort :within)
+                                    (assoc t :split :train :cohort nil)))
+                                fam-tasks))))
+       vec))
+
+(defn generate-curriculum
+  "Build a graded, leakage-safe curriculum.
+
+   opts:
+     :round              ReST-EM round (seed base + part of every :id); default 0
+     :instances-per-family  instances attempted per family per round; default 20
+     :families           families to include; default all in family-defs
+     :eval-families      whole held-out families (compositional cohort); default #{:segmented}
+     :eval-stride        within-family holdout stride; default 4
+     :min-gap :min-struct-gap :max-retries  passed to gen-instance
+
+   Returns {:tasks :train-tasks :eval-tasks :eval-task-ids :by-family :by-complexity
+            :summary}. :eval-task-ids is the (comp name :id) STRING set repl-corpus
+   consumes. Growth: bump :round (and/or :instances-per-family) for a fresh,
+   reproducible, larger batch."
+  ([] (generate-curriculum {}))
+  ([{:keys [round instances-per-family families eval-families eval-stride]
+     :or   {round 0 instances-per-family 20 eval-families #{:segmented} eval-stride 4}
+     :as   opts}]
+   (let [fams    (or families (mapv :family family-defs))
+         per-fam (into {}
+                       (for [fam fams]
+                         [fam (let [gen (keep #(gen-instance fam round % opts) (range instances-per-family))]
+                                {:tasks (vec gen)
+                                 :drops (- instances-per-family (count gen))})]))
+         tasks   (assign-split (vec (mapcat (comp :tasks val) per-fam))
+                               {:eval-families eval-families :eval-stride eval-stride})
+         train   (filterv #(= :train (:split %)) tasks)
+         evals   (filterv #(= :eval (:split %)) tasks)
+         eval-ids (into #{} (map (comp name :id)) evals)
+         by-complexity (into (sorted-map)
+                             (for [[c ts] (group-by :complexity tasks)]
+                               [c {:n (count ts)
+                                   :mean-gap (when (seq ts) (/ (reduce + (map :gap ts)) (count ts)))
+                                   :mean-struct-gap (when (seq ts) (/ (reduce + (map :struct-gap ts)) (count ts)))
+                                   :mean-n-latents (when (seq ts) (/ (reduce + (map :n-latents ts)) (count ts)))}]))]
+     {:tasks tasks :train-tasks train :eval-tasks evals :eval-task-ids eval-ids
+      :by-family (into (sorted-map)
+                       (for [[fam {:keys [tasks drops]}] per-fam]
+                         [fam {:n (count tasks) :drops drops
+                               :complexity (:complexity (family-by-key fam))}]))
+      :by-complexity by-complexity
+      :summary {:round round
+                :n-tasks (count tasks) :n-train (count train) :n-eval (count evals)
+                :eval-within (count (filter #(= :within (:cohort %)) evals))
+                :eval-family (count (filter #(= :family (:cohort %)) evals))
+                :held-out-families (vec eval-families)
+                :n-families (count fams)
+                :total-drops (reduce + (map (comp :drops val) per-fam))}})))
+
+;; ===========================================================================
+;; 6. Consumer adapters.
+;; ===========================================================================
+
+(defn ->probe-task
+  "Project a canonical task into the shape scripts/synth_llm_probe.cljs consumes
+   ({:id :obs :task-desc :np :solve-bar :crude :gold}). The SOLE place :observations
+   is aliased to :obs — the canonical record keeps one source of truth."
+  [{:keys [id observations task-desc solve-bar crude gold]}]
+  {:id id :obs observations :task-desc task-desc :np 0
+   :solve-bar solve-bar :crude crude :gold gold})
+
+(defn family-proposer
+  "A no-LLM structured move-set for a task, so an end-to-end harvest can run WITHOUT the
+   policy LLM. It is the COLD-START / PLUMBING-VALIDATION proposer (the real proposer is
+   the Phase-3 learned LLM): it offers the family's structural edit (crude → the correct
+   structure at a neutral σ) and, once structured, the shared-σ grid — yielding a
+   MULTI-step trajectory so repl-corpus harvests >1 transition. Its rows are a pipeline
+   smoke test, NOT a training corpus (a one-leap crude→gold proposer teaches nothing the
+   north-star §12 cares about).
+
+   `task` is a canonical curriculum record; it carries the FULL ordered :true-params, so
+   the gold structure is rebuilt exactly (no hash-map key-order risk). Returns
+   (fn [spec feedback] -> [candidates]). For :shared-mean (gold == crude shape) there is
+   no structural step, so it goes straight to noise refinement. The refinement branch
+   tunes the OBSERVATION scale; for :ar1 (whose tunable is the latent PROCESS noise) the
+   structural leap alone clears the bar and obs-refinement is a near-no-op — reaching the
+   exact gold-scale is the real (Phase-3 LLM) proposer's job, not this validation stub's."
+  [{:keys [family true-params]}]
+  (let [{:keys [gold]} (family-by-key family)
+        gold-spec     (gold true-params 1.0)
+        gold-n-latent (count (:latents gold-spec))]
+    (fn [spec _feedback]
+      (if (< (count (:latents spec)) gold-n-latent)
+        ;; structural step: adopt the correct structure at a neutral σ; the oracle keeps
+        ;; it iff it improves evidence.
+        [{:edit :add-structure :desc (str "adopt " (name family) " structure")
+          :spec' gold-spec}]
+        ;; refinement: tune the shared observation scale over the grid.
+        (for [g sigma-grid :when (not= g (last (:args (first (:obs spec)))))]
+          {:edit :set-noise :desc (str "shared obs scale -> " g)
+           :spec' (reduce #(syn/set-noise %1 %2 g) spec (map :addr (:obs spec)))})))))

--- a/src/genmlx/world/llm_proposer.cljs
+++ b/src/genmlx/world/llm_proposer.cljs
@@ -1,0 +1,440 @@
+(ns genmlx.world.llm-proposer
+  "A REAL-LLM proposer for the REPL-synthesis loop (beans genmlx-0yv7 / genmlx-wpua):
+   the design's mechanism (a) — INSTRUCT-DRIVEN, FEEDBACK-CONDITIONED, STEPWISE.
+
+   This is the piece that puts a real LLM in the loop. `genmlx.world.synth` (Phase 1)
+   and `genmlx.world.search` (Phase 2) take an INJECTED proposer
+   `(fn [spec feedback] -> [{:edit :desc :spec' ...} ...])`; until now that slot held a
+   hand-coded structured move-vocabulary, so feedback-conditioning was plumbed but never
+   exercised. `make-proposer` here fills the slot with an LLM:
+
+     render the current partial model + its check feedback  ->  PROMPT
+     call the policy LLM K times (temperature)              ->  K completions
+     extract the (fn [trace] ...) form from each            ->  candidate :code
+     parse it (best-effort) back to a synth spec            ->  candidate :spec'
+
+   The candidates flow into the SAME four-level `check` node and oracle — so a real DSL
+   slip (mx/0 unbound, a dist bound without `trace`, (:p trace)->nil, a non-static loop)
+   reaches the check node as the LLM actually wrote it (the check node's raison d'être),
+   producing real :error feedback that the NEXT step is conditioned on. That closed loop
+   is the north-star thesis; this namespace is where the loop meets a real generator.
+
+   NATIVE-FREE, like the oracle spine it complements. The policy LLM lives OUT-OF-PROCESS
+   (a resident `scripts/llm_server.py` mlx-lm worker); `call-server` is the one I/O
+   boundary (a synchronous curl — the driver is synchronous, and an LLM call is a genuine
+   I/O boundary). The pure core — `extract-form`, `parse-spec`, the prompt builders, and
+   `make-proposer` itself (which takes an injected `:call-llm`) — needs no model and is
+   unit-tested with a mock generator.
+
+   Sections:
+     1. The DSL system prompt — teaches the exact skeleton + the anti-cliff rules
+     2. Prompt builders — task block / step (feedback-conditioned) / one-shot (control)
+     3. extract-form — LLM completion -> a (fn [trace] ...) code string (the slips kept)
+     4. parse-spec — code string -> a synth spec (the inverse of synth/render)
+     5. make-proposer / one-shot-candidates — the injected proposer + the control
+     6. call-server — the out-of-process mlx-lm bridge (the sole I/O)"
+  (:require [genmlx.world.synth :as syn]
+            [genmlx.codegen.eval :as ce]
+            [clojure.string :as str]))
+
+;; ===========================================================================
+;; 1. The DSL system prompt
+;;
+;; The cliff (genmlx-d4q4) was the one-shot INTERFACE, not capability: a model that
+;; understands the structure still emits one-eval-away GenMLX slips. This system prompt
+;; teaches the EXACT skeleton + the precise rules that each documented slip violates.
+;; It is given IDENTICALLY to the loop and the one-shot control, so the only difference
+;; the experiment measures is the feedback loop, never the prompt.
+;; ===========================================================================
+
+(def default-system
+  (str
+   "You are an expert ClojureScript programmer writing probabilistic models in GenMLX.\n"
+   "A GenMLX model is a single ClojureScript function: a (fn [trace] ...) whose body is a\n"
+   "`let` of latent variables and returns a map of observations (see the example below).\n\n"
+   "RULES (each one is a real mistake to avoid):\n"
+   "1. Every random variable is  (trace :address (dist/NAME arg ...)).  Latents are\n"
+   "   let-bindings; observations are entries in the RETURNED MAP (a keyword key whose\n"
+   "   value is a trace form). A `dist/...` bound WITHOUT `trace` is NOT a site.\n"
+   "2. Reference a latent in a later expression by its binding SYMBOL (e.g. slope) —\n"
+   "   NEVER by (:slope trace); `trace` is not a map.\n"
+   "3. Numbers are PLAIN literals:  (dist/gaussian 0 2.5).  NEVER write mx/0 or mx/2.5.\n"
+   "4. To compute a mean from latents use mx ops:\n"
+   "     (mx/add (mx/multiply slope (mx/scalar 2.0)) intercept)\n"
+   "   mx/scalar wraps a constant; +,*,-,/ are mx/add, mx/multiply, mx/subtract, mx/divide.\n"
+   "5. Distributions: (dist/gaussian mean std) (dist/uniform lo hi) (dist/bernoulli p)\n"
+   "   (dist/exponential rate) (dist/beta-dist a b) (dist/gamma-dist shape rate).\n"
+   "6. NO loops (doseq/for/map), NO combinators, NO inference calls. Write EVERY site\n"
+   "   explicitly and flat. The form must be STATIC: literal keyword addresses, no `if`.\n"
+   "7. To be scored EXACTLY (not approximately), an observation must be\n"
+   "   (trace :addr (dist/gaussian MEAN NOISE)) where (a) NOISE is a FIXED positive number\n"
+   "   (e.g. 1.0) — NOT a latent (trace :sigma ...) — and (b) MEAN is written DIRECTLY\n"
+   "   inside the (dist/gaussian ...) call as an mx expression of the latents, NOT bound to\n"
+   "   a separate let variable. Example of an exactly-scoreable observation:\n"
+   "     (trace :y3 (dist/gaussian (mx/add (mx/multiply slope (mx/scalar 3.0)) intercept) 1.0))\n"
+   "   A latent noise or a let-factored mean falls back to noisy approximate scoring, so the\n"
+   "   model looks worse than it is. (Try a smaller fixed noise if the data is tightly clustered.)\n\n"
+   "Example (a complete, valid 1-latent model — yours will have DIFFERENT structure):\n"
+   "(fn [trace]\n"
+   "  (let [mu (trace :mu (dist/gaussian 0 5))]\n"
+   "    {:o0 (trace :o0 (dist/gaussian mu 1.0))\n"
+   "     :o1 (trace :o1 (dist/gaussian mu 1.0))}))\n\n"
+   "Respond with ONLY the model: one ```clojure code block with a single (fn [trace] ...) form."))
+
+;; ===========================================================================
+;; 2. Prompt builders
+;; ===========================================================================
+
+(defn- fmt [x] (when (and x (js/isFinite x)) (.toFixed (js/Number x) 2)))
+
+(defn- render-obs
+  "Render the observed data as readable `:addr = value` lines (sorted by address)."
+  [observations]
+  (->> observations
+       (sort-by (comp str key))
+       (map (fn [[k v]] (str "  " k " = " v)))
+       (str/join "\n")))
+
+(defn- feedback-line
+  "Turn a check feedback map into the one instruction the LLM is conditioned on. This is
+   the defining feedback-conditioning step: the model's NEXT proposal sees the exact
+   verifier verdict on its PREVIOUS one (a parse failure, a coverage gap, an eval error,
+   or a model-evidence number to beat)."
+  [fb]
+  (cond
+    (nil? fb)              "(no current model yet — propose an initial model)"
+    (not (:parses? fb))    "The current model does NOT parse as a complete ClojureScript form. Return a complete (fn [trace] ...) form."
+    (not (:schema-ok? fb)) (str "The current model is not a well-formed GenMLX model: " (:error fb)
+                                ". Every latent and observation must be a (trace :addr (dist/... )) site, and the body must return a map of observations.")
+    (not (:covered? fb))   (str "Coverage problem: " (:error fb)
+                                ". Every observed address below must appear as a (trace :addr (dist/...)) entry in the returned map.")
+    (not (:evals? fb))     (str "Evaluating the current model RAISED AN ERROR: " (:error fb)
+                                ". Fix exactly this error in your next model (check rule 2/3/4 above).")
+    (nil? (:evidence fb))  (str "The model is well-formed and evaluates, but its model evidence is NON-FINITE "
+                                "(the data could not be scored). The usual cause is an invalid distribution "
+                                "parameter: a standard deviation / scale that can be non-positive — e.g. a "
+                                "(dist/gaussian ..) PRIOR on a noise scale, which can go negative. Use a FIXED "
+                                "positive number (like 1.0) for observation noise, or a positive-support prior "
+                                "(dist/exponential, dist/gamma-dist); and make sure every distribution name is real.")
+    (:evidence fb)         (str "The current model is VALID. Its Bayesian model evidence (log marginal likelihood; HIGHER is better) is "
+                                (fmt (:evidence fb))
+                                ". Propose a model that fits the data BETTER — add or adjust ONE piece of structure (a latent, a coupling, a per-group mean, a noise scale).")
+    :else                  (str "Current status: " (pr-str (select-keys fb [:parses? :schema-ok? :covered? :evals? :error])))))
+
+(defn step-prompt
+  "The feedback-conditioned step prompt: task + data + the current model + the verifier's
+   verdict on it + the instruction to make ONE targeted improvement."
+  [task-desc observations cur-code fb]
+  (str "TASK\n" task-desc
+       "\n\nOBSERVED DATA\n" (render-obs observations)
+       "\n\nCURRENT MODEL\n" cur-code
+       "\n\nVERIFIER FEEDBACK\n" (feedback-line fb)
+       "\n\nReturn an IMPROVED model as a single (fn [trace] (let [...] {...})) form. "
+       "Make ONE targeted change (fix the error above, or add/adjust one piece of structure "
+       "so the model fits the data better)."))
+
+(defn oneshot-prompt
+  "The one-shot CONTROL prompt: task + data, no current model, no feedback — the model
+   writes its best program in one shot (this is the best-of-K baseline the loop must beat)."
+  [task-desc observations]
+  (str "TASK\n" task-desc
+       "\n\nOBSERVED DATA\n" (render-obs observations)
+       "\n\nWrite the best GenMLX generative model you can for this data, as a single "
+       "(fn [trace] (let [...] {...})) form."))
+
+;; ===========================================================================
+;; 3. extract-form — pull the (fn [trace] ...) form out of an LLM completion
+;;
+;; The slips stay IN: this strips chat scaffolding (a stray <think> block, a ```fence,
+;; prose) and returns the model form the LLM actually wrote — mx/0, (:p trace) and all —
+;; so the check node sees real garbage, not a sanitized version.
+;; ===========================================================================
+
+(defn- strip-think
+  "Drop a (defensive) <think>...</think> block — closed, or unclosed to end-of-string."
+  [s]
+  (-> s
+      (str/replace #"<think>[\s\S]*?</think>" "")
+      (str/replace #"<think>[\s\S]*$" "")))
+
+(defn- strip-fence
+  "If a ```...``` code block is present, return its CONTENTS; else the string unchanged."
+  [s]
+  (if-let [m (re-find #"```[a-zA-Z]*\n?([\s\S]*?)```" s)] (second m) s))
+
+(defn- balanced-from
+  "From index `i` (a `(` in `s`) return the balanced-paren substring, or nil if it never
+   closes. String literals are tracked so parens inside \"...\" do not miscount."
+  [s i]
+  (let [n (count s)]
+    (loop [j i, depth 0, in-str? false, esc? false]
+      (if (>= j n)
+        nil
+        (let [c (nth s j)]
+          (cond
+            (and in-str? esc?)    (recur (inc j) depth true false)
+            (and in-str? (= c \\)) (recur (inc j) depth true true)
+            (and in-str? (= c \")) (recur (inc j) depth false false)
+            in-str?               (recur (inc j) depth true false)
+            (= c \")              (recur (inc j) depth true false)
+            (= c \()              (recur (inc j) (inc depth) false false)
+            (= c \))              (if (= depth 1)
+                                    (subs s i (inc j))
+                                    (recur (inc j) (dec depth) false false))
+            :else                 (recur (inc j) depth false false)))))))
+
+(defn extract-form
+  "An LLM completion -> the (fn [trace] ...) model code string it contains, or nil.
+   Strips a <think> block and a ``` fence, finds the first (fn ...) form and returns the
+   balanced substring (validated by the reader). Slip recovery: if the model emitted a
+   bare (let ...) body without the (fn [trace] ...) wrapper, wrap it — the only
+   normalization done; everything inside the form is left exactly as written."
+  [completion]
+  (when (string? completion)
+    (let [t  (-> completion strip-think strip-fence str/trim)
+          fi (.search t (js/RegExp. "\\(fn\\*?[\\s\\[]"))]
+      (if (>= fi 0)
+        (let [f (balanced-from t fi)]
+          (when (and f (ce/valid-cljs? f)) f))
+        (let [li (.search t (js/RegExp. "\\(let\\*?[\\s\\[]"))]
+          (when (>= li 0)
+            (let [b (balanced-from t li)
+                  w (when b (str "(fn [trace] " b ")"))]
+              (when (and w (ce/valid-cljs? w)) w))))))))
+
+;; ===========================================================================
+;; 4. parse-spec — code string -> a synth spec (the inverse of synth/render)
+;;
+;; Best-effort: it reads exactly the model class the spec represents (flat latents +
+;; an observation map of (trace :addr (dist ...)) sites), preserving argument FORMS
+;; verbatim (so an mx/add mean expression round-trips). It returns nil for anything
+;; off-grammar (a loop, a non-trace binding, a nested helper) — and that is fine: the
+;; candidate still carries its raw :code (what the check node scores), and only ACCEPTED
+;; candidates need a spec (a scored, well-formed, static model is always in-grammar).
+;; ===========================================================================
+
+(defn- dist-name
+  "A dist constructor symbol -> its name string: dist/gaussian -> \"gaussian\"."
+  [sym]
+  (when (symbol? sym) (name sym)))
+
+(defn- parse-site
+  "(trace :addr (dist/NAME arg ...)) -> {:addr :dist :args}, or nil."
+  [expr]
+  (when (and (seq? expr) (= 'trace (first expr)) (keyword? (second expr)))
+    (let [dexpr (nth expr 2 nil)]
+      (when (and (seq? dexpr) (symbol? (first dexpr)))
+        {:addr (second expr) :dist (dist-name (first dexpr)) :args (vec (rest dexpr))}))))
+
+(defn- collect-let-sites
+  "A let binding vector [sym1 e1 sym2 e2 ...] -> [{:sym :addr :dist :args} ...] (one per
+   binding), or nil if any binding is not `symbol + a trace-site`. (Both latents and —
+   in the common 'everything in the let, return a map of references' shape that strong
+   instruct models emit — observations live here; the return map classifies which is which.)"
+  [binds]
+  (when (and (vector? binds) (even? (count binds)))
+    (reduce (fn [acc [sym e]]
+              (let [s (parse-site e)]
+                (if (and (symbol? sym) s) (conj acc (assoc s :sym sym)) (reduced nil))))
+            [] (partition 2 binds))))
+
+(defn- classify-return-map
+  "Split `let-sites` into [latents obs] using the return map. A map value that is a SYMBOL
+   referencing a let site marks that site an OBSERVATION; a map value that is an inline
+   (trace :addr (dist ...)) form is an inline observation (the canonical render shape). A
+   returned symbol that is ALSO referenced in another site's args is a latent DEPENDENCY,
+   not a fresh observation — it must stay let-bound (in scope for that reference), so its
+   return entry is dropped (its trace-site already covers the address); otherwise the
+   round-tripped spec would render an unbound symbol. Observations are deduped by address
+   (a latent returned under multiple keys collapses to one). Latents are the let sites not
+   reclassified as observations. Returns [latents obs] or nil if any map value is neither a
+   known-site reference nor an inline trace site."
+  [let-sites retmap]
+  (when (map? retmap)
+    (let [by-sym     (into {} (map (juxt :sym identity)) let-sites)
+          referenced (into #{} (mapcat #(filter symbol? (tree-seq coll? seq (:args %)))) let-sites)]
+      (when-let [tagged (reduce (fn [acc [_ v]]
+                                  (let [inline (parse-site v)]
+                                    (cond
+                                      (and (symbol? v) (referenced v)) acc   ; latent dependency, not a fresh obs
+                                      (and (symbol? v) (by-sym v))     (conj acc (assoc (by-sym v) :ref (by-sym v)))
+                                      inline                           (conj acc inline)
+                                      :else                            (reduced nil))))
+                                [] retmap)]
+        (let [obs-syms (set (keep #(:sym (:ref %)) tagged))
+              latents  (remove #(obs-syms (:sym %)) let-sites)
+              obs      (->> tagged
+                            (reduce (fn [[seen acc] s]
+                                      (if (seen (:addr s))
+                                        [seen acc]
+                                        [(conj seen (:addr s)) (conj acc (syn/obs (:addr s) (:dist s) (:args s)))]))
+                                    [#{} []])
+                            second)]
+          [(mapv #(syn/latent (:sym %) (:addr %) (:dist %) (:args %)) latents) obs])))))
+
+(defn parse-spec
+  "A (fn [trace] (let [...] {...})) code string -> a synth spec, or nil if off-grammar.
+   Unwraps let/let*/do; handles the canonical shape (latents in the let, observations
+   inline in the return map) AND the 'everything in the let, return a map of references'
+   shape; supports the no-latent case (a bare observation-map body). Arg FORMS are
+   preserved verbatim, so a mean expression round-trips."
+  [code]
+  (let [form (ce/parse-form code)]
+    (when (and (seq? form) (#{'fn 'fn*} (first form)) (vector? (second form)))
+      (loop [b (last (drop 2 form))]
+        (cond
+          (map? b)
+          (when-let [[lat obs] (classify-return-map [] b)] (syn/spec lat obs))
+
+          (and (seq? b) (#{'let 'let*} (first b)) (vector? (second b)))
+          (when-let [sites (collect-let-sites (second b))]
+            (when-let [[lat obs] (classify-return-map sites (last b))] (syn/spec lat obs)))
+
+          (and (seq? b) (= 'do (first b)))
+          (recur (last b))
+
+          :else nil)))))
+
+;; ===========================================================================
+;; 5. make-proposer / one-shot-candidates
+;; ===========================================================================
+
+(defn- candidate-desc [sp]
+  (if sp
+    (str "LLM: " (count (:latents sp)) "L/" (count (:obs sp)) "O")
+    "LLM: off-grammar (raw)"))
+
+(defn progress-level
+  "How far a check verdict got, 0..5 — the depth of the self-check a candidate cleared.
+   Used to pick the MOST-PROGRESSED failed candidate to revise from (the one whose error
+   is the most actionable): 0 not-parse, 1 not-schema, 2 not-covered, 3 eval-error,
+   4 evaluates-but-non-finite-evidence, 5 scored."
+  [fb]
+  (cond (not (:parses? fb))    0
+        (not (:schema-ok? fb)) 1
+        (not (:covered? fb))   2
+        (not (:evals? fb))     3
+        (nil? (:evidence fb))  4
+        :else                  5))
+
+(defn- extract-distinct
+  "The distinct (fn [trace] ...) code strings a batch of completions contains — the shared
+   extract+dedup contract for both candidate builders (slips kept; nils dropped)."
+  [completions]
+  (->> completions (map extract-form) (filter some?) distinct))
+
+(defn completions->candidates
+  "Map raw LLM completions to driver/search candidates: extract the form (slips kept),
+   dedup identical forms, attach the raw :code (what the check node scores) and a
+   best-effort :spec' (for the trajectory / search / backtrack; falls back to the current
+   `spec` when the form is off-grammar, so the loop state stays valid)."
+  [completions spec]
+  (->> (extract-distinct completions)
+       (mapv (fn [code]
+               (let [sp (parse-spec code)]
+                 {:edit (if sp :llm :llm-raw)
+                  :desc (candidate-desc sp)
+                  :code code
+                  :spec' (or sp spec)})))))
+
+(defn make-proposer
+  "Build an injected proposer `(fn [spec feedback] -> [candidate ...])` backed by an LLM —
+   a mini-REPL: the proposer PROPOSES, CHECKS its own output against the verifier, and on a
+   slip RE-PROMPTS the model with that specific error to fix, up to `:revise` times. This
+   is the north-star inner loop (propose → eval → read error → revise); without it a real
+   LLM stalls, because a slip that blocks every candidate (a non-positive σ, a hallucinated
+   distribution, a coverage miss) never produces a scoring candidate for the driver to
+   accept, so the model is never told why. The DRIVER's outer loop still owns FIT
+   improvement (accept a candidate only when its exact evidence climbs); this inner loop
+   owns SELF-CORRECTION. The returned candidates carry raw `:code` (the driver re-checks +
+   selects); the proposer's internal check decides only whether to revise.
+
+   opts:
+     :call-llm     (fn [{:system :prompt :n :temperature :max_tokens :seed}]
+                       -> {:completions [str ...] ...})   REQUIRED (inject `call-server`,
+                   or a mock in tests).
+     :task-desc    natural-language description of the data/goal (no structure given away)
+     :observations the {:addr value} data, rendered into the prompt + used for the check
+     :k            samples per generation call (default 4)
+     :temperature  sampling temperature (default 0.7)
+     :max-tokens   per-sample cap (default 384)
+     :revise       max self-correction re-prompts when no candidate scores (default 0 =
+                   no revision — a pure best-of-K-per-step proposer)
+     :n-particles  IS particles for the internal revise-decision check (default 2000)
+     :system       system prompt (default the DSL reference above)
+     :seed         RNG seed for the worker (reproducible; default 1)
+
+   The current model rendered into the prompt is `(:code feedback)` (the check node
+   records it) falling back to `(syn/render spec)`; on a revision round it is the
+   most-progressed FAILED candidate's own code + the error it hit, so the model fixes
+   its own attempt."
+  [{:keys [call-llm task-desc observations k temperature max-tokens system seed revise n-particles]
+    :or {k 4 temperature 0.7 max-tokens 384 seed 1 revise 0 n-particles 2000}}]
+  (let [sys (or system default-system)]
+    (fn [spec feedback]
+      (loop [r       0
+             cur     (or (:code feedback) (syn/render spec))
+             prompt-fb feedback
+             seen    #{}
+             acc     []]
+        (let [prompt  (step-prompt task-desc observations cur prompt-fb)
+              resp    (call-llm {:system sys :prompt prompt :n k :temperature temperature
+                                 :max_tokens max-tokens :seed (+ seed (* 1000 r))})
+              fresh   (remove #(seen (:code %)) (completions->candidates (:completions resp) spec))
+              checked (mapv (fn [c] (assoc c :feedback (syn/check (:code c) observations {:n-particles n-particles})
+                                           :revised? (pos? r)))
+                            fresh)
+              acc'    (into acc checked)
+              scored  (filter #(syn/scored? (:feedback %)) checked)]
+          (if (or (seq scored) (>= r revise) (empty? checked))
+            ;; done: a candidate scores, budget exhausted, or nothing new to revise.
+            ;; Strip the internal :feedback (the driver re-checks + selects).
+            (mapv #(dissoc % :feedback) acc')
+            ;; revise: re-prompt the most-progressed failed candidate with its own error.
+            (let [worst (last (sort-by (comp progress-level :feedback) checked))]
+              (recur (inc r) (:code worst) (:feedback worst)
+                     (into seen (map :code checked)) acc'))))))))
+
+(defn one-shot-candidates
+  "The best-of-K CONTROL: K full programs from the SAME model + DSL prompt with NO
+   feedback loop. Returns [{:code ...} ...] for the probe to `check`-score and rank — the
+   baseline the LLM-in-the-loop must beat. (`:spec'` defaults to nil; the probe scores
+   `:code` directly.)"
+  [{:keys [call-llm task-desc observations k temperature max-tokens system seed]
+    :or {k 16 temperature 0.8 max-tokens 384 seed 1}}]
+  (let [resp (call-llm {:system (or system default-system)
+                        :prompt (oneshot-prompt task-desc observations)
+                        :n k :temperature temperature :max_tokens max-tokens :seed seed})]
+    (mapv (fn [code] {:code code}) (extract-distinct (:completions resp)))))
+
+;; ===========================================================================
+;; 6. call-server — the out-of-process mlx-lm bridge (the sole I/O boundary)
+;; ===========================================================================
+
+(def ^:private cp (js/require "child_process"))
+(def ^:private fs (js/require "fs"))
+(def ^:private os (js/require "os"))
+(def ^:private node-path (js/require "path"))
+(def ^:private req-counter (atom 0))
+
+(defn call-server
+  "Synchronous POST <url>/generate with the request map (`{:system :prompt :n
+   :temperature :max_tokens :seed}`); returns the parsed worker response
+   `{:completions [...] :gen-time-s :prompt-tokens :completion-tokens :model}`.
+
+   Blocking (execSync + curl): the synthesis driver is synchronous, and the resident
+   policy LLM is a genuine out-of-process I/O boundary. The body is written to a temp
+   file (the prompt is paren/quote/newline-heavy — shell-hostile). On any transport error
+   returns `{:completions [] :error msg}` so the loop degrades gracefully (no candidates
+   -> the driver plateaus) instead of throwing."
+  [url req]
+  (let [tmp (.join node-path (.tmpdir os)
+                   (str "genmlx-llm-req-" (.-pid js/process) "-" (swap! req-counter inc) ".json"))]
+    (try
+      (.writeFileSync fs tmp (js/JSON.stringify (clj->js req)))
+      (let [cmd (str "curl -s --max-time 900 -X POST " url "/generate "
+                     "-H 'content-type: application/json' --data-binary @" tmp)
+            out (.execSync cp cmd #js {:encoding "utf8" :maxBuffer (* 64 1024 1024)})]
+        (js->clj (js/JSON.parse out) :keywordize-keys true))
+      (catch :default e {:completions [] :error (.-message e)})
+      (finally (try (.unlinkSync fs tmp) (catch :default _ nil))))))

--- a/src/genmlx/world/repl_corpus.cljs
+++ b/src/genmlx/world/repl_corpus.cljs
@@ -1,0 +1,94 @@
+(ns genmlx.world.repl-corpus
+  "Phase 3 (genmlx-oexl), done-means #1: harvest the GFI/REPL trace of a SUCCESSFUL loop
+   run into an SFT corpus that teaches the *propose-eval-revise POLICY* — given a partial
+   model + the verifier's feedback, produce the good next edit — NOT whole programs (the
+   distinction the north star rests on: §12 showed the loop's value is the policy, and a
+   cheap 0.8B SFT'd on whole programs can't drive the loop; this corpus is what fixes that).
+
+   THE TRACE OF A GOOD RUN *IS* THE CORPUS. Each accepted step transition (model_i,
+   feedback_i) → model_{i+1} becomes one chat row whose user turn is exactly the step-prompt
+   the proposer saw and whose assistant turn is the edit that improved the exact evidence.
+   So the student learns to imitate the loop's accepted moves (including, on the harder
+   models, the structure→refine sequence the 35B teacher produced).
+
+   NATIVE-FREE: reuses the proposer's prompt builders (`genmlx.world.llm-proposer`) and the
+   four-level `check` node (`genmlx.world.synth`) — no model loads here. Rows match
+   `genmlx.world.sft`'s chat-row shape (`{:task-id :kind :messages}`), so sft_prep /
+   sft_train / sft_eval consume them unchanged, and the SAME leakage-guarded task split
+   applies (the rrps lesson: split at the TASK level, before training).
+
+   Sections:
+     1. trajectory->rows — one successful run's accepted transitions → SFT rows
+     2. build-corpus — many (task, trajectory) runs → rows + a leakage-safe report"
+  (:require [genmlx.world.synth :as syn]
+            [genmlx.world.llm-proposer :as lp]
+            [genmlx.world.sft :as sft]))
+
+;; ===========================================================================
+;; 1. trajectory->rows
+;; ===========================================================================
+
+(defn trajectory->rows
+  "A successful run's trajectory (a vector of accepted states, each at least `{:code ...}`,
+   step 0 = the crude init) + its `task` ({:id :task-desc :observations}) → SFT rows, one
+   per step TRANSITION i→i+1:
+     system    = the DSL prompt (genmlx.world.llm-proposer/default-system)
+     user      = the step-prompt the proposer SAW at step i: task + data + model_i + the
+                 verifier's feedback on model_i (re-derived by `check`, so it is exactly
+                 what conditioned the real proposal)
+     assistant = the model ACCEPTED at step i+1 (fenced — what extract-form expects)
+
+   ORACLE FILTER: a transition is kept only when model_{i+1} scores AND strictly improves
+   model_i's evidence (or model_i was unscored and model_{i+1} scores). An accepted step is
+   improving by construction, but re-verifying makes the corpus self-consistent and lets
+   this run over ANY trajectory source (e.g. a re-loaded artifact) — never trusting a label."
+  ([task trajectory] (trajectory->rows task trajectory {}))
+  ([{:keys [id task-desc observations]} trajectory {:keys [n-particles] :or {n-particles 2000}}]
+   (let [steps (vec trajectory)
+         chk   (fn [code] (when code (syn/check code observations {:n-particles n-particles})))]
+     (vec
+      (for [i (range (dec (count steps)))
+            :let [code-i  (:code (nth steps i))
+                  code-i1 (:code (nth steps (inc i)))
+                  fb-i    (chk code-i)
+                  fb-i1   (chk code-i1)]
+            :when (and code-i code-i1 fb-i fb-i1
+                       (syn/scored? fb-i1)
+                       (or (not (syn/scored? fb-i))
+                           (> (:evidence fb-i1) (:evidence fb-i))))]
+        {:task-id  (name id)
+         :kind     :repl-edit
+         :rank-key (:evidence fb-i1)
+         :messages [{:role "system"    :content lp/default-system}
+                    {:role "user"      :content (lp/step-prompt task-desc observations code-i fb-i)}
+                    {:role "assistant" :content (str "```clojure\n" code-i1 "\n```")}]})))))
+
+;; ===========================================================================
+;; 2. build-corpus
+;; ===========================================================================
+
+(defn build-corpus
+  "Harvest many successful runs into one REPL-edit corpus. `runs` is a seq of
+   `{:task {:id :task-desc :observations} :trajectory [...]}`. Returns
+     {:rows [...]                 ; ALL harvested transition rows
+      :train-rows [...]           ; rows whose task is NOT held out (sft/eval-task-ids or
+                                  ;   the supplied `eval-ids`) — the leakage-safe training set
+      :dropped-eval [...]         ; rows dropped because their task is held out
+      :n-runs n :n-rows n :per-task {task-id count} :train-task-ids #{...}}
+
+   The held-out split is applied at the TASK level via genmlx.world.sft/partition-corpus,
+   so a student trained on `:train-rows` is graded only on tasks it never saw — the same
+   leakage guarantee the distill→SFT pipeline enforces."
+  ([runs] (build-corpus runs {}))
+  ([runs {:keys [n-particles eval-ids] :or {n-particles 2000}}]
+   (let [rows (vec (mapcat (fn [{:keys [task trajectory]}]
+                             (trajectory->rows task trajectory {:n-particles n-particles}))
+                           runs))
+         part (if eval-ids (sft/partition-corpus rows eval-ids) (sft/partition-corpus rows))]
+     {:rows rows
+      :train-rows (:train-rows part)
+      :dropped-eval (:dropped-eval part)
+      :n-runs (count runs)
+      :n-rows (count rows)
+      :per-task (frequencies (map :task-id rows))
+      :train-task-ids (:train-task-ids part)})))

--- a/src/genmlx/world/search.cljs
+++ b/src/genmlx/world/search.cljs
@@ -76,7 +76,10 @@
                      (if expand-k (take expand-k cs) cs))
           cur-ev   (or (:evidence p) ##-Inf)
           children (for [c cands
-                         :let [code (syn/render (:spec' c))
+                         ;; a candidate may carry raw `:code` (a real-LLM proposer emits
+                         ;; the program text directly — genmlx.world.llm-proposer); check
+                         ;; it VERBATIM so DSL slips reach the check node. Else render :spec'.
+                         :let [code (or (:code c) (syn/render (:spec' c)))
                                fb   (syn/check code observations opts)]
                          :when (syn/scored? fb)]
                      {:spec (:spec' c) :feedback fb :evidence (:evidence fb) :done? false

--- a/src/genmlx/world/sft.cljs
+++ b/src/genmlx/world/sft.cljs
@@ -106,7 +106,10 @@
                                        the teacher only generated over train tasks)"
   ([rows] (partition-corpus rows eval-task-ids))
   ([rows eval-ids]
-   (let [{train true dropped false} (group-by #(train-task? (:task-id %)) rows)]
+   ;; group on `eval-ids` directly (NOT the hardcoded train-task?), so a custom
+   ;; held-out set — e.g. the scaled genmlx.world.distill-gen eval ids — is honored.
+   (let [train? (fn [r] (not (contains? eval-ids (:task-id r))))
+         {train true dropped false} (group-by train? rows)]
      {:train-rows            (vec train)
       :dropped-eval          (vec dropped)
       :train-task-ids        (into (sorted-set) (map :task-id) train)

--- a/src/genmlx/world/synth.cljs
+++ b/src/genmlx/world/synth.cljs
@@ -333,10 +333,14 @@
 ;; ===========================================================================
 
 (defn- score-candidates
-  "Render + check every proposed candidate against the observations."
+  "Render + check every proposed candidate against the observations. A candidate may
+   carry a raw `:code` string (a real-LLM proposer emits the program text directly — see
+   genmlx.world.llm-proposer); that raw code is checked VERBATIM so the LLM's DSL slips
+   reach the check node exactly as written. Otherwise the code is rendered from `:spec'`
+   (the structured-proposer path)."
   [candidates observations opts]
   (for [c candidates
-        :let [code (render (:spec' c))
+        :let [code (or (:code c) (render (:spec' c)))
               fb   (check code observations opts)]]
     (assoc c :code code :feedback fb :evidence (:evidence fb))))
 
@@ -395,8 +399,12 @@
                    :method (:method init-fb) :delta nil :accepted? true
                    :n-candidates 0}]]
       (if (>= t max-steps)
-        {:spec (:spec state) :code (render (:spec state)) :feedback (:feedback state)
-         :trajectory traj :stop-reason :max-steps :steps t}
+        ;; report the VERBATIM checked code (the feedback's :code — what actually scored);
+        ;; falls back to render. For the structured proposer these are identical (the spec
+        ;; round-trips); for a real-LLM proposer the verbatim code is authoritative even if
+        ;; its parsed :spec' is an imperfect round-trip (genmlx.world.llm-proposer).
+        {:spec (:spec state) :code (or (:code (:feedback state)) (render (:spec state)))
+         :feedback (:feedback state) :trajectory traj :stop-reason :max-steps :steps t}
         (let [cands (vec (propose (:spec state) (:feedback state)))
               {:keys [best improved?]} (step state cands observations opts)]
           (if-not improved?
@@ -404,8 +412,8 @@
             ;; :stuck = the current state never reached a finite evidence AND no valid
             ;; candidate did either (a structurally-incomplete init the proposer could
             ;; not complete) — NOT a fitted plateau, so report it distinctly.
-            {:spec (:spec state) :code (render (:spec state)) :feedback (:feedback state)
-             :trajectory traj :steps t
+            {:spec (:spec state) :code (or (:code (:feedback state)) (render (:spec state)))
+             :feedback (:feedback state) :trajectory traj :steps t
              :stop-reason (if (scored? (:feedback state)) :plateau :stuck)}
             (let [prev-ev (:evidence (:feedback state))
                   delta   (when (and prev-ev (:evidence best)) (- (:evidence best) prev-ev))]

--- a/test/genmlx/curriculum_test.cljs
+++ b/test/genmlx/curriculum_test.cljs
@@ -1,0 +1,212 @@
+(ns genmlx.curriculum-test
+  "Well-posedness + integration tests for the REPL-synthesis curriculum generator
+   (genmlx.world.curriculum, bean genmlx-ilna). NATIVE-FREE: uses the exact oracle
+   (synth/check) but never the policy LLM.
+
+   Every assertion is one the curriculum's value depends on:
+     - PRNG correctness (the signed-shift / NaN bugs the critique flagged)
+     - per-task well-posedness (crude<bar<gold, exact+reproducible oracle, no structure
+       leak in the task-desc, ground-truth re-scores to gold)
+     - the complexity SPREAD (the resource-rational training signal)
+     - leakage-safe split, proven END-TO-END through repl-corpus (a planted held-out
+       trajectory is actually DROPPED — the rrps no-op-guard failure mode)
+     - consumer compatibility (->probe-task; a multi-step family-proposer harvest)"
+  (:require [genmlx.world.curriculum :as cur]
+            [genmlx.world.synth :as syn]
+            [genmlx.world.repl-corpus :as rc]
+            [clojure.set :as set]
+            [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; Minimal assertion helpers (project convention — no framework).
+;; ---------------------------------------------------------------------------
+(def ^:dynamic *fails* (atom 0))
+(def ^:dynamic *passes* (atom 0))
+(defn assert-true [msg x]
+  (if x (swap! *passes* inc)
+      (do (swap! *fails* inc) (println "  FAIL:" msg))))
+(defn assert-close [msg expected actual tol]
+  (assert-true (str msg " (exp " expected " got " actual ")")
+               (and (number? actual) (< (js/Math.abs (- expected actual)) tol))))
+
+;; ===========================================================================
+;; 1. PRNG correctness — the signed-shift / NaN failure modes.
+;; ===========================================================================
+(println "\n-- PRNG --")
+(let [us (cur/uniforms 7 5000)
+      ns (cur/normals 9 5000)
+      mean (fn [xs] (/ (reduce + xs) (count xs)))
+      std  (fn [xs] (let [m (mean xs)] (js/Math.sqrt (mean (map #(* (- % m) (- % m)) xs)))))]
+  (assert-true "uniforms all in [0,1) (catches signed-shift negatives)"
+               (every? #(and (>= % 0.0) (< % 1.0)) us))
+  (assert-true "uniforms reproducible (same seed)" (= (cur/uniforms 123 200) (cur/uniforms 123 200)))
+  (assert-true "uniforms differ across seeds" (not= (cur/uniforms 1 50) (cur/uniforms 2 50)))
+  (assert-close "uniform mean ~ 0.5 (catches skew from arithmetic shift)" 0.5 (mean us) 0.03)
+  (assert-true "normals all finite (catches Box-Muller log(0) NaN)" (every? js/isFinite ns))
+  (assert-true "normals reproducible" (= (cur/normals 55 200) (cur/normals 55 200)))
+  (assert-close "normal mean ~ 0" 0.0 (mean ns) 0.06)
+  (assert-close "normal std ~ 1" 1.0 (std ns) 0.06))
+(let [s1 (cur/mix-seed 0 1 2 3) s2 (cur/mix-seed 0 1 2 4) s3 (cur/mix-seed 0 1 2 3)]
+  (assert-true "mix-seed deterministic" (= s1 s3))
+  (assert-true "mix-seed distinguishes tuples" (not= s1 s2))
+  (assert-true "mix-seed is a 32-bit int" (and (integer? s1) (<= (js/Math.abs s1) 4294967296))))
+(assert-close "round1 rounds down below .05" 1.0 (cur/round1 1.0499999) 1e-9)
+(assert-close "round1 rounds up at/above .05" 1.1 (cur/round1 1.06) 1e-9)
+
+;; ===========================================================================
+;; 2. Generate a curriculum exercising BOTH eval cohorts.
+;; ===========================================================================
+(println "\n-- generating curriculum (6/family, stride 3) --")
+(def C (cur/generate-curriculum {:round 0 :instances-per-family 6 :eval-stride 3}))
+(def tasks (:tasks C))
+(println "  " (pr-str (:summary C)))
+(assert-true "curriculum is non-empty" (pos? (count tasks)))
+(assert-true "covers all 6 families" (= 6 (count (group-by :family tasks))))
+(assert-true "both eval cohorts present"
+             (and (pos? (:eval-within (:summary C))) (pos? (:eval-family (:summary C)))))
+
+;; ===========================================================================
+;; 3. Per-task well-posedness (the core spec).
+;; ===========================================================================
+(println "\n-- per-task well-posedness --")
+(def banned-structure
+  ["slope" "intercept" "linear" "regress" "coefficient" "autoreg" "markov" "pool"
+   "hierarch" "latent" "prior" "gaussian" "distribution" "variance" "covariance"
+   "mean" "noise" "scale" "drift"])
+(defn rounded-1dp? [x] (< (js/Math.abs (- x (cur/round1 x))) 1e-9))
+
+(doseq [t tasks]
+  (let [{:keys [id family crude crude-tuned gold solve-bar gap struct-gap exact? method
+                task-desc observations ground-truth-code complexity structural?]} t
+        struct? (get (cur/family-by-key family) :structural? true)]
+    ;; oracle quality
+    (assert-true (str id " exact? true") exact?)
+    (assert-true (str id " method exact/kalman") (contains? #{:exact :kalman} method))
+    ;; bar strictly brackets, with margin
+    (assert-true (str id " crude < solve-bar < gold") (and (< crude solve-bar) (< solve-bar gold)))
+    (assert-true (str id " gap >= min-gap") (>= gap cur/default-min-gap))
+    (when struct?
+      (assert-true (str id " struct-gap >= min (structure beats best structureless)")
+                   (>= struct-gap cur/default-min-struct-gap))
+      ;; the core admissibility guarantee: the best STRUCTURELESS noise-tuned model must
+      ;; NOT clear the bar, so 'solved' provably means found-the-structure (not noise tuning).
+      (assert-true (str id " best structureless model does NOT clear the bar")
+                   (< crude-tuned solve-bar)))
+    ;; ground-truth code re-scores to gold (tolerance, float32) + parses + covers
+    (let [fb (syn/check ground-truth-code observations {:n-particles 0})]
+      (assert-true (str id " ground-truth parses+covers+scored") (syn/scored? fb))
+      (assert-close (str id " ground-truth re-scores to gold") gold (:evidence fb)
+                    (+ 1e-3 (* 1e-4 (js/Math.abs gold))))
+      (assert-true (str id " ground-truth clears its own bar") (>= (:evidence fb) solve-bar)))
+    ;; task-desc semantics-only (no structural vocabulary)
+    (let [low (str/lower-case task-desc)]
+      (assert-true (str id " task-desc omits structural words")
+                   (not-any? #(str/includes? low %) banned-structure)))
+    ;; observations rounded; id is a stable string
+    (assert-true (str id " observations rounded to 1dp") (every? rounded-1dp? (vals observations)))
+    (assert-true (str id " :id is a string") (string? id))))
+
+;; global id uniqueness
+(assert-true "all task ids unique" (= (count tasks) (count (distinct (map :id tasks)))))
+
+;; ===========================================================================
+;; 4. The complexity SPREAD — the resource-rational training signal.
+;; ===========================================================================
+(println "\n-- complexity spread --")
+(let [bc (:by-complexity C)
+      cs (sort (keys bc))
+      n-lats (map #(:mean-n-latents (bc %)) cs)]
+  (assert-true "spans >= 3 complexity bands" (>= (count cs) 3))
+  (assert-true "mean n-latents monotone non-decreasing in complexity"
+               (apply <= n-lats))
+  (assert-true "hardest band has a bigger mean gap than the easiest band"
+               (> (:mean-gap (bc (last cs))) (:mean-gap (bc (first cs)))))
+  (doseq [c cs]
+    (println "  c" c " n=" (:n (bc c)) " mean-gap=" (.toFixed (:mean-gap (bc c)) 2)
+             " mean-n-lat=" (.toFixed (:mean-n-latents (bc c)) 2))))
+
+;; ===========================================================================
+;; 5. Reproducibility — same opts ⇒ byte-identical observations.
+;; ===========================================================================
+(println "\n-- reproducibility --")
+(let [C2 (cur/generate-curriculum {:round 0 :instances-per-family 6 :eval-stride 3})
+      by-id  (into {} (map (juxt :id :observations) tasks))
+      by-id2 (into {} (map (juxt :id :observations) (:tasks C2)))]
+  (assert-true "same ids regenerated" (= (set (keys by-id)) (set (keys by-id2))))
+  (assert-true "observations byte-identical across runs" (= by-id by-id2)))
+(let [Cr1 (cur/generate-curriculum {:round 1 :instances-per-family 3})]
+  (assert-true "ReST-EM round changes the data (fresh batch)"
+               (not= (map :observations (:tasks Cr1))
+                     (take (count (:tasks Cr1)) (map :observations tasks)))))
+
+;; ===========================================================================
+;; 6. Leakage-safe split — proven END-TO-END through repl-corpus.
+;; ===========================================================================
+(println "\n-- leakage-safe split (end-to-end) --")
+(let [eval-ids (:eval-task-ids C)
+      train-ids (into #{} (map (comp name :id)) (:train-tasks C))]
+  (assert-true "eval-task-ids are strings ((name id) form)"
+               (every? string? eval-ids))
+  (assert-true "eval-task-ids = (name id) of every eval task"
+               (= eval-ids (into #{} (map (comp name :id)) (:eval-tasks C))))
+  (assert-true "train/eval task-id sets are disjoint"
+               (empty? (set/intersection eval-ids train-ids)))
+  (assert-true "held-out family (:segmented) is entirely eval"
+               (every? #(= :eval (:split %)) (filter #(= :segmented (:family %)) tasks))))
+
+;; Build a real trajectory for one held-out (eval) task + one train task, harvest with
+;; the curriculum's eval-ids, and assert the planted eval rows are DROPPED (not silently
+;; kept) — the no-op-guard failure the rrps lesson is about.
+(defn harvest-run [task]
+  (let [obs (:observations task)
+        res (syn/synthesize {:init-spec (cur/crude-spec obs) :observations obs
+                             :propose (cur/family-proposer task) :max-steps 8})]
+    {:task task :trajectory (:trajectory res) :steps (:steps res)
+     :final (get-in res [:feedback :evidence])}))
+
+(let [eval-task  (first (filter #(= :segmented (:family %)) (:eval-tasks C)))  ; held-out FAMILY
+      train-task (first (filter #(= :varying-slopes (:family %)) (:train-tasks C)))
+      runs (mapv harvest-run [eval-task train-task])
+      corpus (rc/build-corpus runs {:eval-ids (:eval-task-ids C)})]
+  (println "  eval task" (:id eval-task) "trajectory steps:" (:steps (first runs)))
+  (println "  train task" (:id train-task) "trajectory steps:" (:steps (second runs)))
+  (println "  corpus:" (pr-str (select-keys corpus [:n-runs :n-rows :train-task-ids])))
+  (assert-true "harvest produced rows" (pos? (:n-rows corpus)))
+  (assert-true "planted EVAL-task rows are DROPPED (not silently kept)"
+               (seq (:dropped-eval corpus)))
+  (assert-true "no train-row belongs to a held-out eval task"
+               (not-any? #(contains? (:eval-task-ids C) (:task-id %)) (:train-rows corpus)))
+  (assert-true "the train task's rows ARE in train-rows"
+               (some #(= (name (:id train-task)) (:task-id %)) (:train-rows corpus)))
+  ;; close the multi-step harvest claim THROUGH build-corpus (not just at trajectory level):
+  ;; the >1-step train trajectory must yield >1 SFT row.
+  (assert-true "multi-step trajectory harvests >1 row for the train task"
+               (> (count (filter #(= (name (:id train-task)) (:task-id %)) (:train-rows corpus))) 1)))
+
+;; ===========================================================================
+;; 7. Consumer adapter + multi-step family-proposer harvest.
+;; ===========================================================================
+(println "\n-- consumers --")
+(let [t (first (filter #(= :linear (:family %)) tasks))
+      p (cur/->probe-task t)]
+  (assert-true "->probe-task :obs == :observations" (= (:observations t) (:obs p)))
+  (assert-true "->probe-task carries probe knobs"
+               (and (= 0 (:np p)) (= (:solve-bar t) (:solve-bar p))
+                    (= (:crude t) (:crude p)) (= (:gold t) (:gold p)))))
+
+;; the family-proposer must yield a MULTI-step trajectory (structure + noise refinement)
+;; on a structural task, and the loop must SOLVE it (final evidence clears the bar) —
+;; proving the curriculum is consumable by the loop without the LLM.
+(let [t   (first (filter #(= :varying-slopes (:family %)) tasks))
+      res (syn/synthesize {:init-spec (cur/crude-spec (:observations t))
+                           :observations (:observations t)
+                           :propose (cur/family-proposer t) :max-steps 8})]
+  (println "  vslope family-proposer: steps=" (:steps res) " final=" (.toFixed (get-in res [:feedback :evidence]) 2)
+           " bar=" (.toFixed (:solve-bar t) 2))
+  (assert-true "family-proposer trajectory is multi-step (>1 accepted edit)" (> (:steps res) 1))
+  (assert-true "family-proposer solves the task (clears the bar)"
+               (>= (get-in res [:feedback :evidence]) (:solve-bar t))))
+
+;; ===========================================================================
+(println (str "\n=== curriculum_test: " @*passes* " passed, " @*fails* " failed ==="))
+(when (pos? @*fails*) (js/process.exit 1))

--- a/test/genmlx/llm_proposer_test.cljs
+++ b/test/genmlx/llm_proposer_test.cljs
@@ -1,0 +1,264 @@
+;; @tier slow
+(ns genmlx.llm-proposer-test
+  "Acceptance for genmlx.world.llm-proposer — the REAL-LLM proposer for the REPL loop
+   (genmlx-0yv7 / genmlx-wpua). NATIVE-FREE and deterministic: the policy LLM is MOCKED
+   (an injected :call-llm), so every assertion is reproducible and no model loads. The
+   live big/small-model experiment lives in scripts/synth_llm_probe.cljs; this file pins
+   the pure, unit-testable parts AND the end-to-end wiring (a scripted 'LLM' drives the
+   real genmlx.world.synth driver).
+
+   Run: bun run --bun nbb test/genmlx/llm_proposer_test.cljs
+
+   PARTS:
+     A — extract-form: pulls the (fn [trace] ...) form out of fenced / prosey / <think>'d
+         completions, recovers a bare (let ...) body, returns nil on no-form, and KEEPS
+         a DSL slip (mx/0) verbatim (the check node, not the extractor, judges it).
+     B — parse-spec: round-trips render <-> parse for in-grammar models (arg FORMS
+         preserved), and returns nil for off-grammar code (a dist bound without trace,
+         a non-static loop).
+     C — completions->candidates: dedups, attaches :code (raw) + best-effort :spec',
+         labels in-grammar :llm vs off-grammar :llm-raw.
+     D — prompt builders: the step prompt is FEEDBACK-CONDITIONED (the verifier verdict
+         is in the text); the system prompt teaches the anti-cliff rules.
+     E — make-proposer (mock): returns candidates AND passes the feedback into the prompt.
+     F — INTEGRATION: a scripted feedback-sensitive 'LLM' drives the real synth driver —
+         real garbage reaches the check node and is REJECTED, the clean improvement is
+         ACCEPTED, the loop climbs exact evidence and self-terminates on plateau."
+  (:require [genmlx.world.llm-proposer :as lp]
+            [genmlx.world.synth :as s]
+            [genmlx.codegen.eval :as ce]
+            [clojure.string :as str]))
+
+(def ^:private pass (atom 0))
+(def ^:private fail (atom 0))
+(defn assert-true [label v]
+  (if v (do (swap! pass inc) (println "  PASS" label))
+      (do (swap! fail inc) (println "  FAIL" label))))
+(defn assert-close [label expected actual tol]
+  (let [ok (and (number? actual) (js/isFinite actual) (<= (js/Math.abs (- expected actual)) tol))]
+    (if ok (do (swap! pass inc) (println "  PASS" label (str "(" actual " ~ " expected ")")))
+        (do (swap! fail inc) (println "  FAIL" label (str "(" actual " vs " expected ")"))))))
+
+;; ===========================================================================
+(println "\n-- A. extract-form --")
+
+(def good-form
+  "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 5))] {:y0 (trace :y0 (dist/gaussian mu 1.0))}))")
+
+(assert-true "bare form returned verbatim"
+             (= good-form (lp/extract-form good-form)))
+(assert-true "fenced ```clojure block extracted"
+             (= good-form (lp/extract-form (str "Here:\n```clojure\n" good-form "\n```"))))
+(assert-true "prose + bare form: the form is found"
+             (= good-form (lp/extract-form (str "Sure, here is the model: " good-form " — done."))))
+(assert-true "<think> block stripped before extraction"
+             (= good-form (lp/extract-form (str "<think>let me reason (a b c</think>\n" good-form))))
+(assert-true "no model form -> nil"
+             (nil? (lp/extract-form "I cannot help with that. (just prose, no fn)")))
+(assert-true "bare (let ...) body recovered by wrapping in (fn [trace] ..)"
+             (let [r (lp/extract-form "(let [mu (trace :mu (dist/gaussian 0 5))] {:y0 (trace :y0 (dist/gaussian mu 1.0))})")]
+               (and r (str/starts-with? r "(fn [trace]") (ce/valid-cljs? r))))
+;; the slip is KEPT — the extractor never sanitizes; the check node judges it. (mx/zero
+;; is a readable symbol that is UNBOUND at eval — a real cliff slip; mx/0 is not even
+;; reader-valid, so it is caught one level earlier, at the :parses? gate.)
+(assert-true "DSL slip (mx/zero unbound) preserved verbatim in the extracted form"
+             (let [slip "(fn [trace] (let [mu (trace :mu (dist/gaussian mx/zero 1))] {:y0 (trace :y0 (dist/gaussian mu 1.0))}))"]
+               (= slip (lp/extract-form (str "```clojure\n" slip "\n```")))))
+(assert-true "parens inside a string literal don't break balancing"
+             (let [c "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 5))] {:y0 (trace :y0 (dist/gaussian mu 1.0))}))  ;; note: \"a ( b\""]
+               (some? (lp/extract-form c))))
+
+;; ===========================================================================
+(println "\n-- B. parse-spec (inverse of render) --")
+
+(def spec1
+  (s/spec [(s/latent 'slope "gaussian" [0 3])
+           (s/latent 'intercept "gaussian" [0 5])]
+          [(s/obs :y0 "gaussian" [(list 'mx/add (list 'mx/multiply 'slope (list 'mx/scalar 0.0)) 'intercept) 1.0])
+           (s/obs :y1 "gaussian" [(list 'mx/add (list 'mx/multiply 'slope (list 'mx/scalar 1.0)) 'intercept) 1.0])]))
+
+(assert-true "render -> parse-spec round-trips to an equal spec (arg FORMS preserved)"
+             (= spec1 (lp/parse-spec (s/render spec1))))
+(assert-true "round-trip re-renders identically"
+             (= (s/render spec1) (s/render (lp/parse-spec (s/render spec1)))))
+(assert-true "no-latent body (bare obs map) parses"
+             (let [sp (lp/parse-spec "(fn [trace] {:y0 (trace :y0 (dist/gaussian 0 1))})")]
+               (and sp (empty? (:latents sp)) (= 1 (count (:obs sp))))))
+(assert-true "off-grammar: a dist bound WITHOUT trace -> nil (raw :code still checkable)"
+             (nil? (lp/parse-spec "(fn [trace] (let [mu (dist/gaussian 0 5)] {:y0 (trace :y0 (dist/gaussian mu 1))}))")))
+(assert-true "off-grammar: a non-static loop body -> nil"
+             (nil? (lp/parse-spec "(fn [trace] (doseq [i (range 3)] (trace :y (dist/gaussian 0 1))))")))
+(assert-true "an arg-form slip ((:p trace)) round-trips structurally (caught later at eval)"
+             (let [sp (lp/parse-spec "(fn [trace] (let [p (trace :p (dist/beta-dist 1 1))] {:y0 (trace :y0 (dist/bernoulli (:p trace)))}))")]
+               (and sp (= '(:p trace) (first (:args (first (:obs sp))))))))
+;; the shape strong instruct models actually emit: EVERYTHING in the let, return a map of
+;; symbol references. parse-spec classifies referenced sites as observations.
+(assert-true "'everything in the let, map-of-refs' shape (the 35B's shape) parses correctly"
+             (let [sp (lp/parse-spec
+                       (str "(fn [trace] (let [slope (trace :slope (dist/gaussian 1 2)) "
+                            "intercept (trace :intercept (dist/gaussian 0 2)) "
+                            "y0 (trace :y0 (dist/gaussian (mx/add (mx/multiply slope (mx/scalar 0.0)) intercept) 1.0)) "
+                            "y1 (trace :y1 (dist/gaussian (mx/add (mx/multiply slope (mx/scalar 1.0)) intercept) 1.0))] "
+                            "{:y0 y0 :y1 y1}))"))]
+               (and sp (= 2 (count (:latents sp))) (= 2 (count (:obs sp)))
+                    (= #{'slope 'intercept} (set (map :sym (:latents sp))))
+                    (= #{:y0 :y1} (set (map :addr (:obs sp)))))))
+;; regression (review finding): a latent that is BOTH returned in the map AND referenced in
+;; another site's args must STAY let-bound, or the re-render has an unbound symbol.
+(assert-true "a returned latent also referenced in another site's args stays let-bound (no unbound re-render)"
+             (let [code "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 5)) y0 (trace :y0 (dist/gaussian mu 1.0))] {:mu mu :y0 y0}))"
+                   sp (lp/parse-spec code)
+                   fb (s/check (s/render sp) {:y0 1.0} {})]
+               (and sp
+                    (= #{'mu} (set (map :sym (:latents sp))))
+                    (some #(= :y0 (:addr %)) (:obs sp))
+                    (:evals? fb))))
+
+;; ===========================================================================
+(println "\n-- C. completions->candidates --")
+
+(let [comps [(str "```clojure\n" good-form "\n```")
+             (str "```clojure\n" good-form "\n```")               ; duplicate -> deduped
+             "(fn [trace] (doseq [i (range 3)] (trace :y (dist/gaussian 0 1))))" ; off-grammar
+             "sorry, no code here"]                                ; no form -> dropped
+      cands (lp/completions->candidates comps :CURRENT-SPEC)]
+  (assert-true "dedup + drop-no-form -> 2 candidates" (= 2 (count cands)))
+  (assert-true "every candidate carries raw :code" (every? :code cands))
+  (assert-true "in-grammar candidate labeled :llm with a parsed :spec'"
+               (some #(and (= :llm (:edit %)) (map? (:spec' %)) (not= :CURRENT-SPEC (:spec' %))) cands))
+  (assert-true "off-grammar candidate labeled :llm-raw, :spec' falls back to current"
+               (some #(and (= :llm-raw (:edit %)) (= :CURRENT-SPEC (:spec' %))) cands)))
+
+;; ===========================================================================
+(println "\n-- D. prompt builders (feedback-conditioning) --")
+
+(let [obs {:y0 5.0 :y1 5.2}
+      p-err (lp/step-prompt "fit y" obs "(fn [trace] ...)"
+                            {:parses? true :schema-ok? true :covered? true :evals? false
+                             :error "Unbound: mx/0" :evidence nil})
+      p-ev  (lp/step-prompt "fit y" obs "(fn [trace] ...)"
+                            {:parses? true :schema-ok? true :covered? true :evals? true
+                             :error nil :evidence -7.25})]
+  (assert-true "step prompt embeds the data" (str/includes? p-err ":y0 = 5"))
+  (assert-true "step prompt embeds the current model" (str/includes? p-err "CURRENT MODEL"))
+  (assert-true "ERROR feedback is conditioned on (the eval error is in the prompt)"
+               (str/includes? p-err "Unbound: mx/0"))
+  (assert-true "EVIDENCE feedback is conditioned on (the number to beat is in the prompt)"
+               (str/includes? p-ev "-7.25"))
+  (assert-true "system prompt teaches the anti-cliff rules (no mx/0, trace not a map)"
+               (and (str/includes? lp/default-system "mx/0")
+                    (str/includes? lp/default-system "(:slope trace)"))))
+
+;; ===========================================================================
+(println "\n-- E. make-proposer with a mock LLM --")
+
+(let [seen (atom nil)
+      mock (fn [req] (reset! seen req)
+             {:completions [(str "```clojure\n" good-form "\n```")]})
+      prop (lp/make-proposer {:call-llm mock :task-desc "fit y" :observations {:y0 5.0}
+                              :k 1 :temperature 0.5})
+      fb   {:code "(fn [trace] (let [mu (trace :mu (dist/gaussian 0 9))] {:y0 (trace :y0 (dist/gaussian mu 9))}))"
+            :parses? true :schema-ok? true :covered? true :evals? true :evidence -12.0}
+      cands (prop {:dummy :spec} fb)]
+  (assert-true "proposer returns >=1 candidate from the LLM" (pos? (count cands)))
+  (assert-true "candidate carries the LLM's raw :code" (= good-form (:code (first cands))))
+  (assert-true "proposer fed the verifier feedback (evidence -12.0) into the prompt"
+               (str/includes? (:prompt @seen) "-12.0"))
+  (assert-true "proposer rendered the CURRENT model (from :code feedback) into the prompt"
+               (str/includes? (:prompt @seen) "dist/gaussian mu 9")))
+
+;; one-shot control: no feedback, just task+data
+(let [mock (fn [_] {:completions [(str "```clojure\n" good-form "\n```")
+                                  (str "```clojure\n" good-form "\n```")]})
+      cands (lp/one-shot-candidates {:call-llm mock :task-desc "fit y" :observations {:y0 5.0} :k 2})]
+  (assert-true "one-shot-candidates dedups to 1 :code-carrying candidate"
+               (and (= 1 (count cands)) (:code (first cands)))))
+
+;; ===========================================================================
+(println "\n-- F. INTEGRATION: a scripted 'LLM' drives the real synth driver --")
+
+;; Tightly-clustered data near 5 -> a tighter obs noise has HIGHER evidence. Confirm the
+;; direction with an INDEPENDENT closed-form Gaussian-Gaussian marginal (non-circular).
+(def f-obs {:y0 5.0 :y1 5.2 :y2 4.8})
+(defn gg-marginal [ys m0 s0 sn]
+  (let [n (count ys) s0² (* s0 s0) sn² (* sn sn)
+        ds (map #(- % m0) ys) sd (reduce + ds) sd² (reduce + (map #(* % %) ds))
+        denom (+ sn² (* n s0²))
+        logdet (+ (js/Math.log denom) (* (dec n) (js/Math.log sn²)))
+        quad (* (/ 1.0 sn²) (- sd² (* (/ s0² denom) (* sd sd))))]
+    (- (* -0.5 n (js/Math.log (* 2 js/Math.PI))) (* 0.5 logdet) (* 0.5 quad))))
+(assert-true "direction check: tighter noise (1.0) out-scores loose (3.0) for tight data"
+             (> (gg-marginal (vals f-obs) 5 3 1.0) (gg-marginal (vals f-obs) 5 3 3.0)))
+
+;; crude (loose) init: mu ~ N(5,3), each :yj ~ N(mu, 3.0)
+(def f-init (s/spec [(s/latent 'mu "gaussian" [5 3])]
+                    (for [k [:y0 :y1 :y2]] (s/obs k "gaussian" ['mu 3.0]))))
+
+;; scripted 'LLM': each propose returns TWO completions —
+;;  (1) a real DSL slip (a dist bound WITHOUT trace — readable, but evals to garbage) the
+;;      check node must REJECT, and
+;;  (2) a clean improvement (the same model with obs noise tightened to 1.0).
+(def f-tight
+  "(fn [trace] (let [mu (trace :mu (dist/gaussian 5 3))] {:y0 (trace :y0 (dist/gaussian mu 1.0)) :y1 (trace :y1 (dist/gaussian mu 1.0)) :y2 (trace :y2 (dist/gaussian mu 1.0))}))")
+(def f-garbage
+  "(fn [trace] (let [mu (dist/gaussian 0 5)] {:y0 (trace :y0 (dist/gaussian mu 1.0)) :y1 (trace :y1 (dist/gaussian mu 1.0)) :y2 (trace :y2 (dist/gaussian mu 1.0))}))")
+(defn scripted-llm [_req]
+  {:completions [(str "```clojure\n" f-garbage "\n```")
+                 (str "```clojure\n" f-tight "\n```")]})
+
+(let [prop (lp/make-proposer {:call-llm scripted-llm :task-desc "fit y" :observations f-obs :k 2})
+      res  (s/synthesize {:init-spec f-init :observations f-obs :propose prop
+                          :max-steps 4 :plateau-eps 0.05})
+      traj (:trajectory res)
+      start (:evidence (first traj))
+      final (:evidence (last traj))]
+  (assert-true "loop CLIMBS exact evidence (loose -> tight) via the LLM proposer"
+               (> final (+ start 0.05)))
+  (assert-true "loop self-terminates on plateau (not :stuck/:max-steps)"
+               (= :plateau (:stop-reason res)))
+  (assert-true "accepted edit came from the LLM (:llm), garbage rejected"
+               (= :llm (:edit (last traj))))
+  ;; the accepted trajectory row carries the LLM's RAW code (the top-level :code is
+  ;; re-rendered from the spec, where CLJS prints 1.0 as 1 — so assert on the raw row).
+  (assert-true "accepted (raw) model is the tightened one (obs noise 1.0)"
+               (str/includes? (:code (last traj)) "mu 1.0"))
+  (assert-true "the loose noise (3.0) is gone from the re-rendered final model"
+               (not (str/includes? (:code res) "mu 3")))
+  ;; the rejected garbage really WAS scored against the check node and failed (raison d'être)
+  (let [code (lp/extract-form (first (:completions (scripted-llm nil))))
+        fb   (s/check code f-obs {})]
+    (assert-true "the real LLM garbage (dist bound w/o trace) reached check and was NOT scored"
+                 (and code (not (s/scored? fb))))))
+
+;; ===========================================================================
+(println "\n-- G. proposer self-correction (the inner REPL revision loop) --")
+
+(def g-obs {:y0 5.0 :y1 5.2 :y2 4.8})
+;; coverage slip: the model copies the EXAMPLE's :o addresses instead of the observed :y
+(def g-bad
+  "(fn [trace] (let [mu (trace :mu (dist/gaussian 5 3))] {:o0 (trace :o0 (dist/gaussian mu 1.0)) :o1 (trace :o1 (dist/gaussian mu 1.0)) :o2 (trace :o2 (dist/gaussian mu 1.0))}))")
+(def g-good
+  "(fn [trace] (let [mu (trace :mu (dist/gaussian 5 3))] {:y0 (trace :y0 (dist/gaussian mu 1.0)) :y1 (trace :y1 (dist/gaussian mu 1.0)) :y2 (trace :y2 (dist/gaussian mu 1.0))}))")
+;; a scripted 'LLM' that slips until it is told the coverage error, then fixes it
+(defn g-llm [req]
+  {:completions [(str "```clojure\n" (if (str/includes? (:prompt req) "Coverage problem") g-good g-bad) "\n```")]})
+
+(let [prop  (lp/make-proposer {:call-llm g-llm :task-desc "fit y" :observations g-obs :k 1 :revise 2})
+      cands (prop (s/spec [(s/latent 'mu "gaussian" [5 3])] [(s/obs :y0 "gaussian" ['mu 3.0])])
+                  {:parses? true :schema-ok? true :covered? true :evals? true :evidence -20.0})
+      scored (filter #(s/scored? (s/check (:code %) g-obs {})) cands)]
+  (assert-true "with :revise=0 (default) the coverage slip is NOT corrected (control)"
+               (let [p0 (lp/make-proposer {:call-llm g-llm :task-desc "fit y" :observations g-obs :k 1})
+                     c0 (p0 (s/spec [(s/latent 'mu "gaussian" [5 3])] [(s/obs :y0 "gaussian" ['mu 3.0])])
+                            {:parses? true :schema-ok? true :covered? true :evals? true :evidence -20.0})]
+                 (empty? (filter #(s/scored? (s/check (:code %) g-obs {})) c0))))
+  (assert-true "revision turns the coverage-slipped proposer into a SCORING candidate"
+               (seq scored))
+  (assert-true "the scoring candidate is the corrected (:y-address) model"
+               (some #(str/includes? (:code %) ":y0") scored))
+  (assert-true "the corrected candidate is flagged :revised?"
+               (some :revised? cands)))
+
+;; ===========================================================================
+(println (str "\n==== llm_proposer_test: " @pass " passed, " @fail " failed ===="))
+(when (pos? @fail) (js/process.exit 1))

--- a/test/genmlx/repl_corpus_test.cljs
+++ b/test/genmlx/repl_corpus_test.cljs
@@ -1,0 +1,66 @@
+;; @tier slow
+(ns genmlx.repl-corpus-test
+  "Acceptance for genmlx.world.repl-corpus — the REPL-trace SFT-corpus harvester
+   (Phase 3, genmlx-oexl). NATIVE-FREE + deterministic (conjugate models score exact, no
+   model loads): a successful trajectory becomes propose-eval-revise chat rows, the oracle
+   filter drops non-improving transitions, and the leakage-safe task split holds.
+
+   Run: bun run --bun nbb test/genmlx/repl_corpus_test.cljs"
+  (:require [genmlx.world.repl-corpus :as rc]
+            [genmlx.world.synth :as syn]
+            [clojure.string :as str]))
+
+(def ^:private pass (atom 0))
+(def ^:private fail (atom 0))
+(defn assert-true [label v]
+  (if v (do (swap! pass inc) (println "  PASS" label))
+      (do (swap! fail inc) (println "  FAIL" label))))
+
+;; tightly-clustered data near 5 -> a tighter obs noise has higher exact evidence.
+;; Models are RENDERED from specs (no hand-written code strings).
+(def obs {:y0 5.0 :y1 5.2 :y2 4.8})
+(defn- model [noise]
+  (syn/render (syn/spec [(syn/latent 'mu "gaussian" [5 3])]
+                        (for [k [:y0 :y1 :y2]] (syn/obs k "gaussian" ['mu noise])))))
+(def crude (model 3))
+(def tight (model 1))
+(def task {:id :gtest :task-desc "Fit the y observations." :observations obs})
+
+(println "\n-- trajectory->rows --")
+(def rows1 (rc/trajectory->rows task [{:code crude} {:code tight}]))
+(assert-true "an improving transition -> exactly one row" (= 1 (count rows1)))
+(def r1 (first rows1))
+(def msgs1 (:messages r1))
+(def user1 (:content (second msgs1)))
+(def asst1 (:content (nth msgs1 2)))
+(assert-true "row carries the task-id (for the leakage split)" (= "gtest" (:task-id r1)))
+(assert-true "row is a :repl-edit" (= :repl-edit (:kind r1)))
+(assert-true "messages are system/user/assistant" (= ["system" "user" "assistant"] (map :role msgs1)))
+(assert-true "user turn embeds the data" (str/includes? user1 ":y0 = 5"))
+(assert-true "user turn embeds model_i (crude state)" (str/includes? user1 "dist/gaussian mu 3"))
+(assert-true "user turn embeds the verifier feedback (evidence)" (str/includes? user1 "evidence"))
+(assert-true "assistant turn is the ACCEPTED next model (fenced, tightened)"
+             (and (str/includes? asst1 "dist/gaussian mu 1") (str/includes? asst1 "```clojure")))
+
+(println "\n-- oracle filter --")
+(assert-true "a NON-improving transition (same model) is dropped"
+             (empty? (rc/trajectory->rows task [{:code crude} {:code crude}])))
+(assert-true "a 3-step improving trajectory yields 2 rows"
+             (= 2 (count (rc/trajectory->rows task [{:code (model 3)} {:code (model 2)} {:code (model 1)}]))))
+(def broken "(fn [trace] (let [mu (dist/gaussian 0 5)] {:y0 (trace :y0 (dist/gaussian mu 1.0))}))")
+(assert-true "a transition to a BROKEN model is dropped (target must score)"
+             (empty? (rc/trajectory->rows task [{:code crude} {:code broken}])))
+
+(println "\n-- build-corpus + leakage-safe split --")
+(def runs [{:task task :trajectory [{:code crude} {:code tight}]}
+           {:task {:id :held :task-desc "other" :observations obs} :trajectory [{:code crude} {:code tight}]}])
+(def res (rc/build-corpus runs {:eval-ids #{"held"}}))
+(assert-true "harvests rows from both runs" (= 2 (:n-rows res)))
+(assert-true "per-task counts present" (= {"gtest" 1 "held" 1} (:per-task res)))
+(assert-true "train-rows EXCLUDE the held-out task (no leakage)"
+             (and (= 1 (count (:train-rows res))) (= "gtest" (:task-id (first (:train-rows res))))))
+(assert-true "the held-out task's row is reported as dropped, not folded in"
+             (= 1 (count (:dropped-eval res))))
+
+(println (str "\n==== repl_corpus_test: " @pass " passed, " @fail " failed ===="))
+(when (pos? @fail) (js/process.exit 1))


### PR DESCRIPTION
## Phase 3 of the north star (stacks on #156)

Builds on **#156** (Phase 1+2 kernel + search). Base is `feat/phase1-repl-synthesis-kernel` — **retarget to `main` once #156 merges** (or merge #156 first).

### Commits
1. **`fix(sft)`** — `partition-corpus` 2-arity must honor its `eval-ids` arg (main's version silently ignored it for the hardcoded SFT set). The REPL-trace harvest's leakage-safety depends on this. (4 lines.)
2. **Real LLM in the loop** (`genmlx-0yv7`, `world/llm_proposer.cljs` + `scripts/llm_server.py` resident mlx-lm worker): feedback-conditioned proposer with REPL revision + the LLM⊕σ-grid hybrid. **35B result: the loop beats one-shot and the margin grows with structural complexity** (linreg tie / kalman +0.6 / varying-slopes +10.6 nats). `llm_proposer_test` 41/41.
3. **Harvester** (`genmlx-oexl` #1, `world/repl_corpus.cljs`): REPL-trace → SFT-corpus (each accepted transition → a propose-eval-revise chat row, oracle-filtered + leakage-safe). `repl_corpus_test` 15/15.
4. **Curriculum generator** (`genmlx-ilna`, `world/curriculum.cljs`): graded, oracle-grounded, leakage-safe bank of structured linear-Gaussian tasks; 6 families × 3 complexity bands; `solve-bar = (crude-tuned + gold)/2` so clearing it provably requires structure; a 149-task run is well-posed end-to-end (0 leaks, no-LLM loop solves 6/6). `curriculum_test` 456/456.

### Why this is sliced this way
Supersedes the broader #158 (now closed): #158 also dragged in the cljs-coder substrate (`distill_gen`, SFT scripts, an experimental/wedged GRPO commit) that #156 deliberately excluded. This PR carries only what Phase 3 needs on top of #156 — including the minimal `sft` fix — keeping `main` clean. The eliminator fix is separate (#157); `CompositeEdit` is separate (#159).

### Tests (on this stacked base)
llm_proposer 41/41, repl_corpus 15/15, curriculum 456/456.

### Next
Phase 3 proper (`genmlx-oexl`): run the 35B loop over the curriculum → harvest at scale → SFT the 0.8B → GRPO → eval on the task-disjoint split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)