### PR TITLE
docs: add required @genmlx/core build step (fresh-clone fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,11 +112,17 @@ bun run --bun nbb test/genmlx/vectorized_test.cljs
 bun run --bun nbb test/genmlx/vectorized_benchmark.cljs
 ```
 
-No build step, no compilation. nbb interprets ClojureScript directly.
+No build step for the ClojureScript — nbb interprets it directly. The **native
+addon does** need building from the `mlx-node` submodule on a fresh clone:
+`cd mlx-node && yarn install && yarn build && node packages/genmlx-core/build.mjs`.
+That last step is **required and easy to miss**: `yarn build` builds the
+`@mlx-node/core` addon, but GenMLX's Layer 0 loads **`@genmlx/core`**
+(`packages/genmlx-core/index.node`, gitignored), which only `build.mjs` produces —
+skip it and every `nbb` run fails at `(js/require "@genmlx/core")`.
 
-**Requirements:** macOS with Apple Silicon, Bun (or Node.js 18+), `npm install`
-for `@mlx-node/core` and `@mlx-node/lm`, and nbb `1.4.208` (pinned via the `nbb`
-script in `package.json`). Malli is a git submodule tracking **official upstream
+**Requirements:** macOS with Apple Silicon, Bun (or Node.js 18+), the native build
+above (`@genmlx/core` via `build.mjs`, plus `@mlx-node/core`/`@mlx-node/lm`), and
+nbb `1.4.208` (pinned via the `nbb` script in `package.json`). Malli is a git submodule tracking **official upstream
 `metosin/malli`** on the nbb classpath — the earlier robert-johansson/malli fork
 existed only for nbb 1.4.206 compatibility, which 1.4.208 made unnecessary (its
 SCI exposes `IPrintWithWriter`).

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ yarn build             # runs build:native (cmake + cargo) AND build:ts (tsc -b)
                        # Do NOT use `yarn build:native` alone — without build:ts,
                        # @mlx-node/lm has no dist/ and the LLM API won't import.
                        # Needs cmake, cargo, and (macOS 26+) the Metal Toolchain on PATH.
+node packages/genmlx-core/build.mjs   # REQUIRED: builds the @genmlx/core addon
+                       # (packages/genmlx-core/index.node) that GenMLX actually loads
+                       # at genmlx.mlx, plus colocates mlx.metallib/paged_attn.metallib.
+                       # `yarn build` above builds the SEPARATE @mlx-node/core addon, NOT
+                       # this one — skip this line and every `nbb` run fails at
+                       # (js/require "@genmlx/core"). Run it AFTER `yarn build` (it reuses
+                       # the metallibs that build produced). The .node is gitignored, so
+                       # this regenerates it on every fresh clone.
 cd ..
 
 # Install GenMLX's native dependency. @mlx-node/core and @mlx-node/lm resolve from


### PR DESCRIPTION
## Summary
Fresh-clone reproducibility audit found the one step that breaks a literal README-following clone+build: GenMLX loads **`@genmlx/core`** (`packages/genmlx-core/index.node`, gitignored) at `genmlx.mlx`, but that addon is produced **only** by `node packages/genmlx-core/build.mjs`. The documented `yarn build` builds the **separate** `@mlx-node/core` addon, and there's no postinstall hook — so a follower never builds `@genmlx/core` and every `nbb` run fails at `(js/require "@genmlx/core")`.

Adds the `build.mjs` step (after `yarn build`, which it depends on for the metallibs) to the README Quick Start and the CLAUDE.md requirements. The source is fully committed, so this just regenerates the gitignored addon on each clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)