### PR TITLE
fix: three latent robustness nits from idiomatic sweep (genmlx-983x)

### DIFF
--- a/src/genmlx/inference/compiled_optimizer.cljs
+++ b/src/genmlx/inference/compiled_optimizer.cljs
@@ -300,6 +300,8 @@
    args: model arguments (vector)
    observations: ChoiceMap of observed values
    addresses: vector of latent addresses to optimize
+   opts (optional):
+     :fd-h — finite-diff step for the handler path's :loss-grad-fn (default 1e-4)
 
    Returns:
      {:loss-grad-fn       (fn [params-tensor] -> [loss grad])
@@ -308,7 +310,9 @@
       :n-params           int
       :compilation-level  :tensor-native | :compiled-generate | :handler
       :latent-index       {addr -> int}}"
-  [model args observations addresses]
+  ([model args observations addresses]
+   (make-compiled-loss-grad model args observations addresses {}))
+  ([model args observations addresses {:keys [fd-h] :or {fd-h 1e-4}}]
   (let [model-keyed (dyn/auto-key model)
         ;; L3.5: filter out analytically eliminated addresses
         eliminated (u/get-eliminated-addresses model)
@@ -355,7 +359,7 @@
             neg-score (fn [params] (mx/negative (gfi-score-fn params)))
             loss-grad (fn [params]
                         (let [loss (neg-score params)
-                              grad (finite-diff-grad neg-score params 1e-4)]
+                              grad (finite-diff-grad neg-score params fd-h)]
                           (mx/materialize! loss grad)
                           [loss grad]))]
         {:loss-grad-fn loss-grad
@@ -363,7 +367,7 @@
          :init-params init-params
          :n-params n-params
          :compilation-level :handler
-         :latent-index latent-index}))))
+         :latent-index latent-index})))))
 
 (defn learn
   "Learn model parameters via compiled gradient optimization.
@@ -393,7 +397,7 @@
     :or {iterations 1000 lr 0.01 log-every 50}
     :as opts}]
   (let [{:keys [score-fn init-params n-params compilation-level latent-index]}
-        (make-compiled-loss-grad model args observations addresses)
+        (make-compiled-loss-grad model args observations addresses opts)
         train-opts (merge {:iterations iterations :lr lr :log-every log-every
                            :callback callback}
                           (select-keys opts [:beta1 :beta2 :epsilon :fd-h]))

--- a/src/genmlx/inference/mcmc.cljs
+++ b/src/genmlx/inference/mcmc.cljs
@@ -821,31 +821,6 @@
 ;; Vectorized Compiled Trajectory MH (N chains × K steps per dispatch)
 ;; ---------------------------------------------------------------------------
 
-(defn- make-vectorized-compiled-chain
-  "Build a compiled K-step MH chain for [N,D]-shaped params as one fused lazy-graph evaluation.
-   Returns compiled fn: (params [N,D], noise [K,N,D], uniforms [K,N]) → params [N,D]."
-  [k-steps score-fn proposal-std n-chains n-params]
-  (let [chain-fn
-        (fn [params noise-3d uniforms-2d]
-          (loop [p params, i 0]
-            (if (>= i k-steps) p
-                (let [row (mx/reshape
-                           (mx/take-idx noise-3d (mx/array [i] mx/int32) 0)
-                           [n-chains n-params])
-                      proposal (mx/add p (mx/multiply proposal-std row))
-                      s-cur (score-fn p)
-                      s-prop (score-fn proposal)
-                      log-alpha (mx/subtract s-prop s-cur)
-                      u-row (mx/reshape
-                             (mx/take-idx uniforms-2d (mx/array [i] mx/int32) 0)
-                             [n-chains])
-                      log-u (mx/log u-row)
-                      accept? (mx/greater log-alpha log-u)
-                      p' (mx/where (mx/expand-dims accept? 1) proposal p)]
-                  (recur p' (inc i))))))
-        compiled (mx/compile-fn chain-fn)]
-    compiled))
-
 (defn- make-vectorized-compiled-trajectory
   "Build a compiled K-step MH trajectory for [N,D]-shaped params.
    Returns compiled fn: (params [N,D], noise [K,N,D], uniforms [K,N]) → [K,N,D]."

--- a/src/genmlx/verify.cljs
+++ b/src/genmlx/verify.cljs
@@ -243,7 +243,7 @@
                                          (check-no-mutation source)
                                          (check-no-hof-gen-fns source)))
          ;; Runtime trials — execution-based checks
-         base-key (or key (rng/fresh-key))
+         base-key (rng/ensure-key key)
          trial-keys (rng/split-n base-key n-trials)
          trial-results (mapv #(run-validation-trial gf args %) trial-keys)
          trial-violations (->> (mapcat :violations trial-results)

--- a/test/genmlx/compiled_loss_grad_test.cljs
+++ b/test/genmlx/compiled_loss_grad_test.cljs
@@ -52,6 +52,16 @@
            (trace (keyword (str "y" i)) (dist/gaussian mu 1)))
          mu)))
 
+(def dynamic-cauchy-model
+  "Handler-path model with a NON-quadratic cauchy likelihood, so the
+   finite-difference gradient genuinely depends on the step size :fd-h
+   (a quadratic Gaussian score is exact under central FD for any h)."
+  (gen [n]
+       (let [mu (trace :mu (dist/gaussian 0 10))]
+         (dotimes [i (mx/item n)]
+           (trace (keyword (str "y" i)) (dist/cauchy mu 1)))
+         mu)))
+
 ;; ---------------------------------------------------------------------------
 ;; 1. Compilation level detection
 ;; ---------------------------------------------------------------------------
@@ -133,6 +143,49 @@
           [loss grad] (loss-grad-fn params)]
       (mx/materialize! loss grad)
       (is (> (first (mx/->clj grad)) 0) "gradient at mu=5 points back toward data (grad > 0 for loss)"))))
+
+;; ---------------------------------------------------------------------------
+;; 4b. :fd-h threads into the handler-path :loss-grad-fn (genmlx-983x)
+;; ---------------------------------------------------------------------------
+
+(deftest fd-h-threading-test
+  (testing ":fd-h configures the finite-diff step of the returned :loss-grad-fn"
+    (let [obs    (cm/choicemap :y0 (mx/scalar 3.0) :y1 (mx/scalar -2.0))
+          args   [(mx/scalar 2)]
+          addrs  [:mu]
+          params (mx/array [0.5])
+          big-h   0.3
+          small-h 1e-4
+          {big-lg :loss-grad-fn score-fn :score-fn level :compilation-level}
+          (co/make-compiled-loss-grad dynamic-cauchy-model args obs addrs {:fd-h big-h})
+          {small-lg :loss-grad-fn}
+          (co/make-compiled-loss-grad dynamic-cauchy-model args obs addrs {:fd-h small-h})
+          ;; default arity (no opts) must behave as :fd-h 1e-4
+          {def-lg :loss-grad-fn}
+          (co/make-compiled-loss-grad dynamic-cauchy-model args obs addrs)
+          [_ big-grad]   (big-lg params)
+          [_ small-grad] (small-lg params)
+          [_ def-grad]   (def-lg params)
+          ;; Independent oracle: central finite difference of -score at big-h.
+          neg-score (fn [p] (mx/negative (score-fn p)))
+          ei (mx/array [big-h])
+          oracle-big (/ (- (mx/item (neg-score (mx/add params ei)))
+                           (mx/item (neg-score (mx/subtract params ei))))
+                        (* 2.0 big-h))]
+      (mx/materialize! big-grad small-grad def-grad)
+      (let [bg (first (mx/->clj big-grad))
+            sg (first (mx/->clj small-grad))
+            dg (first (mx/->clj def-grad))]
+        (is (= :handler level) "non-quadratic dynamic model uses the handler path")
+        (is (h/close? bg oracle-big 1e-5)
+            ":loss-grad-fn gradient equals central-FD at the configured :fd-h")
+        (is (h/close? dg sg 1e-9)
+            "default arity (no opts) uses :fd-h 1e-4")
+        ;; Anti-vacuity: on a non-quadratic score a different step yields a
+        ;; genuinely different gradient, proving :fd-h is actually threaded
+        ;; rather than ignored in favour of a hardcoded constant.
+        (is (> (js/Math.abs (- bg sg)) 1e-4)
+            "different :fd-h yields a different gradient (threading is non-vacuous)")))))
 
 ;; ---------------------------------------------------------------------------
 ;; 5. Convergence: Gaussian mean estimation (tensor-native)


### PR DESCRIPTION
## Summary

Closes **genmlx-983x** — three latent robustness/config defects spotted (not just cosmetic) during the second idiomatic sweep. Each was verified against current behavior before fixing.

### 1. `verify.cljs` — `validate-gen-fn` key handling
Switched `(or key (rng/fresh-key))` → `(rng/ensure-key key)`. `ensure-key` returns a fresh key for `nil` and **raises** on a non-nil malformed key (e.g. a float scalar from a coerced-nil autograd arg), where the old shorthand let it slip through to `split-n` and silently produce garbage samples. No behavior change for existing callers (all pass a nil key).

### 2. `compiled_optimizer.cljs` — `:fd-h` not tunable on the returned `:loss-grad-fn`
`make-compiled-loss-grad`'s returned `:loss-grad-fn` hardcoded the finite-diff step at `1e-4`, so direct callers couldn't tune it (only `handler-train`, which `learn` routes through, respected `:fd-h`). Added an optional opts arity carrying `:fd-h` (default `1e-4`), threaded into the handler-path `finite-diff-grad`; `learn` now forwards `opts`. The existing 4-arg call convention is preserved via a delegating arity, so no caller breaks.

New `fd-h-threading-test` (non-vacuous, oracle-based): on a non-quadratic cauchy handler-path score,
- the returned gradient equals an **independent same-step central-FD oracle**,
- the default arity matches `:fd-h 1e-4`,
- a different `:fd-h` yields a genuinely different gradient (anti-vacuity — proves the step is actually threaded, not ignored).

### 3. `mcmc.cljs` — dead private fn
Removed `make-vectorized-compiled-chain` (private, **zero references** across src/test/examples/dev; superseded by the live `make-vectorized-compiled-trajectory` used by the vectorized compiled-trajectory MH path).

## Verification
`verify_test` 9/9 · `well_formedness_test` 37/37 · `compiled_loss_grad_test` 15/15 · `compiled_optimizer_test` 14/14 · `vectorized_mcmc_fix_test` 3/3 · `l2_mcmc_test` 7/7 — all green. Diff: 4 files, +62/−30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)